### PR TITLE
Ensure cwd inside workspace

### DIFF
--- a/copilot/common/workspace_utils.py
+++ b/copilot/common/workspace_utils.py
@@ -24,3 +24,12 @@ def get_workspace_path(workspace: Optional[str] = None) -> Path:
         return Path(env_path)
 
     return Path.cwd()
+
+
+def _within_workspace(path: Path, workspace: Path) -> bool:
+    """Return True if ``path`` resides within ``workspace``."""
+    try:
+        path.resolve().relative_to(workspace.resolve())
+        return True
+    except ValueError:
+        return False

--- a/critical_flake8_error_corrector.py
+++ b/critical_flake8_error_corrector.py
@@ -19,6 +19,10 @@ import re
 from pathlib import Path
 from datetime import datetime
 from tqdm import tqdm
+from copilot.common.workspace_utils import (
+    get_workspace_path,
+    _within_workspace,
+)
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -92,9 +96,15 @@ class EnterpriseFlake8Corrector:
         """Validate that corrections were successful"""
         return len(files) > 0
 
-def main():
+def main() -> bool:
     """Main execution function"""
-    corrector = EnterpriseFlake8Corrector()
+    workspace = get_workspace_path()
+    if not _within_workspace(Path.cwd(), workspace):
+        print(
+            f"{TEXT_INDICATORS['error']} Current directory is outside {workspace}"
+        )
+        return False
+    corrector = EnterpriseFlake8Corrector(workspace_path=str(workspace))
     success = corrector.execute_correction()
 
     if success:

--- a/database_first_flake8_compliance_scanner.py
+++ b/database_first_flake8_compliance_scanner.py
@@ -19,6 +19,10 @@ import re
 from pathlib import Path
 from datetime import datetime
 from tqdm import tqdm
+from copilot.common.workspace_utils import (
+    get_workspace_path,
+    _within_workspace,
+)
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -92,9 +96,15 @@ class EnterpriseFlake8Corrector:
         """Validate that corrections were successful"""
         return len(files) > 0
 
-def main():
+def main() -> bool:
     """Main execution function"""
-    corrector = EnterpriseFlake8Corrector()
+    workspace = get_workspace_path()
+    if not _within_workspace(Path.cwd(), workspace):
+        print(
+            f"{TEXT_INDICATORS['error']} Current directory is outside {workspace}"
+        )
+        return False
+    corrector = EnterpriseFlake8Corrector(workspace_path=str(workspace))
     success = corrector.execute_correction()
 
     if success:

--- a/scripts/visual_processing_compliance_validator.py
+++ b/scripts/visual_processing_compliance_validator.py
@@ -19,6 +19,10 @@ import re
 from pathlib import Path
 from datetime import datetime
 from tqdm import tqdm
+from copilot.common.workspace_utils import (
+    get_workspace_path,
+    _within_workspace,
+)
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -92,9 +96,15 @@ class EnterpriseFlake8Corrector:
         """Validate that corrections were successful"""
         return len(files) > 0
 
-def main():
+def main() -> bool:
     """Main execution function"""
-    corrector = EnterpriseFlake8Corrector()
+    workspace = get_workspace_path()
+    if not _within_workspace(Path.cwd(), workspace):
+        print(
+            f"{TEXT_INDICATORS['error']} Current directory is outside {workspace}"
+        )
+        return False
+    corrector = EnterpriseFlake8Corrector(workspace_path=str(workspace))
     success = corrector.execute_correction()
 
     if success:

--- a/targeted_flake8_fixer.py
+++ b/targeted_flake8_fixer.py
@@ -19,6 +19,10 @@ import re
 from pathlib import Path
 from datetime import datetime
 from tqdm import tqdm
+from copilot.common.workspace_utils import (
+    get_workspace_path,
+    _within_workspace,
+)
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -92,9 +96,15 @@ class EnterpriseFlake8Corrector:
         """Validate that corrections were successful"""
         return len(files) > 0
 
-def main():
+def main() -> bool:
     """Main execution function"""
-    corrector = EnterpriseFlake8Corrector()
+    workspace = get_workspace_path()
+    if not _within_workspace(Path.cwd(), workspace):
+        print(
+            f"{TEXT_INDICATORS['error']} Current directory is outside {workspace}"
+        )
+        return False
+    corrector = EnterpriseFlake8Corrector(workspace_path=str(workspace))
     success = corrector.execute_correction()
 
     if success:

--- a/tests/test_workspace_validation_scripts.py
+++ b/tests/test_workspace_validation_scripts.py
@@ -1,0 +1,32 @@
+import importlib
+import pytest
+
+MODULES = [
+    "critical_flake8_error_corrector",
+    "database_first_flake8_compliance_scanner",
+    "targeted_flake8_fixer",
+    "scripts.visual_processing_compliance_validator",
+]
+
+@pytest.mark.parametrize("module_name", MODULES)
+def test_main_passes_within_workspace(tmp_path, monkeypatch, module_name):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "example.py").write_text("print('hi')\n")
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.chdir(workspace)
+    module = importlib.import_module(module_name)
+    assert module.main()
+
+
+@pytest.mark.parametrize("module_name", MODULES)
+def test_main_fails_outside_workspace(tmp_path, monkeypatch, module_name):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "example.py").write_text("print('hi')\n")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.chdir(outside)
+    module = importlib.import_module(module_name)
+    assert module.main() is False


### PR DESCRIPTION
## Summary
- validate working directory for various flake8 tools
- expose `_within_workspace` helper in `workspace_utils`
- test correct and incorrect cwd scenarios

## Testing
- `make test` *(fails: flake8 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687324859ba88331973e51b0c1484913