### PR TITLE
Validate copilot instruction file

### DIFF
--- a/builds/production/builds/artifacts/validation/github_copilot_instruction_set_validator.py
+++ b/builds/production/builds/artifacts/validation/github_copilot_instruction_set_validator.py
@@ -10,6 +10,7 @@ Enterprise Standards Compliance:
 """
 
 import logging
+import sys
 from pathlib import Path
 from datetime import datetime
 
@@ -52,8 +53,26 @@ class EnterpriseUtility:
             return False
 
     def perform_utility_function(self) -> bool:
-        """Perform the utility function"""
-        # Implementation placeholder
+        """Validate presence of required Copilot instructions."""
+        instructions = self.workspace_path / "copilot" / "copilot-instructions.md"
+        if not instructions.exists():
+            self.logger.error(
+                f"{TEXT_INDICATORS['error']} Instructions not found: {instructions}"
+            )
+            return False
+
+        content = instructions.read_text(encoding="utf-8").lower()
+        required = ["dual copilot", "visual processing indicators"]
+        missing = [r for r in required if r not in content]
+        if missing:
+            self.logger.error(
+                f"{TEXT_INDICATORS['error']} Missing keywords: {', '.join(missing)}"
+            )
+            return False
+
+        self.logger.info(
+            f"{TEXT_INDICATORS['success']} Instruction set validated"
+        )
         return True
 
 

--- a/tests/test_instruction_validator.py
+++ b/tests/test_instruction_validator.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from builds.production.builds.artifacts.validation.github_copilot_instruction_set_validator import EnterpriseUtility
+
+
+def test_instruction_validator_pass(tmp_path):
+    workspace = Path(tmp_path)
+    copilot_dir = workspace / "copilot"
+    copilot_dir.mkdir()
+    instructions = copilot_dir / "copilot-instructions.md"
+    instructions.write_text("Dual Copilot\nVisual Processing Indicators")
+
+    util = EnterpriseUtility(str(workspace))
+    assert util.perform_utility_function() is True
+
+def test_instruction_validator_fail(tmp_path):
+    workspace = Path(tmp_path)
+    copilot_dir = workspace / "copilot"
+    copilot_dir.mkdir()
+    instructions = copilot_dir / "copilot-instructions.md"
+    instructions.write_text("Just some text")
+
+    util = EnterpriseUtility(str(workspace))
+    assert util.perform_utility_function() is False


### PR DESCRIPTION
## Summary
- implement validation logic in `github_copilot_instruction_set_validator.py`
- add tests for validator behavior

## Testing
- `ruff check builds/production/builds/artifacts/validation/github_copilot_instruction_set_validator.py`
- `ruff check tests/test_instruction_validator.py`
- `pytest tests/test_instruction_validator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e59b66f84833193c212b8d259f51c