### PR TITLE
Add logging to sync scheduler

### DIFF
--- a/documentation/CONSOLIDATED_DATABASE_LIST.md
+++ b/documentation/CONSOLIDATED_DATABASE_LIST.md
@@ -3,6 +3,7 @@
 The following SQLite databases remain after consolidating analytics data:
 
 - analytics.db
+- enterprise_assets.db
 - archive.db
 - autonomous_decisions.db
 - capability_scaler.db

--- a/documentation/PLAN_ISSUE_STATEMENT.md
+++ b/documentation/PLAN_ISSUE_STATEMENT.md
@@ -1,58 +1,58 @@
 # 📋 PLAN ISSUE STATEMENT – Enterprise Database Consolidation
 
-This document outlines the finalized strategy for merging 40+ SQLite databases into a single, compliant database while ensuring all scripts and documentation remain fully regenerable.
+This document outlines the finalized strategy for merging 40 + SQLite databases into a single, compliant database while ensuring all scripts and documentation remain fully regenerable.
 
-## 🎯 Objective
-- **Primary Goal:** Consolidate all existing databases into `enterprise_assets.db`.
-- **Success Metrics:**
+# 🎯 Objective
+- **Primary Goal: ** Consolidate all existing databases into `enterprise_assets.db`.
+- **Success Metrics: **
   - All data migrated without loss.
   - Each resulting database under 99.9 MB.
   - Synchronization and regeneration tools operate from the unified database.
   - `CONSOLIDATED_DATABASE_LIST.md` updated.
-- **Timeline:** 3–4 week phased rollout.
+- **Timeline: ** 3–4 week phased rollout.
 
-## 📊 Situation Analysis
+# 📊 Situation Analysis
 - `production.db` stores only `enterprise_metadata` and `integration_tracking`.
 - Over 44 databases contain templates, scripts, analytics, and documentation.
 - `DOCUMENTATION_DB_ANALYSIS_REPORT.md` lists duplicates and backups in `documentation.db`.
 - Previous consolidation reduced databases from 63 to 39.
-- **Constraint:** no database may exceed 99.9 MB.
+- **Constraint: ** no database may exceed 99.9 MB.
 
-## 🗄️ Database-First Analysis
+# 🗄️ Database-First Analysis
 - Use `scripts/database/database_consolidation_analyzer.py` and `scripts/temp_db_check.py` to list tables and sizes for each database.
 - Validate inventory against `documentation/CONSOLIDATED_DATABASE_LIST.md`.
 
-## 📋 Implementation Strategy
-### Phase 1 – Unified Schema
-- Script: `scripts/database/unified_database_initializer.py` *(to be created)*.
+# 📋 Implementation Strategy
+# Phase 1 – Unified Schema
+- Script: `scripts/database/unified_database_initializer.py`.
 - Create `enterprise_assets.db` with tables:
   - `script_assets`, `documentation_assets`, `template_assets`, `pattern_assets`.
   - `enterprise_metadata`, `integration_tracking`.
   - `cross_database_sync_operations`.
 
-### Phase 2 – Data Migration
-- Scripts: `intelligent_database_merger.py`, `safe_database_migrator.py`, `database_consolidation_migration.py`, `database_consolidation_validator.py`, `database_migration_verifier.py`, `unified_database_migration.py` *(to be created)*.
+# Phase 2 – Data Migration
+ - Scripts: `intelligent_database_merger.py`, `safe_database_migrator.py`, `database_consolidation_migration.py`, `database_consolidation_validator.py`, `database_migration_verifier.py`, `unified_database_migration.py`.
 - Run analysis, merge, and migration utilities.
 - Populate templates and documentation using existing scripts.
 - Log progress to `cross_database_sync_operations`.
 - Abort if any file grows beyond 99.9 MB.
 
 ### Phase 3 – Synchronization Workflow
-- Scripts: `database_sync_scheduler.py`, `enterprise_script_database_synchronizer_complete.py`, `script_database_validator.py`, `database_script_reproducibility_validator.py`, `unified_database_management_system.py`, `cross_database_sync_logger.py` *(to be created)*.
+ - Scripts: `database_sync_scheduler.py`, `enterprise_script_database_synchronizer_complete.py`, `script_database_validator.py`, `database_script_reproducibility_validator.py`, `unified_database_management_system.py`, `cross_database_sync_logger.py`.
 - Sync only `enterprise_assets.db`.
 - Record all sync operations in `cross_database_sync_operations`.
 
 ### Phase 4 – Documentation Cleanup and Ingestion
