### PR TITLE
Add text report utility and tests

### DIFF
--- a/tests/test_new_utils.py
+++ b/tests/test_new_utils.py
@@ -1,6 +1,10 @@
 import json
 from utils.general_utils import operations_main
-from utils.reporting_utils import generate_json_report, generate_markdown_report
+from utils.reporting_utils import (
+    generate_json_report,
+    generate_markdown_report,
+    generate_text_report,
+)
 from utils.validation_utils import (
     detect_zero_byte_files,
     validate_path,
@@ -26,6 +30,13 @@ def test_generate_markdown_report(tmp_path):
     generate_markdown_report({"a": 1}, out, title="T")
     text = out.read_text()
     assert text.startswith("# T") and "**a**" in text
+
+
+def test_generate_text_report(tmp_path):
+    out = tmp_path / "report.txt"
+    generate_text_report({"a": 1, "b": 2}, out)
+    text = out.read_text()
+    assert "a: 1" in text and "b: 2" in text
 
 
 def test_detect_zero_byte_files(tmp_path):

--- a/utils/reporting_utils.py
+++ b/utils/reporting_utils.py
@@ -22,3 +22,11 @@ def generate_markdown_report(data: Dict[str, Any], output_path: Path, title: str
     output_path.write_text("\n".join(lines), encoding="utf-8")
     return output_path
 
+
+def generate_text_report(data: Dict[str, Any], output_path: Path) -> Path:
+    """Write ``data`` to ``output_path`` in plain text format."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{key}: {value}" for key, value in data.items()]
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+    return output_path
+


### PR DESCRIPTION
## Summary
- extend reporting utils with plain text generation
- update reporting utils tests

## Testing
- `ruff check .` *(fails: 2326 errors)*
- `pytest tests/test_new_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687dadf8f52083318a4b9bb8506a164b