### PR TITLE
Add database-first copilot tasks summary

### DIFF
--- a/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
+++ b/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
@@ -1,0 +1,45 @@
+# Database-First Copilot Task Suggestions
+
+This document lists high-level tasks required to fully implement the database-first Codex/Copilot integration. Use it as a reference for planning and tracking future development.
+
+## 1. Database-First Integration
+- Expand `DatabaseFirstCopilotEnhancer` with anti-recursion checks and query similarity scoring.
+- Ensure all operations query the databases (`production.db`, `documentation.db`, `template_documentation.db`) before interacting with the filesystem.
+- Provide unit tests validating the scoring logic and environment adaptation.
+
+## 2. Template Synchronization
+- Finish `synchronize_templates()` in `copilot/copilot-instructions.md` with transactional integrity and audit logging.
+- Synchronize templates across development, staging and production databases.
+
+## 3. Documentation Generation System
+- Update `EnterpriseDocumentationManager` to select the best template based on compliance scores and log generation events.
+- Modify `scripts/documentation_generation_system.py` to query templates from `documentation.db` and render markdown files with progress indicators.
+- Add tests in `tests/test_documentation_consolidator.py` covering template selection and file output.
+
+## 4. Integration-Ready Code Generation
+- Implement `generate_integration_ready_code()` with progress indicators and metadata mapping from requirements to generated code.
+- Add tests covering activation scenarios and compliance verification.
+
+## 5. Correction and Rollback Patterns
+- Record correction history in `analytics.db` and add iteration tracking in conversation logs under `builds/*/documentation/*convo.md`.
+- Generate compliance reports describing applied corrections.
+
+## 6. Database Schema Enhancements
+- Extend `enhanced_script_tracking` with new columns including `importance_score` and `template_version`.
+- Create `code_templates`, `template_usage_tracking` and `template_registry` tables. Write migration scripts for existing databases.
+- Ensure `documentation` table stores `compliance_score` for each document.
+
+## 7. Template Engine Upgrades
+- Replace the placeholder clustering in `template_engine/auto_generator.py` with `sklearn.cluster.KMeans`.
+- Add a `get_cluster_representatives()` method and unit tests verifying cluster selection and retrieval.
+
+## 8. Placeholder Implementations
+- Search the repository for "Implementation placeholder" comments and replace them with real database-driven functionality.
+- Update utilities like `documentation_db_analyzer.py` and `enterprise_database_driven_documentation_manager.py` to process database entries and log progress.
+
+## 9. Documentation Updates
+- Extend `docs/README.md` with references to the new database-first utilities.
+- Keep `DATABASE_FIRST_USAGE_GUIDE.md` aligned with the implemented logic.
+
+---
+These tasks derive from the provided enhancement prompt and are meant to guide ongoing work toward a robust database-first Copilot integration.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,3 +30,4 @@ baseline entry.
 
 ## Additional Guides
 See [DATABASE_FIRST_USAGE_GUIDE.md](DATABASE_FIRST_USAGE_GUIDE.md) for database-first workflow details.
+For upcoming work items, refer to [DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md](DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md).


### PR DESCRIPTION
## Summary
- outline upcoming database-first Copilot tasks in a new doc
- link the new task list from docs README

## Testing
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687de844fbc08331987bbd4408bfcbf2