### PR TITLE
Update workspace defaults

### DIFF
--- a/copilot/core/enterprise_json_serialization_fix.py
+++ b/copilot/core/enterprise_json_serialization_fix.py
@@ -11,9 +11,9 @@ Enterprise Standards Compliance:
 
 import json
 import logging
+import os
 import sys
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -29,7 +29,7 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
+    def __init__(self, workspace_path: Path = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))):
         self.workspace_path = Path(workspace_path)
         self.logger = logging.getLogger(__name__)
 

--- a/copilot/core/enterprise_orchestrator.py
+++ b/copilot/core/enterprise_orchestrator.py
@@ -9,6 +9,7 @@ Enterprise Standards Compliance:
 - Visual processing indicators
 """
 import logging
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -25,7 +26,7 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
+    def __init__(self, workspace_path: Path = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))):
         self.workspace_path = Path(workspace_path)
         self.logger = logging.getLogger(__name__)
 

--- a/copilot/orchestrators/UNIFIED_DEPLOYMENT_ORCHESTRATOR_TEST_SUITE.py
+++ b/copilot/orchestrators/UNIFIED_DEPLOYMENT_ORCHESTRATOR_TEST_SUITE.py
@@ -8,11 +8,11 @@ Enterprise Standards Compliance:
 - Emoji-free code (text-based indicators only)
 - Visual processing indicators
 """
-import sys
-
 import logging
-from pathlib import Path
+import os
+import sys
 from datetime import datetime
+from pathlib import Path
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -26,7 +26,7 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
+    def __init__(self, workspace_path: Path = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))):
         self.workspace_path = Path(workspace_path)
         self.logger = logging.getLogger(__name__)
 

--- a/copilot/orchestrators/final_enterprise_orchestrator.py
+++ b/copilot/orchestrators/final_enterprise_orchestrator.py
@@ -9,6 +9,7 @@ Enterprise Standards Compliance:
 - Visual processing indicators
 """
 import logging
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -25,7 +26,7 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
+    def __init__(self, workspace_path: Path = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))):
         self.workspace_path = Path(workspace_path)
         self.logger = logging.getLogger(__name__)
 

--- a/quantum/quantum_optimization.py
+++ b/quantum/quantum_optimization.py
@@ -10,6 +10,7 @@ Enterprise Standards Compliance:
 """
 
 import logging
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -26,7 +27,7 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
+    def __init__(self, workspace_path: Path = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))):
         self.workspace_path = Path(workspace_path)
         self.logger = logging.getLogger(__name__)
 

--- a/tests/test_autonomous_file_manager.py
+++ b/tests/test_autonomous_file_manager.py
@@ -9,6 +9,7 @@ Enterprise Standards Compliance:
 - Visual processing indicators
 """
 import logging
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -25,7 +26,7 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
+    def __init__(self, workspace_path: Path = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))):
         self.workspace_path = Path(workspace_path)
         self.logger = logging.getLogger(__name__)
 
@@ -70,8 +71,9 @@ def main():
     return success
 
 
-def test_execute_utility(tmp_path):
+def test_execute_utility(tmp_path, monkeypatch):
     """Ensure the utility executes successfully."""
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     util = EnterpriseUtility(workspace_path=str(tmp_path))
     assert util.execute_utility()
 

--- a/tests/test_documentation_consolidator.py
+++ b/tests/test_documentation_consolidator.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
+import logging
+import os
 import shutil
 import sqlite3
 from pathlib import Path
 
 from scripts.documentation_consolidator import consolidate
-import logging
 
 
 def _prepare_db(src: Path, dest: Path) -> None:
@@ -19,7 +20,7 @@ def _prepare_db(src: Path, dest: Path) -> None:
                 "BACKUP_LOG",
                 "Backup",
                 "data",
-                "e:/gh_COPILOT/backups/tmp.bak",
+                str(Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())) + "/backups/tmp.bak"),
             ),
         )
         conn.execute(

--- a/tests/test_web_gui_endpoints.py
+++ b/tests/test_web_gui_endpoints.py
@@ -9,6 +9,7 @@ Enterprise Standards Compliance:
 - Visual processing indicators
 """
 import logging
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -25,7 +26,7 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
+    def __init__(self, workspace_path: Path = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))):
         self.workspace_path = Path(workspace_path)
         self.logger = logging.getLogger(__name__)
 
