### PR TITLE
Extend file type detection

### DIFF
--- a/documentation/UNIFIED_WRAP_UP_ORCHESTRATOR_IMPLEMENTATION_COMPLETE.md
+++ b/documentation/UNIFIED_WRAP_UP_ORCHESTRATOR_IMPLEMENTATION_COMPLETE.md
@@ -60,7 +60,7 @@
   - Component dependency mapping
   - Modularization recommendations
   - Database-driven script organization patterns
-  - `prevent_executable_misclassification()` inspects headers and magic numbers to ensure Python, shell, and batch scripts are correctly recognized and flagged when extensions lie
+  - `prevent_executable_misclassification()` inspects headers and magic numbers to ensure Python, shell, batch, JavaScript, Ruby, Perl and PHP scripts are correctly recognized. It raises an error when a shebang does not match the file extension, preventing misclassified text files from executing.
 
 ---
 


### PR DESCRIPTION
## Summary
- handle more executable types in the wrap-up orchestrator
- raise errors when a script shebang mismatches its extension
- add tests for the new detection logic
- document the enhanced misclassification protection

## Testing
- `ruff check scripts/orchestrators/unified_wrapup_orchestrator.py tests/test_prevent_executable_misclassification.py documentation/UNIFIED_WRAP_UP_ORCHESTRATOR_IMPLEMENTATION_COMPLETE.md`
- `pytest tests/test_prevent_executable_misclassification.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d54590adc8331b459cd07a7f7240a