### PR TITLE
Add Makefile for minimal test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: setup test
+
+setup:
+	pip install -r requirements-test.txt
+
+test: setup
+	pytest

--- a/docs/EXTERNAL_DEPENDENCIES.md
+++ b/docs/EXTERNAL_DEPENDENCIES.md
@@ -13,5 +13,14 @@ Install Python dependencies using:
 pip install -r requirements.txt
 ```
 
+For local testing or CI pipelines, use the provided `Makefile`:
+
+```bash
+make test
+```
+
+The `test` target installs the packages listed in `requirements-test.txt`
+(including `requests`) before invoking `pytest`.
+
 Some scripts expect certain JSON reports or configuration files to be present in
 the working directory. Review the README files for details on each module.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+requests
+pytest
+psutil


### PR DESCRIPTION
## Summary
- provide a Makefile with `setup` and `test` targets for installing test requirements
- document how to run tests with the new Makefile
- add lightweight `requirements-test.txt` for CI usage

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686bad56b0888331b2c0e8f00d8bfbde