@@ -70,8 +71,9 @@ def main():
     return success
 
 
-def test_execute_utility(tmp_path):
+def test_execute_utility(tmp_path, monkeypatch):
     """Ensure the web GUI utility runs successfully."""
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     util = EnterpriseUtility(workspace_path=str(tmp_path))
     assert util.execute_utility()
 

--- a/utils/configuration_utils.py
+++ b/utils/configuration_utils.py
@@ -1,32 +1,35 @@
 """Configuration utilities for gh_COPILOT Enterprise Toolkit"""
 
-import os
 import json
+import os
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
+
 
 def load_enterprise_configuration(config_path: Optional[str] = None) -> Dict[str, Any]:
     """Load enterprise configuration with defaults"""
     if config_path is None:
-        config_path = os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT") + "/config/enterprise.json"
-    
+        workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+        config_path = str(workspace_root / "config" / "enterprise.json")
+
     defaults = {
-        "workspace_root": os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"),
+        "workspace_root": os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()),
         "database_path": "databases/production.db",
         "logging_level": "INFO",
         "enterprise_mode": True
     }
-    
+
     try:
         with open(config_path, 'r', encoding='utf-8') as f:
             config = json.load(f)
         defaults.update(config)
     except FileNotFoundError:
         pass  # Use defaults
-    
+
     return defaults
+
 
 def validate_environment_compliance() -> bool:
     """Validate enterprise environment compliance"""
-    workspace = os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")
+    workspace = os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())
     return workspace.endswith("gh_COPILOT")

--- a/utils/database_utils.py
+++ b/utils/database_utils.py
@@ -1,17 +1,18 @@
 """Database utilities for gh_COPILOT Enterprise Toolkit"""
 
-import sqlite3
 import os
-from pathlib import Path
+import sqlite3
 from contextlib import contextmanager
-from typing import Optional, Iterator
+from pathlib import Path
+from typing import Iterator, Optional
+
 
 @contextmanager
 def get_enterprise_database_connection(db_name: str = "production.db") -> Iterator[sqlite3.Connection]:
     """Get enterprise database connection with proper handling"""
-    workspace = os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")
+    workspace = os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())
     db_path = Path(workspace) / "databases" / db_name
-    
+
     conn = None
     try:
         conn = sqlite3.connect(db_path)
@@ -20,6 +21,7 @@ def get_enterprise_database_connection(db_name: str = "production.db") -> Iterat
     finally:
         if conn:
             conn.close()
+
 
 def execute_safe_query(query: str, params: tuple = (), db_name: str = "production.db") -> Optional[list]:
     """Execute database query safely"""
@@ -30,6 +32,7 @@ def execute_safe_query(query: str, params: tuple = (), db_name: str = "productio
             return cursor.fetchall()
     except Exception:
         return None
+
 
 def check_table_exists(table_name: str, db_name: str = "production.db") -> bool:
     """Check if table exists in database"""

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -2,18 +2,19 @@
 
 import logging
 import os
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+
 
 def setup_enterprise_logging(level: str = "INFO", log_file: str = None) -> logging.Logger:
     """Setup enterprise-grade logging configuration"""
-    
+
     if log_file is None:
-        workspace = os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")
+        workspace = os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())
         log_dir = Path(workspace) / "logs"
         log_dir.mkdir(exist_ok=True)
         log_file = log_dir / f"enterprise_{datetime.now().strftime('%Y%m%d')}.log"
-    
+
     logging.basicConfig(
         level=getattr(logging, level.upper()),
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
@@ -22,13 +23,14 @@ def setup_enterprise_logging(level: str = "INFO", log_file: str = None) -> loggi
             logging.StreamHandler()
         ]
     )
-    
+
     return logging.getLogger("gh_COPILOT")
