### PR TITLE
Add env var override for UnifiedDatabaseManager

### DIFF
--- a/tests/test_database_list.py
+++ b/tests/test_database_list.py
@@ -6,6 +6,6 @@ from unified_database_management_system import UnifiedDatabaseManager
 def test_verify_expected_databases(monkeypatch):
     repo_root = Path(__file__).resolve().parents[1]
     monkeypatch.setenv(UnifiedDatabaseManager.WORKSPACE_ENV_VAR, str(repo_root))
-    manager = UnifiedDatabaseManager(workspace_root=str(repo_root))
+    manager = UnifiedDatabaseManager()
     expected_ok, missing = manager.verify_expected_databases()
     assert expected_ok, f"Missing database files: {missing}"

--- a/unified_database_management_system.py
+++ b/unified_database_management_system.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 from pathlib import Path
 from typing import Iterable, Tuple
@@ -11,13 +12,15 @@ from typing import Iterable, Tuple
 logger = logging.getLogger(__name__)
 
 DATABASE_LIST_FILE = Path("documentation") / "DATABASE_LIST.md"
+WORKSPACE_ENV_VAR = "GH_COPILOT_WORKSPACE"
 
 
 class UnifiedDatabaseManager:
     """Manage expected databases for the workspace."""
 
     def __init__(self, workspace_root: str = ".") -> None:
-        self.workspace_root = Path(workspace_root)
+        workspace = os.getenv(WORKSPACE_ENV_VAR, workspace_root)
+        self.workspace_root = Path(workspace)
         self.databases_dir = self.workspace_root / "databases"
 
     def _load_expected_names(self) -> list[str]:
@@ -49,6 +52,7 @@ def synchronize_databases(master: Path, replicas: Iterable[Path]) -> None:
     """Synchronize replica databases with the master database."""
     for replica in replicas:
         _backup_database(master, replica)
+
 
 if __name__ == "__main__":
     mgr = UnifiedDatabaseManager(Path.cwd())


### PR DESCRIPTION
## Summary
- allow UnifiedDatabaseManager to read workspace path from `GH_COPILOT_WORKSPACE`
- update database list test to rely on the env var

## Testing
- `make test` *(fails: ImportError: cannot import name 'solve_qubo_bruteforce'...)*

------
https://chatgpt.com/codex/tasks/task_e_6871378271e08331b54b301c5fe7284f