### PR TITLE
Fix enterprise_assets description

### DIFF
--- a/documentation/CONSOLIDATED_DATABASE_LIST.md
+++ b/documentation/CONSOLIDATED_DATABASE_LIST.md
@@ -2,7 +2,7 @@
 
 ## Active Enterprise Databases
 
-- enterprise_assets.db
+- enterprise_assets.db  # Limit: 99.9 MB
 - archive.db  # Size: 2.57 MB
 - development.db  # Size: 2.57 MB
 - staging.db  # Size: 22.98 MB


### PR DESCRIPTION
## Summary
- note the 99.9 MB limit for `enterprise_assets.db`

## Testing
- `python scripts/generate_docs_metrics.py --db-path deployment/deployment_package_20250710_182951/databases/production.db`
- `python scripts/validate_docs_metrics.py --db-path deployment/deployment_package_20250710_182951/databases/production.db` *(fails: COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md missing)*
- `make test` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_687a0377c2b483318b4a1ea45278892d