### PR TITLE
Add compression step to migration

### DIFF
--- a/tests/test_compress_database.py
+++ b/tests/test_compress_database.py
@@ -1,0 +1,17 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.unified_database_migration import _compress_database
+
+
+def test_compress_database_reduces_size(tmp_path: Path) -> None:
+    db = tmp_path / "sample.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE t (data TEXT)")
+        for _ in range(1000):
+            conn.execute("INSERT INTO t (data) VALUES (?)", ("x" * 100,))
+        conn.commit()
+
+    original_size = db.stat().st_size
+    _compress_database(db)
+    assert db.stat().st_size <= original_size


### PR DESCRIPTION
## Summary
- compress source and target databases before and after consolidation
- add unit test for compression helper

## Testing
- `make test` *(fails: 17 errors during collection)*
- `python scripts/generate_docs_metrics.py --db-path databases/production.db` *(fails: no such table)*
- `python scripts/validate_docs_metrics.py --db-path databases/production.db` *(fails: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_687a03d88a9c8331a603639f9f894163