### PR TITLE
feat: add workspace validation entrypoint

### DIFF
--- a/documentation/MODULARIZATION_PHASE_4_IMPLEMENTATION_PLAN.md
+++ b/documentation/MODULARIZATION_PHASE_4_IMPLEMENTATION_PLAN.md
@@ -150,7 +150,14 @@ def operations_save_analysis_results():
     """File saving patterns"""
 ```
 The validation utilities also expose ``detect_zero_byte_files`` and
-``validate_path`` for thorough workspace checks.
+``validate_path`` for thorough workspace checks. Call
+``operations_validate_workspace`` in your entrypoint to print a JSON
+report summarizing integrity, organization, and zero-byte file checks:
+
+```python
+if __name__ == "__main__":
+    operations_validate_workspace()
+```
 
 ### **Phase 4.3: Integration & Migration (Week 3)**
 

--- a/tests/test_new_utils.py
+++ b/tests/test_new_utils.py
@@ -1,7 +1,11 @@
 import json
 from utils.general_utils import operations_main
 from utils.reporting_utils import generate_json_report, generate_markdown_report
-from utils.validation_utils import detect_zero_byte_files, validate_path
+from utils.validation_utils import (
+    detect_zero_byte_files,
+    validate_path,
+    operations_validate_workspace,
+)
 
 
 def test_operations_main(capsys):
@@ -45,4 +49,18 @@ def test_validate_path(tmp_path, monkeypatch):
     outside = bk / "b.txt"
     outside.touch()
     assert not validate_path(outside)
+
+
+def test_operations_validate_workspace(tmp_path, monkeypatch, capsys):
+    ws = tmp_path / "ws"
+    bk = tmp_path / "bk"
+    ws.mkdir()
+    bk.mkdir()
+    for name in ["databases", "scripts", "utils", "documentation"]:
+        (ws / name).mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
+    operations_validate_workspace()
+    out = json.loads(capsys.readouterr().out)
+    assert out["integrity"]["overall_status"] == "VALID"
 

--- a/utils/validation_utils.py
+++ b/utils/validation_utils.py
@@ -1,6 +1,7 @@
 """Validation utilities for gh_COPILOT Enterprise Toolkit"""
 
 import os
+import json
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -92,3 +93,17 @@ def validate_path(path: Path) -> bool:
     except FileNotFoundError:
         return False
     return workspace in resolved.parents and backup_root not in resolved.parents
+
+
+def operations_validate_workspace() -> None:
+    """Run comprehensive workspace checks and print a JSON report."""
+    workspace = CrossPlatformPathManager.get_workspace_path()
+    integrity = validate_workspace_integrity()
+    organization = validate_script_organization()
+    zero_bytes = [str(p) for p in detect_zero_byte_files(workspace)]
+    report = {
+        "integrity": integrity,
+        "organization": organization,
+        "zero_byte_files": zero_bytes,
+    }
+    print(json.dumps(report, indent=2))


### PR DESCRIPTION
## Summary
- enhance validation utils with `operations_validate_workspace`
- document calling the new utility
- test workspace validation workflow

## Testing
- `ruff check utils/general_utils.py utils/reporting_utils.py utils/validation_utils.py tests/test_new_utils.py documentation/MODULARIZATION_PHASE_4_IMPLEMENTATION_PLAN.md`
- `pytest tests/test_new_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687ce37ce48c833181713a5ecf690ffa