### PR TITLE
feat: implement documentation DB analyzers

### DIFF
--- a/archive/consolidated_scripts/documentation_db_analyzer.py
+++ b/archive/consolidated_scripts/documentation_db_analyzer.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 
 import sqlite3
 import logging
+import sys
 from pathlib import Path
 from datetime import datetime
 
@@ -58,10 +59,34 @@ class EnterpriseDatabaseProcessor:
     def process_operations(self, cursor) -> bool:
         """Process database operations"""
         try:
-            # Implementation for database operations
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='enterprise_documentation'"
+            )
+            if not cursor.fetchone():
+                self.logger.error(
+                    f"{TEXT_INDICATORS['error']} Missing enterprise_documentation table"
+                )
+                return False
+
+            cursor.execute("SELECT COUNT(*) FROM enterprise_documentation")
+            total = cursor.fetchone()[0]
+            self.logger.info(
+                f"{TEXT_INDICATORS['info']} Documentation entries: {total}"
+            )
+
+            cursor.execute(
+                "SELECT doc_type, COUNT(*) FROM enterprise_documentation GROUP BY doc_type"
+            )
+            for doc_type, count in cursor.fetchall():
+                self.logger.info(
+                    f"{TEXT_INDICATORS['info']} {doc_type}: {count}"
+                )
+
             return True
         except Exception as e:
-            self.logger.error(f"{TEXT_INDICATORS['error']} Operation failed: {e}")
+            self.logger.error(
+                f"{TEXT_INDICATORS['error']} Operation failed: {e}"
+            )
             return False
 
 

--- a/archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py
+++ b/archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 
 import sqlite3
 import logging
+import sys
 from pathlib import Path
 from datetime import datetime
 
@@ -58,10 +59,29 @@ class EnterpriseDatabaseProcessor:
     def process_operations(self, cursor) -> bool:
         """Process database operations"""
         try:
-            # Implementation for database operations
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='enterprise_documentation'"
+            )
+            if not cursor.fetchone():
+                self.logger.error(
+                    f"{TEXT_INDICATORS['error']} Missing enterprise_documentation table"
+                )
+                return False
+
+            cursor.execute(
+                "SELECT title, COUNT(*) FROM enterprise_documentation GROUP BY title"
+            )
+            summaries = cursor.fetchall()
+            for title, count in summaries:
+                self.logger.info(
+                    f"{TEXT_INDICATORS['info']} {title}: {count} versions"
+                )
+
             return True
         except Exception as e:
-            self.logger.error(f"{TEXT_INDICATORS['error']} Operation failed: {e}")
+            self.logger.error(
+                f"{TEXT_INDICATORS['error']} Operation failed: {e}"
+            )
             return False
 
 

--- a/tests/test_documentation_db_analyzer.py
+++ b/tests/test_documentation_db_analyzer.py
@@ -1,0 +1,24 @@
+import logging
+import sqlite3
+from archive.consolidated_scripts.documentation_db_analyzer import EnterpriseDatabaseProcessor
+
+
+def test_process_operations(tmp_path, caplog):
+    db_path = tmp_path / "docs.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE enterprise_documentation (doc_id TEXT, doc_type TEXT, title TEXT, content TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO enterprise_documentation VALUES (?,?,?,?)",
+            [
+                ("1", "README", "Title1", "content1"),
+                ("2", "GUIDE", "Title2", "content2"),
+            ],
+        )
+
+    processor = EnterpriseDatabaseProcessor(database_path=str(db_path))
+    with caplog.at_level(logging.INFO):
+        assert processor.execute_processing()
+    messages = " ".join(caplog.messages)
+    assert "Documentation entries: 2" in messages

--- a/tests/test_enterprise_documentation_manager.py
+++ b/tests/test_enterprise_documentation_manager.py
@@ -1,0 +1,24 @@
+import logging
+import sqlite3
+from archive.consolidated_scripts.enterprise_database_driven_documentation_manager import EnterpriseDatabaseProcessor
+
+
+def test_process_operations(tmp_path, caplog):
+    db_path = tmp_path / "docs.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE enterprise_documentation (doc_id TEXT, doc_type TEXT, title TEXT, content TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO enterprise_documentation VALUES (?,?,?,?)",
+            [
+                ("1", "README", "Title1", "content1"),
+                ("2", "README", "Title1", "content2"),
+            ],
+        )
+
+    processor = EnterpriseDatabaseProcessor(database_path=str(db_path))
+    with caplog.at_level(logging.INFO):
+        assert processor.execute_processing()
+    messages = " ".join(caplog.messages)
+    assert "Title1: 2 versions" in messages


### PR DESCRIPTION
## Summary
- complete documentation_db_analyzer process logic
- complete enterprise_documentation_manager process logic
- add tests for new database processing utilities

## Testing
- `ruff check archive/consolidated_scripts/documentation_db_analyzer.py archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py tests/test_documentation_db_analyzer.py tests/test_enterprise_documentation_manager.py`
- `pytest tests/test_documentation_db_analyzer.py tests/test_enterprise_documentation_manager.py tests/test_documentation_generation_system.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687dea36c22883319515af45378b4336