### PR TITLE
Switch to EstimatorQNN

### DIFF
--- a/quantum_algorithms_functional.py
+++ b/quantum_algorithms_functional.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 
 import logging
 import time
-from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import numpy as np
 from qiskit_aer import AerSimulator

--- a/tests/test_quantum_benchmarking.py
+++ b/tests/test_quantum_benchmarking.py
@@ -1,5 +1,7 @@
 import pytest
+from qiskit_machine_learning.neural_networks import EstimatorQNN
 
+from quantum import benchmarking as benchmarking_module
 from quantum.benchmarking import (benchmark_physics_engine, benchmark_qnn,
                                   load_metrics)
 
@@ -22,3 +24,8 @@ def test_benchmark_qnn():
     except ImportError:
         pytest.skip("qiskit_machine_learning backend unavailable")
     assert 0.0 <= results["accuracy"] <= 1.0
+
+
+def test_benchmarking_uses_estimator_qnn():
+    pytest.importorskip("qiskit_machine_learning")
+    assert benchmarking_module.EstimatorQNN is EstimatorQNN

--- a/tests/test_quantum_predictive_maintenance.py
+++ b/tests/test_quantum_predictive_maintenance.py
@@ -1,13 +1,20 @@
 import logging
+
 import pytest
 
 pytest.importorskip("qiskit_machine_learning")
 
 try:
-    from quantum_neural_networks_predictive_maintenance import EnterpriseUtility
+    from quantum_neural_networks_predictive_maintenance import \
+        EnterpriseUtility
+    from quantum_neural_networks_predictive_maintenance import \
+        EstimatorQNN as ModuleEstimatorQNN
 except Exception as exc:  # pragma: no cover - skip if dependencies missing
     EnterpriseUtility = None
+    ModuleEstimatorQNN = None
     SKIP_REASON = str(exc)
+else:
+    SKIP_REASON = ""
 
 
 def test_qnn_predictive_maintenance_accuracy(caplog):
@@ -26,3 +33,11 @@ def test_qnn_predictive_maintenance_accuracy(caplog):
             break
     else:
         raise AssertionError("Accuracy log not found")
+
+
+def test_predictive_maintenance_uses_estimator_qnn():
+    if ModuleEstimatorQNN is None:
+        pytest.skip(SKIP_REASON)
+    from qiskit_machine_learning.neural_networks import EstimatorQNN
+
+    assert ModuleEstimatorQNN is EstimatorQNN


### PR DESCRIPTION
## Summary
- refactor quantum neural network examples to use `EstimatorQNN`
- keep classical fallback if quantum training fails
- expose `EstimatorQNN` in benchmarking and predictive maintenance modules
- check for the new class in related tests

## Testing
- `flake8 quantum_algorithms_functional.py quantum/benchmarking.py quantum_neural_networks_predictive_maintenance.py tests/test_quantum_benchmarking.py tests/test_quantum_predictive_maintenance.py`
- `make test` *(fails: tests/test_complete_template_generator.py::test_create_templates ...)*

------
https://chatgpt.com/codex/tasks/task_e_68731e8d95508331952b535f03c7adf8