### PR TITLE
Add hello world helper and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ result = generator.generate_with_validation(
 print(f"[SUCCESS] Generated with {result.confidence_score}% confidence")
 ```
 
+### Run Simplified Quantum Integration Orchestrator
+```bash
+python simplified_quantum_integration_orchestrator.py
+```
+
 ---
 
 ## 🗄️ DATABASE-FIRST ARCHITECTURE

--- a/quantum_algorithm_library_expansion.py
+++ b/quantum_algorithm_library_expansion.py
@@ -15,6 +15,10 @@ import numpy as np
 class EnterpriseUtility:
     """Minimal enterprise utility wrapper used for testing."""
 
+    def __init__(self, workspace_path: str | None = None) -> None:  # pragma: no cover - thin wrapper
+        """Initialize utility; workspace path is optional."""
+        self.workspace_path = workspace_path
+
     def perform_utility_function(self) -> bool:  # pragma: no cover - thin wrapper
         """Run the Grover demo and report success."""
         return demo_grover_search() == 3

--- a/simplified_quantum_integration_orchestrator.py
+++ b/simplified_quantum_integration_orchestrator.py
@@ -1,5 +1,16 @@
 """Thin wrapper for :mod:`archive.consolidated_scripts.simplified_quantum_integration_orchestrator`."""
-from archive.consolidated_scripts.simplified_quantum_integration_orchestrator import \
-    EnterpriseUtility
+from archive.consolidated_scripts.simplified_quantum_integration_orchestrator import (
+    EnterpriseUtility,
+)
 
-__all__ = ["EnterpriseUtility"]
+__all__ = ["EnterpriseUtility", "hello_world"]
+
+
+def hello_world() -> None:
+    """Print a friendly greeting."""
+
+    print("Hello, world!")
+
+
+if __name__ == "__main__":
+    hello_world()

--- a/tests/test_simplified_quantum_integration_orchestrator.py
+++ b/tests/test_simplified_quantum_integration_orchestrator.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 from archive.consolidated_scripts.simplified_quantum_integration_orchestrator import EnterpriseUtility
-import logging
+from simplified_quantum_integration_orchestrator import hello_world
 
 
 def test_perform_utility_function_runs():
     util = EnterpriseUtility()
     assert util.perform_utility_function() is True
+
+
+def test_hello_world_output(capsys):
+    hello_world()
+    captured = capsys.readouterr()
+    assert "Hello, world!" in captured.out


### PR DESCRIPTION
## Summary
- add `hello_world` helper function to simplified orchestrator
- provide README usage note for running the script
- extend library utility with optional workspace argument
- test the new greeting

## Testing
- `ruff check simplified_quantum_integration_orchestrator.py tests/test_simplified_quantum_integration_orchestrator.py quantum_algorithm_library_expansion.py`
- `pytest tests/test_simplified_quantum_integration_orchestrator.py -q`
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687dd10f6b388331a112e23e1d679777