### PR TITLE
Fix enterprise_dashboard startup

### DIFF
--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -145,10 +145,6 @@ def health_check():
         "database": "connected" if dashboard.production_db.exists() else "disconnected"
     })
 
-if __name__ == '__main__':
-    logging.info("[NETWORK] Starting Enterprise Flask Dashboard...")
-    logging.info("[CHAIN] Access at: http://localhost:5000")
-    app.run(debug=True, host='0.0.0.0', port=5000)
 
 # Simplified health endpoint used by automated tests
 @app.route('/health')
@@ -160,5 +156,3 @@ if __name__ == '__main__':
     port = int(os.environ.get('FLASK_RUN_PORT', 5000))
     print(f"[CHAIN] Access at: http://localhost:{port}")
     app.run(debug=True, host='0.0.0.0', port=port)
-
-    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- remove extra dashboard run blocks
- rely on `FLASK_RUN_PORT` for configurable port

## Testing
- `pytest tests/test_dashboard.py::test_enterprise_dashboard_launch -q`

------
https://chatgpt.com/codex/tasks/task_e_686c0834cd048331baf1f5a3142210b6