### PR TITLE
Fix database sync test and clean lint

### DIFF
--- a/web_gui/scripts/flask_apps/__init__.py
+++ b/web_gui/scripts/flask_apps/__init__.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python3
-import logging
-#!/usr/bin/env python3
 # Flask Apps Module
-"""
-Flask applications for gh_COPILOT enterprise dashboard
-Database-driven web interfaces
-"""
+"""Flask applications for gh_COPILOT enterprise dashboard."""
+


### PR DESCRIPTION
## Summary
- remove unused imports from web_gui
- patch database sync test to avoid CLI dependency and update dummy progress bar

## Testing
- `ruff check tests/test_database_sync.py web_gui/scripts/flask_apps/__init__.py`
- `pytest tests/test_database_sync.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d29e4cbcc8331864fa788ab29763c