### PR TITLE
Fix database count references

### DIFF
--- a/.github/instructions/ENTERPRISE_CONTEXT.instructions.md
+++ b/.github/instructions/ENTERPRISE_CONTEXT.instructions.md
@@ -22,7 +22,7 @@ applyTo: '**'
 - **✅ REAL-TIME INTELLIGENCE**: Unified analytics across all enterprise systems
 
 #### **Core Components**
-- **22 Synchronized Databases**: Enterprise data management system
+- **32 Synchronized Databases**: Enterprise data management system
 - **Flask Enterprise Dashboard**: 7-endpoint web interface with real-time metrics
 - **Template Intelligence Platform**: 16,500+ tracked scripts, 89 placeholders
 - **Quantum Algorithm Integration**: 5 quantum-enhanced algorithms operational
@@ -68,7 +68,7 @@ applyTo: '**'
 
 ### 🗄️ **DATABASE INFRASTRUCTURE**
 
-**Primary Databases (22 Total):**
+**Primary Databases (32 Total):**
 - **production.db**: Main operational database
 - **zendesk_core.db**: Zendesk entity management
 - **agent_workspace.db**: Agent activity tracking
@@ -91,7 +91,7 @@ applyTo: '**'
 │   ├── ready_for_processing/ (Input staging)
 │   ├── done_with_processing/ (Completed files)
 │   └── analysis_results/ (Output data)
-├── databases/ (22 synchronized databases)
+├── databases/ (32 synchronized databases)
 ├── src/ (Core source code)
 ├── scripts/ (Automation and utilities)
 ├── documentation/ (Enterprise documentation)

--- a/disaster_recovery/backups/MEDIUM_07062025-1250.md
+++ b/disaster_recovery/backups/MEDIUM_07062025-1250.md
@@ -24,7 +24,7 @@ From analyzing your current ecosystem, I've identified a significant opportunity
 **What's Already Excellent:**
 - ✅ **67+ Production-Ready Python Scripts** with enterprise patterns
 - ✅ **Comprehensive Web GUI Infrastructure** (Flask apps, dashboards, wizards)
-- ✅ **22 Synchronized Databases** with real-time monitoring
+- ✅ **32 Synchronized Databases** with real-time monitoring
 - ✅ **Advanced Cache Analytics** with performance tracking
 - ✅ **Query Performance Leaderboards** with gamification
 - ✅ **Enterprise Dashboard Components** with visual indicators
@@ -337,7 +337,7 @@ Your Enhanced Analytics Intelligence Platform is now **fully deployed and operat
 - **Cost Optimization**: Automatic identification of 15-40% savings opportunities
 
 ### **Enterprise Integration:**
-- **Database Connectivity**: 22+ synchronized enterprise databases
+- **Database Connectivity**: 32+ synchronized enterprise databases
 - **Dashboard Enhancement**: Existing Flask dashboards now intelligence-enabled
 - **API Bridge**: Unified intelligence API at port 5002
 - **Zero Disruption**: Seamless integration without replacing existing systems
@@ -663,7 +663,7 @@ Based on the comprehensive analysis, the instruction sets should be updated to i
 - Automated scaling and resource management protocols
 
 ### **2. Enterprise Monitoring Standards**:
-- Multi-system health monitoring across 22+ databases
+- Multi-system health monitoring across 32+ databases
 - Performance trend analysis with predictive forecasting
 - Business impact scoring and executive reporting
 
@@ -1052,7 +1052,7 @@ def validate_session_end() -> SessionIntegrityResult:
 
 ### **📊 ARCHIVAL COMPONENTS FOUND**
 
-#### **Database Systems (22 synchronized databases)**
+#### **Database Systems (32 synchronized databases)**
 - Session tracking across all enterprise databases
 - Performance metrics archival and reporting
 - Real-time analytics data preservation
@@ -1093,7 +1093,7 @@ Based on the discovered code, here's the optimal session wrap-up sequence:
 
 ### **Complete System State Preservation**
 - ✅ **Process State**: All platform processes gracefully terminated
-- ✅ **Database State**: All 22 databases optimized and preserved
+- ✅ **Database State**: All 32 databases optimized and preserved
 - ✅ **Configuration State**: System configuration backed up
 - ✅ **Performance Metrics**: Complete analytics archived
 - ✅ **Session Analytics**: Comprehensive session data preserved
