### PR TITLE
Document historical validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ The gh_COPILOT Toolkit is an enterprise-grade system following database-first ar
 ├── scripts/            # 1,679 validated scripts
 ├── web_gui/            # Flask enterprise dashboard
 ├── Archive/tests/     # Archived test backups pending QA review
+├── archives/validation_tests/  # Historical validation scripts (excluded from regular test runs)
 └── .github/            # Enterprise instructions & patterns
 ```
 
 Archived test backups in `Archive/tests/` are reviewed regularly by the QA team
 to determine whether they should be reintegrated or safely removed.
+See `archives/validation_tests/README.md` for historical validation scripts that are skipped during regular test runs.
 
 ### 🚀 **GETTING STARTED**
 1. **Environment Setup**: Follow enterprise environment configuration

--- a/archives/validation_tests/README.md
+++ b/archives/validation_tests/README.md
@@ -1,0 +1,3 @@
+# Validation Tests Archive
+
+The scripts in this directory are historical artifacts from early validation efforts. They remain for reference only and are not executed in standard test runs or CI workflows.


### PR DESCRIPTION
## Summary
- add README for historical validation test scripts
- link new archive from main README

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'qiskit.algorithms')*

------
https://chatgpt.com/codex/tasks/task_e_68709733d6148331bcc712a4335d7e99