### PR TITLE
Add standalone lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint Python
+
+on: [pull_request, push]
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Flake8
+        run: pip install flake8
+      - name: Run Flake8
+        run: flake8 . --count --show-source --statistics


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Flake8 on pushes and pull requests

All code files already pass `flake8` with zero violations.

## Testing
- `flake8 . --count --statistics`
- `make test` *(fails: qiskit-aer wheel build requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_686dfd8daaa483318f34e998e4c30440