### PR TITLE
Fix flake8 in verify_databases script

### DIFF
--- a/scripts/verify_databases.py
+++ b/scripts/verify_databases.py
@@ -1,17 +1,21 @@
-"""\U0001f50d Verify all .db files in databases/ have expected new tables/indexes."""
+"""Verify all .db files in databases/ have expected new tables and indexes."""
+
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 from tqdm import tqdm
-from datetime import datetime
+
 
 def validate_db(path: Path, expected: set) -> dict:
-    """Return missing tables/indexes in this DB."""
+    """Return missing tables or indexes in this DB."""
     conn = sqlite3.connect(path)
     cur = conn.cursor()
-    cur.execute("SELECT name FROM sqlite_master WHERE type IN ('table','index')")
+    query = "SELECT name FROM sqlite_master " "WHERE type IN ('table','index')"
+    cur.execute(query)
     existing = {r[0] for r in cur.fetchall()}
     conn.close()
     return {"missing": expected - existing, "extra": existing - expected}
+
 
 def main():
     start = datetime.now()
@@ -19,9 +23,18 @@ def main():
     db_dir = Path(__file__).resolve().parents[1] / "databases"
     # expected new objects per recent updates
     expectations = {
-        "production.db": {"quantum_processing_results", "optimization_metrics"},
-        "enhanced_script_tracking.db": {"enhanced_script_tracking", "script_templates"},
-        "consolidation_tracking.db": {"script_generation_consolidation", "consolidation_manifest"},
+        "production.db": {
+            "quantum_processing_results",
+            "optimization_metrics",
+        },
+        "enhanced_script_tracking.db": {
+            "enhanced_script_tracking",
+            "script_templates",
+        },
+        "consolidation_tracking.db": {
+            "script_generation_consolidation",
+            "consolidation_manifest",
+        },
         "optimization_metrics.db": {"optimization_metrics"},
         "cleanup_actions.db": {"cleanup_actions"},
         # add other DB: expected_tables...
@@ -35,6 +48,7 @@ def main():
     print(f"\n\u2705 Verification completed in {duration:.2f}s")
     for db, res in results.items():
         print(f"{db}: missing={res['missing']} extra={res['extra']}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- clean up verify_databases script for PEP8
- break long SQL query and format dictionary

## Testing
- `flake8 scripts/verify_databases.py`
- `black --check scripts/verify_databases.py`


------
https://chatgpt.com/codex/tasks/task_e_686df656ad64833183116f79afa002bb