### PR TITLE
Fix test env var

### DIFF
--- a/tests/test_database_list.py
+++ b/tests/test_database_list.py
@@ -5,7 +5,7 @@ from unified_database_management_system import UnifiedDatabaseManager
 
 def test_verify_expected_databases(monkeypatch):
     repo_root = Path(__file__).resolve().parents[1]
-    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(repo_root))
+    monkeypatch.setenv(UnifiedDatabaseManager.WORKSPACE_ENV_VAR, str(repo_root))
     manager = UnifiedDatabaseManager(workspace_root=str(repo_root))
     expected_ok, missing = manager.verify_expected_databases()
     assert expected_ok, f"Missing database files: {missing}"


### PR DESCRIPTION
## Summary
- ensure database listing test uses `GH_COPILOT_WORKSPACE` environment variable

## Testing
- `make test` *(fails: qiskit-aer wheel build error due to certificate verification)*

------
https://chatgpt.com/codex/tasks/task_e_68708832cb688331b530e659a7698564