+
 
 def log_enterprise_operation(operation: str, status: str, details: str = "") -> None:
     """Log enterprise operation with standard format"""
     logger = logging.getLogger("gh_COPILOT")
-    
+
     if status.upper() == "SUCCESS":
         logger.info(f"✅ {operation}: {details}")
     elif status.upper() == "WARNING":

--- a/utils/validation_utils.py
+++ b/utils/validation_utils.py
@@ -2,46 +2,48 @@
 
 import os
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+
 
 def validate_workspace_integrity() -> Dict[str, Any]:
     """Validate workspace integrity and structure"""
-    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
-    
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+
     validation_results = {
         "workspace_exists": workspace.exists(),
         "required_directories": {},
         "forbidden_patterns": [],
         "overall_status": "UNKNOWN"
     }
-    
+
     # Check required directories
     required_dirs = ["databases", "scripts", "utils", "documentation"]
     for dir_name in required_dirs:
         dir_path = workspace / dir_name
         validation_results["required_directories"][dir_name] = dir_path.exists()
-    
+
     # Check for forbidden patterns (anti-recursion)
     forbidden = ["backup", "temp", "copy"]
     for pattern in forbidden:
         if pattern in str(workspace).lower():
             validation_results["forbidden_patterns"].append(pattern)
-    
+
     # Determine overall status
-    if (validation_results["workspace_exists"] and 
+    if (validation_results["workspace_exists"] and
         all(validation_results["required_directories"].values()) and
-        not validation_results["forbidden_patterns"]):
+            not validation_results["forbidden_patterns"]):
         validation_results["overall_status"] = "VALID"
     else:
         validation_results["overall_status"] = "INVALID"
-    
+
     return validation_results
+
 
 def validate_script_organization() -> Dict[str, Any]:
     """Validate script organization structure"""
-    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
     scripts_dir = workspace / "scripts"
-    
+
     organization_status = {
         "scripts_directory_exists": scripts_dir.exists(),
         "categories": {},
@@ -49,7 +51,7 @@ def validate_script_organization() -> Dict[str, Any]:
         "organized_python_files": 0,
         "organization_percentage": 0.0
     }
-    
+
     if scripts_dir.exists():
         # Count organized scripts
         for category_dir in scripts_dir.iterdir():
@@ -57,16 +59,17 @@ def validate_script_organization() -> Dict[str, Any]:
                 py_files = list(category_dir.glob("*.py"))
                 organization_status["categories"][category_dir.name] = len(py_files)
                 organization_status["organized_python_files"] += len(py_files)
-    
+
     # Count root Python files
     root_py_files = list(workspace.glob("*.py"))
     organization_status["root_python_files"] = len(root_py_files)
-    
+
     # Calculate organization percentage
-    total_scripts = organization_status["organized_python_files"] + organization_status["root_python_files"]
+    total_scripts = organization_status["organized_python_files"] + \
+        organization_status["root_python_files"]
     if total_scripts > 0:
         organization_status["organization_percentage"] = (
             organization_status["organized_python_files"] / total_scripts * 100
         )
-    
+
     return organization_status

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -8,15 +8,15 @@ Enterprise Standards Compliance:
 - Emoji-free code (text-based indicators only)
 - Visual processing indicators
 """
-import flask
-
-import sys
 import logging
+import os
 import sqlite3
-from pathlib import Path
+import sys
 from datetime import datetime
-from typing import List, Dict
+from pathlib import Path
+from typing import Dict, List
 
+import flask
 from flask import Flask, jsonify, render_template
 
 # Text-based indicators (NO Unicode emojis)
@@ -68,7 +68,7 @@ def metrics() -> "flask.Response":
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
+    def __init__(self, workspace_path: Path = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))):
         self.workspace_path = Path(workspace_path)
         self.logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- default to `GH_COPILOT_WORKSPACE` wherever `e:/gh_COPILOT` was used
- rely on `Path` objects for cross-platform compatibility
- set workspace in tests

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'template_engine')*

------
https://chatgpt.com/codex/tasks/task_e_687aac9261a88331b0781edc66e392d6