-- Scripts: `documentation_db_analyzer.py`, `documentation_consolidator.py`, `documentation_ingestor.py` *(to be created)*.
+- Scripts: `documentation_db_analyzer.py`, `documentation_consolidator.py`, `documentation_ingestor.py`.
 - Remove duplicates and unwanted backups.
 - Import Markdown files and README content into `documentation_assets` with hashes and timestamps.
 
 ### Phase 5 – Template and Pattern Ingestion
-- Scripts: `complete_template_generator.py`, `template_asset_ingestor.py` *(to be created)*.
+- Scripts: `complete_template_generator.py`, `template_asset_ingestor.py`.
 - Store template and pattern data in `template_assets` and `pattern_assets` while tracking usage metrics.
 
 ### Phase 6 – Compliance & Validation
-- Scripts: `size_compliance_checker.py` *(to be created)*, `database_consolidation_validator.py`, `database_script_reproducibility_validator.py`.
+- Scripts: `size_compliance_checker.py`, `database_consolidation_validator.py`, `database_script_reproducibility_validator.py`.
 - Verify no database exceeds 99.9 MB; halt if it does.
 - Run reproducibility and consolidation validators.
 
@@ -93,12 +93,6 @@ This document outlines the finalized strategy for merging 40+ SQLite databases i
 - `database_migration_verifier.py`
 
 ### Scripts to Create
-- `unified_database_initializer.py`
-- `unified_database_migration.py`
-- `documentation_ingestor.py`
-- `template_asset_ingestor.py`
-- `size_compliance_checker.py`
-- `cross_database_sync_logger.py`
 - Unit tests covering new utilities
 
 ## 🗂️ Autonomous File Management

--- a/scripts/database/cross_database_sync_logger.py
+++ b/scripts/database/cross_database_sync_logger.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Log cross-database sync operations."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def log_sync_operation(db_path: Path, operation: str) -> None:
+    """Insert a sync operation record into the tracking table."""
+    timestamp = datetime.now(timezone.utc).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO cross_database_sync_operations (operation, timestamp)"
+            " VALUES (?, ?)",
+            (operation, timestamp),
+        )
+        conn.commit()
+    logger.info("Logged sync operation %s at %s", operation, timestamp)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Log a sync operation")
+    parser.add_argument(
+        "--database",
+        default=Path(__file__).resolve().parents[1] / "databases" / "enterprise_assets.db",
+        type=Path,
+        help="Path to enterprise_assets.db",
+    )
+    parser.add_argument(
+        "operation",
+        default="manual_invocation",
+        help="Operation description",
+    )
+
+    args = parser.parse_args()
+    if not args.database.exists():
+        logger.error("Database not found: %s", args.database)
+    else:
+        log_sync_operation(args.database, args.operation)

--- a/scripts/database/documentation_ingestor.py
+++ b/scripts/database/documentation_ingestor.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Ingest Markdown files into documentation_assets table."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from tqdm import tqdm
+
+from .size_compliance_checker import check_database_sizes
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _gather_markdown_files(directory: Path) -> list[Path]:
+    """Return a sorted list of Markdown files under ``directory``."""
+    files = [p for p in directory.rglob("*.md") if p.is_file()]
+    return sorted(files)
+
+
+def ingest_documentation(workspace: Path, docs_dir: Path | None = None) -> None:
+    """Ingest Markdown files into ``enterprise_assets.db``.
+
+    Parameters
+    ----------
+    workspace:
+        The workspace root containing the ``databases`` directory.
+    docs_dir:
+        Optional path to the documentation directory. Defaults to
+        ``workspace / 'documentation'``.
+    """
+    db_dir = workspace / "databases"
+    db_path = db_dir / "enterprise_assets.db"
+    docs_dir = docs_dir or (workspace / "documentation")
+    files = _gather_markdown_files(docs_dir)
+
+    with sqlite3.connect(db_path) as conn, tqdm(total=len(files), desc="Docs", unit="file") as bar:
+        for path in files:
+            content = path.read_text(encoding="utf-8")
+            digest = hashlib.sha256(content.encode()).hexdigest()
+            conn.execute(
+                "INSERT INTO documentation_assets (doc_path, content_hash, created_at) VALUES (?, ?, ?)",
+                (str(path.relative_to(workspace)), digest, datetime.now(timezone.utc).isoformat()),
+            )
+            bar.update(1)
+        conn.commit()
+
+    if not check_database_sizes(db_dir):
+        raise RuntimeError("Database size limit exceeded")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Ingest documentation")
+    parser.add_argument(
+        "--workspace",
+        default=Path(__file__).resolve().parents[1],
+        type=Path,
+        help="Workspace root",
+    )
+    parser.add_argument(
+        "--docs-dir",
+        type=Path,
+        help="Directory containing markdown files",
+    )
+
+    args = parser.parse_args()
+    ingest_documentation(args.workspace, args.docs_dir)

