### PR TITLE
Extend configuration loader with YAML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ python scripts/validation/enterprise_dual_copilot_validator.py --validate-all
 Several small modules provide common helpers:
 
 - `utils.general_utils.operations_main` – standard script entrypoint wrapper.
-- `utils.configuration_utils.load_enterprise_configuration` – load toolkit configuration with defaults.
+- `utils.configuration_utils.load_enterprise_configuration` – load toolkit configuration from JSON or YAML with environment overrides.
 - `utils.reporting_utils.generate_json_report` – write data to a JSON file.
 - `utils.reporting_utils.generate_markdown_report` – produce a Markdown report.
 - `utils.validation_utils.detect_zero_byte_files` – find empty files for cleanup.

--- a/tests/test_configuration_utils.py
+++ b/tests/test_configuration_utils.py
@@ -1,0 +1,67 @@
+import json
+import os
+import yaml
+
+from utils.configuration_utils import load_enterprise_configuration, operations___init__
+
+
+def test_load_json_config(tmp_path, monkeypatch):
+    ws = tmp_path / "ws"
+    config_dir = ws / "config"
+    config_dir.mkdir(parents=True)
+    cfg_file = config_dir / "enterprise.json"
+    cfg_file.write_text(json.dumps({"database_path": "db.sqlite"}))
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    cfg = load_enterprise_configuration()
+    assert cfg["database_path"] == "db.sqlite"
+    assert cfg["workspace_root"] == str(ws)
+
+
+def test_load_yaml_config(tmp_path, monkeypatch):
+    ws = tmp_path / "ws"
+    config_dir = ws / "config"
+    config_dir.mkdir(parents=True)
+    cfg_file = config_dir / "enterprise.yaml"
+    cfg_file.write_text(yaml.safe_dump({"logging_level": "DEBUG"}))
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    cfg = load_enterprise_configuration(str(cfg_file))
+    assert cfg["logging_level"] == "DEBUG"
+
+
+def test_environment_override(tmp_path, monkeypatch):
+    ws = tmp_path / "ws"
+    config_dir = ws / "config"
+    config_dir.mkdir(parents=True)
+    cfg_file = config_dir / "enterprise.json"
+    cfg_file.write_text("{}")
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    monkeypatch.setenv("DATABASE_PATH", "override.db")
+    cfg = load_enterprise_configuration()
+    assert cfg["database_path"] == "override.db"
+
+
+def test_invalid_config(tmp_path, monkeypatch):
+    ws = tmp_path / "ws"
+    config_dir = ws / "config"
+    config_dir.mkdir(parents=True)
+    cfg_file = config_dir / "enterprise.json"
+    cfg_file.write_text("{invalid}")
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    try:
+        load_enterprise_configuration()
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_operations_init_sets_env(tmp_path, monkeypatch):
+    ws = tmp_path / "ws"
+    config_dir = ws / "config"
+    config_dir.mkdir(parents=True)
+    cfg_file = config_dir / "enterprise.json"
+    cfg_file.write_text("{}")
+    cfg = operations___init__(workspace_path=str(ws), config_path=str(cfg_file))
+    assert os.environ["GH_COPILOT_WORKSPACE"] == str(ws)
+    assert cfg["workspace_root"] == str(ws)
+

--- a/utils/configuration_utils.py
+++ b/utils/configuration_utils.py
@@ -1,35 +1,74 @@
-"""Configuration utilities for gh_COPILOT Enterprise Toolkit"""
+"""Configuration utilities for gh_COPILOT Enterprise Toolkit."""
+
+from __future__ import annotations
 
 import json
 import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import yaml
+
 
 def load_enterprise_configuration(config_path: Optional[str] = None) -> Dict[str, Any]:
-    """Load enterprise configuration with defaults"""
+    """Load enterprise configuration from JSON or YAML with environment overrides."""
+    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+
     if config_path is None:
-        workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
-        config_path = str(workspace_root / "config" / "enterprise.json")
+        config_path = workspace_root / "config" / "enterprise.json"
+    else:
+        config_path = Path(config_path)
 
     defaults = {
-        "workspace_root": os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()),
+        "workspace_root": str(workspace_root),
         "database_path": "databases/production.db",
         "logging_level": "INFO",
-        "enterprise_mode": True
+        "enterprise_mode": True,
     }
 
+    config: Dict[str, Any] = {}
     try:
-        with open(config_path, 'r', encoding='utf-8') as f:
-            config = json.load(f)
-        defaults.update(config)
+        with open(config_path, "r", encoding="utf-8") as fh:
+            if config_path.suffix.lower() in {".yaml", ".yml"}:
+                config = yaml.safe_load(fh) or {}
+            else:
+                config = json.load(fh)
     except FileNotFoundError:
-        pass  # Use defaults
+        pass  # Use defaults only
+    except (json.JSONDecodeError, yaml.YAMLError) as exc:
+        raise ValueError(f"Invalid configuration file: {config_path}") from exc
 
-    return defaults
+    cfg = {**defaults, **config}
+
+    for key in list(cfg.keys()):
+        env_val = os.getenv(key.upper())
+        if env_val is not None:
+            cfg[key] = env_val
+
+    required = ["workspace_root", "database_path", "logging_level", "enterprise_mode"]
+    for field in required:
+        if field not in cfg or cfg[field] in (None, ""):
+            raise ValueError(f"Missing required configuration value: {field}")
+
+    return cfg
 
 
 def validate_environment_compliance() -> bool:
     """Validate enterprise environment compliance"""
     workspace = os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())
     return workspace.endswith("gh_COPILOT")
+
+
+def operations___init__(workspace_path: Optional[str] = None,
+                        config_path: Optional[str] = None) -> Dict[str, Any]:
+    """Universal initialization pattern for scripts.
+
+    This helper sets ``GH_COPILOT_WORKSPACE`` if ``workspace_path`` is provided
+    and loads the enterprise configuration via :func:`load_enterprise_configuration`.
+    """
+
+    if workspace_path is not None:
+        os.environ["GH_COPILOT_WORKSPACE"] = str(Path(workspace_path))
+
+    config = load_enterprise_configuration(config_path)
+    return config


### PR DESCRIPTION
## Summary
- add YAML handling in `load_enterprise_configuration`
- implement `operations___init__` helper for universal init
- document configuration loading capabilities
- add tests for JSON/YAML config loading and env overrides

## Testing
- `ruff check utils/configuration_utils.py tests/test_configuration_utils.py README.md`
- `pytest tests/test_configuration_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687da53568d08331aed7af734016a4c9