@@ -2044,7 +2044,7 @@ Based on my comprehensive analysis of the workspace, I can confirm:
 6. **Template Intelligence Platform** - 16,500+ patterns operational
 7. **Flask Enterprise Dashboard** - 7 endpoints, production ready
 8. **Continuous Operation Mode** - 24/7 automated monitoring active
-9. **Database Infrastructure** - 22 synchronized databases operational
+9. **Database Infrastructure** - 32 synchronized databases operational
 10. **Web-GUI Framework** - 100% documentation coverage completed
 
 ### 📋 **NEXT SESSION PREPARATION**

--- a/disaster_recovery/backups/MEDIUM_07062025-1405.md
+++ b/disaster_recovery/backups/MEDIUM_07062025-1405.md
@@ -186,7 +186,7 @@ GitHub Copilot: # 🎯 COMPREHENSIVE NEXT SESSION OPTIMIZATION PLAN
 - ✅ **Enhancement Iterator**: 100% operational (4+ successful cycles)
 - ✅ **Phase 4 Continuous Optimization**: 94.95% excellence
 - ✅ **Phase 5 Quantum Integration**: 98.47% excellence (43.24% success)
-- ✅ **Database Systems**: 22 databases synchronized
+- ✅ **Database Systems**: 32 databases synchronized
 - ✅ **Enterprise Infrastructure**: 100% operational
 
 ---

--- a/disaster_recovery/backups/MEDIUM_ENTERPRISE_CONTEXT.instructions.md
+++ b/disaster_recovery/backups/MEDIUM_ENTERPRISE_CONTEXT.instructions.md
@@ -22,7 +22,7 @@ applyTo: '**'
 - **✅ REAL-TIME INTELLIGENCE**: Unified analytics across all enterprise systems
 
 #### **Core Components**
-- **22 Synchronized Databases**: Enterprise data management system
+- **32 Synchronized Databases**: Enterprise data management system
 - **Flask Enterprise Dashboard**: 7-endpoint web interface with real-time metrics
 - **Template Intelligence Platform**: 16,500+ tracked scripts, 89 placeholders
 - **Quantum Algorithm Integration**: 5 quantum-enhanced algorithms operational
@@ -68,7 +68,7 @@ applyTo: '**'
 
 ### 🗄️ **DATABASE INFRASTRUCTURE**
 
-**Primary Databases (22 Total):**
+**Primary Databases (32 Total):**
 - **production.db**: Main operational database
 - **zendesk_core.db**: Zendesk entity management
 - **agent_workspace.db**: Agent activity tracking
@@ -91,7 +91,7 @@ applyTo: '**'
 │   ├── ready_for_processing/ (Input staging)
 │   ├── done_with_processing/ (Completed files)
 │   └── analysis_results/ (Output data)
-├── databases/ (22 synchronized databases)
+├── databases/ (32 synchronized databases)
 ├── src/ (Core source code)
 ├── scripts/ (Automation and utilities)
 ├── documentation/ (Enterprise documentation)

--- a/github_integration/.github/copilot/conversations_with_human/07062025-1250.md
+++ b/github_integration/.github/copilot/conversations_with_human/07062025-1250.md
@@ -24,7 +24,7 @@ From analyzing your current ecosystem, I've identified a significant opportunity
 **What's Already Excellent:**
 - ✅ **67+ Production-Ready Python Scripts** with enterprise patterns
 - ✅ **Comprehensive Web GUI Infrastructure** (Flask apps, dashboards, wizards)
-- ✅ **22 Synchronized Databases** with real-time monitoring
+- ✅ **32 Synchronized Databases** with real-time monitoring
 - ✅ **Advanced Cache Analytics** with performance tracking
 - ✅ **Query Performance Leaderboards** with gamification
 - ✅ **Enterprise Dashboard Components** with visual indicators
@@ -337,7 +337,7 @@ Your Enhanced Analytics Intelligence Platform is now **fully deployed and operat
 - **Cost Optimization**: Automatic identification of 15-40% savings opportunities
 
 ### **Enterprise Integration:**
-- **Database Connectivity**: 22+ synchronized enterprise databases
+- **Database Connectivity**: 32+ synchronized enterprise databases
 - **Dashboard Enhancement**: Existing Flask dashboards now intelligence-enabled
 - **API Bridge**: Unified intelligence API at port 5002
 - **Zero Disruption**: Seamless integration without replacing existing systems
