### PR TITLE
Update maintenance scheduler

### DIFF
--- a/tests/test_maintenance_scheduler.py
+++ b/tests/test_maintenance_scheduler.py
@@ -11,9 +11,9 @@ def test_run_cycle(tmp_path: Path) -> None:
     db_dir.mkdir()
     docs_dir.mkdir()
 
-    master = db_dir / "production.db"
+    master = db_dir / "enterprise_assets.db"
     replica = db_dir / "replica.db"
-    log_db = db_dir / "enterprise_assets.db"
+    log_db = master
     initialize_database(log_db)
 
     with sqlite3.connect(master) as conn:
@@ -22,7 +22,7 @@ def test_run_cycle(tmp_path: Path) -> None:
 
     list_file = docs_dir / "CONSOLIDATED_DATABASE_LIST.md"
     list_file.write_text(
-        "- production.db  # Size: 0.01 MB\n"
+        "- enterprise_assets.db  # Size: 0.01 MB\n"
         "- replica.db  # Size: 0.01 MB\n"
     )
 


### PR DESCRIPTION
## Summary
- update `maintenance_scheduler.run_cycle` to use `enterprise_assets.db` as master
- add progress bars and cycle logging
- adjust maintenance scheduler test

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'qiskit.algorithms')*

------
https://chatgpt.com/codex/tasks/task_e_687acc39b5ac8331b636c5c79ddc5e49