### PR TITLE
Add design doc for DatabaseFirstCopilotEnhancer

### DIFF
--- a/docs/DATABASE_FIRST_COPILOT_ENHANCER_DESIGN.md
+++ b/docs/DATABASE_FIRST_COPILOT_ENHANCER_DESIGN.md
@@ -1,0 +1,69 @@
+# DatabaseFirstCopilotEnhancer Design Overview
+
+This document outlines the high-level architecture and workflow of the
+`DatabaseFirstCopilotEnhancer` class described in
+`builds/*/documentation/*set_of_prompts.md`. The goal of the enhancer is to
+ensure all Copilot automation begins with database queries before interacting
+with the filesystem, while enforcing anti-recursion and compliance protocols.
+
+## Architecture
+
+`DatabaseFirstCopilotEnhancer` is structured around three core components:
+
+1. **Environment Compliance Layer** – Validates that the workspace adheres to
+   anti-recursion rules and enterprise policies. Initialization calls
+   `validate_environment_compliance()` before any other action.
+2. **Database Connector** – Establishes a connection to `production.db` and
+   exposes query helpers used to locate existing solutions and templates. This
+   connector is used prior to any filesystem operations.
+3. **Template Engine** – Retrieved via `_initialize_template_engine()`, this
+   engine selects templates from the database and adapts them to the current
+   environment.
+
+The class stores the database path in `self.production_db` and holds a template
+engine instance for reuse across methods.
+
+## Workflow
+
+### Initialization
+1. Perform environment compliance validation.
+2. Set `self.production_db` to `databases/production.db`.
+3. Initialize the template engine.
+
+### `query_before_filesystem(objective)`
+1. **Database Query** – `_query_database_solutions()` searches
+   `production.db` for past solutions related to the provided objective.
+2. **Template Matching** – `_find_template_matches()` locates candidate
+   templates that align with the objective.
+3. **Environment Adaptation** – `_adapt_to_current_environment()` adjusts the
+   template code based on workspace specifics.
+4. **Result Construction** – A dictionary containing the database results,
+   adapted template code, confidence score, and integration flag is returned.
+
+```python
+return {
+    "database_solutions": existing_solutions,
+    "template_code": adapted_code,
+    "confidence_score": self._calculate_confidence(existing_solutions),
+    "integration_ready": True,
+}
+```
+
+### Integration-Ready Code Generation
+`generate_integration_ready_code()` provides a structured process to produce
+code with progress indicators:
+
+1. Query proven patterns from the database (30% of progress).
+2. Adapt patterns to the current environment (40%).
+3. Prepare the code for integration (30%).
+4. Log the total duration and return the final code string.
+
+Progress is displayed using `tqdm`, and all steps are logged to ensure audit
+traceability.
+
+## Summary
+
+The `DatabaseFirstCopilotEnhancer` class enforces a database-first workflow,
+leveraging existing patterns before generating new code. By validating the
+environment, querying `production.db`, adapting templates, and providing visual
+indicators, it aligns Copilot automation with enterprise compliance standards.


### PR DESCRIPTION
## Summary
- add a new design overview explaining DatabaseFirstCopilotEnhancer architecture and workflow

## Testing
- `ruff check .`
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687df3d9bef083319cd9e9a9092e1d45