### PR TITLE
Improve workspace path handling

### DIFF
--- a/copilot/common/workspace_utils.py
+++ b/copilot/common/workspace_utils.py
@@ -1,13 +1,26 @@
+"""Utilities for resolving the workspace path."""
+
 from pathlib import Path
 import os
 from typing import Optional
 
+
 DEFAULT_ENV_VAR = "GH_COPILOT_WORKSPACE"
-DEFAULT_PATH = Path("e:/gh_COPILOT")
 
 
 def get_workspace_path(workspace: Optional[str] = None) -> Path:
-    """Return a workspace path from a parameter or environment variable."""
+    """Return a workspace path from a parameter or environment variable.
+
+    When ``workspace`` is provided its value is used directly. Otherwise the
+    ``GH_COPILOT_WORKSPACE`` environment variable is consulted. If that is not
+    set, ``Path.home()`` is returned.
+    """
+
     if workspace:
         return Path(workspace)
-    return Path(os.getenv(DEFAULT_ENV_VAR, DEFAULT_PATH))
+
+    env_path = os.getenv(DEFAULT_ENV_VAR)
+    if env_path:
+        return Path(env_path)
+
+    return Path.home()

--- a/session_protocol_validator.py
+++ b/session_protocol_validator.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """SessionProtocolValidator - Validates workspace for zero-byte files."""
 import logging
-import os
-from pathlib import Path
+
+from copilot.common.workspace_utils import get_workspace_path
 
 TEXT_INDICATORS = {
     'start': '[START]',
@@ -16,8 +16,7 @@ class SessionProtocolValidator:
     """Check workspace integrity on startup."""
 
     def __init__(self, workspace_path: str | None = None) -> None:
-        self.workspace_path = Path(
-            workspace_path or os.getenv('GH_COPILOT_WORKSPACE', '.'))
+        self.workspace_path = get_workspace_path(workspace_path)
         self.logger = logging.getLogger(__name__)
 
     def validate_startup(self) -> bool:

--- a/tests/test_session_protocol_validator.py
+++ b/tests/test_session_protocol_validator.py
@@ -18,3 +18,11 @@ def test_unified_session_start_fails_with_zero_byte(tmp_path, monkeypatch):
     zero_file.write_text("")
     mgr = UnifiedSessionManagementSystem()
     assert mgr.start_session() is False
+
+
+def test_unicode_workspace_path(tmp_path, monkeypatch):
+    unicode_dir = tmp_path / "路径"
+    unicode_dir.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(unicode_dir))
+    validator = SessionProtocolValidator()
+    assert validator.validate_startup() is True

--- a/tests/test_workspace_utils.py
+++ b/tests/test_workspace_utils.py
@@ -1,0 +1,14 @@
+import os
+from pathlib import Path
+
+from copilot.common.workspace_utils import get_workspace_path
+
+
+def test_env_var_used(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    assert get_workspace_path() == tmp_path
+
+
+def test_home_fallback(monkeypatch):
+    monkeypatch.delenv("GH_COPILOT_WORKSPACE", raising=False)
+    assert get_workspace_path() == Path.home()

--- a/unified_session_management_system.py
+++ b/unified_session_management_system.py
@@ -10,9 +10,9 @@ Enterprise Standards Compliance:
 """
 
 import logging
-import os
 from datetime import datetime
-from pathlib import Path
+
+from copilot.common.workspace_utils import get_workspace_path
 
 from session_protocol_validator import SessionProtocolValidator
 
@@ -29,8 +29,7 @@ class UnifiedSessionManagementSystem:
     """Manage session start validation."""
 
     def __init__(self, workspace_root: str | None = None) -> None:
-        self.workspace_root = Path(
-            workspace_root or os.getenv("GH_COPILOT_WORKSPACE", "."))
+        self.workspace_root = get_workspace_path(workspace_root)
         self.validator = SessionProtocolValidator(str(self.workspace_root))
 
     def start_session(self) -> bool:


### PR DESCRIPTION
## Summary
- add helper for consistent workspace path resolution
- normalize path usage in session utilities
- test unicode paths and path resolution

## Testing
- `make test` *(fails: ImportError: cannot import name 'solve_qubo_bruteforce', ImportError: cannot import name 'EnterpriseJSONSerializer')*

------
https://chatgpt.com/codex/tasks/task_e_68713771f544833197d3a80245bb5877