### PR TITLE
Link requirements in repo root

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+logs/requirements.txt


### PR DESCRIPTION
## Summary
- symlink logs/requirements.txt to repo root as requirements.txt for Dockerfile and docs

## Testing
- `make test` *(fails: ModuleNotFoundError)*
- `pip install -r logs/requirements-test.txt`
- `pytest tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6879ded66600833182f6d1ee50d98704