### PR TITLE
Add init for scripts.database

### DIFF
--- a/scripts/database/__init__.py
+++ b/scripts/database/__init__.py
@@ -1,0 +1,5 @@
+"""Database utilities package for the gh_COPILOT toolkit."""
+
+__version__ = "1.0.0"
+
+__all__ = []


### PR DESCRIPTION
## Summary
- make `scripts/database` a proper Python package

## Testing
- `scripts/generate_docs_metrics.py --db-path deployment/deployment_package_20250710_182951/databases/production.db`
- `scripts/validate_docs_metrics.py --db-path deployment/deployment_package_20250710_182951/databases/production.db`
- `make test` *(fails: ModuleNotFoundError: No module named 'template_engine')*

------
https://chatgpt.com/codex/tasks/task_e_687a90c97ed0833181a3d515019488ab