### PR TITLE
Add dill to requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ Flask
 qiskit>=1.4,<2.0
 qiskit-aer==0.17.1
 qiskit-machine-learning>=0.6.0
+dill>=0.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ isort==6.0.1
 autopep8==2.3.2
 ipython==9.4.0
 jupyter==1.1.1
+dill>=0.3.7
 
 # --- AWS/Cloud, if present in codebase ---
 boto3==1.39.3  # Omit if not actually imported/used


### PR DESCRIPTION
## Summary
- include `dill>=0.3.7` for test suite compatibility with Python 3.11

## Testing
- `make test` *(fails: 7 failed, 52 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68731e954fb08331ab6859d64ff127ab