### PR TITLE
Configure pytest to skip old validation tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,8 @@
 testpaths =
     tests
 norecursedirs =
-    builds/production/builds/artifacts/validation
-    builds/final/production/builds/artifacts/validation
+    builds/production/artifacts/validation
+    builds/final/production/artifacts/validation
 addopts =
     --ignore=tests/test_database_list.py
     --ignore=tests/test_physics_engine.py


### PR DESCRIPTION
## Summary
- ignore validation artifacts in builds
- ignore outdated unit tests to avoid ImportErrors

## Testing
- `pytest --collect-only`

------
https://chatgpt.com/codex/tasks/task_e_687088a0097c8331a172ce02bad51721