### PR TITLE
Fix test imports

### DIFF
--- a/tests/test_monitoring_optimization_system.py
+++ b/tests/test_monitoring_optimization_system.py
@@ -3,7 +3,7 @@ import shutil
 import sqlite3
 from pathlib import Path
 
-from archive.consolidated_scripts.unified_monitoring_optimization_system import EnterpriseUtility
+from unified_monitoring_optimization_system import EnterpriseUtility
 import logging
 
 

--- a/tests/test_quantum_performance_integration_tester.py
+++ b/tests/test_quantum_performance_integration_tester.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from archive.consolidated_scripts.quantum_performance_integration_tester import EnterpriseUtility
+from quantum_performance_integration_tester import EnterpriseUtility
 import logging
 
 

--- a/tests/test_session_management_consolidation_executor.py
+++ b/tests/test_session_management_consolidation_executor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from archive.consolidated_scripts.session_management_consolidation_executor import EnterpriseUtility
+from session_management_consolidation_executor import EnterpriseUtility
 import logging
 
 

--- a/tests/test_simplified_quantum_integration_orchestrator.py
+++ b/tests/test_simplified_quantum_integration_orchestrator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from archive.consolidated_scripts.simplified_quantum_integration_orchestrator import EnterpriseUtility
+from simplified_quantum_integration_orchestrator import EnterpriseUtility
 import logging
 
 


### PR DESCRIPTION
## Summary
- update validation tests to import wrappers

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_687a9031f18483318a6a85427aee66fe