@@ -663,7 +663,7 @@ Based on the comprehensive analysis, the instruction sets should be updated to i
 - Automated scaling and resource management protocols
 
 ### **2. Enterprise Monitoring Standards**:
-- Multi-system health monitoring across 22+ databases
+- Multi-system health monitoring across 32+ databases
 - Performance trend analysis with predictive forecasting
 - Business impact scoring and executive reporting
 
@@ -1052,7 +1052,7 @@ def validate_session_end() -> SessionIntegrityResult:
 
 ### **📊 ARCHIVAL COMPONENTS FOUND**
 
-#### **Database Systems (22 synchronized databases)**
+#### **Database Systems (32 synchronized databases)**
 - Session tracking across all enterprise databases
 - Performance metrics archival and reporting
 - Real-time analytics data preservation
@@ -1093,7 +1093,7 @@ Based on the discovered code, here's the optimal session wrap-up sequence:
 
 ### **Complete System State Preservation**
 - ✅ **Process State**: All platform processes gracefully terminated
-- ✅ **Database State**: All 22 databases optimized and preserved
+- ✅ **Database State**: All 32 databases optimized and preserved
 - ✅ **Configuration State**: System configuration backed up
 - ✅ **Performance Metrics**: Complete analytics archived
 - ✅ **Session Analytics**: Comprehensive session data preserved
@@ -2044,7 +2044,7 @@ Based on my comprehensive analysis of the workspace, I can confirm:
 6. **Template Intelligence Platform** - 16,500+ patterns operational
 7. **Flask Enterprise Dashboard** - 7 endpoints, production ready
 8. **Continuous Operation Mode** - 24/7 automated monitoring active
-9. **Database Infrastructure** - 22 synchronized databases operational
+9. **Database Infrastructure** - 32 synchronized databases operational
 10. **Web-GUI Framework** - 100% documentation coverage completed
 
 ### 📋 **NEXT SESSION PREPARATION**

--- a/github_integration/.github/copilot/conversations_with_human/07062025-1405.md
+++ b/github_integration/.github/copilot/conversations_with_human/07062025-1405.md
@@ -186,7 +186,7 @@ GitHub Copilot: # 🎯 COMPREHENSIVE NEXT SESSION OPTIMIZATION PLAN
 - ✅ **Enhancement Iterator**: 100% operational (4+ successful cycles)
 - ✅ **Phase 4 Continuous Optimization**: 94.95% excellence
 - ✅ **Phase 5 Quantum Integration**: 98.47% excellence (43.24% success)
-- ✅ **Database Systems**: 22 databases synchronized
+- ✅ **Database Systems**: 32 databases synchronized
 - ✅ **Enterprise Infrastructure**: 100% operational
 
 ---

--- a/github_integration/.github/instructions/ENTERPRISE_CONTEXT.instructions.md
+++ b/github_integration/.github/instructions/ENTERPRISE_CONTEXT.instructions.md
@@ -22,7 +22,7 @@ applyTo: '**'
 - **✅ REAL-TIME INTELLIGENCE**: Unified analytics across all enterprise systems
 
 #### **Core Components**
-- **22 Synchronized Databases**: Enterprise data management system
+- **32 Synchronized Databases**: Enterprise data management system
 - **Flask Enterprise Dashboard**: 7-endpoint web interface with real-time metrics
 - **Template Intelligence Platform**: 16,500+ tracked scripts, 89 placeholders
 - **Quantum Algorithm Integration**: 5 quantum-enhanced algorithms operational
@@ -68,7 +68,7 @@ applyTo: '**'
 
 ### 🗄️ **DATABASE INFRASTRUCTURE**
 
-**Primary Databases (22 Total):**
+**Primary Databases (32 Total):**
 - **production.db**: Main operational database
 - **zendesk_core.db**: Zendesk entity management
 - **agent_workspace.db**: Agent activity tracking
@@ -91,7 +91,7 @@ applyTo: '**'
 │   ├── ready_for_processing/ (Input staging)
 │   ├── done_with_processing/ (Completed files)
 │   └── analysis_results/ (Output data)
-├── databases/ (22 synchronized databases)
+├── databases/ (32 synchronized databases)
 ├── src/ (Core source code)
 ├── scripts/ (Automation and utilities)
 ├── documentation/ (Enterprise documentation)


### PR DESCRIPTION
## Summary
- update documentation to reflect 32 total databases
- adjust conversation logs mentioning 22 databases

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686c085489948331a452bdaf2387567b