### PR TITLE
Clean wrapper imports in tests

### DIFF
--- a/tests/test_autonomous_database_health_optimizer.py
+++ b/tests/test_autonomous_database_health_optimizer.py
@@ -15,7 +15,8 @@ import os
 # Add the project root to Python path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from autonomous_database_health_optimizer import AutonomousDatabaseHealthOptimizer
+from scripts.automation.autonomous_database_health_optimizer import \
+    AutonomousDatabaseHealthOptimizer
 
 
 class TestAutonomousDatabaseHealthOptimizer:
@@ -99,7 +100,7 @@ class TestAutonomousDatabaseHealthOptimizer:
     def test_tqdm_import_handling(self):
         """Test that tqdm import is handled gracefully"""
         # Test that tqdm can be imported from the module
-        from autonomous_database_health_optimizer import tqdm
+        from scripts.automation.autonomous_database_health_optimizer import tqdm
         
         # Test fallback implementation if real tqdm is not available
         # Create a test instance
@@ -145,7 +146,8 @@ class TestAutonomousDatabaseHealthOptimizer:
     
     def test_strategy_selection(self, optimizer):
         """Test optimal strategy selection"""
-        from autonomous_database_health_optimizer import DatabaseHealthMetrics
+        from scripts.automation.autonomous_database_health_optimizer import \
+            DatabaseHealthMetrics
         from datetime import datetime
         
         # Create test health metrics with integrity issues

--- a/tests/test_complete_template_generator.py
+++ b/tests/test_complete_template_generator.py
@@ -2,7 +2,7 @@
 import sqlite3
 from pathlib import Path
 
-from complete_template_generator import CompleteTemplateGenerator
+from scripts.utilities.complete_template_generator import CompleteTemplateGenerator
 import logging
 
 

--- a/tests/test_correction_history.py
+++ b/tests/test_correction_history.py
@@ -4,7 +4,7 @@ import shutil
 import sqlite3
 from pathlib import Path
 
