### PR TITLE
Clean up obsolete phase4 references

### DIFF
--- a/.github/instructions/COMPREHENSIVE_SESSION_INTEGRITY.instructions.md
+++ b/.github/instructions/COMPREHENSIVE_SESSION_INTEGRITY.instructions.md
@@ -33,7 +33,7 @@ The gh_COPILOT Enterprise Toolkit has achieved exceptional results:
 python emergency_c_temp_violation_prevention.py --emergency-cleanup
 
 # NEW: Phase 4 & Phase 5 validation
-python phase4_continuous_optimization_engine.py --validate-session
+python unified_monitoring_optimization_system.py --validate-session
 python phase5_advanced_ai_integration.py --validate-excellence
 
 # NEW: Continuous operation mode validation

--- a/ENTERPRISE_SCRIPT_CONSOLIDATION_STRATEGY.md
+++ b/ENTERPRISE_SCRIPT_CONSOLIDATION_STRATEGY.md
@@ -63,8 +63,6 @@
 **Current Scripts:**
 - `enterprise_performance_monitor.py` (scripts/ & scripts/deployment/)
 - `unified_monitoring_optimization_system.py` (root)
-- `phase4_continuous_optimization_engine.py` (scripts/ & scripts/deployment/)
-- `enterprise_continuous_optimization_engine.py` (core/ & scripts/deployment/)
 - `master_framework_orchestrator.py` (scripts/ & scripts/deployment/ & scripts/regenerated/)
 - `final_enterprise_orchestrator.py` (root)
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,16 @@
 1. **enterprise_unicode_compatibility_fix.py** - Unicode/emoji compatibility fixes
 2. **unified_monitoring_optimization_system.py** - Unified monitoring and optimization
 3. **enterprise_json_serialization_fix.py** - JSON serialization enhancements
-4. **advanced_analytics_phase4_phase5_enhancement.py** - Advanced analytics and reporting
+4. **phase5_advanced_ai_integration.py** - Phase 5 AI integration tools
 5. **final_deployment_validator.py** - Professional environment validation
 6. **ADVANCED_AUTONOMOUS_FRAMEWORK_7_PHASE_COMPREHENSIVE_SCOPE.py** - Core framework
+
+### Included Phase 4/5 Tools
+- `unified_monitoring_optimization_system.py` (Phase 4)
+- `phase4_comprehensive_completion_summary.py` (Phase 4)
+- `phase5_advanced_ai_integration.py` (Phase 5)
+- `phase5_enterprise_scale_deployment.py` (Phase 5)
+- `phase5_final_enterprise_completion.py` (Phase 5)
 
 ## Issues Resolved
 - [RESOLVED] Emoji encoding issues across all Python files
@@ -46,7 +53,7 @@
 ## Next Steps
 - Execute the gh_COPILOT system from the workspace directory
 - Monitor performance using unified_monitoring_optimization_system.py
-- Access advanced analytics through advanced_analytics_phase4_phase5_enhancement.py
+ - Access advanced analytics and monitoring through unified_monitoring_optimization_system.py
 
 ## Support
 All components are validated for deployment.

--- a/copilot/core/enterprise_orchestrator.py
+++ b/copilot/core/enterprise_orchestrator.py
@@ -110,14 +110,14 @@ class EnterpriseOrchestrator:
                 timeout=30
             ),
             'advanced_analytics': ServiceConfig(
-                name='Advanced Analytics Engine',
-                script_path='core/advanced_analytics_phase4_phase5_enhancement.py',
+                name='Monitoring & Optimization System',
+                script_path='unified_monitoring_optimization_system.py',
                 critical=True,
                 timeout=45
             ),
             'continuous_optimization': ServiceConfig(
-                name='Continuous Optimization Engine',
-                script_path='core/enterprise_continuous_optimization_engine.py',
+                name='Monitoring & Optimization System',
+                script_path='unified_monitoring_optimization_system.py',
                 critical=True,
                 timeout=30
             ),

--- a/copilot/core/final_deployment_validator.py
+++ b/copilot/core/final_deployment_validator.py
@@ -165,12 +165,12 @@ class FinalDeploymentValidator:
         """Validate advanced analytics enhancement"""
         logger.info("Validating analytics enhancement...")
         
