### PR TITLE
Add db path option for docs metrics scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Consult [`docs/INSTRUCTION_INDEX.md`](docs/INSTRUCTION_INDEX.md) for all availab
 - Do **not** modify version‑controlled SQLite databases.
 - Add or update unit tests when modifying code and run `make test`.
 - Keep commit messages short and imperative.
-- Track documentation metrics with `scripts/generate_docs_metrics.py` and verify via `scripts/validate_docs_metrics.py`.
+- Track documentation metrics with `scripts/generate_docs_metrics.py` and verify via `scripts/validate_docs_metrics.py`. Both scripts accept `--db-path` for specifying an alternate database.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,15 +7,16 @@ This folder contains helper documentation for keeping repository metrics in sync
 Run `python scripts/generate_docs_metrics.py` to refresh metrics in the main
 `README.md` and under `documentation/generated/`. The script queries
 `production.db` for the current number of tracked scripts and templates and counts
-database entries from `documentation/DATABASE_LIST.md`.
+database entries from `documentation/DATABASE_LIST.md`. Use the
+`--db-path` option to specify an alternate database file if needed.
 
 ## Validation
 
 After updating documentation, execute
 `python scripts/validate_docs_metrics.py`. The validator compares the numbers in
 `README.md`, `documentation/generated/README.md`, and the technical whitepaper
-against the real database values. The command exits with an error if any values
-are inconsistent.
+against the real database values. Pass `--db-path` to override the database
+location. The command exits with an error if any values are inconsistent.
 
 This workflow ensures that documentation statistics accurately reflect the
 contents of the production database.

--- a/scripts/validate_docs_metrics.py
+++ b/scripts/validate_docs_metrics.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
+import argparse
 import re
 import sqlite3
 import sys
 from pathlib import Path
-import logging
 
 ROOT = Path(__file__).resolve().parents[1]
 DB_PATH = ROOT / "production.db"
@@ -63,9 +63,9 @@ def parse_template_metric(path: Path) -> int | None:
     return None
 
 
-def validate() -> bool:
+def validate(db_path: Path = DB_PATH) -> bool:
     """Validate metrics across documentation."""
-    db_metrics = get_db_metrics(DB_PATH)
+    db_metrics = get_db_metrics(db_path)
     readme_metrics = parse_readme(README_PATH)
     generated_metrics = parse_readme(GENERATED_README)
     whitepaper_templates = parse_template_metric(WHITEPAPER_PATH)
@@ -88,9 +88,9 @@ def validate() -> bool:
 
     if whitepaper_templates is not None and whitepaper_templates != db_metrics["templates"]:
         print(
-        f"Mismatch in whitepaper templates: {whitepaper_templates} vs {db_metrics['templates']}",
-        file=sys.stderr,
-    )
+            f"Mismatch in whitepaper templates: {whitepaper_templates} vs {db_metrics['templates']}",
+            file=sys.stderr,
+        )
         success = False
 
     if success:
@@ -99,4 +99,14 @@ def validate() -> bool:
 
 
 if __name__ == "__main__":
-    sys.exit(0 if validate() else 1)
+    parser = argparse.ArgumentParser(
+        description="Validate documentation metrics against the database."
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=DB_PATH,
+        help="Path to the production database",
+    )
+    args = parser.parse_args()
+    sys.exit(0 if validate(args.db_path) else 1)

--- a/tests/test_docs_metrics.py
+++ b/tests/test_docs_metrics.py
@@ -1,0 +1,38 @@
+import sqlite3
+from pathlib import Path
+
+from scripts import generate_docs_metrics, validate_docs_metrics
+
+
+def _setup_db(path: Path) -> Path:
+    db = path / "test.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE enterprise_script_tracking(id INTEGER)")
+        conn.execute("CREATE TABLE script_template_patterns(id INTEGER)")
+        conn.executemany(
+            "INSERT INTO enterprise_script_tracking(id) VALUES (?)",
+            [(1,), (2,)],
+        )
+        conn.executemany(
+            "INSERT INTO script_template_patterns(id) VALUES (?)",
+            [(1,), (2,), (3,)],
+        )
+    return db
+
+
+def test_generate_get_metrics(tmp_path, monkeypatch):
+    db_path = _setup_db(tmp_path)
+    db_list = tmp_path / "DATABASE_LIST.md"
+    db_list.write_text("- a.db\n- b.db\n")
+    monkeypatch.setattr(generate_docs_metrics, "DATABASE_LIST", db_list)
+    metrics = generate_docs_metrics.get_metrics(db_path)
+    assert metrics == {"scripts": 2, "templates": 3, "databases": 2}
+
+
+def test_validate_get_db_metrics(tmp_path, monkeypatch):
+    db_path = _setup_db(tmp_path)
+    db_list = tmp_path / "DATABASE_LIST.md"
+    db_list.write_text("- c.db\n")
+    monkeypatch.setattr(validate_docs_metrics, "DATABASE_LIST", db_list)
+    metrics = validate_docs_metrics.get_db_metrics(db_path)
+    assert metrics == {"scripts": 2, "templates": 3, "databases": 1}


### PR DESCRIPTION
## Summary
- allow overriding production database path when generating or validating metrics
- document new `--db-path` option
- cover database metrics helpers with tests

## Testing
- `make test` *(fails: 42 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6879f560b07083319f76381172956ad0