### PR TITLE
Add environment setup guidance

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,7 @@
 # Workspace root used by scripts and tests
 # Workspace root used by all scripts, tests, and utilities
 WORKSPACE_ROOT=/path/to/workspace
+GH_COPILOT_WORKSPACE=/path/to/workspace
 
 # Approved backup directory
 GH_COPILOT_BACKUP_ROOT=E:/temp/gh_COPILOT_Backups

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This guide is written for **automated ChatGPT Codex agents ** operating within t
     ```
 4. Run tests with `make test`. This installs packages from `requirements-test.txt` such as `tqdm`, `numpy`, `qiskit >= 1.4, < 2.0`, `qiskit-aer`, and `qiskit-machine-learning`.
 5. Set the workspace root via the `GH_COPILOT_WORKSPACE` environment variable.
+6. Populate the `.env` file with `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT`, then `source .env` to load these variables before running tasks.
 
 Consult[`docs/INSTRUCTION_INDEX.md`](docs/INSTRUCTION_INDEX.md) for all available instruction modules.
 

--- a/deployment/deployment_package_20250710_182951/documentation/AGENTS.md
+++ b/deployment/deployment_package_20250710_182951/documentation/AGENTS.md
@@ -18,6 +18,7 @@ The **gh\_COPILOT Toolkit v4.0** repository supports enterprise deployment, moni
 * Tests: `make test` (installs `requirements-test.txt` and runs `pytest`)
 * Test dependencies include `tqdm`, `numpy`, `qiskit` (>=1.4,<2.0), `qiskit-aer`, and `qiskit-machine-learning` (installed from `requirements-test.txt`).
 * Set workspace root via `GH_COPILOT_WORKSPACE` (default `/path/to/workspace`).
+* Populate `.env` with `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT`, then `source .env` before executing scripts.
 
 ---
 

--- a/docs/ENVIRONMENT_CONFIGURATION.md
+++ b/docs/ENVIRONMENT_CONFIGURATION.md
@@ -1,0 +1,24 @@
+# ChatGPT Codex Environment Configuration
+
+This guide explains how to configure environment variables for the gh_COPILOT toolkit.
+
+## Required Variables
+
+- `GH_COPILOT_WORKSPACE`: Absolute path to the repository workspace. Used by tests and scripts to locate databases and configuration files.
+- `GH_COPILOT_BACKUP_ROOT`: External directory for backups. Must not reside inside the workspace. Defaults to `E:/temp/gh_COPILOT_Backups` on Windows or `/tmp/<user>/gh_COPILOT_Backups` on Linux.
+
+Set these variables by editing the provided `.env` file:
+
+```bash
+# Example .env
+GH_COPILOT_WORKSPACE=/path/to/workspace
+GH_COPILOT_BACKUP_ROOT=/external/backup/location
+```
+
+Load the variables in your shell before running tasks:
+
+```bash
+source .env
+```
+
+All unit tests (`make test`) and scripts rely on these variables for path validation and anti-recursion compliance.


### PR DESCRIPTION
## Summary
- include .env setup instructions in AGENTS.md
- sync deployment AGENTS.md with new environment guidance
- define GH_COPILOT_WORKSPACE in `.env`
- document environment configuration steps

## Testing
- `flake8 AGENTS.md deployment/deployment_package_20250710_182951/documentation/AGENTS.md`
- `make test` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687a9bf472a48331a09b784aebabda54