### PR TITLE
Add db integrity checks

### DIFF
--- a/scripts/FINAL_COMPREHENSIVE_PRODUCTION_TEST.py
+++ b/scripts/FINAL_COMPREHENSIVE_PRODUCTION_TEST.py
@@ -14,6 +14,7 @@ import sys
 import logging
 from pathlib import Path
 from datetime import datetime
+import sqlite3
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -53,8 +54,21 @@ class EnterpriseUtility:
 
     def perform_utility_function(self) -> bool:
         """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        try:
+            prod_db = self.workspace_path / "production.db"
+            analytics_db = self.workspace_path / "analytics.db"
+
+            with sqlite3.connect(prod_db) as prod_conn:
+                prod_result = prod_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            with sqlite3.connect(analytics_db) as an_conn:
+                an_result = an_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            return prod_result and prod_result[0] == "ok" and an_result and an_result[0] == "ok"
+
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} Database error: {exc}")
+            return False
 
 def main():
     """Main execution function"""

--- a/scripts/FINAL_PRODUCTION_COMPLETER.py
+++ b/scripts/FINAL_PRODUCTION_COMPLETER.py
@@ -14,6 +14,7 @@ import sys
 import logging
 from pathlib import Path
 from datetime import datetime
+import sqlite3
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -53,8 +54,21 @@ class EnterpriseUtility:
 
     def perform_utility_function(self) -> bool:
         """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        try:
+            prod_db = self.workspace_path / "production.db"
+            analytics_db = self.workspace_path / "analytics.db"
+
+            with sqlite3.connect(prod_db) as prod_conn:
+                prod_result = prod_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            with sqlite3.connect(analytics_db) as an_conn:
+                an_result = an_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            return prod_result and prod_result[0] == "ok" and an_result and an_result[0] == "ok"
+
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} Database error: {exc}")
+            return False
 
 def main():
     """Main execution function"""

--- a/scripts/MISSION_COMPLETION_SUMMARY.py
+++ b/scripts/MISSION_COMPLETION_SUMMARY.py
@@ -14,6 +14,7 @@ import sys
 import logging
 from pathlib import Path
 from datetime import datetime
+import sqlite3
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -53,8 +54,21 @@ class EnterpriseUtility:
 
     def perform_utility_function(self) -> bool:
         """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        try:
+            prod_db = self.workspace_path / "production.db"
+            analytics_db = self.workspace_path / "analytics.db"
+
+            with sqlite3.connect(prod_db) as prod_conn:
+                prod_result = prod_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            with sqlite3.connect(analytics_db) as an_conn:
+                an_result = an_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            return prod_result and prod_result[0] == "ok" and an_result and an_result[0] == "ok"
+
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} Database error: {exc}")
+            return False
 
 def main():
     """Main execution function"""

--- a/scripts/chunk2_completion_processor.py
+++ b/scripts/chunk2_completion_processor.py
@@ -14,6 +14,7 @@ import sys
 import logging
 from pathlib import Path
 from datetime import datetime
+import sqlite3
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -53,8 +54,21 @@ class EnterpriseUtility:
 
     def perform_utility_function(self) -> bool:
         """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        try:
+            prod_db = self.workspace_path / "production.db"
+            analytics_db = self.workspace_path / "analytics.db"
+
+            with sqlite3.connect(prod_db) as prod_conn:
+                prod_result = prod_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            with sqlite3.connect(analytics_db) as an_conn:
+                an_result = an_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            return prod_result and prod_result[0] == "ok" and an_result and an_result[0] == "ok"
+
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} Database error: {exc}")
+            return False
 
 def main():
     """Main execution function"""

--- a/scripts/chunk3_final_completion_generator.py
+++ b/scripts/chunk3_final_completion_generator.py
@@ -14,6 +14,7 @@ import sys
 import logging
 from pathlib import Path
 from datetime import datetime
+import sqlite3
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -53,8 +54,21 @@ class EnterpriseUtility:
 
     def perform_utility_function(self) -> bool:
         """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        try:
+            prod_db = self.workspace_path / "production.db"
+            analytics_db = self.workspace_path / "analytics.db"
+
+            with sqlite3.connect(prod_db) as prod_conn:
+                prod_result = prod_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            with sqlite3.connect(analytics_db) as an_conn:
+                an_result = an_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            return prod_result and prod_result[0] == "ok" and an_result and an_result[0] == "ok"
+
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} Database error: {exc}")
+            return False
 
 def main():
     """Main execution function"""

--- a/scripts/final_project_completion_summary_generator.py
+++ b/scripts/final_project_completion_summary_generator.py
@@ -14,6 +14,7 @@ import sys
 import logging
 from pathlib import Path
 from datetime import datetime
+import sqlite3
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -53,8 +54,21 @@ class EnterpriseUtility:
 
     def perform_utility_function(self) -> bool:
         """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        try:
+            prod_db = self.workspace_path / "production.db"
+            analytics_db = self.workspace_path / "analytics.db"
+
+            with sqlite3.connect(prod_db) as prod_conn:
+                prod_result = prod_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            with sqlite3.connect(analytics_db) as an_conn:
+                an_result = an_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            return prod_result and prod_result[0] == "ok" and an_result and an_result[0] == "ok"
+
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} Database error: {exc}")
+            return False
 
 def main():
     """Main execution function"""

--- a/scripts/phase4_comprehensive_completion_summary.py
+++ b/scripts/phase4_comprehensive_completion_summary.py
@@ -14,6 +14,7 @@ import sys
 import logging
 from pathlib import Path
 from datetime import datetime
+import sqlite3
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -53,8 +54,21 @@ class EnterpriseUtility:
 
     def perform_utility_function(self) -> bool:
         """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        try:
+            prod_db = self.workspace_path / "production.db"
+            analytics_db = self.workspace_path / "analytics.db"
+
+            with sqlite3.connect(prod_db) as prod_conn:
+                prod_result = prod_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            with sqlite3.connect(analytics_db) as an_conn:
+                an_result = an_conn.execute("PRAGMA integrity_check;").fetchone()
+
+            return prod_result and prod_result[0] == "ok" and an_result and an_result[0] == "ok"
+
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} Database error: {exc}")
+            return False
 
 def main():
     """Main execution function"""


### PR DESCRIPTION
## Summary
- improve completion scripts to verify database integrity across production and analytics DBs

## Testing
- `make test` *(fails: 6 failed, 66 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68732a90a9348331b47bafb083700752