### PR TITLE
Add migration orchestrator and sync logger

### DIFF
--- a/documentation/CONSOLIDATED_DATABASE_LIST.md
+++ b/documentation/CONSOLIDATED_DATABASE_LIST.md
@@ -3,6 +3,7 @@
 The following SQLite databases remain after consolidating analytics data:
 
 - analytics.db
+- enterprise_assets.db
 - archive.db
 - autonomous_decisions.db
 - capability_scaler.db

--- a/documentation/PLAN_ISSUE_STATEMENT.md
+++ b/documentation/PLAN_ISSUE_STATEMENT.md
@@ -31,14 +31,14 @@ This document outlines the finalized strategy for merging 40+ SQLite databases i
   - `cross_database_sync_operations`.
 
 ### Phase 2 – Data Migration
-- Scripts: `intelligent_database_merger.py`, `safe_database_migrator.py`, `database_consolidation_migration.py`, `database_consolidation_validator.py`, `database_migration_verifier.py`, `unified_database_migration.py` *(to be created)*.
+ - Scripts: `intelligent_database_merger.py`, `safe_database_migrator.py`, `database_consolidation_migration.py`, `database_consolidation_validator.py`, `database_migration_verifier.py`, `unified_database_migration.py`.
 - Run analysis, merge, and migration utilities.
 - Populate templates and documentation using existing scripts.
 - Log progress to `cross_database_sync_operations`.
 - Abort if any file grows beyond 99.9 MB.
 
 ### Phase 3 – Synchronization Workflow
-- Scripts: `database_sync_scheduler.py`, `enterprise_script_database_synchronizer_complete.py`, `script_database_validator.py`, `database_script_reproducibility_validator.py`, `unified_database_management_system.py`, `cross_database_sync_logger.py` *(to be created)*.
+ - Scripts: `database_sync_scheduler.py`, `enterprise_script_database_synchronizer_complete.py`, `script_database_validator.py`, `database_script_reproducibility_validator.py`, `unified_database_management_system.py`, `cross_database_sync_logger.py`.
 - Sync only `enterprise_assets.db`.
 - Record all sync operations in `cross_database_sync_operations`.
 
@@ -94,11 +94,9 @@ This document outlines the finalized strategy for merging 40+ SQLite databases i
 
 ### Scripts to Create
 - `unified_database_initializer.py`
-- `unified_database_migration.py`
 - `documentation_ingestor.py`
 - `template_asset_ingestor.py`
 - `size_compliance_checker.py`
-- `cross_database_sync_logger.py`
 - Unit tests covering new utilities
 
 ## 🗂️ Autonomous File Management

--- a/scripts/database/cross_database_sync_logger.py
+++ b/scripts/database/cross_database_sync_logger.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Log cross-database sync operations."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def log_sync_operation(db_path: Path, operation: str) -> None:
+    """Insert a sync operation record into the tracking table."""
+    timestamp = datetime.utcnow().isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO cross_database_sync_operations (operation, timestamp)"
+            " VALUES (?, ?)",
+            (operation, timestamp),
+        )
+        conn.commit()
+    logger.info("Logged sync operation %s at %s", operation, timestamp)
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parents[1]
+    db_path = root / "databases" / "enterprise_assets.db"
+    if not db_path.exists():
+        logger.error("Database not found: %s", db_path)
+    else:
+        log_sync_operation(db_path, "manual invocation")

