### PR TITLE
Add database initializer and compliance tool

### DIFF
--- a/documentation/CONSOLIDATED_DATABASE_LIST.md
+++ b/documentation/CONSOLIDATED_DATABASE_LIST.md
@@ -3,6 +3,7 @@
 The following SQLite databases remain after consolidating analytics data:
 
 - analytics.db
+- enterprise_assets.db
 - archive.db
 - autonomous_decisions.db
 - capability_scaler.db

--- a/scripts/database/size_compliance_checker.py
+++ b/scripts/database/size_compliance_checker.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Verify SQLite database sizes do not exceed 99.9 MB."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from tqdm import tqdm
+
+THRESHOLD_MB = 99.9
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def check_database_sizes(directory: Path, threshold_mb: float = THRESHOLD_MB) -> bool:
+    """Return True if all database files are below the size threshold."""
+    db_files = list(directory.glob("*.db"))
+    compliant = True
+    with tqdm(total=len(db_files), desc="Checking sizes", unit="db") as bar:
+        for db_path in db_files:
+            size_mb = db_path.stat().st_size / (1024 * 1024)
+            if size_mb > threshold_mb:
+                logger.error("%s exceeds %.1f MB (%.2f MB)", db_path, threshold_mb, size_mb)
+                compliant = False
+            bar.update(1)
+    return compliant
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    databases_dir = root / "databases"
+    if not databases_dir.exists():
+        logger.error("Databases directory not found: %s", databases_dir)
+        sys.exit(1)
+    if check_database_sizes(databases_dir):
+        logger.info("All databases comply with size restrictions")
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Initialize the enterprise_assets.db database."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+from tqdm import tqdm
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+TABLES: dict[str, str] = {
+    "script_assets": (
+        "CREATE TABLE IF NOT EXISTS script_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "script_path TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "documentation_assets": (
+        "CREATE TABLE IF NOT EXISTS documentation_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "doc_path TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "template_assets": (
+        "CREATE TABLE IF NOT EXISTS template_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "template_path TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "pattern_assets": (
+        "CREATE TABLE IF NOT EXISTS pattern_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "pattern TEXT NOT NULL,"
+        "usage_count INTEGER DEFAULT 0,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "enterprise_metadata": (
+        "CREATE TABLE IF NOT EXISTS enterprise_metadata ("
+        "id INTEGER PRIMARY KEY,"
+        "key TEXT NOT NULL,"
+        "value TEXT NOT NULL"
+        ")"
+    ),
+    "integration_tracking": (
+        "CREATE TABLE IF NOT EXISTS integration_tracking ("
+        "id INTEGER PRIMARY KEY,"
+        "integration_name TEXT NOT NULL,"
+        "status TEXT NOT NULL,"
+        "last_synced TEXT"
+        ")"
+    ),
+    "cross_database_sync_operations": (
+        "CREATE TABLE IF NOT EXISTS cross_database_sync_operations ("
+        "id INTEGER PRIMARY KEY,"
+        "operation TEXT NOT NULL,"
+        "timestamp TEXT NOT NULL"
+        ")"
+    ),
+}
+
+
+def initialize_database(db_path: Path) -> None:
+    """Create enterprise_assets.db with the expected schema."""
+    logger.info("Initializing %s", db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn, tqdm(
+        total=len(TABLES), desc="Creating tables", unit="table"
+    ) as bar:
+        for sql in TABLES.values():
+            conn.execute(sql)
+            bar.update(1)
+        conn.commit()
+    logger.info("Database initialization complete")
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    db_path = root / "databases" / "enterprise_assets.db"
+    if db_path.exists():
+        logger.info("%s already exists", db_path)
+        return
+    initialize_database(db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_unified_database_initializer.py
+++ b/tests/test_unified_database_initializer.py
@@ -1,0 +1,26 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def test_initializer_creates_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "enterprise_assets.db"
+    initialize_database(db_path)
+    with sqlite3.connect(db_path) as conn:
+        tables = set(
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        )
+    expected = {
+        "script_assets",
+        "documentation_assets",
+        "template_assets",
+        "pattern_assets",
+        "enterprise_metadata",
+        "integration_tracking",
+        "cross_database_sync_operations",
+    }
+    assert expected.issubset(tables)


### PR DESCRIPTION
## Summary
- create `unified_database_initializer.py` to build the new `enterprise_assets.db`
- add `size_compliance_checker.py` for database size validation
- document new database in `CONSOLIDATED_DATABASE_LIST.md`
- test initializer logic

## Testing
- `pytest tests/test_unified_database_initializer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68795176830c8331a211d8e5fb234546