### PR TITLE
Use archives for doc DB

### DIFF
--- a/tests/test_documentation_consolidator.py
+++ b/tests/test_documentation_consolidator.py
@@ -43,10 +43,11 @@ def test_documentation_consolidator(tmp_path, monkeypatch):
     doc_dir = workspace / "documentation"
     db_dir.mkdir()
     doc_dir.mkdir()
-    _prepare_db(repo_root / "databases" / "documentation.db", db_dir / "documentation.db")
+    _prepare_db(repo_root / "archives" / "documentation.db", db_dir / "documentation.db")
     shutil.copy(repo_root / "documentation" / "README.md", doc_dir / "README.md")
 
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("DOCUMENTATION_DB_PATH", str(db_dir / "documentation.db"))
     consolidate()
 
     with sqlite3.connect(db_dir / "documentation.db") as conn:


### PR DESCRIPTION
## Summary
- allow overriding documentation database path through `DOCUMENTATION_DB_PATH`
- default to `archives/documentation.db` and validate database exists
- update unit test for the new configuration

## Testing
- `make test` *(fails: ModuleNotFoundError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6879f54fefe0833192fef11b422c7a20