--- a/scripts/database/size_compliance_checker.py
+++ b/scripts/database/size_compliance_checker.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Verify SQLite database sizes do not exceed 99.9 MB."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from tqdm import tqdm
+
+THRESHOLD_MB = 99.9
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def check_database_sizes(directory: Path, threshold_mb: float = THRESHOLD_MB) -> bool:
+    """Return True if all database files are below the size threshold."""
+    db_files = list(directory.glob("*.db"))
+    compliant = True
+    with tqdm(total=len(db_files), desc="Checking sizes", unit="db") as bar:
+        for db_path in db_files:
+            size_mb = db_path.stat().st_size / (1024 * 1024)
+            if size_mb > threshold_mb:
+                logger.error("%s exceeds %.1f MB (%.2f MB)", db_path, threshold_mb, size_mb)
+                compliant = False
+            bar.update(1)
+    return compliant
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    databases_dir = root / "databases"
+    if not databases_dir.exists():
+        logger.error("Databases directory not found: %s", databases_dir)
+        sys.exit(1)
+    if check_database_sizes(databases_dir):
+        logger.info("All databases comply with size restrictions")
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Initialize the enterprise_assets.db database."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+from tqdm import tqdm
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+TABLES: dict[str, str] = {
+    "script_assets": (
+        "CREATE TABLE IF NOT EXISTS script_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "script_path TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "documentation_assets": (
+        "CREATE TABLE IF NOT EXISTS documentation_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "doc_path TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "template_assets": (
+        "CREATE TABLE IF NOT EXISTS template_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "template_path TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "pattern_assets": (
+        "CREATE TABLE IF NOT EXISTS pattern_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "pattern TEXT NOT NULL,"
+        "usage_count INTEGER DEFAULT 0,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "enterprise_metadata": (
+        "CREATE TABLE IF NOT EXISTS enterprise_metadata ("
+        "id INTEGER PRIMARY KEY,"
+        "key TEXT NOT NULL,"
+        "value TEXT NOT NULL"
+        ")"
+    ),
+    "integration_tracking": (
+        "CREATE TABLE IF NOT EXISTS integration_tracking ("
+        "id INTEGER PRIMARY KEY,"
+        "integration_name TEXT NOT NULL,"
+        "status TEXT NOT NULL,"
+        "last_synced TEXT"
+        ")"
+    ),
+    "cross_database_sync_operations": (
+        "CREATE TABLE IF NOT EXISTS cross_database_sync_operations ("
+        "id INTEGER PRIMARY KEY,"
+        "operation TEXT NOT NULL,"
+        "timestamp TEXT NOT NULL"
+        ")"
+    ),
+}
+
+
+def initialize_database(db_path: Path) -> None:
+    """Create enterprise_assets.db with the expected schema."""
+    logger.info("Initializing %s", db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn, tqdm(
+        total=len(TABLES), desc="Creating tables", unit="table"
+    ) as bar:
+        for sql in TABLES.values():
+            conn.execute(sql)
+            bar.update(1)
+        conn.commit()
+    logger.info("Database initialization complete")
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    db_path = root / "databases" / "enterprise_assets.db"
+    if db_path.exists():
+        logger.info("%s already exists", db_path)
+        return
+    initialize_database(db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/database/unified_database_migration.py
+++ b/scripts/database/unified_database_migration.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Orchestrate migration of assets into enterprise_assets.db."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from tqdm import tqdm
+
+from .cross_database_sync_logger import log_sync_operation
+from .database_consolidation_migration import consolidate_databases
+from .size_compliance_checker import check_database_sizes
+from .unified_database_initializer import initialize_database
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+DEFAULT_SOURCES = [
+    "analytics.db",
+    "documentation.db",
+    "template_completion.db",
+]
+
+
+def run_migration(workspace: Path, sources: list[str] = DEFAULT_SOURCES) -> None:
+    """Migrate selected databases into enterprise_assets.db."""
+    db_dir = workspace / "databases"
+    enterprise_db = db_dir / "enterprise_assets.db"
+    initialize_database(enterprise_db)
+
+    source_paths = [db_dir / name for name in sources if (db_dir / name).exists()]
+
+    with tqdm(total=len(source_paths), desc="Migrating", unit="db") as bar:
+        for src in source_paths:
+            logger.info("Migrating %s", src.name)
+            log_sync_operation(enterprise_db, f"start_migrate_{src.name}")
+            consolidate_databases(enterprise_db, [src])
+            log_sync_operation(enterprise_db, f"completed_migrate_{src.name}")
+            bar.update(1)
+            if not check_database_sizes(db_dir):
+                raise RuntimeError("Database size limit exceeded")
+
+    log_sync_operation(enterprise_db, "migration_complete")
+    logger.info("Migration process completed")
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parents[1]
+    run_migration(root)

--- a/tests/test_cross_database_sync_logger.py
+++ b/tests/test_cross_database_sync_logger.py
@@ -1,0 +1,16 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.cross_database_sync_logger import log_sync_operation
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def test_log_sync_operation(tmp_path: Path) -> None:
+    db_path = tmp_path / "enterprise_assets.db"
+    initialize_database(db_path)
+    log_sync_operation(db_path, "test_op")
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM cross_database_sync_operations"
+        ).fetchone()[0]
+    assert count == 1

--- a/tests/test_unified_database_initializer.py
+++ b/tests/test_unified_database_initializer.py
@@ -1,0 +1,26 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def test_initializer_creates_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "enterprise_assets.db"
+    initialize_database(db_path)
+    with sqlite3.connect(db_path) as conn:
+        tables = set(
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        )
+    expected = {
+        "script_assets",
+        "documentation_assets",
+        "template_assets",
+        "pattern_assets",
+        "enterprise_metadata",
+        "integration_tracking",
+        "cross_database_sync_operations",
+    }
+    assert expected.issubset(tables)

--- a/tests/test_unified_database_migration.py
+++ b/tests/test_unified_database_migration.py
@@ -1,0 +1,17 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.unified_database_migration import run_migration
+
+
+def test_run_migration_creates_db(tmp_path: Path) -> None:
+    databases = tmp_path / "databases"
+    databases.mkdir()
+    run_migration(tmp_path, sources=[])
+    db_path = databases / "enterprise_assets.db"
+    assert db_path.exists()
+    with sqlite3.connect(db_path) as conn:
+        tables = [row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )]
+    assert "cross_database_sync_operations" in tables


### PR DESCRIPTION
## Summary
- create `cross_database_sync_logger.py` for audit logging
- add `unified_database_migration.py` to orchestrate database merges
- document migration utilities now available
- test sync logging and migration initialization

## Testing
- `pytest tests/test_cross_database_sync_logger.py tests/test_unified_database_initializer.py tests/test_unified_database_migration.py -q`
- `python scripts/generate_docs_metrics.py` *(fails: no such table)*
- `python scripts/validate_docs_metrics.py` *(fails: no such table)*
- `make test` *(fails: requirements-test.txt missing)*

------
https://chatgpt.com/codex/tasks/task_e_68795176830c8331a211d8e5fb234546