-        analytics_path = self.workspace_path / "advanced_analytics_phase4_phase5_enhancement.py"
+        analytics_path = self.workspace_path / "unified_monitoring_optimization_system.py"
         
         if not analytics_path.exists():
             self.validation_results["issues_found"].append({
                 "type": "analytics_enhancement",
-                "error": "Advanced analytics enhancement not found",
+                "error": "Monitoring & optimization system not found",
                 "severity": "medium"
             })
             return False

--- a/copilot/orchestrators/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py
+++ b/copilot/orchestrators/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py
@@ -681,8 +681,7 @@ class UnifiedEnterpriseDeploymentOrchestrator:
             "enterprise_performance_monitor_windows.py": "Performance Monitor",
             "enterprise_unicode_compatibility_fix.py": "Unicode Compatibility",
             "enterprise_json_serialization_fix.py": "JSON Serialization",
-            "advanced_analytics_phase4_phase5_enhancement.py": "Advanced Analytics",
-            "enterprise_continuous_optimization_engine.py": "Optimization Engine",
+            "unified_monitoring_optimization_system.py": "Monitoring & Optimization",
             "final_deployment_validator.py": "Deployment Validator",
             "ADVANCED_AUTONOMOUS_FRAMEWORK_7_PHASE_COMPREHENSIVE_SCOPE.py": "Autonomous Framework",
             "efficiency_optimization_engine_100_percent.py": "Efficiency Optimizer",
@@ -999,8 +998,7 @@ class QuantumOptimizer:
         
         # Phase 4 & 5 components
         phase_components = [
-            "advanced_analytics_phase4_phase5_enhancement.py",
-            "phase4_continuous_optimization.py",
+            "unified_monitoring_optimization_system.py",
             "phase5_advanced_ai_integration.py",
             "continuous_operation_monitor.py"
         ]

--- a/copilot/orchestrators/final_enterprise_orchestrator.py
+++ b/copilot/orchestrators/final_enterprise_orchestrator.py
@@ -177,14 +177,14 @@ class FinalEnterpriseOrchestrator:
                 'cwd': str(self.workspace_root)
             },
             {
-                'name': 'Advanced Analytics Engine',
-                'script': 'advanced_analytics_phase4_phase5_enhancement.py',
+                'name': 'Monitoring & Optimization System',
+                'script': 'unified_monitoring_optimization_system.py',
                 'port': None,
                 'cwd': str(self.workspace_root)
             },
             {
-                'name': 'Continuous Optimization Engine',
-                'script': 'core/enterprise_continuous_optimization_engine.py',
+                'name': 'Monitoring & Optimization System',
+                'script': 'unified_monitoring_optimization_system.py',
                 'port': None,
                 'cwd': str(self.workspace_root)
             },

--- a/deployment/validation_report.json
+++ b/deployment/validation_report.json
@@ -68,14 +68,6 @@
       "exists": true,
       "size": 16800
     },
