### PR TITLE
Fix enterprise dashboard path references

### DIFF
--- a/.github/instructions/ENTERPRISE_CONTEXT.instructions.md
+++ b/.github/instructions/ENTERPRISE_CONTEXT.instructions.md
@@ -39,7 +39,7 @@ applyTo: '**'
 ### 🌐 **WEB-GUI ENTERPRISE DEPLOYMENT**
 
 **Flask Enterprise Dashboard (PRODUCTION READY):**
-- **Location**: `web_gui_scripts/flask_apps/enterprise_dashboard.py`
+- **Location**: `web_gui/scripts/flask_apps/enterprise_dashboard.py`
 - **Endpoints**: 7 production-ready API endpoints
 - **Templates**: 5 responsive HTML templates (100% coverage)
 - **Database Integration**: Real-time metrics from production.db
@@ -48,7 +48,7 @@ applyTo: '**'
 
 **Web Interface Components:**
 ```
-├── web_gui_scripts/
+├── web_gui/scripts/
 │   ├── flask_apps/enterprise_dashboard.py (7 endpoints)
 │   └── requirements.txt (Flask dependencies)
 ├── templates/html/ (5 responsive templates)

--- a/.github/instructions/WEB_GUI_INTEGRATION.instructions.md
+++ b/.github/instructions/WEB_GUI_INTEGRATION.instructions.md
@@ -20,7 +20,7 @@ applyTo: '**'
 **Flask Enterprise Dashboard Pattern:**
 ```python
 # MANDATORY: Use completed Flask enterprise dashboard
-from web_gui_scripts.flask_apps.enterprise_dashboard import app, dashboard
+from web_gui/scripts.flask_apps.enterprise_dashboard import app, dashboard
 
 class WebGUIIntegrator:
     """🌐 Enterprise Web-GUI Integration Engine"""
