### PR TITLE
Fix logging config in DB modules

### DIFF
--- a/scripts/database/cross_database_sync_logger.py
+++ b/scripts/database/cross_database_sync_logger.py
@@ -8,12 +8,10 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
+from utils.logging_utils import setup_enterprise_logging
+
 from .unified_database_initializer import initialize_database
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 
@@ -64,4 +62,5 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    setup_enterprise_logging()
     log_sync_operation(args.database, args.operation)

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -9,10 +9,8 @@ from pathlib import Path
 
 from tqdm import tqdm
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
+from utils.logging_utils import setup_enterprise_logging
+
 logger = logging.getLogger(__name__)
 
 TABLES: dict[str, str] = {
@@ -97,4 +95,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    setup_enterprise_logging()
     main()


### PR DESCRIPTION
## Summary
- remove logging.basicConfig from modules that may be imported
- configure logging inside `__main__` using `setup_enterprise_logging`

## Testing
- `make test` *(fails: qiskit not installed)*
- `python -m py_compile scripts/database/cross_database_sync_logger.py scripts/database/unified_database_initializer.py`

------
https://chatgpt.com/codex/tasks/task_e_687a03874a888331877e328be9999b74