### PR TITLE
Fix flake8 violations in maintenance scripts

### DIFF
--- a/scripts/database/maintenance_scheduler.py
+++ b/scripts/database/maintenance_scheduler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import signal
 import time
 from pathlib import Path
 
@@ -16,6 +17,8 @@ logger = logging.getLogger(__name__)
 def configure_logging():
     """Configure logging for the script."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+
 def _load_database_names(list_file: Path) -> list[str]:
     """Return database names listed in the markdown file."""
     names: list[str] = []

--- a/scripts/documentation_consolidator.py
+++ b/scripts/documentation_consolidator.py
@@ -9,7 +9,6 @@ import sqlite3
 import uuid
 from pathlib import Path
 from typing import Iterable, Tuple
-import logging
 
 CLEANUP_SQL = (
     "DELETE FROM enterprise_documentation "


### PR DESCRIPTION
## Summary
- add missing `signal` import and correct spacing in maintenance scheduler
- remove unused logging import from documentation consolidator

## Testing
- `flake8 scripts/database/maintenance_scheduler.py scripts/documentation_consolidator.py`
- `make test` *(fails: ModuleNotFoundError: No module named 'autonomous_database_health_optimizer')*

------
https://chatgpt.com/codex/tasks/task_e_6879bfab1bf88331a3519579deec469b