### PR TITLE
Enhance sync logger with status tracking

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,3 +10,4 @@ qiskit-aer==0.17.1
 qiskit-machine-learning>=0.6.0
 dill>=0.3.7
 py7zr
+schedule

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -65,6 +65,9 @@ TABLES: dict[str, str] = {
         "CREATE TABLE IF NOT EXISTS cross_database_sync_operations ("
         "id INTEGER PRIMARY KEY,"
         "operation TEXT NOT NULL,"
+        "status TEXT NOT NULL,"
+        "start_time TEXT NOT NULL,"
+        "duration REAL NOT NULL,"
         "timestamp TEXT NOT NULL"
         ")"
     ),

--- a/tests/test_cross_database_sync_logger.py
+++ b/tests/test_cross_database_sync_logger.py
@@ -1,4 +1,5 @@
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 
 from scripts.database.cross_database_sync_logger import log_sync_operation
@@ -6,9 +7,13 @@ from scripts.database.cross_database_sync_logger import log_sync_operation
 
 def test_log_sync_operation(tmp_path: Path) -> None:
     db_path = tmp_path / "enterprise_assets.db"
-    log_sync_operation(db_path, "test_op")
+    start = datetime.now(timezone.utc)
+    log_sync_operation(db_path, "test_op", status="SUCCESS", start_time=start)
     with sqlite3.connect(db_path) as conn:
-        count = conn.execute(
-            "SELECT COUNT(*) FROM cross_database_sync_operations"
-        ).fetchone()[0]
-    assert count == 1
+        row = conn.execute(
+            "SELECT operation, status, start_time, duration, timestamp FROM cross_database_sync_operations"
+        ).fetchone()
+    assert row[0] == "test_op"
+    assert row[1] == "SUCCESS"
+    assert row[2] == start.isoformat()
+    assert row[3] >= 0


### PR DESCRIPTION
## Summary
- extend cross database sync logger with status, start time and duration
- update DB schema for new fields
- log multiple operations via CLI with progress display
- verify new columns in unit tests
- add `schedule` to test requirements

## Testing
- `make test` *(fails: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_687acc10f3bc8331bfec9c57acab7efa