### PR TITLE
Fix workspace env variable and tests

### DIFF
--- a/copilot/core/autonomous_file_manager.py
+++ b/copilot/core/autonomous_file_manager.py
@@ -32,7 +32,9 @@ class BaseDatabaseManager:
     """Utility mixin providing a connection to ``production.db``."""
 
     def __init__(self, workspace_path: Optional[str] = None) -> None:
-        self.workspace_path = get_workspace_path(workspace_path or os.getenv("WORKSPACE_PATH"))
+        self.workspace_path = get_workspace_path(
+            workspace_path or os.getenv("GH_COPILOT_WORKSPACE")
+        )
         self.production_db = self.workspace_path / "production.db"
 
     def get_database_connection(self) -> sqlite3.Connection:

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -139,24 +139,13 @@ def health_check():
         "database": "connected" if dashboard.production_db.exists() else "disconnected"
     })
 
+# Simplified health endpoint used by automated tests
+@app.route('/health')
+def health_root():
+    return jsonify(status="ok")
+
 if __name__ == '__main__':
     print("[NETWORK] Starting Enterprise Flask Dashboard...")
-    print("[CHAIN] Access at: http://localhost:5000")
-    app.run(debug=True, host='0.0.0.0', port=5000)
-=======
-from flask import Flask, jsonify
-import os
-
-app = Flask(__name__)
-
-@app.route('/')
-def index():
-    return 'Enterprise Dashboard'
-
-@app.route('/health')
-def health():
-    return jsonify(status='ok')
-
-if __name__ == '__main__':
     port = int(os.environ.get('FLASK_RUN_PORT', 5000))
+    print(f"[CHAIN] Access at: http://localhost:{port}")
     app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- use `GH_COPILOT_WORKSPACE` in BaseDatabaseManager
- clean up enterprise_dashboard Flask app
- add `/health` endpoint for orchestrator checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c016eb344833180626e5b6c5f191d