-from database_first_windows_compatible_flake8_corrector import (
+from scripts.database.database_first_windows_compatible_flake8_corrector import (
     CorrectionPattern, DatabaseFirstFlake8Corrector, FlakeViolation)
 
 

--- a/tests/test_database_consolidation_migration.py
+++ b/tests/test_database_consolidation_migration.py
@@ -3,7 +3,7 @@ import logging
 import sqlite3
 from pathlib import Path
 
-from database_consolidation_migration import consolidate_databases
+from scripts.database.database_consolidation_migration import consolidate_databases
 
 
 def benchmark_queries(queries, db_path=None):

--- a/tests/test_database_driven_flake8_corrector_functional.py
+++ b/tests/test_database_driven_flake8_corrector_functional.py
@@ -2,7 +2,7 @@
 import logging
 import sqlite3
 
-from database_driven_flake8_corrector_functional import \
+from scripts.database.database_driven_flake8_corrector_functional import \
     DatabaseDrivenFlake8CorrectorFunctional
 
 

--- a/tests/test_database_driven_flake8_validator_new.py
+++ b/tests/test_database_driven_flake8_validator_new.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import pytest
-import database_driven_flake8_corrector_functional as mod
-from database_driven_flake8_corrector_functional import DatabaseDrivenFlake8CorrectorFunctional
+import scripts.database.database_driven_flake8_corrector_functional as mod
+from scripts.database.database_driven_flake8_corrector_functional import DatabaseDrivenFlake8CorrectorFunctional
 from pathlib import PureWindowsPath
 import logging
 

--- a/tests/test_database_list.py
+++ b/tests/test_database_list.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from pathlib import Path
 
-from unified_database_management_system import UnifiedDatabaseManager
+from scripts.database.unified_database_management_system import UnifiedDatabaseManager
 import logging
 
 

--- a/tests/test_expanded_quantum_algorithm_library.py
+++ b/tests/test_expanded_quantum_algorithm_library.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from expanded_quantum_algorithm_library import EnterpriseUtility
+from scripts.utilities.expanded_quantum_algorithm_library import EnterpriseUtility
 import logging
 
 

--- a/tests/test_flake8_corrector.py
+++ b/tests/test_flake8_corrector.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from database_first_windows_compatible_flake8_corrector import \
+from scripts.database.database_first_windows_compatible_flake8_corrector import \
     DatabaseFirstFlake8Corrector
 
 

--- a/tests/test_generate_completion_report.py
+++ b/tests/test_generate_completion_report.py
@@ -3,7 +3,7 @@ import logging
 import sqlite3
 from datetime import datetime, timedelta
 
-from database_first_windows_compatible_flake8_corrector import \
+from scripts.database.database_first_windows_compatible_flake8_corrector import \
     DatabaseFirstFlake8Corrector
 
 

--- a/tests/test_monitoring_optimization_system.py
+++ b/tests/test_monitoring_optimization_system.py
@@ -3,7 +3,7 @@ import shutil
 import sqlite3
 from pathlib import Path
 
-from unified_monitoring_optimization_system import EnterpriseUtility
+from archive.consolidated_scripts.unified_monitoring_optimization_system import EnterpriseUtility
 import logging
 
 

--- a/tests/test_performance_validation_complete.py
+++ b/tests/test_performance_validation_complete.py
@@ -4,7 +4,7 @@ import sqlite3
 import time
 
 
-from performance_validation_complete import benchmark
+from scripts.validation.performance_validation_complete import benchmark
 
 
 def test_benchmark_runs():
@@ -19,23 +19,23 @@ def test_metrics_are_stored(tmp_path, monkeypatch):
     db_file = tmp_path / "bench.db"
 
     monkeypatch.setattr(
-        "performance_validation_complete.run_grover_search",
+        "scripts.validation.performance_validation_complete.run_grover_search",
         lambda *a, **k: time.sleep(0.01),
     )
     monkeypatch.setattr(
-        "performance_validation_complete.run_kmeans_clustering",
+        "scripts.validation.performance_validation_complete.run_kmeans_clustering",
         lambda *a, **k: time.sleep(0.01),
     )
     monkeypatch.setattr(
-        "performance_validation_complete.run_simple_qnn",
+        "scripts.validation.performance_validation_complete.run_simple_qnn",
         lambda *a, **k: time.sleep(0.01),
     )
     monkeypatch.setattr(
-        "performance_validation_complete.TemplateSynthesisEngine.synthesize_templates",
+        "scripts.validation.performance_validation_complete.TemplateSynthesisEngine.synthesize_templates",
         lambda self: None,
     )
     monkeypatch.setattr(
-        "performance_validation_complete.DatabaseD \
+        "scripts.validation.performance_validation_complete.DatabaseD \
             rivenFlake8CorrectorFunctional.execute_correction",
         lambda self: True,
     )
@@ -53,23 +53,23 @@ def test_regression_warning(tmp_path, monkeypatch, caplog):
 
     # baseline run
     monkeypatch.setattr(
-        "performance_validation_complete.run_grover_search",
+        "scripts.validation.performance_validation_complete.run_grover_search",
         lambda *a, **k: time.sleep(0.01),
     )
     monkeypatch.setattr(
-        "performance_validation_complete.run_kmeans_clustering",
+        "scripts.validation.performance_validation_complete.run_kmeans_clustering",
         lambda *a, **k: time.sleep(0.01),
     )
     monkeypatch.setattr(
-        "performance_validation_complete.run_simple_qnn",
+        "scripts.validation.performance_validation_complete.run_simple_qnn",
         lambda *a, **k: time.sleep(0.01),
     )
     monkeypatch.setattr(
-        "performance_validation_complete.TemplateSynthesisEngine.synthesize_templates",
+        "scripts.validation.performance_validation_complete.TemplateSynthesisEngine.synthesize_templates",
         lambda self: None,
     )
     monkeypatch.setattr(
-        "performance_validation_complete.DatabaseD \
+        "scripts.validation.performance_validation_complete.DatabaseD \
             rivenFlake8CorrectorFunctional.execute_correction",
         lambda self: True,
     )
@@ -78,15 +78,15 @@ def test_regression_warning(tmp_path, monkeypatch, caplog):
 
     # slower second run to trigger regression
     monkeypatch.setattr(
-        "performance_validation_complete.run_grover_search",
+        "scripts.validation.performance_validation_complete.run_grover_search",
         lambda *a, **k: time.sleep(0.02),
     )
     monkeypatch.setattr(
-        "performance_validation_complete.run_kmeans_clustering",
+        "scripts.validation.performance_validation_complete.run_kmeans_clustering",
         lambda *a, **k: time.sleep(0.02),
     )
     monkeypatch.setattr(
-        "performance_validation_complete.run_simple_qnn",
+        "scripts.validation.performance_validation_complete.run_simple_qnn",
         lambda *a, **k: time.sleep(0.02),
     )
 

--- a/tests/test_performance_validation_framework.py
+++ b/tests/test_performance_validation_framework.py
@@ -4,7 +4,7 @@ import sqlite3
 import time
 from pathlib import Path
 
-from performance_validation_framework import PerformanceValidationFramework
+from scripts.validation.performance_validation_framework import PerformanceValidationFramework
 
 
 def _patch_algorithms(monkeypatch, delay: float) -> None:
@@ -13,30 +13,30 @@ def _patch_algorithms(monkeypatch, delay: float) -> None:
         return {}
 
     monkeypatch.setattr(
-        'performance_validation_framework.run_grover_search', _sleep
+        'scripts.validation.performance_validation_framework.run_grover_search', _sleep
     )
     monkeypatch.setattr(
-        'performance_validation_framework.run_kmeans_clustering', _sleep
+        'scripts.validation.performance_validation_framework.run_kmeans_clustering', _sleep
     )
     monkeypatch.setattr(
-        'performance_validation_framework.run_simple_qnn', _sleep
+        'scripts.validation.performance_validation_framework.run_simple_qnn', _sleep
     )
     monkeypatch.setattr(
-        'performance_validation_framework.TemplateSynthesisEngine.synthesize_templates',
+        'scripts.validation.performance_validation_framework.TemplateSynthesisEngine.synthesize_templates',
         lambda self: ["tmpl"] * 5
     )
     monkeypatch.setattr(
-        'performance_validation_framework.Database \
+        'scripts.validation.performance_validation_framework.Database \
             DrivenFlake8CorrectorFunctional.scan_python_files',
         lambda self: [Path("a.py")] * 5
     )
     monkeypatch.setattr(
-        'performance_validation_framework.DatabaseD \
+        'scripts.validation.performance_validation_framework.DatabaseD \
             rivenFlake8CorrectorFunctional.execute_correction',
         lambda self: True
     )
     monkeypatch.setattr(
-        'performance_validation_framework.SecondaryCopilotValidator.validate_corrections',
+        'scripts.validation.performance_validation_framework.SecondaryCopilotValidator.validate_corrections',
         lambda self, files: True
     )
 

--- a/tests/test_physics_engine.py
+++ b/tests/test_physics_engine.py
@@ -8,12 +8,12 @@ from qiskit import QuantumCircuit
 try:
     from qiskit.algorithms import Shor
 except Exception:  # pragma: no cover - use local fallback
-    from physics_optimization_engine import Shor  # type: ignore
+    from scripts.optimization.physics_optimization_engine import Shor  # type: ignore
 from qiskit.circuit.library import QFT
 from qiskit.quantum_info import Statevector
 from qiskit_aer import AerSimulator
 
-from physics_optimization_engine import PhysicsOptimizationEngine
+from scripts.optimization.physics_optimization_engine import PhysicsOptimizationEngine
 import numpy as np
 import logging
 

--- a/tests/test_quantum_algorithm_library_expansion.py
+++ b/tests/test_quantum_algorithm_library_expansion.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from quantum_algorithm_library_expansion import EnterpriseUtility
+from scripts.utilities.quantum_algorithm_library_expansion import EnterpriseUtility
 import logging
 
 

--- a/tests/test_quantum_algorithms_functional.py
+++ b/tests/test_quantum_algorithms_functional.py
@@ -2,9 +2,11 @@
 
 import logging
 
-from quantum_algorithms_functional import (run_grover_search,
-                                           run_kmeans_clustering,
-                                           run_simple_qnn)
+from scripts.utilities.quantum_algorithms_functional import (
+    run_grover_search,
+    run_kmeans_clustering,
+    run_simple_qnn,
+)
 
 
 def test_run_grover_search_find_index():

--- a/tests/test_quantum_clustering.py
+++ b/tests/test_quantum_clustering.py
@@ -5,7 +5,7 @@ import pytest
 
 pytest.importorskip("qiskit_machine_learning")
 
-from quantum_clustering_file_organization import EnterpriseUtility
+from scripts.utilities.quantum_clustering_file_organization import EnterpriseUtility
 # isort: on
 
 logging.getLogger().setLevel(logging.CRITICAL)

--- a/tests/test_quantum_clustering_file_organization.py
+++ b/tests/test_quantum_clustering_file_organization.py
@@ -2,7 +2,7 @@
 import logging
 import os
 
-from quantum_clustering_file_organization import EnterpriseUtility
+from scripts.utilities.quantum_clustering_file_organization import EnterpriseUtility
 
 
 def test_quantum_clustering(tmp_path, caplog):

--- a/tests/test_quantum_performance_integration_tester.py
+++ b/tests/test_quantum_performance_integration_tester.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from quantum_performance_integration_tester import EnterpriseUtility
+from archive.consolidated_scripts.quantum_performance_integration_tester import EnterpriseUtility
 import logging
 
 

--- a/tests/test_quantum_predictive_maintenance.py
+++ b/tests/test_quantum_predictive_maintenance.py
@@ -6,7 +6,7 @@ import pytest
 pytest.importorskip("qiskit_machine_learning")
 
 try:
-    from quantum_neural_networks_predictive_maintenance import (
+    from scripts.utilities.quantum_neural_networks_predictive_maintenance import (
         EnterpriseUtility,
         EstimatorQNN as ModuleEstimatorQNN,
     )

--- a/tests/test_qubo_integration.py
+++ b/tests/test_qubo_integration.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import logging
 
-from quantum_integration_orchestrator import integrate_qubo_problems
+from scripts.automation.quantum_integration_orchestrator import integrate_qubo_problems
 
 logging.getLogger().setLevel(logging.CRITICAL)
 

--- a/tests/test_qubo_solver.py
+++ b/tests/test_qubo_solver.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import logging
 
-from advanced_qubo_optimization import solve_qubo_bruteforce
+from scripts.optimization.advanced_qubo_optimization import solve_qubo_bruteforce
 
 logging.getLogger().setLevel(logging.CRITICAL)
 

--- a/tests/test_session_management_consolidation_executor.py
+++ b/tests/test_session_management_consolidation_executor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from session_management_consolidation_executor import EnterpriseUtility
+from archive.consolidated_scripts.session_management_consolidation_executor import EnterpriseUtility
 import logging
 
 

--- a/tests/test_session_protocol_validator.py
+++ b/tests/test_session_protocol_validator.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 
-from session_protocol_validator import SessionProtocolValidator
-from unified_session_management_system import UnifiedSessionManagementSystem
+from validation.protocols.session import SessionProtocolValidator
+from scripts.utilities.unified_session_management_system import UnifiedSessionManagementSystem
 import logging
 
 

--- a/tests/test_simplified_quantum_integration_orchestrator.py
+++ b/tests/test_simplified_quantum_integration_orchestrator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from simplified_quantum_integration_orchestrator import EnterpriseUtility
+from archive.consolidated_scripts.simplified_quantum_integration_orchestrator import EnterpriseUtility
 import logging
 
 

--- a/tests/test_template_auto_generation_complete.py
+++ b/tests/test_template_auto_generation_complete.py
@@ -3,7 +3,7 @@ import logging
 import sqlite3
 from pathlib import Path
 
-from template_auto_generation_complete import TemplateSynthesisEngine
+from scripts.automation.template_auto_generation_complete import TemplateSynthesisEngine
 
 
 def create_dbs(tmp_path: Path):

--- a/tests/test_unified_script_generation_system.py
+++ b/tests/test_unified_script_generation_system.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 import shutil
 
-from unified_script_generation_system import EnterpriseUtility
+from scripts.utilities.unified_script_generation_system import EnterpriseUtility
 import logging
 
 

--- a/tests/test_workspace_from_env.py
+++ b/tests/test_workspace_from_env.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from database_purification_engine import DatabasePurificationEngine
+from scripts.database.database_purification_engine import DatabasePurificationEngine
 
 
 def test_engine_uses_env_var(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- update tests to import directly from original modules instead of wrapper modules

## Testing
- `make test` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687a0385145083318c6c227623fa3909