### PR TITLE
Allow GH_COPILOT workspace override

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Package Information
 - **Package Name**: gh_COPILOT_Enterprise_Package_20250706_181036
 - **Created**: 2025-07-06 18:10:37
-- **Source Environment**: e:/gh_COPILOT
-- **Target Environment**: e:/gh_COPILOT
+- **Source Environment**: `e:/gh_COPILOT` (override with `GH_COPILOT_WORKSPACE`)
+- **Target Environment**: `e:/gh_COPILOT` (override with `GH_COPILOT_WORKSPACE`)
 - **Validation Status**: PASSED - Ready for Professional Deployment
 
 ## Deployment Status
@@ -32,13 +32,13 @@
 - **Deployment Ready**: TRUE
 
 ## Deployment Instructions
-1. All core files have been copied to e:/gh_COPILOT
+1. All core files have been copied to the workspace directory (default `e:/gh_COPILOT`)
 2. Configuration files are in place
 3. Run final_deployment_validator.py to confirm environment
 4. System is ready for production use
 
 ## Next Steps
-- Execute the gh_COPILOT system from e:/gh_COPILOT
+- Execute the gh_COPILOT system from the workspace directory
 - Monitor performance using unified_monitoring_optimization_system.py
 - Access advanced analytics through advanced_analytics_phase4_phase5_enhancement.py
 

--- a/copilot/common/__init__.py
+++ b/copilot/common/__init__.py
@@ -1,0 +1,2 @@
+from .workspace_utils import get_workspace_path
+

--- a/copilot/common/workspace_utils.py
+++ b/copilot/common/workspace_utils.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import os
+from typing import Optional
+
+DEFAULT_ENV_VAR = "GH_COPILOT_WORKSPACE"
+DEFAULT_PATH = Path("e:/gh_COPILOT")
+
+
+def get_workspace_path(workspace: Optional[str] = None) -> Path:
+    """Return a workspace path from a parameter or environment variable."""
+    if workspace:
+        return Path(workspace)
+    return Path(os.getenv(DEFAULT_ENV_VAR, DEFAULT_PATH))
+

