### PR TITLE
feat: extend reporting utils and wrapup classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,3 +531,7 @@ Planned highlights include:
    healing recommendations.
 3. **Compliance Framework Evolution** – stricter session validation and
    enterprise audit logging improvements.
+4. **Reporting Enhancements** – standardized text report output alongside
+   JSON and Markdown formats.
+5. **Improved Script Classification** – broader file-type detection to prevent
+   misclassification of non-executable files.

--- a/docs/quantum/INDEX.md
+++ b/docs/quantum/INDEX.md
@@ -55,6 +55,8 @@ The library now includes reference implementations for:
 4. Variational Quantum Eigensolver
 5. Quantum Phase Estimation
 6. Quantum teleportation
+All algorithms leverage Qiskit's simulator backend for reproducible results in
+test environments.
 
 ---
 *Quantum Documentation Suite - Enterprise Grade*

--- a/scripts/orchestrators/unified_wrapup_orchestrator.py
+++ b/scripts/orchestrators/unified_wrapup_orchestrator.py
@@ -639,7 +639,7 @@ class UnifiedWrapUpOrchestrator:
         elif "#!" in first_line:
             if "python" in first_line:
                 detected = "python"
-            elif any(sh in first_line for sh in ["sh", "bash", "zsh", "pwsh", "powershell"]):
+            elif any(sh in first_line for sh in ["sh", "bash", "zsh", "ksh", "csh", "tcsh", "dash", "pwsh", "powershell"]):
                 detected = "shell"
             elif "node" in first_line or "javascript" in first_line:
                 detected = "javascript"
@@ -654,18 +654,26 @@ class UnifiedWrapUpOrchestrator:
         else:
             detected = {
                 ".py": "python",
+                ".pyi": "python",
                 ".pyw": "python",
                 ".pyc": "python",
                 ".sh": "shell",
+                ".ksh": "shell",
+                ".csh": "shell",
+                ".tcsh": "shell",
+                ".dash": "shell",
                 ".bash": "shell",
                 ".zsh": "shell",
                 ".ps1": "shell",
+                ".psm1": "shell",
                 ".bat": "batch",
                 ".cmd": "batch",
                 ".js": "javascript",
                 ".rb": "ruby",
                 ".pl": "perl",
                 ".php": "php",
+                ".vbs": "vbscript",
+                ".vbe": "vbscript",
                 ".exe": "binary",
                 ".dll": "binary",
                 ".jar": "java",
@@ -674,8 +682,9 @@ class UnifiedWrapUpOrchestrator:
         # If a script type was detected from the header but extension does not
         # match, raise an error to flag potential misclassification.
         if detected != "unknown" and ext not in {
-            ".py", ".pyw", ".pyc", ".sh", ".bash", ".zsh", ".ps1", ".bat", ".cmd",
-            ".js", ".rb", ".pl", ".php", ".exe", ".dll", ".jar",
+            ".py", ".pyi", ".pyw", ".pyc", ".sh", ".bash", ".zsh", ".ksh", ".csh",
+            ".tcsh", ".dash", ".ps1", ".psm1", ".bat", ".cmd", ".js", ".rb",
+            ".pl", ".php", ".vbs", ".vbe", ".exe", ".dll", ".jar",
         }:
             raise ValueError(f"File extension {ext} does not match detected script type {detected}")
 

--- a/tests/test_new_utils.py
+++ b/tests/test_new_utils.py
@@ -1,6 +1,10 @@
 import json
 from utils.general_utils import operations_main
-from utils.reporting_utils import generate_json_report, generate_markdown_report
+from utils.reporting_utils import (
+    generate_json_report,
+    generate_markdown_report,
+    generate_text_report,
+)
 from utils.validation_utils import (
     detect_zero_byte_files,
     validate_path,
@@ -26,6 +30,14 @@ def test_generate_markdown_report(tmp_path):
     generate_markdown_report({"a": 1}, out, title="T")
     text = out.read_text()
     assert text.startswith("# T") and "**a**" in text
+
+
+def test_generate_text_report(tmp_path):
+    out = tmp_path / "report.txt"
+    generate_text_report({"a": 1}, out, title="MyReport")
+    text = out.read_text()
+    assert text.splitlines()[0] == "MyReport"
+    assert "a: 1" in text
 
 
 def test_detect_zero_byte_files(tmp_path):

--- a/tests/test_prevent_executable_misclassification.py
+++ b/tests/test_prevent_executable_misclassification.py
@@ -43,6 +43,13 @@ def test_classify_batch(tmp_path: Path) -> None:
     assert orchestrator.prevent_executable_misclassification(path) == "batch"
 
 
+def test_classify_psm1(tmp_path: Path) -> None:
+    path = tmp_path / "module.psm1"
+    path.write_text("Write-Host hello")
+    orchestrator = UnifiedWrapUpOrchestrator(workspace_path=str(tmp_path))
+    assert orchestrator.prevent_executable_misclassification(path) == "shell"
+
+
 def test_detect_pyc(tmp_path: Path) -> None:
     path = tmp_path / "module.pyc"
     with open(path, "wb") as f:

--- a/utils/reporting_utils.py
+++ b/utils/reporting_utils.py
@@ -22,3 +22,13 @@ def generate_markdown_report(data: Dict[str, Any], output_path: Path, title: str
     output_path.write_text("\n".join(lines), encoding="utf-8")
     return output_path
 
+
+def generate_text_report(data: Dict[str, Any], output_path: Path, title: str = "Report") -> Path:
+    """Write ``data`` to ``output_path`` in a simple text table."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [title]
+    for key, value in data.items():
+        lines.append(f"{key}: {value}")
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+    return output_path
+


### PR DESCRIPTION
## Summary
- add plain text report generation
- extend executable misclassification logic to cover more script types
- test new text report utility
- test detection of PowerShell modules
- document updates in README and quantum docs

## Testing
- `ruff check utils/reporting_utils.py scripts/orchestrators/unified_wrapup_orchestrator.py tests/test_new_utils.py tests/test_prevent_executable_misclassification.py`
- `pytest -q tests/test_new_utils.py tests/test_prevent_executable_misclassification.py`

------
https://chatgpt.com/codex/tasks/task_e_687d98baa53c83319450201acdee2755