### PR TITLE
Update pytest config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,3 @@
 [pytest]
-testpaths =
-    tests
-norecursedirs =
-    builds/production/builds/artifacts/validation
-    builds/final/production/builds/artifacts/validation
-addopts =
-    --ignore-glob=tests/test_*_validator.py
+testpaths = ["tests"]
+addopts = "--ignore=archives"


### PR DESCRIPTION
## Summary
- simplify pytest configuration
- ignore archived modules during test collection

## Testing
- `make test` *(fails: ModuleNotFoundError for `qiskit.algorithms`)*

------
https://chatgpt.com/codex/tasks/task_e_6870974933f883319dfae4670a904889