### PR TITLE
Add progress logging to sync logger

### DIFF
--- a/scripts/database/cross_database_sync_logger.py
+++ b/scripts/database/cross_database_sync_logger.py
@@ -8,11 +8,21 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
+from tqdm import tqdm
+
 from utils.logging_utils import setup_enterprise_logging
 
 from .unified_database_initializer import initialize_database
 
 logger = logging.getLogger(__name__)
+
+# Text-based indicators for consistent log output
+TEXT_INDICATORS = {
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "progress": "[PROGRESS]",
+}
 
 
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
@@ -25,24 +35,49 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
 
 
 def log_sync_operation(db_path: Path, operation: str) -> None:
-    """Insert a sync operation record into the tracking table."""
-    if not db_path.exists():
-        initialize_database(db_path)
+    """Insert a sync operation record into the tracking table with progress."""
 
-    timestamp = datetime.now(timezone.utc).isoformat()
-    with sqlite3.connect(db_path) as conn:
-        if not _table_exists(conn, "cross_database_sync_operations"):
-            conn.close()
+    start_dt = datetime.now(timezone.utc)
+    logger.info(
+        "%s Logging sync operation %s at %s",
+        TEXT_INDICATORS["start"],
+        operation,
+        start_dt.isoformat(),
+    )
+
+    with tqdm(
+        total=3,
+        desc=f"{TEXT_INDICATORS['progress']} log_sync",
+        unit="step",
+        bar_format="{l_bar}{bar}| {n}/{total} {unit} [{elapsed}<{remaining}]",
+    ) as bar:
+        if not db_path.exists():
             initialize_database(db_path)
-            conn = sqlite3.connect(db_path)
-        with conn:  # Start a transaction context
-            conn.execute(
-                "INSERT INTO cross_database_sync_operations (operation, timestamp)"
-                " VALUES (?, ?)",
-                (operation, timestamp),
-            )
-            conn.commit()
-    logger.info("Logged sync operation %s at %s", operation, timestamp)
+        bar.update(1)
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        with sqlite3.connect(db_path) as conn:
+            if not _table_exists(conn, "cross_database_sync_operations"):
+                conn.close()
+                initialize_database(db_path)
+                conn = sqlite3.connect(db_path)
+            bar.update(1)
+            with conn:
+                conn.execute(
+                    "INSERT INTO cross_database_sync_operations (operation, timestamp)"
+                    " VALUES (?, ?)",
+                    (operation, timestamp),
+                )
+                conn.commit()
+            bar.update(1)
+
+    duration = (datetime.now(timezone.utc) - start_dt).total_seconds()
+    logger.info(
+        "%s Logged sync operation %s in %.2fs",
+        TEXT_INDICATORS["success"],
+        operation,
+        duration,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add progress bar and start time logging to `log_sync_operation`
- show duration with success indicator

## Testing
- `pytest tests/test_cross_database_sync_logger.py`
- `make test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a90e828bc8331adfdc969d0d37c87