@@ -130,7 +130,7 @@ class EnterpriseWebDeployment:
     def deploy_web_interface(self, deployment_env: str = "production") -> Dict[str, str]:
         """🚀 Deploy web interface with enterprise standards"""
         deployment_config = {
-            "flask_app_path": "web_gui_scripts/flask_apps/enterprise_dashboard.py",
+            "flask_app_path": "web_gui/scripts/flask_apps/enterprise_dashboard.py",
             "template_directory": "templates/html/",
             "static_assets": "static/",
             "database_connection": "production.db",
@@ -153,7 +153,7 @@ class EnterpriseWebDeployment:
 ### **Pattern 1: Dashboard Integration**
 ```python
 # MANDATORY: Use enterprise dashboard integration pattern
-from web_gui_scripts.flask_apps.enterprise_dashboard import app
+from web_gui/scripts.flask_apps.enterprise_dashboard import app
 
 @app.route('/api/custom_endpoint')
 def custom_enterprise_endpoint():
@@ -225,7 +225,7 @@ MANDATORY: Follow enterprise web deployment standards
 ### **Standard Web Integration Pattern:**
 ```python
 # MANDATORY: Use enterprise web-GUI integration
-from web_gui_scripts.flask_apps.enterprise_dashboard import app, dashboard
+from web_gui/scripts.flask_apps.enterprise_dashboard import app, dashboard
 
 # Integrate custom functionality
 web_integrator = WebGUIIntegrator()

--- a/copilot/orchestrators/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py
+++ b/copilot/orchestrators/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py
@@ -790,7 +790,7 @@ class UnifiedEnterpriseDeploymentOrchestrator:
         # Web GUI components from all orchestrators
         web_components = {
             "web_gui/": "Web GUI directory",
-            "web_gui_scripts/": "Web GUI scripts",
+            "web_gui/scripts/": "Web GUI scripts",
             "web_gui_documentation/": "Web GUI documentation",
             "templates/html/": "HTML templates"
         }

--- a/disaster_recovery/backups/HIGH_UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py
+++ b/disaster_recovery/backups/HIGH_UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py
@@ -790,7 +790,7 @@ class UnifiedEnterpriseDeploymentOrchestrator:
         # Web GUI components from all orchestrators
         web_components = {
             "web_gui/": "Web GUI directory",
-            "web_gui_scripts/": "Web GUI scripts",
+            "web_gui/scripts/": "Web GUI scripts",
             "web_gui_documentation/": "Web GUI documentation",
             "templates/html/": "HTML templates"
         }

--- a/disaster_recovery/backups/MEDIUM_07062025-1250.md
+++ b/disaster_recovery/backups/MEDIUM_07062025-1250.md
@@ -310,7 +310,7 @@ Your Enhanced Analytics Intelligence Platform is now **fully deployed and operat
 - **5-Phase Deployment**: Validation → Integration → Automation → Optimization → Final Validation
 
 ### **Enhanced Enterprise Dashboard:**
-- **File**: `web_gui_scripts/flask_apps/enhanced_enterprise_dashboard.py`
+- **File**: `web_gui/scripts/flask_apps/enhanced_enterprise_dashboard.py`
 - **Port**: 5001
 - **Intelligence Integration**: Real-time AI metrics, recommendations, anomaly alerts
 - **Business Impact**: Executive-level dashboards with customizable scoring
@@ -362,7 +362,7 @@ python enhanced_analytics_intelligence_platform.py
 
 ### **2. Enhanced Enterprise Dashboard:**
 ```bash
-python web_gui_scripts/flask_apps/enhanced_enterprise_dashboard.py
+python web_gui/scripts/flask_apps/enhanced_enterprise_dashboard.py
 ```
 - **Access**: http://localhost:5001
 
@@ -606,7 +606,7 @@ def start_automation_monitoring(self):
 ## 🌐 **WEB-GUI CONTINUOUS OPERATION SUPPORT**
 
 ### **Flask Enterprise Dashboard**:
-**Location**: `web_gui_scripts/flask_apps/enterprise_dashboard.py`
+**Location**: `web_gui/scripts/flask_apps/enterprise_dashboard.py`
 - **7 Production Endpoints**: Real-time system access
 - **5 HTML Templates**: Complete responsive interface
 - **Database Integration**: Live metrics from production.db

--- a/disaster_recovery/backups/MEDIUM_07062025-1405.md
+++ b/disaster_recovery/backups/MEDIUM_07062025-1405.md
@@ -841,7 +841,7 @@ Now let me run the validator again: 🎉 **MISSION ACCOMPLISHED!**
 
 ### 🔄 **SYNCHRONIZATION ACTIONS COMPLETED:**
 1. **File Synchronization**: 5 critical optimization scripts deployed to staging
-2. **Directory Creation**: 2 compliance directories created (web_gui_scripts, templates)
+2. **Directory Creation**: 2 compliance directories created (web_gui/scripts, templates)
 3. **Enterprise Logging**: 10 comprehensive log files generated across both environments
 4. **Database Validation**: 39 databases verified and operational
 5. **Compliance Fixing**: Log detection logic corrected for 100% compliance

--- a/disaster_recovery/backups/MEDIUM_ENTERPRISE_CONTEXT.instructions.md
+++ b/disaster_recovery/backups/MEDIUM_ENTERPRISE_CONTEXT.instructions.md
@@ -39,7 +39,7 @@ applyTo: '**'
 ### 🌐 **WEB-GUI ENTERPRISE DEPLOYMENT**
 
 **Flask Enterprise Dashboard (PRODUCTION READY):**
-- **Location**: `web_gui_scripts/flask_apps/enterprise_dashboard.py`
+- **Location**: `web_gui/scripts/flask_apps/enterprise_dashboard.py`
 - **Endpoints**: 7 production-ready API endpoints
 - **Templates**: 5 responsive HTML templates (100% coverage)
 - **Database Integration**: Real-time metrics from production.db
@@ -48,7 +48,7 @@ applyTo: '**'
 
 **Web Interface Components:**
 ```
-├── web_gui_scripts/
+├── web_gui/scripts/
 │   ├── flask_apps/enterprise_dashboard.py (7 endpoints)
 │   └── requirements.txt (Flask dependencies)
 ├── templates/html/ (5 responsive templates)

--- a/disaster_recovery/backups/MEDIUM_README.md
+++ b/disaster_recovery/backups/MEDIUM_README.md
@@ -8,7 +8,7 @@
 ### Accessing the Dashboard
 1. **Start the Application**:
    ```bash
-   cd web_gui_scripts/flask_apps
+   cd web_gui/scripts/flask_apps
    python enterprise_dashboard.py
    ```
 

--- a/disaster_recovery/backups/MEDIUM_WEB_GUI_INTEGRATION.instructions.md
+++ b/disaster_recovery/backups/MEDIUM_WEB_GUI_INTEGRATION.instructions.md
@@ -20,7 +20,7 @@ applyTo: '**'
 **Flask Enterprise Dashboard Pattern:**
 ```python
 # MANDATORY: Use completed Flask enterprise dashboard
-from web_gui_scripts.flask_apps.enterprise_dashboard import app, dashboard
+from web_gui/scripts.flask_apps.enterprise_dashboard import app, dashboard
 
 class WebGUIIntegrator:
     """🌐 Enterprise Web-GUI Integration Engine"""
@@ -130,7 +130,7 @@ class EnterpriseWebDeployment:
     def deploy_web_interface(self, deployment_env: str = "production") -> Dict[str, str]:
         """🚀 Deploy web interface with enterprise standards"""
         deployment_config = {
-            "flask_app_path": "web_gui_scripts/flask_apps/enterprise_dashboard.py",
+            "flask_app_path": "web_gui/scripts/flask_apps/enterprise_dashboard.py",
             "template_directory": "templates/html/",
             "static_assets": "static/",
             "database_connection": "production.db",
@@ -153,7 +153,7 @@ class EnterpriseWebDeployment:
 ### **Pattern 1: Dashboard Integration**
 ```python
 # MANDATORY: Use enterprise dashboard integration pattern
-from web_gui_scripts.flask_apps.enterprise_dashboard import app
+from web_gui/scripts.flask_apps.enterprise_dashboard import app
 
 @app.route('/api/custom_endpoint')
 def custom_enterprise_endpoint():
@@ -225,7 +225,7 @@ MANDATORY: Follow enterprise web deployment standards
 ### **Standard Web Integration Pattern:**
 ```python
 # MANDATORY: Use enterprise web-GUI integration
-from web_gui_scripts.flask_apps.enterprise_dashboard import app, dashboard
+from web_gui/scripts.flask_apps.enterprise_dashboard import app, dashboard
 
 # Integrate custom functionality
 web_integrator = WebGUIIntegrator()

--- a/github_integration/.github/copilot/conversations_with_human/07062025-1250.md
+++ b/github_integration/.github/copilot/conversations_with_human/07062025-1250.md
@@ -310,7 +310,7 @@ Your Enhanced Analytics Intelligence Platform is now **fully deployed and operat
 - **5-Phase Deployment**: Validation → Integration → Automation → Optimization → Final Validation
 
 ### **Enhanced Enterprise Dashboard:**
-- **File**: `web_gui_scripts/flask_apps/enhanced_enterprise_dashboard.py`
+- **File**: `web_gui/scripts/flask_apps/enhanced_enterprise_dashboard.py`
 - **Port**: 5001
 - **Intelligence Integration**: Real-time AI metrics, recommendations, anomaly alerts
 - **Business Impact**: Executive-level dashboards with customizable scoring
@@ -362,7 +362,7 @@ python enhanced_analytics_intelligence_platform.py
 
 ### **2. Enhanced Enterprise Dashboard:**
 ```bash
-python web_gui_scripts/flask_apps/enhanced_enterprise_dashboard.py
+python web_gui/scripts/flask_apps/enhanced_enterprise_dashboard.py
 ```
 - **Access**: http://localhost:5001
 
@@ -606,7 +606,7 @@ def start_automation_monitoring(self):
 ## 🌐 **WEB-GUI CONTINUOUS OPERATION SUPPORT**
 
 ### **Flask Enterprise Dashboard**:
-**Location**: `web_gui_scripts/flask_apps/enterprise_dashboard.py`
+**Location**: `web_gui/scripts/flask_apps/enterprise_dashboard.py`
 - **7 Production Endpoints**: Real-time system access
 - **5 HTML Templates**: Complete responsive interface
 - **Database Integration**: Live metrics from production.db

--- a/github_integration/.github/copilot/conversations_with_human/07062025-1405.md
+++ b/github_integration/.github/copilot/conversations_with_human/07062025-1405.md
@@ -841,7 +841,7 @@ Now let me run the validator again: 🎉 **MISSION ACCOMPLISHED!**
 
 ### 🔄 **SYNCHRONIZATION ACTIONS COMPLETED:**
 1. **File Synchronization**: 5 critical optimization scripts deployed to staging
-2. **Directory Creation**: 2 compliance directories created (web_gui_scripts, templates)
+2. **Directory Creation**: 2 compliance directories created (web_gui/scripts, templates)
 3. **Enterprise Logging**: 10 comprehensive log files generated across both environments
 4. **Database Validation**: 39 databases verified and operational
 5. **Compliance Fixing**: Log detection logic corrected for 100% compliance

--- a/github_integration/.github/instructions/ENTERPRISE_CONTEXT.instructions.md
+++ b/github_integration/.github/instructions/ENTERPRISE_CONTEXT.instructions.md
@@ -39,7 +39,7 @@ applyTo: '**'
 ### 🌐 **WEB-GUI ENTERPRISE DEPLOYMENT**
 
 **Flask Enterprise Dashboard (PRODUCTION READY):**
-- **Location**: `web_gui_scripts/flask_apps/enterprise_dashboard.py`
+- **Location**: `web_gui/scripts/flask_apps/enterprise_dashboard.py`
 - **Endpoints**: 7 production-ready API endpoints
 - **Templates**: 5 responsive HTML templates (100% coverage)
 - **Database Integration**: Real-time metrics from production.db
@@ -48,7 +48,7 @@ applyTo: '**'
 
 **Web Interface Components:**
 ```
-├── web_gui_scripts/
+├── web_gui/scripts/
 │   ├── flask_apps/enterprise_dashboard.py (7 endpoints)
 │   └── requirements.txt (Flask dependencies)
 ├── templates/html/ (5 responsive templates)

--- a/github_integration/.github/instructions/WEB_GUI_INTEGRATION.instructions.md
+++ b/github_integration/.github/instructions/WEB_GUI_INTEGRATION.instructions.md
@@ -20,7 +20,7 @@ applyTo: '**'
 **Flask Enterprise Dashboard Pattern:**
 ```python
 # MANDATORY: Use completed Flask enterprise dashboard
-from web_gui_scripts.flask_apps.enterprise_dashboard import app, dashboard
+from web_gui/scripts.flask_apps.enterprise_dashboard import app, dashboard
 
 class WebGUIIntegrator:
     """🌐 Enterprise Web-GUI Integration Engine"""
@@ -130,7 +130,7 @@ class EnterpriseWebDeployment:
     def deploy_web_interface(self, deployment_env: str = "production") -> Dict[str, str]:
         """🚀 Deploy web interface with enterprise standards"""
         deployment_config = {
-            "flask_app_path": "web_gui_scripts/flask_apps/enterprise_dashboard.py",
+            "flask_app_path": "web_gui/scripts/flask_apps/enterprise_dashboard.py",
             "template_directory": "templates/html/",
             "static_assets": "static/",
             "database_connection": "production.db",
@@ -153,7 +153,7 @@ class EnterpriseWebDeployment:
 ### **Pattern 1: Dashboard Integration**
 ```python
 # MANDATORY: Use enterprise dashboard integration pattern
-from web_gui_scripts.flask_apps.enterprise_dashboard import app
+from web_gui/scripts.flask_apps.enterprise_dashboard import app
 
 @app.route('/api/custom_endpoint')
 def custom_enterprise_endpoint():
@@ -225,7 +225,7 @@ MANDATORY: Follow enterprise web deployment standards
 ### **Standard Web Integration Pattern:**
 ```python
 # MANDATORY: Use enterprise web-GUI integration
-from web_gui_scripts.flask_apps.enterprise_dashboard import app, dashboard
+from web_gui/scripts.flask_apps.enterprise_dashboard import app, dashboard
 
 # Integrate custom functionality
 web_integrator = WebGUIIntegrator()

--- a/scripts/archived_deployment_scripts/MIGRATION_20250707_061405/enterprise_gh_copilot_deployment_orchestrator.py
+++ b/scripts/archived_deployment_scripts/MIGRATION_20250707_061405/enterprise_gh_copilot_deployment_orchestrator.py
@@ -370,7 +370,7 @@ class EnterpriseGhCopilotDeploymentOrchestrator:
             web_gui_dir = self.target_path / "web_gui"
             
             # Copy web GUI scripts
-            web_gui_source = self.sandbox_path / "web_gui_scripts"
+            web_gui_source = self.sandbox_path / "web_gui/scripts"
             if web_gui_source.exists():
                 shutil.copytree(web_gui_source, web_gui_dir / "scripts", dirs_exist_ok=True)
                 logger.info("📁 Copied web GUI scripts")

--- a/scripts/comprehensive_deployment_validator.py
+++ b/scripts/comprehensive_deployment_validator.py
@@ -255,7 +255,7 @@ class ComprehensiveDeploymentValidator:
         # Enterprise compliance checks
         compliance_checks = [
             ('instructions_directory', env_path / '.github' / 'instructions'),
-            ('web_gui_scripts', env_path / 'web_gui_scripts'),
+            ('web_gui/scripts', env_path / 'web_gui/scripts'),
             ('templates_directory', env_path / 'templates'),
             ('databases_directory', env_path / 'databases'),
             ('production_db', env_path / 'databases' / 'production.db'),

--- a/scripts/database_driven_web_gui_generator.py
+++ b/scripts/database_driven_web_gui_generator.py
@@ -38,7 +38,7 @@ class DatabaseDrivenWebGUIGenerator:
         self.enhanced_intelligence_db_path = self.workspace_path / "enhanced_intelligence.db"
         
         # [TARGET] VISUAL PROCESSING INDICATOR: Web-GUI Generator Initialization
-        self.web_scripts_path = self.workspace_path / "web_gui_scripts"
+        self.web_scripts_path = self.workspace_path / "web_gui/scripts"
         self.templates_path = self.workspace_path / "templates"
         self.documentation_path = self.workspace_path / "web_gui_documentation"
         
@@ -791,7 +791,7 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 ### [NETWORK] Web GUI Components
 
 #### Flask Dashboard Application
-- **File**: `web_gui_scripts/flask_apps/enterprise_dashboard.py`
+- **File**: `web_gui/scripts/flask_apps/enterprise_dashboard.py`
 - **Features**: Executive dashboard, database management, real-time metrics
 - **Access**: http://localhost:5000
 
@@ -815,7 +815,7 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 
 1. **Start the Flask Dashboard**:
    ```bash
-   cd web_gui_scripts/flask_apps
+   cd web_gui/scripts/flask_apps
    python enterprise_dashboard.py
    ```
 

--- a/scripts/deployment/comprehensive_deployment_validator.py
+++ b/scripts/deployment/comprehensive_deployment_validator.py
@@ -255,7 +255,7 @@ class ComprehensiveDeploymentValidator:
         # Enterprise compliance checks
         compliance_checks = [
             ('instructions_directory', env_path / '.github' / 'instructions'),
-            ('web_gui_scripts', env_path / 'web_gui_scripts'),
+            ('web_gui/scripts', env_path / 'web_gui/scripts'),
             ('templates_directory', env_path / 'templates'),
             ('databases_directory', env_path / 'databases'),
             ('production_db', env_path / 'databases' / 'production.db'),

--- a/scripts/deployment/database_driven_web_gui_generator.py
+++ b/scripts/deployment/database_driven_web_gui_generator.py
@@ -38,7 +38,7 @@ class DatabaseDrivenWebGUIGenerator:
         self.enhanced_intelligence_db_path = self.workspace_path / "enhanced_intelligence.db"
         
         # [TARGET] VISUAL PROCESSING INDICATOR: Web-GUI Generator Initialization
-        self.web_scripts_path = self.workspace_path / "web_gui_scripts"
+        self.web_scripts_path = self.workspace_path / "web_gui/scripts"
         self.templates_path = self.workspace_path / "templates"
         self.documentation_path = self.workspace_path / "web_gui_documentation"
         
@@ -791,7 +791,7 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 ### [NETWORK] Web GUI Components
 
 #### Flask Dashboard Application
-- **File**: `web_gui_scripts/flask_apps/enterprise_dashboard.py`
+- **File**: `web_gui/scripts/flask_apps/enterprise_dashboard.py`
 - **Features**: Executive dashboard, database management, real-time metrics
 - **Access**: http://localhost:5000
 
@@ -815,7 +815,7 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 
 1. **Start the Flask Dashboard**:
    ```bash
-   cd web_gui_scripts/flask_apps
+   cd web_gui/scripts/flask_apps
    python enterprise_dashboard.py
    ```
 

--- a/scripts/deployment/deployment_synchronization_fix.py
+++ b/scripts/deployment/deployment_synchronization_fix.py
@@ -61,7 +61,7 @@ CRITICAL_FILES = [
 
 # Compliance Directories
 COMPLIANCE_DIRS = [
-    "web_gui_scripts",
+    "web_gui/scripts",
     "templates"
 ]
 

--- a/scripts/deployment/enterprise_gh_copilot_deployment_orchestrator.py
+++ b/scripts/deployment/enterprise_gh_copilot_deployment_orchestrator.py
@@ -370,7 +370,7 @@ class EnterpriseGhCopilotDeploymentOrchestrator:
             web_gui_dir = self.target_path / "web_gui"
             
             # Copy web GUI scripts
-            web_gui_source = self.sandbox_path / "web_gui_scripts"
+            web_gui_source = self.sandbox_path / "web_gui/scripts"
             if web_gui_source.exists():
                 shutil.copytree(web_gui_source, web_gui_dir / "scripts", dirs_exist_ok=True)
                 logger.info("📁 Copied web GUI scripts")

--- a/scripts/deployment/final_project_completion_summary_generator.py
+++ b/scripts/deployment/final_project_completion_summary_generator.py
@@ -35,7 +35,7 @@ def generate_final_project_summary():
                 "status": "[SUCCESS] COMPLETE",
                 "endpoints": 7,
                 "templates": 5,
-                "location": "web_gui_scripts/flask_apps/enterprise_dashboard.py"
+                "location": "web_gui/scripts/flask_apps/enterprise_dashboard.py"
             },
             "html_templates": {
                 "status": "[SUCCESS] COMPLETE",

--- a/scripts/deployment/final_web_gui_validation_and_certification.py
+++ b/scripts/deployment/final_web_gui_validation_and_certification.py
@@ -38,8 +38,8 @@ class FinalWebGUIValidator:
         """[NETWORK] Validate Flask enterprise dashboard application"""
         print("[SEARCH] Validating Flask Enterprise Dashboard...")
         
-        flask_app_path = self.workspace_path / "web_gui_scripts" / "flask_apps" / "enterprise_dashboard.py"
-        requirements_path = self.workspace_path / "web_gui_scripts" / "requirements.txt"
+        flask_app_path = self.workspace_path / "web_gui/scripts" / "flask_apps" / "enterprise_dashboard.py"
+        requirements_path = self.workspace_path / "web_gui/scripts" / "requirements.txt"
         
         validation = {
             "app_exists": flask_app_path.exists(),
@@ -206,7 +206,7 @@ class FinalWebGUIValidator:
         gaps_resolved["web_gui_error_recovery"] = (doc_base / "error_recovery" / "README.md").exists()
         
         # Check dashboard interface
-        flask_app = self.workspace_path / "web_gui_scripts" / "flask_apps" / "enterprise_dashboard.py"
+        flask_app = self.workspace_path / "web_gui/scripts" / "flask_apps" / "enterprise_dashboard.py"
         gaps_resolved["web_gui_dashboard_interface"] = flask_app.exists()
         
         # Check database-driven generation

--- a/scripts/deployment/immediate_deployment_status_check.py
+++ b/scripts/deployment/immediate_deployment_status_check.py
@@ -63,7 +63,7 @@ class DeploymentStatusChecker:
             'enterprise_intelligence_deployment_orchestrator.py',
             'enterprise_business_rules_customization.py',
             'quick_start_intelligence_platform.py',
-            'web_gui_scripts/flask_apps/enterprise_dashboard.py'
+            'web_gui/scripts/flask_apps/enterprise_dashboard.py'
         ]
         
         file_status = {}
@@ -126,7 +126,7 @@ class DeploymentStatusChecker:
             f"Q:/python_venv/.venv_clean/Scripts/python.exe enhanced_analytics_intelligence_platform.py",
             "",
             "# 2. Start Enterprise Dashboard",
-            f"Q:/python_venv/.venv_clean/Scripts/python.exe web_gui_scripts/flask_apps/enterprise_dashboard.py",
+            f"Q:/python_venv/.venv_clean/Scripts/python.exe web_gui/scripts/flask_apps/enterprise_dashboard.py",
             "",
             "# 3. Configure Business Rules",
             f"Q:/python_venv/.venv_clean/Scripts/python.exe enterprise_business_rules_customization.py",

--- a/scripts/deployment/launch_platform.bat
+++ b/scripts/deployment/launch_platform.bat
@@ -37,7 +37,7 @@ if %choice%==2 (
     echo 🌐 Launching Enterprise Dashboard...
     echo Dashboard will be available at: http://localhost:5001
     echo.
-    cd web_gui_scripts\flask_apps
+    cd web_gui\scripts\flask_apps
     Q:/python_venv/.venv_clean/Scripts/python.exe enterprise_dashboard.py
 )
 
@@ -62,7 +62,7 @@ if %choice%==5 (
     echo Critical Files:
     if exist enhanced_analytics_intelligence_platform.py (echo ✅ Main Platform: Found) else (echo ❌ Main Platform: Missing)
     if exist enterprise_business_rules_customization.py (echo ✅ Business Rules: Found) else (echo ❌ Business Rules: Missing)
-    if exist web_gui_scripts\flask_apps\enterprise_dashboard.py (echo ✅ Enterprise Dashboard: Found) else (echo ❌ Enterprise Dashboard: Missing)
+    if exist web_gui\scripts\flask_apps\enterprise_dashboard.py (echo ✅ Enterprise Dashboard: Found) else (echo ❌ Enterprise Dashboard: Missing)
     echo.
     echo Configuration Files:
     if exist enterprise_deployment\active_customization_config.json (echo ✅ Active Config: Found) else (echo ❌ Active Config: Missing)

--- a/scripts/deployment/simple_platform_activator.py
+++ b/scripts/deployment/simple_platform_activator.py
@@ -38,7 +38,7 @@ def activate_platform():
     critical_files = [
         "enhanced_analytics_intelligence_platform.py",
         "enterprise_business_rules_customization.py",
-        "web_gui_scripts/flask_apps/enterprise_dashboard.py"
+        "web_gui/scripts/flask_apps/enterprise_dashboard.py"
     ]
     
     missing_files = []
@@ -67,7 +67,7 @@ def activate_platform():
         },
         {
             'name': 'Enterprise Dashboard',
-            'command': f'cd web_gui_scripts/flask_apps && {python_exe} enterprise_dashboard.py',
+            'command': f'cd web_gui/scripts/flask_apps && {python_exe} enterprise_dashboard.py',
             'description': 'Executive dashboard for real-time insights'
         },
         {

--- a/scripts/deployment/web_gui_development_success_reporter.py
+++ b/scripts/deployment/web_gui_development_success_reporter.py
@@ -71,7 +71,7 @@ class WebGUICompletionReporter:
         # Generated Web-GUI Components
         generated_components = {
             "flask_application": {
-                "file": "web_gui_scripts/flask_apps/enterprise_dashboard.py",
+                "file": "web_gui/scripts/flask_apps/enterprise_dashboard.py",
                 "features": [
                     "Executive dashboard with real-time metrics",
                     "Database visualization and management", 
@@ -177,7 +177,7 @@ class WebGUICompletionReporter:
                 "documentation_complete": True
             },
             "deployment_ready": {
-                "requirements_file": "web_gui_scripts/requirements.txt",
+                "requirements_file": "web_gui/scripts/requirements.txt",
                 "installation_scripts": True,
                 "configuration_templates": True,
                 "testing_procedures": True
@@ -206,7 +206,7 @@ class WebGUICompletionReporter:
             "success_metrics": success_metrics,
             "next_steps": {
                 "immediate": [
-                    "Deploy Flask application: cd web_gui_scripts/flask_apps && python enterprise_dashboard.py",
+                    "Deploy Flask application: cd web_gui/scripts/flask_apps && python enterprise_dashboard.py",
                     "Access dashboard: http://localhost:5000",
                     "Test all API endpoints and functionality"
                 ],
@@ -296,7 +296,7 @@ Successfully leveraged enterprise databases to discover and utilize existing pat
 ### Deploy and Test Web-GUI:
 ```bash
 # 1. Start Flask Application
-cd web_gui_scripts/flask_apps
+cd web_gui/scripts/flask_apps
 python enterprise_dashboard.py
 
 # 2. Access Dashboard
@@ -374,7 +374,7 @@ def main():
     print("="*80)
     
     print("\n[NETWORK] NEXT STEPS:")
-    print("1. cd web_gui_scripts/flask_apps")
+    print("1. cd web_gui/scripts/flask_apps")
     print("2. python enterprise_dashboard.py")
     print("3. Open browser: http://localhost:5000")
     print("4. Test all web-GUI functionality")

--- a/scripts/deployment_synchronization_fix.py
+++ b/scripts/deployment_synchronization_fix.py
@@ -61,7 +61,7 @@ CRITICAL_FILES = [
 
 # Compliance Directories
 COMPLIANCE_DIRS = [
-    "web_gui_scripts",
+    "web_gui/scripts",
     "templates"
 ]
 

--- a/scripts/final_project_completion_summary_generator.py
+++ b/scripts/final_project_completion_summary_generator.py
@@ -35,7 +35,7 @@ def generate_final_project_summary():
                 "status": "[SUCCESS] COMPLETE",
                 "endpoints": 7,
                 "templates": 5,
-                "location": "web_gui_scripts/flask_apps/enterprise_dashboard.py"
+                "location": "web_gui/scripts/flask_apps/enterprise_dashboard.py"
             },
             "html_templates": {
                 "status": "[SUCCESS] COMPLETE",

--- a/scripts/final_web_gui_validation_and_certification.py
+++ b/scripts/final_web_gui_validation_and_certification.py
@@ -38,8 +38,8 @@ class FinalWebGUIValidator:
         """[NETWORK] Validate Flask enterprise dashboard application"""
         print("[SEARCH] Validating Flask Enterprise Dashboard...")
         
-        flask_app_path = self.workspace_path / "web_gui_scripts" / "flask_apps" / "enterprise_dashboard.py"
-        requirements_path = self.workspace_path / "web_gui_scripts" / "requirements.txt"
+        flask_app_path = self.workspace_path / "web_gui/scripts" / "flask_apps" / "enterprise_dashboard.py"
+        requirements_path = self.workspace_path / "web_gui/scripts" / "requirements.txt"
         
         validation = {
             "app_exists": flask_app_path.exists(),
@@ -206,7 +206,7 @@ class FinalWebGUIValidator:
         gaps_resolved["web_gui_error_recovery"] = (doc_base / "error_recovery" / "README.md").exists()
         
         # Check dashboard interface
-        flask_app = self.workspace_path / "web_gui_scripts" / "flask_apps" / "enterprise_dashboard.py"
+        flask_app = self.workspace_path / "web_gui/scripts" / "flask_apps" / "enterprise_dashboard.py"
         gaps_resolved["web_gui_dashboard_interface"] = flask_app.exists()
         
         # Check database-driven generation

--- a/scripts/immediate_deployment_status_check.py
+++ b/scripts/immediate_deployment_status_check.py
@@ -63,7 +63,7 @@ class DeploymentStatusChecker:
             'enterprise_intelligence_deployment_orchestrator.py',
             'enterprise_business_rules_customization.py',
             'quick_start_intelligence_platform.py',
-            'web_gui_scripts/flask_apps/enterprise_dashboard.py'
+            'web_gui/scripts/flask_apps/enterprise_dashboard.py'
         ]
         
         file_status = {}
@@ -126,7 +126,7 @@ class DeploymentStatusChecker:
             f"Q:/python_venv/.venv_clean/Scripts/python.exe enhanced_analytics_intelligence_platform.py",
             "",
             "# 2. Start Enterprise Dashboard",
-            f"Q:/python_venv/.venv_clean/Scripts/python.exe web_gui_scripts/flask_apps/enterprise_dashboard.py",
+            f"Q:/python_venv/.venv_clean/Scripts/python.exe web_gui/scripts/flask_apps/enterprise_dashboard.py",
             "",
             "# 3. Configure Business Rules",
             f"Q:/python_venv/.venv_clean/Scripts/python.exe enterprise_business_rules_customization.py",

--- a/scripts/simple_platform_activator.py
+++ b/scripts/simple_platform_activator.py
@@ -38,7 +38,7 @@ def activate_platform():
     critical_files = [
         "enhanced_analytics_intelligence_platform.py",
         "enterprise_business_rules_customization.py",
-        "web_gui_scripts/flask_apps/enterprise_dashboard.py"
+        "web_gui/scripts/flask_apps/enterprise_dashboard.py"
     ]
     
     missing_files = []
@@ -67,7 +67,7 @@ def activate_platform():
         },
         {
             'name': 'Enterprise Dashboard',
-            'command': f'cd web_gui_scripts/flask_apps && {python_exe} enterprise_dashboard.py',
+            'command': f'cd web_gui/scripts/flask_apps && {python_exe} enterprise_dashboard.py',
             'description': 'Executive dashboard for real-time insights'
         },
         {

--- a/scripts/web_gui_development_success_reporter.py
+++ b/scripts/web_gui_development_success_reporter.py
@@ -71,7 +71,7 @@ class WebGUICompletionReporter:
         # Generated Web-GUI Components
         generated_components = {
             "flask_application": {
-                "file": "web_gui_scripts/flask_apps/enterprise_dashboard.py",
+                "file": "web_gui/scripts/flask_apps/enterprise_dashboard.py",
                 "features": [
                     "Executive dashboard with real-time metrics",
                     "Database visualization and management", 
@@ -177,7 +177,7 @@ class WebGUICompletionReporter:
                 "documentation_complete": True
             },
             "deployment_ready": {
-                "requirements_file": "web_gui_scripts/requirements.txt",
+                "requirements_file": "web_gui/scripts/requirements.txt",
                 "installation_scripts": True,
                 "configuration_templates": True,
                 "testing_procedures": True
@@ -206,7 +206,7 @@ class WebGUICompletionReporter:
             "success_metrics": success_metrics,
             "next_steps": {
                 "immediate": [
-                    "Deploy Flask application: cd web_gui_scripts/flask_apps && python enterprise_dashboard.py",
+                    "Deploy Flask application: cd web_gui/scripts/flask_apps && python enterprise_dashboard.py",
                     "Access dashboard: http://localhost:5000",
                     "Test all API endpoints and functionality"
                 ],
@@ -296,7 +296,7 @@ Successfully leveraged enterprise databases to discover and utilize existing pat
 ### Deploy and Test Web-GUI:
 ```bash
 # 1. Start Flask Application
-cd web_gui_scripts/flask_apps
+cd web_gui/scripts/flask_apps
 python enterprise_dashboard.py
 
 # 2. Access Dashboard
@@ -374,7 +374,7 @@ def main():
     print("="*80)
     
     print("\n[NETWORK] NEXT STEPS:")
-    print("1. cd web_gui_scripts/flask_apps")
+    print("1. cd web_gui/scripts/flask_apps")
     print("2. python enterprise_dashboard.py")
     print("3. Open browser: http://localhost:5000")
     print("4. Test all web-GUI functionality")

--- a/web_gui/database_driven_web_gui_generator.py
+++ b/web_gui/database_driven_web_gui_generator.py
@@ -38,7 +38,7 @@ class DatabaseDrivenWebGUIGenerator:
         self.enhanced_intelligence_db_path = self.workspace_path / "enhanced_intelligence.db"
         
         # [TARGET] VISUAL PROCESSING INDICATOR: Web-GUI Generator Initialization
-        self.web_scripts_path = self.workspace_path / "web_gui_scripts"
+        self.web_scripts_path = self.workspace_path / "web_gui/scripts"
         self.templates_path = self.workspace_path / "templates"
         self.documentation_path = self.workspace_path / "web_gui_documentation"
         
@@ -791,7 +791,7 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 ### [NETWORK] Web GUI Components
 
 #### Flask Dashboard Application
-- **File**: `web_gui_scripts/flask_apps/enterprise_dashboard.py`
+- **File**: `web_gui/scripts/flask_apps/enterprise_dashboard.py`
 - **Features**: Executive dashboard, database management, real-time metrics
 - **Access**: http://localhost:5000
 
@@ -815,7 +815,7 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 
 1. **Start the Flask Dashboard**:
    ```bash
-   cd web_gui_scripts/flask_apps
+   cd web_gui/scripts/flask_apps
    python enterprise_dashboard.py
    ```
 

--- a/web_gui/documentation/README.md
+++ b/web_gui/documentation/README.md
@@ -20,7 +20,7 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 ### 🌐 Web GUI Components
 
 #### Flask Dashboard Application
-- **File**: `web_gui_scripts/flask_apps/enterprise_dashboard.py`
+- **File**: `web_gui/scripts/flask_apps/enterprise_dashboard.py`
 - **Features**: Executive dashboard, database management, real-time metrics
 - **Access**: http://localhost:5000
 
@@ -44,7 +44,7 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 
 1. **Install Dependencies** (only if you plan to use the web dashboard):
    ```bash
-   cd web_gui_scripts
+   cd web_gui/scripts
    pip install -r requirements.txt  # only install if using the web dashboard
    ```
 

--- a/web_gui/documentation/deployment/README.md
+++ b/web_gui/documentation/deployment/README.md
@@ -21,7 +21,7 @@
 python backup_scripts/create_backup.py --env staging
 
 # Install dependencies for the dashboard
-cd web_gui_scripts
+cd web_gui/scripts
 pip install -r requirements.txt  # install only if the web dashboard is required
 
 # Deploy to staging
@@ -40,7 +40,7 @@ python validation_scripts/pre_production_check.py
 python deployment_scripts/deploy_to_production.py
 
 # Start Flask application
-cd web_gui_scripts/flask_apps
+cd web_gui/scripts/flask_apps
 python enterprise_dashboard.py
 
 # Post-deployment verification
@@ -50,7 +50,7 @@ python validation_scripts/post_production_check.py
 ### 3. Flask Application Deployment
 ```bash
 # Production deployment with Gunicorn
-cd web_gui_scripts/flask_apps
+cd web_gui/scripts/flask_apps
 gunicorn -w 4 -b 0.0.0.0:5000 enterprise_dashboard:app
 
 # Or with Waitress (Windows-friendly)

--- a/web_gui/documentation/error_recovery/README.md
+++ b/web_gui/documentation/error_recovery/README.md
@@ -227,7 +227,7 @@ ls -la e:/gh_COPILOT/production.db
 ls -la e:/gh_COPILOT/templates/html/
 
 # 3. Restart services
-cd e:/gh_COPILOT/web_gui_scripts/flask_apps
+cd e:/gh_COPILOT/web_gui/scripts/flask_apps
 python enterprise_dashboard.py
 
 # 4. Verify functionality
@@ -246,10 +246,10 @@ cp -r e:/gh_COPILOT e:/gh_COPILOT_backup
 python backup_scripts/restore_latest_backup.py
 
 # 4. Reinstall dashboard dependencies
-pip install -r web_gui_scripts/requirements.txt  # only needed for the dashboard
+pip install -r web_gui/scripts/requirements.txt  # only needed for the dashboard
 
 # 5. Restart all services
-cd web_gui_scripts/flask_apps
+cd web_gui/scripts/flask_apps
 python enterprise_dashboard.py
 
 # 6. Validate recovery
@@ -270,8 +270,8 @@ mv e:/gh_COPILOT_fresh e:/gh_COPILOT
 
 # 4. Reinstall and restart (dashboard only)
 cd e:/gh_COPILOT
-pip install -r web_gui_scripts/requirements.txt  # reinstall dashboard packages
-cd web_gui_scripts/flask_apps
+pip install -r web_gui/scripts/requirements.txt  # reinstall dashboard packages
+cd web_gui/scripts/flask_apps
 python enterprise_dashboard.py
 ```
 
@@ -309,7 +309,7 @@ BACKUP_DIR="e:/_copilot_backups"
 
 # Backup web GUI components
 tar -czf $BACKUP_DIR/web_gui_$DATE.tar.gz \
-    web_gui_scripts/ \
+    web_gui/scripts/ \
     templates/ \
     web_gui_documentation/
 

--- a/web_gui/documentation/migration/README.md
+++ b/web_gui/documentation/migration/README.md
@@ -110,7 +110,7 @@ python migration_scripts/verify_database.py \
 #### Step 3: Application Migration
 ```bash
 # Copy web GUI components
-cp -r e:/gh_COPILOT/web_gui_scripts e:/gh_COPILOT/
+cp -r e:/gh_COPILOT/web_gui/scripts e:/gh_COPILOT/
 cp -r e:/gh_COPILOT/templates e:/gh_COPILOT/
 cp -r e:/gh_COPILOT/web_gui_documentation e:/gh_COPILOT/
 
@@ -122,7 +122,7 @@ python migration_scripts/update_config_paths.py \
 #### Step 4: Validation
 ```bash
 # Start staging application
-cd e:/gh_COPILOT/web_gui_scripts/flask_apps
+cd e:/gh_COPILOT/web_gui/scripts/flask_apps
 python enterprise_dashboard.py &
 
 # Run validation tests
@@ -155,7 +155,7 @@ python migration_scripts/deploy_to_production.py \
 #### Step 3: Production Validation
 ```bash
 # Start production services
-cd e:/_copilot_production/web_gui_scripts/flask_apps
+cd e:/_copilot_production/web_gui/scripts/flask_apps
 python enterprise_dashboard.py &
 
 # Run production validation
@@ -214,7 +214,7 @@ python migration_scripts/cross_platform_migrate.py \
   --platform-conversion
 
 # Fix file permissions (Linux)
-chmod +x /opt/copilot/production/web_gui_scripts/flask_apps/*.py
+chmod +x /opt/copilot/production/web_gui/scripts/flask_apps/*.py
 ```
 
 ### Database Schema Migration
@@ -274,7 +274,7 @@ python backup_scripts/restore_backup.py \
   --target e:/_copilot_production
 
 # Restart services
-cd e:/_copilot_production/web_gui_scripts/flask_apps
+cd e:/_copilot_production/web_gui/scripts/flask_apps
 python enterprise_dashboard.py
 ```
 

--- a/web_gui/documentation/user_guides/README.md
+++ b/web_gui/documentation/user_guides/README.md
@@ -8,7 +8,7 @@
 ### Accessing the Dashboard
 1. **Start the Application**:
    ```bash
-   cd web_gui_scripts/flask_apps
+   cd web_gui/scripts/flask_apps
    python enterprise_dashboard.py
    ```
 


### PR DESCRIPTION
## Summary
- update all references from `web_gui_scripts/flask_apps/enterprise_dashboard.py`
  to `web_gui/scripts/flask_apps/enterprise_dashboard.py`
- update related directory paths in orchestrators, docs and scripts
- adjust Windows batch script paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: requests, psutil)*

------
https://chatgpt.com/codex/tasks/task_e_686bf4fcde68833192745b4ee49356ab