### PR TITLE
Improve sync logging and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ python scripts/database/database_initializer.py
 python scripts/database/database_sync_scheduler.py \
     --workspace . \
     --add-documentation-sync documentation/EXTRA_DATABASES.md \
+#    Optional: --timeout 300
     --target staging.db
+# Progress bars display elapsed time and estimated completion while operations
+# are logged with start time and duration in `cross_database_sync_operations`.
 
 # 3c. Consolidate databases with compression
 python scripts/database/complete_consolidation_orchestrator.py \

--- a/documentation/ENTERPRISE_ASSET_DB_MAINTENANCE_GUIDE.md
+++ b/documentation/ENTERPRISE_ASSET_DB_MAINTENANCE_GUIDE.md
@@ -5,6 +5,12 @@
 ### Overview
 The enhanced database sync scheduler automatically logs all sync operations to the `cross_database_sync_operations` table in `enterprise_assets.db`.
 
+Each log entry records the operation name, status, start time captured when the
+operation began, the duration in seconds, and the timestamp when the record was
+created.  Before any write occurs `validate_enterprise_operation()` is invoked
+to enforce audit compliance.  Batch CLI commands display a progress bar so long
+running jobs show elapsed time and an estimated time to completion (ETC).
+
 ### Monitoring Sync Operations
 ```sql
 -- View recent sync operations
@@ -14,8 +20,16 @@ ORDER BY timestamp DESC
 LIMIT 20;
 
 -- Check for failed operations
-SELECT * FROM cross_database_sync_operations 
+SELECT * FROM cross_database_sync_operations
 WHERE operation LIKE '%failed%';
+```
+
+```sql
+-- Retrieve average duration of successful sync cycles
+SELECT operation, AVG(duration) AS avg_seconds
+FROM cross_database_sync_operations
+WHERE status = 'SUCCESS'
+GROUP BY operation;
 ```
 
 ### Scheduled Sync Cycles

--- a/scripts/database/cross_database_sync_logger.py
+++ b/scripts/database/cross_database_sync_logger.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Log cross-database sync operations."""
+"""Cross-database sync operation logger.
+
+This module provides :func:`log_sync_operation` which records an operation name,
+status, caller supplied start time, calculated duration and a timestamp to the
+``cross_database_sync_operations`` table.  The
+``validate_enterprise_operation`` guard is executed before any write occurs and
+CLI usage displays a progress bar when logging multiple operations.
+"""
 
 from __future__ import annotations
 
@@ -29,10 +36,17 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
 def log_sync_operation(
     db_path: Path,
     operation: str,
+    *,
     status: str = "SUCCESS",
     start_time: datetime | None = None,
-) -> None:
-    """Insert a sync operation record into the tracking table."""
+) -> datetime:
+    """Insert a sync operation record and return the start timestamp.
+
+    ``start_time`` should be the timestamp captured when the operation began.
+    If ``None`` it is set to the current time so callers can reuse the returned
+    value when logging completion events.  ``duration`` is computed from the
+    captured start time to the log call time.
+    """
     validate_enterprise_operation()
 
     if not db_path.exists():
@@ -61,6 +75,7 @@ def log_sync_operation(
         timestamp,
         status,
     )
+    return start_dt
 
 
 if __name__ == "__main__":

--- a/scripts/database/database_sync_scheduler.py
+++ b/scripts/database/database_sync_scheduler.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import datetime
 import logging
 import time
+from datetime import timezone
 from pathlib import Path
 from sqlite3 import connect
 from typing import Iterable, List
@@ -38,7 +39,11 @@ def _copy_database(source: Path, target: Path) -> None:
 
 
 def synchronize_databases(
-    master: Path, replicas: Iterable[Path], log_db: Path | None = None
+    master: Path,
+    replicas: Iterable[Path],
+    *,
+    log_db: Path | None = None,
+    timeout: int | None = None,
 ) -> None:
     """Synchronize replica databases with the master database.
 