-    "advanced_analytics_phase4_phase5_enhancement.py": {
-      "exists": true,
-      "size": 33295
-    },
-    "enterprise_continuous_optimization_engine.py": {
-      "exists": true,
-      "size": 39338
-    },
     "final_deployment_validator.py": {
       "exists": true,
       "size": 12259
@@ -395,12 +387,10 @@
       "phase3_5_deployment_completion.py": 9130,
       "phase4_advanced_analytics_dashboard.py": 16273,
       "phase4_comprehensive_completion_summary.py": 15579,
-      "phase4_continuous_optimization_engine.py": 35304,
       "phase4_realtime_monitoring_system.py": 20130,
       "phase5_advanced_ai_integration.py": 30718,
       "phase5_enterprise_scale_deployment.py": 22797,
       "phase5_final_enterprise_completion.py": 20889,
-      "phase5_quantum_optimization_engine.py": 29601,
       "phase_3_cross_database_aggregation.py": 20771,
       "phase_4_environment_adaptation.py": 24782,
       "phase_5_comprehensive_documentation.py": 31567,

--- a/documentation/SYSTEM_OVERVIEW.md
+++ b/documentation/SYSTEM_OVERVIEW.md
@@ -13,8 +13,7 @@
 - unified_monitoring_optimization_system.py: Monitoring & Optimization
 - enterprise_unicode_compatibility_fix.py: Unicode Compatibility
 - enterprise_json_serialization_fix.py: JSON Serialization
-- advanced_analytics_phase4_phase5_enhancement.py: Advanced Analytics
-- enterprise_continuous_optimization_engine.py: Optimization Engine
+- phase5_advanced_ai_integration.py: AI Integration Tools
 - final_deployment_validator.py: Deployment Validator
 - ADVANCED_AUTONOMOUS_FRAMEWORK_7_PHASE_COMPREHENSIVE_SCOPE.py: Autonomous Framework
 

--- a/final_deployment_validator.py
+++ b/final_deployment_validator.py
@@ -165,12 +165,12 @@ class FinalDeploymentValidator:
         """Validate advanced analytics enhancement"""
         logger.info("Validating analytics enhancement...")
         
-        analytics_path = self.workspace_path / "advanced_analytics_phase4_phase5_enhancement.py"
+        analytics_path = self.workspace_path / "unified_monitoring_optimization_system.py"
         
         if not analytics_path.exists():
             self.validation_results["issues_found"].append({
                 "type": "analytics_enhancement",
-                "error": "Advanced analytics enhancement not found",
+                "error": "Monitoring & optimization system not found",
                 "severity": "medium"
             })
             return False

--- a/github_integration/.github/instructions/COMPREHENSIVE_SESSION_INTEGRITY.instructions.md
+++ b/github_integration/.github/instructions/COMPREHENSIVE_SESSION_INTEGRITY.instructions.md
@@ -33,7 +33,7 @@ The gh_COPILOT Enterprise Toolkit has achieved exceptional results:
 python emergency_c_temp_violation_prevention.py --emergency-cleanup
 
 # NEW: Phase 4 & Phase 5 validation
-python phase4_continuous_optimization_engine.py --validate-session
+python unified_monitoring_optimization_system.py --validate-session
 python phase5_advanced_ai_integration.py --validate-excellence
 
 # NEW: Continuous operation mode validation

--- a/scripts/deployment/phase4_comprehensive_completion_summary.py
+++ b/scripts/deployment/phase4_comprehensive_completion_summary.py
@@ -49,8 +49,8 @@ class Phase4CompletionSummary:
         print("[SUCCESS] Validating PHASE 4 Components...")
         
         components = {
-            "continuous_optimization_engine": {
-                "file": "phase4_continuous_optimization_engine.py",
+            "monitoring_optimization_system": {
+                "file": "unified_monitoring_optimization_system.py",
                 "status": "deployed",
                 "validation": "passed",
                 "performance_score": 92.6

--- a/scripts/phase4_comprehensive_completion_summary.py
+++ b/scripts/phase4_comprehensive_completion_summary.py
@@ -49,8 +49,8 @@ class Phase4CompletionSummary:
         print("[SUCCESS] Validating PHASE 4 Components...")
         
         components = {
-            "continuous_optimization_engine": {
-                "file": "phase4_continuous_optimization_engine.py",
+            "monitoring_optimization_system": {
+                "file": "unified_monitoring_optimization_system.py",
                 "status": "deployed",
                 "validation": "passed",
                 "performance_score": 92.6

--- a/validation/deployment_validation_report.py
+++ b/validation/deployment_validation_report.py
@@ -61,10 +61,10 @@ def validate_deployment_structure():
     core_components = [
         "template_intelligence_platform.py",
         "enterprise_performance_monitor_windows.py",
+        "unified_monitoring_optimization_system.py",
         "enterprise_unicode_compatibility_fix.py",
         "enterprise_json_serialization_fix.py",
-        "advanced_analytics_phase4_phase5_enhancement.py",
-        "enterprise_continuous_optimization_engine.py",
+        "phase5_advanced_ai_integration.py",
         "final_deployment_validator.py",
         "ADVANCED_AUTONOMOUS_FRAMEWORK_7_PHASE_COMPREHENSIVE_SCOPE.py"
     ]


### PR DESCRIPTION
## Summary
- update docs to drop obsolete phase4_continuous_optimization_engine
- list actual Phase 4/5 scripts in README and system overview
- switch instructions and scripts to use unified_monitoring_optimization_system
- remove old references from validation files

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686c131d09ac833183205881a95ca91a