### PR TITLE
Add backup and restore documentation

### DIFF
--- a/web_gui/documentation/backup_restore/README.md
+++ b/web_gui/documentation/backup_restore/README.md
@@ -1,0 +1,59 @@
+# Backup & Restore Guide
+========================
+
+💾 Data protection procedures via the web interface
+
+## Accessing the Backup Interface
+
+1. **Start the Flask dashboard** (if it is not already running):
+   ```bash
+   cd web_gui_scripts/flask_apps
+   python enterprise_dashboard.py
+   ```
+2. **Open your browser** and navigate to:
+   ```
+   http://localhost:5000/backup
+   ```
+3. **Backup Dashboard** will display available backup options and history.
+
+## Creating a Backup
+
+1. Click **"Create Backup"**.
+2. Choose the backup type:
+   - **Full** – database, scripts, templates and configuration
+   - **Database Only** – `production.db` and related files
+   - **Scripts Only** – scripts and templates
+3. Select the destination directory for the backup archive.
+4. Monitor the progress indicator. When finished, a new entry will appear in the backup history table.
+
+### Example Backup Command (CLI alternative)
+```bash
+python backup_scripts/create_backup.py --target e:/_copilot_backups --full
+```
+
+## Restoring from a Backup
+
+1. From the **Backup Dashboard**, locate the backup you wish to restore.
+2. Click **"Restore"** next to the backup entry.
+3. Confirm the restore destination. The default location is the current working environment.
+4. Wait for the operation to complete and check the on-screen status messages.
+5. Restart the Flask dashboard if necessary:
+   ```bash
+   pkill -f "enterprise_dashboard.py"
+   python enterprise_dashboard.py
+   ```
+
+## Verifying Backup Integrity
+
+- After creating a backup, click **"Verify"** to run an automated integrity check.
+- The system calculates checksums and validates file counts.
+- Any errors will be logged to `backup.log` in the backup directory.
+
+## Best Practices
+
+- Schedule regular full backups for production systems.
+- Store backup archives in a secure off-site location.
+- Test the restore procedure periodically to ensure reliability.
+- Monitor available disk space to prevent backup failures.
+
+Generated: 2025-01-06T04:53:00Z


### PR DESCRIPTION
## Summary
- document backup and restore procedures via the web GUI
- reference the new section from the web GUI docs index

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686bf4bce9ac8331b8b75bb9d65bbd88