### PR TITLE
Add py7zr dependency and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **32 Synchronized Databases:** Production.db, Analytics.db, Monitoring.db
 - **Flask Enterprise Dashboard:** 7 endpoints, 5 responsive templates
 - **Template Intelligence Platform:** 16,500+ tracked scripts, 89 placeholders
-- **Script Validation**: 2 scripts synchronized (100% coverage)
+- **Script Validation**: 1,679 scripts synchronized (100% coverage)
 - **Self-Healing Systems:** Autonomous correction and optimization
 - **Continuous Operation Mode:** 24/7 monitoring and intelligence gathering
 
@@ -49,7 +49,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - Python 3.8+
 - PowerShell (for Windows automation)
 - SQLite3
-- Required packages: `pip install -r requirements.txt`
+- Required packages: `pip install -r requirements.txt` (includes `py7zr` for 7z archive support)
 
 ### **Installation & Setup**
 ```bash

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -689,7 +689,7 @@ def health_check():
     return jsonify(get_comprehensive_health_status())
 ```
 
-#### **HTML Template Architecture (5 Templates - 100% Coverage)**
+#### **HTML Template Architecture (4 Templates - 100% Coverage)**
 
 **1. dashboard.html - Executive Dashboard**
 ```html

--- a/documentation/generated/README.md
+++ b/documentation/generated/README.md
@@ -1,7 +1,7 @@
 # 🏢 gh_COPILOT Toolkit v4.0 Enterprise Documentation Hub
 ## Database-Driven Documentation Management System
 
-*Generated from Enterprise Documentation Database on 2025-07-11 17:28:18*
+*Generated from Enterprise Documentation Database on 2025-07-18 09:01:16*
 
 ### 🎯 **SYSTEM OVERVIEW**
 

--- a/documentation/generated/SYSTEM_STATUS.md
+++ b/documentation/generated/SYSTEM_STATUS.md
@@ -1,7 +1,7 @@
 # 📊 SYSTEM STATUS REPORT
 ## Enterprise System Health & Performance
 
-*Generated on 2025-07-11 17:28:18*
+*Generated on 2025-07-18 09:01:16*
 
 ### 🎯 **OVERALL SYSTEM STATUS: ✅ OPERATIONAL**
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest
+py7zr

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ boto3==1.39.3  # Omit if not actually imported/used
 qiskit-aer==0.17.1  # Omit if not imported
 
 # --- Any other verified code dependencies can go here ---
+py7zr
 
 # ===========================
 # End of requirements


### PR DESCRIPTION
## Summary
- add `py7zr` to main and test requirements
- document the new dependency in the quick start guide
- sync documentation metrics
- fix whitepaper metrics to match database

## Testing
- `python scripts/validate_docs_metrics.py --db-path deployment/deployment_package_20250710_182951/databases/production.db`
- `make test` *(fails: ModuleNotFoundError: No module named 'template_engine')*

------
https://chatgpt.com/codex/tasks/task_e_687a0bc752248331905a218ab547f82c