### PR TITLE
Document quantum stubs

### DIFF
--- a/copilot/orchestrators/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py
+++ b/copilot/orchestrators/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py
@@ -936,7 +936,11 @@ class UnifiedEnterpriseDeploymentOrchestrator:
         return deployed_count > 0
     
     def _deploy_quantum_algorithms(self) -> bool:
-        """⚛️ Phase 11: Deploy quantum optimization algorithms"""
+        """⚛️ Phase 11: Deploy quantum optimization algorithms
+
+        NOTE: This phase only creates placeholder files. No real quantum
+        optimization logic is implemented yet.
+        """
         
         if not self.config.enable_quantum_optimization:
             logger.info("⏩ Quantum optimization disabled")
@@ -957,7 +961,8 @@ class UnifiedEnterpriseDeploymentOrchestrator:
         quantum_stub = '''#!/usr/bin/env python3
 """
 ⚛️ Quantum Optimization Algorithm Stub
-This is a placeholder for future quantum algorithm implementation
+This file is generated automatically.
+STUB: Quantum optimization logic is not implemented.
 """
 
 class QuantumOptimizer:

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -11,6 +11,9 @@ This is the **gh_COPILOT Enterprise Toolkit**, a collection of deployment and ma
 - **Algorithm Performance:** modest improvements over baseline
 - **Template Completion:** automation scripts demonstrate partial coverage
 - **Quantum Optimization:** planned feature (not implemented)
+- **Quantum Optimizer Stubs:** the `QuantumOptimizer` class and the
+  `_deploy_quantum_algorithms()` method are placeholders with no real
+  quantum functionality
 - **Enterprise Systems:** monitoring and validation modules operational
 - **Security Compliance:** Anti-recursion, zero-byte protection, DUAL COPILOT pattern
 - **Performance Monitoring:** monitoring scripts available
@@ -42,6 +45,7 @@ This is the **gh_COPILOT Enterprise Toolkit**, a collection of deployment and ma
 
 - These items describe aspirational functionality and are not part of the current release.
 - **Quantum Algorithm Optimization**: superposition and entanglement processing (not implemented)
+- **Quantum Optimizer Stubs:** `QuantumOptimizer` and related functions are present only as illustrative placeholders
 - **Ultra-Aggressive Template Completion**: target completion rate subject to future development
 - **Real-time Performance Monitoring**: conceptual self-learning analytics
 - **Substantial Algorithm Boost**: planned quantum-inspired performance enhancements
@@ -142,6 +146,9 @@ print(f"Algorithm Boost: {result['algorithm_boost']}%")
 ```python
 from quantum_algorithm_optimizer import QuantumAlgorithmOptimizer
 
+# NOTE: QuantumAlgorithmOptimizer is a stub. This example illustrates
+# planned functionality and will not perform real quantum optimization.
+
 # Run quantum-inspired optimization
 optimizer = QuantumAlgorithmOptimizer()
 results = optimizer.optimize(
@@ -176,6 +183,8 @@ print(f"Zero-byte Protection: {validation['zero_byte_protection']}")
 - **Quality Score:** stable baseline
 ### Planned Quantum Optimization
 - The following metrics describe aspirational features and are not active in the current release.
+- **Note:** `QuantumOptimizer` and other quantum-related functions are stubs and
+  currently perform no real optimization.
 - **Superposition Enhancement:** concept only
 - **Entanglement Optimization:** concept only
 - **Coherence Stability:** concept only

--- a/enterprise_wrap_up_engine.py
+++ b/enterprise_wrap_up_engine.py
@@ -170,8 +170,12 @@ class EnterpriseWrapUpEngine:
         }
     
     def check_quantum_integration(self) -> Dict[str, Any]:
-        """⚛️ Check quantum optimization integration"""
-        
+        """⚛️ Check quantum optimization integration
+
+        NOTE: This function only searches for placeholder files. Quantum
+        optimization has not been implemented yet.
+        """
+
         # Check for quantum-related files
         quantum_files = list(self.workspace_root.glob("**/*quantum*.py"))
         


### PR DESCRIPTION
## Summary
- note that `_deploy_quantum_algorithms` just makes placeholder files
- clarify that `check_quantum_integration` is a stub
- document quantum optimizer stubs in README

## Testing
- `make test` *(fails: tests/test_dashboard.py::test_enterprise_dashboard_launch)*

------
https://chatgpt.com/codex/tasks/task_e_686c0a76ee6483319da38617dd8c8b37