### PR TITLE
Add web GUI integration scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Environment is compatible with Windows systems.
 - `unified_database_management_system.py` – handles SQLite operations
 - `unified_disaster_recovery_system.py` – backup and restore utilities
 - `unified_monitoring_optimization_system.py` – performance monitoring
+- `web_gui_integration_system.py` – wraps Web-GUI components under one interface
 - `final_deployment_validator.py` – verifies production readiness
 
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -36,6 +36,7 @@
 - `unified_session_management_system.py` – manages user session data
 - `unified_script_generation_system.py` – generates scripts from templates
 - `unified_monitoring_optimization_system.py` – collects performance data
+- `web_gui_integration_system.py` – wraps Web-GUI components under one interface
 - `unified_database_management_system.py` – utilities for SQLite operations
 - `unified_disaster_recovery_system.py` – backup and restoration helpers
 - `enterprise_unicode_compatibility_fix.py` – handles Unicode issues

--- a/web_gui_integration_system.py
+++ b/web_gui_integration_system.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Unified Web GUI Integration System.
+
+This module provides a high-level interface that wraps existing Web-GUI
+components into a single integration point.
+
+TODO:
+    - Consolidate the Flask dashboard application.
+    - Unify template management for the web interface.
+    - Centralize database connection logic used by web components.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class WebGUIConfig:
+    """Configuration for Web GUI integration."""
+
+    workspace_root: Path
+    database_path: Path
+    templates_path: Path
+
+
+class WebGUIIntegrationSystem:
+    """Scaffolding for a unified Web-GUI integration layer."""
+
+    def __init__(self, workspace_root: Optional[str] = None) -> None:
+        self.config = WebGUIConfig(
+            workspace_root=Path(workspace_root or "."),
+            database_path=Path(workspace_root or ".") /
+            "databases" / "production.db",
+            templates_path=Path(workspace_root or ".") /
+            "web_gui" / "templates",
+        )
+        # TODO: initialize Flask dashboard, template loader, and database session
+        self._initialized = False
+
+    def initialize(self) -> None:
+        """Initialize all Web-GUI components in a unified manner."""
+        # TODO: implement startup logic combining dashboard, templates and DB
+        self._initialized = True
+
+    def status(self) -> Dict[str, Any]:
+        """Return current status of the integration system."""
+        return {
+            "initialized": self._initialized,
+            "workspace_root": str(self.config.workspace_root),
+            "database": str(self.config.database_path),
+            "templates": str(self.config.templates_path),
+        }
+
+
+if __name__ == "__main__":
+    system = WebGUIIntegrationSystem()
+    system.initialize()
+    print(system.status())


### PR DESCRIPTION
## Summary
- create `web_gui_integration_system.py` with unified interface scaffolding
- reference the new module in README and docs

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686c47be4fc0833188227c3290d80484