### PR TITLE
Enhance session validator

### DIFF
--- a/tests/test_session_protocol_validator.py
+++ b/tests/test_session_protocol_validator.py
@@ -3,7 +3,6 @@
 
 from validation.protocols.session import SessionProtocolValidator
 from scripts.utilities.unified_session_management_system import UnifiedSessionManagementSystem
-import logging
 
 
 def test_startup_detects_zero_byte(tmp_path, monkeypatch):
@@ -11,7 +10,7 @@ def test_startup_detects_zero_byte(tmp_path, monkeypatch):
     zero_file = tmp_path / "a.py"
     zero_file.write_text("")
     validator = SessionProtocolValidator()
-    assert validator.validate_startup() is False
+    assert not validator.validate_startup().is_success
 
 
 def test_unified_session_start_fails_with_zero_byte(tmp_path, monkeypatch):
@@ -19,7 +18,7 @@ def test_unified_session_start_fails_with_zero_byte(tmp_path, monkeypatch):
     zero_file = tmp_path / "b.py"
     zero_file.write_text("")
     mgr = UnifiedSessionManagementSystem()
-    assert mgr.start_session() is False
+    assert not mgr.start_session().is_success
 
 
 def test_unicode_workspace_path(tmp_path, monkeypatch):
@@ -27,4 +26,13 @@ def test_unicode_workspace_path(tmp_path, monkeypatch):
     unicode_dir.mkdir()
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(unicode_dir))
     validator = SessionProtocolValidator()
-    assert validator.validate_startup() is True
+    assert validator.validate_startup().is_success
+
+
+def test_comprehensive_validation_fails(monkeypatch):
+    monkeypatch.setenv("MY_PASSWORD", "secret")
+    monkeypatch.setenv("SESSION_TIMEOUT", "30")
+    monkeypatch.setenv("USE_HTTPS", "0")
+    validator = SessionProtocolValidator()
+    result = validator.validate_comprehensive_session()
+    assert result.is_failure


### PR DESCRIPTION
## Summary
- extend `SessionProtocolValidator` with credential, timeout, and HTTPS checks
- add comprehensive session validation tests
- update validation package tests

## Testing
- `ruff check validation/protocols/session.py tests/test_validation_package.py tests/test_session_protocol_validator.py`
- `pytest -q tests/test_session_protocol_validator.py tests/test_validation_package.py`

------
https://chatgpt.com/codex/tasks/task_e_687dc99ee1e483318e6b068ed3fd7159