### PR TITLE
Add sqlite3 connect import

### DIFF
--- a/database_sync_scheduler.py
+++ b/database_sync_scheduler.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-
+from sqlite3 import connect
 from typing import Iterable
 
 logging.basicConfig()
@@ -44,6 +44,7 @@ def _load_database_names(list_file: Path) -> list[str]:
             if name:
                 names.append(name)
     return names
+
 
 if __name__ == "__main__":
     workspace = Path("./databases")


### PR DESCRIPTION
## Summary
- add missing `sqlite3.connect` import to database sync scheduler

## Testing
- `flake8 database_sync_scheduler.py`
- `make test` *(fails: qiskit-aer build error)*

------
https://chatgpt.com/codex/tasks/task_e_68708818cee88331b9d0e4037c986e7c