### PR TITLE
Implement DB-driven doc generation

### DIFF
--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -1,0 +1,30 @@
+# Database-First Usage Guide
+
+This guide describes how to operate the **gh_COPILOT** toolkit using the recommended database-first workflow.
+
+## 1. Query Before Code
+- Always query `production.db`, `template_documentation.db` or `documentation.db` for existing patterns before creating new code or documentation.
+- Example:
+  ```python
+  import sqlite3
+  with sqlite3.connect('databases/production.db') as conn:
+      cur = conn.cursor()
+      cur.execute("SELECT content FROM code_templates WHERE name=?", ('build_script',))
+      template = cur.fetchone()[0]
+  ```
+
+## 2. Generate From Templates
+- Use retrieved templates as the base for new scripts.
+- Log template usage in `template_usage_tracking` for auditing.
+
+## 3. Documentation Generation
+- Documentation patterns are stored in `documentation.db`.
+- Render Markdown files from these entries and record the generation event.
+
+## 4. Synchronization
+- Run `synchronize_templates()` to ensure templates are consistent across all databases.
+
+## 5. Compliance & Correction
+- All generation actions must be logged for compliance review.
+- When corrections occur, update `analytics.db:correction_patterns` for future reference.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,3 +26,7 @@ contents of the production database.
 Benchmark results are stored in ``benchmark_metrics.db``. Remove this file to
 clear previous baselines. The next call to ``benchmark()`` will generate a new
 baseline entry.
+
+
+## Additional Guides
+See [DATABASE_FIRST_USAGE_GUIDE.md](DATABASE_FIRST_USAGE_GUIDE.md) for database-first workflow details.

--- a/tests/test_documentation_generation_system.py
+++ b/tests/test_documentation_generation_system.py
@@ -1,0 +1,21 @@
+import sqlite3
+from scripts.documentation_generation_system import EnterpriseUtility
+
+
+def test_generation_system(tmp_path, monkeypatch):
+    db_dir = tmp_path / "archives"
+    db_dir.mkdir()
+    db_path = db_dir / "documentation.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE documentation_templates (template_name TEXT, template_content TEXT, enterprise_compliant BOOLEAN)"
+        )
+        conn.execute(
+            "INSERT INTO documentation_templates VALUES ('sample', '# Example', 1)"
+        )
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    util = EnterpriseUtility(workspace_path=str(tmp_path))
+    assert util.perform_utility_function() is True
+    output = tmp_path / "documentation" / "generated" / "templates" / "sample.md"
+    assert output.exists()
+    assert output.read_text() == "# Example"


### PR DESCRIPTION
## Summary
- add database-first usage guide
- implement documentation template rendering from DB
- improve database access layer statistics collection
- update scaling framework to read production database
- expand unit tests for new features

## Testing
- `ruff check scripts/documentation_generation_system.py db_tools/operations/access.py scripts/regenerated/scaling_innovation_framework.py tests/test_documentation_generation_system.py tests/test_db_tools.py`
- `pytest tests/test_documentation_generation_system.py tests/test_db_tools.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687de382b6108331be41abcd796bff10