### PR TITLE
Add correction history logging

### DIFF
--- a/database_first_windows_compatible_flake8_corrector.py
+++ b/database_first_windows_compatible_flake8_corrector.py
@@ -454,6 +454,25 @@ class DatabaseFirstFlake8Corrector:
                         self.session_id
                     ))
 
+                # Record individual fixes in correction_history
+                for violation, result in zip(violations, corrections):
+                    if result.success:
+                        for fix in result.violations_fixed:
+                            cursor.execute(
+                                '''
+                                INSERT INTO correction_history
+                                (session_id, file_path, violation_code, fix_applied, timestamp)
+                                VALUES (?, ?, ?, ?, ?)
+                                ''',
+                                (
+                                    self.session_id,
+                                    violation.file_path,
+                                    violation.error_code,
+                                    fix,
+                                    datetime.now().isoformat(),
+                                ),
+                            )
+
         except Exception as e:
             self.logger.error(f"Error saving to database: {e}")
 

--- a/databases/migrations/add_correction_history.sql
+++ b/databases/migrations/add_correction_history.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS correction_history;
+CREATE TABLE correction_history (
+    session_id TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    violation_code TEXT NOT NULL,
+    fix_applied TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_correction_history_session_id ON correction_history(session_id);
+CREATE INDEX IF NOT EXISTS idx_correction_history_file_path ON correction_history(file_path);
+CREATE INDEX IF NOT EXISTS idx_correction_history_timestamp ON correction_history(timestamp);

--- a/deployment/deployment_package_20250710_182951/scripts/database_first_windows_compatible_flake8_corrector.py
+++ b/deployment/deployment_package_20250710_182951/scripts/database_first_windows_compatible_flake8_corrector.py
@@ -456,6 +456,25 @@ class DatabaseFirstFlake8Corrector:
                         self.session_id
                     ))
 
+                # Record individual fixes in correction_history
+                for violation, result in zip(violations, corrections):
+                    if result.success:
+                        for fix in result.violations_fixed:
+                            cursor.execute(
+                                '''
+                                INSERT INTO correction_history
+                                (session_id, file_path, violation_code, fix_applied, timestamp)
+                                VALUES (?, ?, ?, ?, ?)
+                                ''',
+                                (
+                                    self.session_id,
+                                    violation.file_path,
+                                    violation.error_code,
+                                    fix,
+                                    datetime.now().isoformat(),
+                                ),
+                            )
+
         except Exception as e:
             self.logger.error(f"Error saving to database: {e}")
 

--- a/deployment/deployment_package_20250710_183234/scripts/database_first_windows_compatible_flake8_corrector.py
+++ b/deployment/deployment_package_20250710_183234/scripts/database_first_windows_compatible_flake8_corrector.py
@@ -456,6 +456,25 @@ class DatabaseFirstFlake8Corrector:
                         self.session_id
                     ))
 
+                # Record individual fixes in correction_history
+                for violation, result in zip(violations, corrections):
+                    if result.success:
+                        for fix in result.violations_fixed:
+                            cursor.execute(
+                                '''
+                                INSERT INTO correction_history
+                                (session_id, file_path, violation_code, fix_applied, timestamp)
+                                VALUES (?, ?, ?, ?, ?)
+                                ''',
+                                (
+                                    self.session_id,
+                                    violation.file_path,
+                                    violation.error_code,
+                                    fix,
+                                    datetime.now().isoformat(),
+                                ),
+                            )
+
         except Exception as e:
             self.logger.error(f"Error saving to database: {e}")
 

--- a/tests/test_correction_history.py
+++ b/tests/test_correction_history.py
@@ -1,0 +1,62 @@
+import shutil
+import sqlite3
+from pathlib import Path
+
+from database_first_windows_compatible_flake8_corrector import (
+    DatabaseFirstFlake8Corrector,
+    FlakeViolation,
+    CorrectionPattern,
+)
+
+
+def test_correction_history_records(tmp_path, monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    workspace = tmp_path
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+
+    # copy analytics.db and run migration
+    src_db = repo_root / "databases" / "analytics.db"
+    dest_db = db_dir / "analytics.db"
+    shutil.copy(src_db, dest_db)
+
+    migration_sql = (
+        repo_root / "databases" / "migrations" / "add_correction_history.sql"
+    ).read_text()
+    with sqlite3.connect(dest_db) as conn:
+        conn.executescript(migration_sql)
+
+    # prepare file with trailing whitespace violation
+    test_file = workspace / "example.py"
+    test_file.write_text("print('hi') \n")
+
+    corrector = DatabaseFirstFlake8Corrector(workspace_path=str(workspace))
+    corrector.analytics_db = str(dest_db)
+    corrector.correction_patterns["W293"] = CorrectionPattern(
+        pattern_id="test",
+        error_code="W293",
+        pattern_regex="",
+        replacement_template="",
+        confidence_score=1.0,
+        success_rate=1.0,
+        usage_count=0,
+    )
+
+    violation = FlakeViolation(
+        file_path=str(test_file),
+        line_number=1,
+        column=1,
+        error_code="W293",
+        message="trailing whitespace",
+    )
+    result = corrector.apply_correction_pattern(str(test_file), violation)
+
+    corrector.save_correction_results_to_database([violation], [result])
+
+    with sqlite3.connect(dest_db) as conn:
+        rows = conn.execute(
+            "SELECT file_path, violation_code, fix_applied FROM correction_history"
+        ).fetchall()
+
+    assert rows, "Correction history not recorded"
+    assert len(rows) == len(result.violations_fixed)


### PR DESCRIPTION
## Summary
- add migration for `correction_history`
- log fixes into `correction_history`
- mirror updates in deployment scripts
- test that fixes are recorded

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'qiskit.algorithms')*

------
https://chatgpt.com/codex/tasks/task_e_6871471106cc8331beb7212e09c35658