--- a/copilot/core/enterprise_json_serialization_fix.py
+++ b/copilot/core/enterprise_json_serialization_fix.py
@@ -17,15 +17,17 @@ import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Union
+
+from copilot.common import get_workspace_path
 import logging
 from dataclasses import dataclass, asdict
 
 class EnterpriseJSONSerializer:
     """Enterprise-grade JSON serializer with datetime handling."""
     
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
-        self.staging_path = Path("e:/gh_COPILOT")
+    def __init__(self, workspace_path: Optional[str] = None):
+        self.workspace_path = get_workspace_path(workspace_path)
+        self.staging_path = get_workspace_path(workspace_path)
         
         # Setup logging
         logging.basicConfig(
@@ -329,9 +331,9 @@ class OptimizationReport:
 
 class EnterpriseReportGenerator:
     """Enterprise report generator with proper datetime handling."""
-    
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+
+    def __init__(self, workspace_path: Optional[str] = None):
+        self.workspace_path = get_workspace_path(workspace_path)
         self.serializer = EnterpriseJSONSerializer(workspace_path)
         
     def generate_optimization_report(self, optimization_data: Dict[str, Any]) -> OptimizationReport:

--- a/copilot/core/enterprise_unicode_compatibility_fix.py
+++ b/copilot/core/enterprise_unicode_compatibility_fix.py
@@ -30,7 +30,9 @@ import re
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Tuple, Any, Optional
+
+from copilot.common import get_workspace_path
 import json
 import shutil
 import subprocess
@@ -38,9 +40,9 @@ import subprocess
 class EnterpriseUnicodeCompatibilityFix:
     """Enterprise-grade Unicode compatibility fix for Windows systems."""
     
-    def __init__(self):
-        self.workspace_path = Path("e:/gh_COPILOT")
-        self.staging_path = Path("e:/gh_COPILOT")
+    def __init__(self, workspace_path: Optional[str] = None, staging_path: Optional[str] = None):
+        self.workspace_path = get_workspace_path(workspace_path)
+        self.staging_path = get_workspace_path(staging_path)
         self.backup_dir = self.workspace_path / f"_unicode_fix_backup_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         self.results = {
             'fix_timestamp': datetime.now().isoformat(),

--- a/copilot/core/final_deployment_validator.py
+++ b/copilot/core/final_deployment_validator.py
@@ -12,6 +12,9 @@ from datetime import datetime
 from pathlib import Path
 import re
 import traceback
+from typing import Optional
+
+from copilot.common import get_workspace_path
 
 # Professional logging setup
 logging.basicConfig(
@@ -25,8 +28,8 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 class FinalDeploymentValidator:
-    def __init__(self):
-        self.workspace_path = Path("e:/gh_COPILOT")
+    def __init__(self, workspace_path: Optional[str] = None):
+        self.workspace_path = get_workspace_path(workspace_path)
         self.validation_results = {
             "timestamp": datetime.now().isoformat(),
             "validation_status": "PENDING",

--- a/documentation/additional/user_guides/quick_start_guide.md
+++ b/documentation/additional/user_guides/quick_start_guide.md
@@ -27,10 +27,11 @@ pip install -e .
 ### 1. Initialize the Platform
 ```python
 from template_intelligence import TemplateIntelligencePlatform
+import os
 
 # Initialize with your environment
 platform = TemplateIntelligencePlatform(
-    environment_root="e:/gh_COPILOT",
+    environment_root=os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"),
     environment_type="development"
 )
 ```

--- a/enterprise_unicode_compatibility_fix.py
+++ b/enterprise_unicode_compatibility_fix.py
@@ -18,7 +18,9 @@ import re
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Tuple, Any, Optional
+
+from copilot.common import get_workspace_path
 import json
 import shutil
 import subprocess
@@ -26,9 +28,9 @@ import subprocess
 class EnterpriseUnicodeCompatibilityFix:
     """Enterprise-grade Unicode compatibility fix for Windows systems."""
     
-    def __init__(self):
-        self.workspace_path = Path("e:/gh_COPILOT")
-        self.staging_path = Path("e:/gh_COPILOT")
+    def __init__(self, workspace_path: Optional[str] = None, staging_path: Optional[str] = None):
+        self.workspace_path = get_workspace_path(workspace_path)
+        self.staging_path = get_workspace_path(staging_path)
         self.backup_dir = self.workspace_path / f"_unicode_fix_backup_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         self.results = {
             'fix_timestamp': datetime.now().isoformat(),

--- a/final_deployment_validator.py
+++ b/final_deployment_validator.py
@@ -12,6 +12,9 @@ from datetime import datetime
 from pathlib import Path
 import re
 import traceback
+from typing import Optional
+
+from copilot.common import get_workspace_path
 
 # Professional logging setup
 logging.basicConfig(
@@ -25,8 +28,8 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 class FinalDeploymentValidator:
-    def __init__(self):
-        self.workspace_path = Path("e:/gh_COPILOT")
+    def __init__(self, workspace_path: Optional[str] = None):
+        self.workspace_path = get_workspace_path(workspace_path)
         self.validation_results = {
             "timestamp": datetime.now().isoformat(),
             "validation_status": "PENDING",

--- a/session_protocol_validator.py
+++ b/session_protocol_validator.py
@@ -9,15 +9,17 @@ sessions are started or completed.
 """
 
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 import logging
+
+from copilot.common import get_workspace_path
 
 
 class SessionProtocolValidator:
     """Enforce basic session startup and shutdown rules."""
 
-    def __init__(self, workspace_root: str = "e:/gh_COPILOT"):
-        self.workspace_root = Path(workspace_root)
+    def __init__(self, workspace_root: Optional[str] = None):
+        self.workspace_root = get_workspace_path(workspace_root)
         self.logger = logging.getLogger(__name__)
 
     # internal helper -----------------------------------------------------

--- a/tests/test_autonomous_file_manager.py
+++ b/tests/test_autonomous_file_manager.py
@@ -38,22 +38,24 @@ def _setup_db(db_path: Path, base: Path) -> None:
 
 
 
-def test_organize_files_autonomously(tmp_path):
+def test_organize_files_autonomously(tmp_path, monkeypatch):
     db = tmp_path / "production.db"
     _setup_db(db, tmp_path)
 
-    mgr = AutonomousFileManager(workspace_path=str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    mgr = AutonomousFileManager()
     result = mgr.organize_files_autonomously(["foo.py", "bar.sh"])
 
     assert result["foo.py"] == str(tmp_path / "utilities" / "foo.py")
     assert result["bar.sh"] == str(tmp_path / "scripts" / "bar.sh")
 
 
-def test_classify_file_autonomously(tmp_path):
+def test_classify_file_autonomously(tmp_path, monkeypatch):
     db = tmp_path / "production.db"
     _setup_db(db, tmp_path)
 
-    classifier = IntelligentFileClassifier(workspace_path=str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    classifier = IntelligentFileClassifier()
     info = classifier.classify_file_autonomously("foo.py")
 
     assert info["category"] == "utilities"
@@ -68,7 +70,8 @@ def test_create_intelligent_backup(tmp_path, monkeypatch):
     (tmp_path / "a.py").write_text("print('a')")
     (tmp_path / "b.sh").write_text("echo b")
 
-    mgr = AutonomousBackupManager(workspace_path=str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    mgr = AutonomousBackupManager()
     backup_root = Path(tempfile.mkdtemp())
     monkeypatch.setattr(mgr, "backup_root", backup_root)
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,8 +2,9 @@ from datetime import datetime
 from copilot.core.enterprise_json_serialization_fix import EnterpriseJSONSerializer
 
 
-def test_round_trip_datetime():
-    serializer = EnterpriseJSONSerializer(workspace_path='.')
+def test_round_trip_datetime(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    serializer = EnterpriseJSONSerializer()
     data = {'time': datetime(2021, 1, 1, 12, 0)}
     dumped = serializer.safe_json_dumps(data)
     loaded = serializer.safe_json_loads(dumped)

--- a/tests/test_session_protocol_validator.py
+++ b/tests/test_session_protocol_validator.py
@@ -1,21 +1,20 @@
-import os
 from pathlib import Path
 
 from session_protocol_validator import SessionProtocolValidator
 from unified_session_management_system import UnifiedSessionManagementSystem
 
 
-def test_startup_detects_zero_byte(tmp_path):
+def test_startup_detects_zero_byte(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     zero_file = tmp_path / "a.py"
     zero_file.write_text("")
-
-    validator = SessionProtocolValidator(workspace_root=str(tmp_path))
+    validator = SessionProtocolValidator()
     assert validator.validate_startup() is False
 
 
-def test_unified_session_start_fails_with_zero_byte(tmp_path):
+def test_unified_session_start_fails_with_zero_byte(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     zero_file = tmp_path / "b.py"
     zero_file.write_text("")
-
-    mgr = UnifiedSessionManagementSystem(workspace_root=str(tmp_path))
+    mgr = UnifiedSessionManagementSystem()
     assert mgr.start_session() is False

--- a/unified_session_management_system.py
+++ b/unified_session_management_system.py
@@ -36,6 +36,8 @@ import psutil
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Tuple, Set
+
+from copilot.common import get_workspace_path
 from dataclasses import dataclass, asdict
 from tqdm import tqdm
 import logging
@@ -192,8 +194,8 @@ class UnifiedSessionManagementSystem:
     lifecycle management, and compliance certification.
     """
     
-    def __init__(self, workspace_root: str = r"e:\gh_COPILOT"):
-        self.workspace_root = Path(workspace_root)
+    def __init__(self, workspace_root: Optional[str] = None):
+        self.workspace_root = get_workspace_path(workspace_root)
         self.session_id = f"UNIFIED_SESSION_{int(time.time())}"
         self.start_time = datetime.now()
         


### PR DESCRIPTION
## Summary
- make workspace path configurable via `GH_COPILOT_WORKSPACE`
- document workspace override usage
- update tests to exercise the environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf2d658d08331b1b17e55bf74a603