@@ -52,22 +57,45 @@ def synchronize_databases(
         Optional path to ``enterprise_assets.db`` for audit logging.
     """
     if log_db:
-        log_sync_operation(log_db, f"start_sync_from_{master.name}")
+        start_dt = log_sync_operation(log_db, f"start_sync_from_{master.name}")
+    else:
+        start_dt = datetime.datetime.now(timezone.utc)
     start_time = time.time()
     logger.info("Starting synchronization at %s", datetime.datetime.fromtimestamp(start_time))
 
     replica_list = list(replicas)
-    for replica in tqdm(replica_list, desc="Syncing", unit="db"):
-        _copy_database(master, replica)
-        if log_db:
-            log_sync_operation(log_db, f"synchronized_{replica.name}")
+    status = "SUCCESS"
+    try:
+        with tqdm(total=len(replica_list), desc="Syncing", unit="db", dynamic_ncols=True) as bar:
+            for replica in replica_list:
+                if timeout and time.time() - start_time > timeout:
+                    logger.error("Synchronization timed out")
+                    status = "TIMEOUT"
+                    break
+                _copy_database(master, replica)
+                if log_db:
+                    log_sync_operation(
+                        log_db, f"synchronized_{replica.name}", start_time=start_dt
+                    )
+                etc = bar.format_dict.get("elapsed", 0) + bar.format_dict.get("remaining", 0)
+                etc_time = datetime.datetime.fromtimestamp(start_time + etc)
+                bar.set_postfix_str(f"ETC {etc_time.strftime('%H:%M:%S')}")
+                bar.update(1)
+    except Exception:
+        status = "FAILURE"
+        raise
 
     end_time = time.time()
     logger.info(
         "Finished synchronization at %s", datetime.datetime.fromtimestamp(end_time)
     )
     if log_db:
-        log_sync_operation(log_db, f"completed_sync_from_{master.name}")
+        op = (
+            f"timeout_sync_from_{master.name}"
+            if status == "TIMEOUT"
+            else f"completed_sync_from_{master.name}"
+        )
+        log_sync_operation(log_db, op, status=status, start_time=start_dt)
 
 
 def _load_database_names(list_file: Path) -> list[str]:
@@ -89,7 +117,7 @@ def _load_database_names(list_file: Path) -> list[str]:
 class EnhancedDatabaseSyncScheduler:
     """Scheduler with detailed sync cycle logging."""
 
-    def __init__(self, workspace_root: Path = Path(".")) -> None:
+    def __init__(self, workspace_root: Path = Path("."), timeout: int | None = None) -> None:
         self.workspace_root = workspace_root.resolve()
         self.databases_dir = self.workspace_root / "databases"
         self.enterprise_db = self.databases_dir / "enterprise_assets.db"
@@ -99,11 +127,14 @@ class EnhancedDatabaseSyncScheduler:
         self.list_file = (
             self.workspace_root / "documentation" / "CONSOLIDATED_DATABASE_LIST.md"
         )
+        self.timeout = timeout
 
     def execute_sync_cycle(self) -> None:
         """Execute a synchronization cycle with logging."""
         cycle_id = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        log_sync_operation(self.enterprise_db, f"sync_cycle_start_{cycle_id}")
+        start_dt = log_sync_operation(
+            self.enterprise_db, f"sync_cycle_start_{cycle_id}"
+        )
         try:
             db_names: List[str] = _load_database_names(self.list_file)
             replicas = [
@@ -112,15 +143,22 @@ class EnhancedDatabaseSyncScheduler:
                 if name != self.master_db.name
             ]
             synchronize_databases(
-                self.master_db, replicas, log_db=self.enterprise_db
+                self.master_db,
+                replicas,
+                log_db=self.enterprise_db,
+                timeout=self.timeout,
             )
             log_sync_operation(
-                self.enterprise_db, f"sync_cycle_complete_{cycle_id}"
+                self.enterprise_db,
+                f"sync_cycle_complete_{cycle_id}",
+                start_time=start_dt,
             )
         except Exception as exc:
             log_sync_operation(
                 self.enterprise_db,
                 f"sync_cycle_failed_{cycle_id}_{format_exception_message(exc)}",
+                status="FAILURE",
+                start_time=start_dt,
             )
             raise
 
@@ -187,6 +225,12 @@ if __name__ == "__main__":
         default=1800,
         help="Interval between cycles in continuous mode (seconds)",
     )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help="Abort sync if it runs longer than this many seconds",
+    )
 
     args = parser.parse_args()
 
@@ -208,4 +252,9 @@ if __name__ == "__main__":
     replica_dbs = [workspace / name for name in db_names if name != master_name]
 
     log_db_path = workspace / args.log_db if args.log_db else None
-    synchronize_databases(master_db, replica_dbs, log_db=log_db_path)
+    synchronize_databases(
+        master_db,
+        replica_dbs,
+        log_db=log_db_path,
+        timeout=args.timeout,
+    )

--- a/scripts/database/unified_database_management_system.py
+++ b/scripts/database/unified_database_management_system.py
@@ -8,6 +8,7 @@ import os
 import sqlite3
 from pathlib import Path
 from typing import Iterable, Tuple
+import datetime
 
 from tqdm import tqdm
 
@@ -60,6 +61,7 @@ class UnifiedDatabaseManager:
 def _backup_database(source: Path, target: Path, log_db: Path | None = None) -> None:
     """Copy source SQLite database to target using backup API."""
     validate_enterprise_operation()
+    start_time = datetime.datetime.now(datetime.timezone.utc)
     with sqlite3.connect(source) as src, sqlite3.connect(target) as dest, tqdm(
         total=1, desc=f"Backup {source.name}", unit="db"
     ) as bar:
@@ -67,7 +69,11 @@ def _backup_database(source: Path, target: Path, log_db: Path | None = None) -> 
         bar.update(1)
     logger.info("Synchronized %s -> %s", source, target)
     if log_db:
-        log_sync_operation(log_db, f"backup_{source.name}_to_{target.name}")
+        log_sync_operation(
+            log_db,
+            f"backup_{source.name}_to_{target.name}",
+            start_time=start_time,
+        )
 
 
 def synchronize_databases(master: Path, replicas: Iterable[Path], log_db: Path | None = None) -> None:

--- a/tests/test_cross_database_sync_logger.py
+++ b/tests/test_cross_database_sync_logger.py
@@ -1,4 +1,5 @@
 import sqlite3
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -8,6 +9,7 @@ from scripts.database.cross_database_sync_logger import log_sync_operation
 def test_log_sync_operation(tmp_path: Path) -> None:
     db_path = tmp_path / "enterprise_assets.db"
     start = datetime.now(timezone.utc)
+    time.sleep(0.01)
     log_sync_operation(db_path, "test_op", status="SUCCESS", start_time=start)
     with sqlite3.connect(db_path) as conn:
         row = conn.execute(
@@ -16,4 +18,4 @@ def test_log_sync_operation(tmp_path: Path) -> None:
     assert row[0] == "test_op"
     assert row[1] == "SUCCESS"
     assert row[2] == start.isoformat()
-    assert row[3] >= 0
+    assert row[3] > 0


### PR DESCRIPTION
## Summary
- document sync operation logging
- enforce start time parameter in `log_sync_operation`
- add timeout handling and ETC display in schedulers
- track start times in database management scripts
- update duration assertion in tests

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'copilot.template_intelligence')*

------
https://chatgpt.com/codex/tasks/task_e_687c5c43283483318ec8ee20145c7e2f