--- a/scripts/database/size_compliance_checker.py
+++ b/scripts/database/size_compliance_checker.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Verify SQLite database sizes do not exceed 99.9 MB."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from tqdm import tqdm
+
+THRESHOLD_MB = 99.9
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def check_database_sizes(directory: Path, threshold_mb: float = THRESHOLD_MB) -> bool:
+    """Return True if all database files are below the size threshold."""
+    db_files = list(directory.glob("*.db"))
+    compliant = True
+    with tqdm(total=len(db_files), desc="Checking sizes", unit="db") as bar:
+        for db_path in db_files:
+            size_mb = db_path.stat().st_size / (1024 * 1024)
+            if size_mb > threshold_mb:
+                logger.error("%s exceeds %.1f MB (%.2f MB)", db_path, threshold_mb, size_mb)
+                compliant = False
+            bar.update(1)
+    return compliant
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Check SQLite database sizes")
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default=Path(__file__).resolve().parents[1] / "databases",
+        type=Path,
+        help="Directory containing databases",
+    )
+
+    args = parser.parse_args()
+
+    if not args.directory.exists():
+        logger.error("Databases directory not found: %s", args.directory)
+        sys.exit(1)
+    if check_database_sizes(args.directory):
+        logger.info("All databases comply with size restrictions")
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/database/template_asset_ingestor.py
+++ b/scripts/database/template_asset_ingestor.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Ingest templates and patterns into enterprise_assets.db."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tqdm import tqdm
+
+from .size_compliance_checker import check_database_sizes
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _gather_template_files(directory: Path) -> list[Path]:
+    """Return a sorted list of Markdown template files under ``directory``."""
+    files = [p for p in directory.rglob("*.md") if p.is_file()]
+    return sorted(files)
+
+
+def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
+    """Load template and pattern data into ``enterprise_assets.db``.
+
+    Parameters
+    ----------
+    workspace:
+        The workspace root containing the ``databases`` directory.
+    template_dir:
+        Optional path to the template directory. Defaults to
+        ``workspace / 'prompts'``.
+    """
+    db_dir = workspace / "databases"
+    db_path = db_dir / "enterprise_assets.db"
+    template_dir = template_dir or (workspace / "prompts")
+    files = _gather_template_files(template_dir)
+
+    with sqlite3.connect(db_path) as conn, tqdm(total=len(files), desc="Templates", unit="file") as bar:
+        for path in files:
+            content = path.read_text(encoding="utf-8")
+            digest = hashlib.sha256(content.encode()).hexdigest()
+            conn.execute(
+                "INSERT INTO template_assets (template_path, content_hash, created_at) VALUES (?, ?, ?)",
+                (str(path.relative_to(workspace)), digest, datetime.now(timezone.utc).isoformat()),
+            )
+            conn.execute(
+                "INSERT INTO pattern_assets (pattern, usage_count, created_at) VALUES (?, 0, ?)",
+                (content[:1000], datetime.now(timezone.utc).isoformat()),
+            )
+            bar.update(1)
+        conn.commit()
+
+    if not check_database_sizes(db_dir):
+        raise RuntimeError("Database size limit exceeded")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Ingest templates")
+    parser.add_argument(
+        "--workspace",
+        default=Path(__file__).resolve().parents[1],
+        type=Path,
+        help="Workspace root",
+    )
+    parser.add_argument(
+        "--templates-dir",
+        type=Path,
+        help="Directory containing template markdown files",
+    )
+
+    args = parser.parse_args()
+    ingest_templates(args.workspace, args.templates_dir)

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Initialize the enterprise_assets.db database."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+from tqdm import tqdm
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+TABLES: dict[str, str] = {
+    "script_assets": (
+        "CREATE TABLE IF NOT EXISTS script_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "script_path TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "documentation_assets": (
+        "CREATE TABLE IF NOT EXISTS documentation_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "doc_path TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "template_assets": (
+        "CREATE TABLE IF NOT EXISTS template_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "template_path TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "pattern_assets": (
+        "CREATE TABLE IF NOT EXISTS pattern_assets ("
+        "id INTEGER PRIMARY KEY,"
+        "pattern TEXT NOT NULL,"
+        "usage_count INTEGER DEFAULT 0,"
+        "created_at TEXT NOT NULL"
+        ")"
+    ),
+    "enterprise_metadata": (
+        "CREATE TABLE IF NOT EXISTS enterprise_metadata ("
+        "id INTEGER PRIMARY KEY,"
+        "key TEXT NOT NULL,"
+        "value TEXT NOT NULL"
+        ")"
+    ),
+    "integration_tracking": (
+        "CREATE TABLE IF NOT EXISTS integration_tracking ("
+        "id INTEGER PRIMARY KEY,"
+        "integration_name TEXT NOT NULL,"
+        "status TEXT NOT NULL,"
+        "last_synced TEXT"
+        ")"
+    ),
+    "cross_database_sync_operations": (
+        "CREATE TABLE IF NOT EXISTS cross_database_sync_operations ("
+        "id INTEGER PRIMARY KEY,"
+        "operation TEXT NOT NULL,"
+        "timestamp TEXT NOT NULL"
+        ")"
+    ),
+}
+
+
+def initialize_database(db_path: Path) -> None:
+    """Create enterprise_assets.db with the expected schema."""
+    logger.info("Initializing %s", db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn, tqdm(
+        total=len(TABLES), desc="Creating tables", unit="table"
+    ) as bar:
+        for sql in TABLES.values():
+            conn.execute(sql)
+            bar.update(1)
+        conn.commit()
+    logger.info("Database initialization complete")
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    db_path = root / "databases" / "enterprise_assets.db"
+    if db_path.exists():
+        logger.info("%s already exists", db_path)
+        return
+    initialize_database(db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/database/unified_database_migration.py
+++ b/scripts/database/unified_database_migration.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Orchestrate migration of assets into enterprise_assets.db."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from tqdm import tqdm
+
+from .cross_database_sync_logger import log_sync_operation
+from .database_consolidation_migration import consolidate_databases
+from .size_compliance_checker import check_database_sizes
+from .unified_database_initializer import initialize_database
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+DEFAULT_SOURCES = [
+    "analytics.db",
+    "documentation.db",
+    "template_completion.db",
+]
+
+
+def run_migration(workspace: Path, sources: list[str] = DEFAULT_SOURCES) -> None:
+    """Migrate the given database ``sources`` into ``enterprise_assets.db``.
+
+    Parameters
+    ----------
+    workspace:
+        Workspace root containing the ``databases`` directory.
+    sources:
+        List of database file names to migrate.
+    """
+    db_dir = workspace / "databases"
+    enterprise_db = db_dir / "enterprise_assets.db"
+    initialize_database(enterprise_db)
+
+    source_paths = [db_dir / name for name in sources if (db_dir / name).exists()]
+
+    with tqdm(total=len(source_paths), desc="Migrating", unit="db") as bar:
+        for src in source_paths:
+            logger.info("Migrating %s", src.name)
+            log_sync_operation(enterprise_db, f"start_migrate_{src.name}")
+            consolidate_databases(enterprise_db, [src])
+            log_sync_operation(enterprise_db, f"completed_migrate_{src.name}")
+            bar.update(1)
+            if not check_database_sizes(db_dir):
+                raise RuntimeError("Database size limit exceeded")
+
+    log_sync_operation(enterprise_db, "migration_complete")
+    logger.info("Migration process completed")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run unified database migration")
+    parser.add_argument(
+        "--workspace",
+        default=Path(__file__).resolve().parents[1],
+        type=Path,
+        help="Workspace root",
+    )
+    parser.add_argument(
+        "sources",
+        nargs="*",
+        default=DEFAULT_SOURCES,
+        help="Database files to migrate",
+    )
+
+    args = parser.parse_args()
+    run_migration(args.workspace, args.sources)

--- a/tests/test_cross_database_sync_logger.py
+++ b/tests/test_cross_database_sync_logger.py
@@ -1,0 +1,16 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.cross_database_sync_logger import log_sync_operation
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def test_log_sync_operation(tmp_path: Path) -> None:
+    db_path = tmp_path / "enterprise_assets.db"
+    initialize_database(db_path)
+    log_sync_operation(db_path, "test_op")
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM cross_database_sync_operations"
+        ).fetchone()[0]
+    assert count == 1

--- a/tests/test_database_sync.py
+++ b/tests/test_database_sync.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python3
 import sqlite3
 
-
-from database_sync_scheduler import synchronize_databases
-import logging
+from scripts.database.database_sync_scheduler import synchronize_databases
+from scripts.database.unified_database_initializer import initialize_database
 
 
 def test_synchronize_databases(tmp_path):
     master = tmp_path / "master.db"
     replica = tmp_path / "replica.db"
+    log_db = tmp_path / "enterprise_assets.db"
+    initialize_database(log_db)
     with sqlite3.connect(master) as conn:
         conn.execute("CREATE TABLE t (id INTEGER)")
         conn.execute("INSERT INTO t (id) VALUES (1)")
-    synchronize_databases(master, [replica])
+    synchronize_databases(master, [replica], log_db=log_db)
     with sqlite3.connect(replica) as conn:
         cur = conn.execute("SELECT COUNT(*) FROM t")
         assert cur.fetchone()[0] == 1
+    with sqlite3.connect(log_db) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM cross_database_sync_operations"
+        ).fetchone()[0]
+    assert count >= 2

--- a/tests/test_documentation_ingestor.py
+++ b/tests/test_documentation_ingestor.py
@@ -1,0 +1,21 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.documentation_ingestor import ingest_documentation
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def test_ingest_documentation(tmp_path: Path) -> None:
+    workspace = tmp_path
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+    db_path = db_dir / "enterprise_assets.db"
+    initialize_database(db_path)
+    docs_dir = workspace / "documentation"
+    docs_dir.mkdir()
+    doc = docs_dir / "guide.md"
+    doc.write_text("# Guide")
+    ingest_documentation(workspace, docs_dir)
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM documentation_assets").fetchone()[0]
+    assert count == 1

--- a/tests/test_template_asset_ingestor.py
+++ b/tests/test_template_asset_ingestor.py
@@ -1,0 +1,23 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.template_asset_ingestor import ingest_templates
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def test_ingest_templates(tmp_path: Path) -> None:
+    workspace = tmp_path
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+    db_path = db_dir / "enterprise_assets.db"
+    initialize_database(db_path)
+    templates_dir = workspace / "prompts"
+    templates_dir.mkdir()
+    temp_file = templates_dir / "sample.md"
+    temp_file.write_text("Sample template")
+    ingest_templates(workspace, templates_dir)
+    with sqlite3.connect(db_path) as conn:
+        t_count = conn.execute("SELECT COUNT(*) FROM template_assets").fetchone()[0]
+        p_count = conn.execute("SELECT COUNT(*) FROM pattern_assets").fetchone()[0]
+    assert t_count == 1
+    assert p_count == 1

--- a/tests/test_unified_database_initializer.py
+++ b/tests/test_unified_database_initializer.py
@@ -1,0 +1,26 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def test_initializer_creates_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "enterprise_assets.db"
+    initialize_database(db_path)
+    with sqlite3.connect(db_path) as conn:
+        tables = set(
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        )
+    expected = {
+        "script_assets",
+        "documentation_assets",
+        "template_assets",
+        "pattern_assets",
+        "enterprise_metadata",
+        "integration_tracking",
+        "cross_database_sync_operations",
+    }
+    assert expected.issubset(tables)

--- a/tests/test_unified_database_migration.py
+++ b/tests/test_unified_database_migration.py
@@ -1,0 +1,17 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.unified_database_migration import run_migration
+
+
+def test_run_migration_creates_db(tmp_path: Path) -> None:
+    databases = tmp_path / "databases"
+    databases.mkdir()
+    run_migration(tmp_path, sources=[])
+    db_path = databases / "enterprise_assets.db"
+    assert db_path.exists()
+    with sqlite3.connect(db_path) as conn:
+        tables = [row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )]
+    assert "cross_database_sync_operations" in tables


### PR DESCRIPTION
## Summary
- integrate cross-database logger into `database_sync_scheduler`
- expose CLI options for workspace and logging database
- test scheduler logging behavior

## Testing
- `pytest tests/test_documentation_ingestor.py tests/test_template_asset_ingestor.py tests/test_cross_database_sync_logger.py tests/test_unified_database_initializer.py tests/test_unified_database_migration.py tests/test_database_sync.py -q`
- `python scripts/generate_docs_metrics.py` *(fails: no such table)*
- `python scripts/validate_docs_metrics.py` *(fails: no such table)*
- `make test` *(fails: requirements-test.txt missing)*

------
https://chatgpt.com/codex/tasks/task_e_68795176830c8331a211d8e5fb234546