### PR TITLE
feat: add wrap-up result validation

### DIFF
--- a/scripts/orchestrators/unified_wrapup_orchestrator.py
+++ b/scripts/orchestrators/unified_wrapup_orchestrator.py
@@ -56,7 +56,10 @@ class WrapUpResult:
     error_details: List[str] = field(default_factory=list)
 
     def __post_init__(self):
-        pass
+        if self.end_time is not None and self.end_time < self.start_time:
+            raise ValueError("end_time cannot be earlier than start_time")
+        if not 0.0 <= self.compliance_score <= 100.0:
+            raise ValueError("compliance_score must be between 0 and 100")
 
 
 class UnifiedWrapUpOrchestrator:

--- a/tests/test_unified_wrapup_orchestrator_postinit.py
+++ b/tests/test_unified_wrapup_orchestrator_postinit.py
@@ -1,0 +1,17 @@
+import datetime
+import pytest
+from scripts.orchestrators.unified_wrapup_orchestrator import WrapUpResult
+
+def test_wrapup_result_post_init_valid():
+    result = WrapUpResult(session_id="id", start_time=datetime.datetime.now())
+    assert result.compliance_score == 0.0
+
+def test_wrapup_result_post_init_invalid_end_time():
+    start = datetime.datetime.now()
+    with pytest.raises(ValueError):
+        WrapUpResult(session_id="id", start_time=start, end_time=start - datetime.timedelta(seconds=1))
+
+def test_wrapup_result_post_init_invalid_score():
+    start = datetime.datetime.now()
+    with pytest.raises(ValueError):
+        WrapUpResult(session_id="id", start_time=start, compliance_score=150.0)


### PR DESCRIPTION
## Summary
- validate compliance score and end time in `WrapUpResult`
- add tests for the new validation rules

## Testing
- `pytest tests/test_unified_wrapup_orchestrator_postinit.py -q`
- `ruff check tests/test_unified_wrapup_orchestrator_postinit.py scripts/orchestrators/unified_wrapup_orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_687dc70ce28483319f6939dccb77c1c8