### PR TITLE
Fix PEP8 violations

### DIFF
--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -36,7 +36,9 @@ class EnterpriseDashboardApp:
     def __init__(self, workspace_path=None):
         workspace_path = workspace_path or os.getenv("ENTERPRISE_WORKSPACE_PATH", "./workspace")
         self.workspace_path = Path(workspace_path)
-        self.production_db = self.workspace_path / "production.db"
+        self.production_db = (
+            self.workspace_path / "production.db"
+        )
         
     def get_database_connection(self):
         """Get production database connection"""
@@ -130,10 +132,12 @@ def migration_interface():
     """[PROCESSING] Migration tools interface"""
     return render_template('migration.html')
 
+
 @app.route('/deployment')
 def deployment_interface():
     """[LAUNCH] Deployment management interface"""
     return render_template('deployment.html')
+
 
 @app.route('/api/health')
 def health_check():
@@ -141,7 +145,9 @@ def health_check():
     return jsonify({
         "status": "healthy",
         "timestamp": datetime.now().isoformat(),
-        "database": "connected" if dashboard.production_db.exists() else "disconnected"
+        "database": (
+            "connected" if dashboard.production_db.exists() else "disconnected"
+        )
     })
 
 

--- a/web_gui_integration_system.py
+++ b/web_gui_integration_system.py
@@ -37,7 +37,8 @@ class WebGUIIntegrationSystem:
             templates_path=Path(workspace_root or ".") /
             "web_gui" / "templates",
         )
-        # TODO: initialize Flask dashboard, template loader, and database session
+        # TODO: initialize Flask dashboard, template loader,
+        # and database session
         self._initialized = False
 
     def initialize(self) -> None:


### PR DESCRIPTION
## Summary
- add missing blank lines in enterprise_dashboard
- break long line for health check
- wrap database path

## Testing
- `make test` *(fails: Failed building wheel for qiskit-aer)*

------
https://chatgpt.com/codex/tasks/task_e_686dec2e4ae883318d7152ca5b536020