### PR TITLE
Implement database table helper

### DIFF
--- a/scripts/database/documentation_ingestor.py
+++ b/scripts/database/documentation_ingestor.py
@@ -13,9 +13,8 @@ from tqdm import tqdm
 
 from .size_compliance_checker import check_database_sizes
 from .unified_database_initializer import initialize_database
-
-
 from .utils import _table_exists
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 

--- a/scripts/database/utils.py
+++ b/scripts/database/utils.py
@@ -1,0 +1,15 @@
+"""Helper utilities for database operations."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    """Return ``True`` if ``table`` exists in the given connection."""
+    result = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    return result is not None
+


### PR DESCRIPTION
## Summary
- add `_table_exists` helper in `scripts/database/utils.py`
- use the new helper in `documentation_ingestor`

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'secondary_copilot_validator', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687a90c741d083319eccf48c0fa1fb4c