### PR TITLE
Enhance database-first copilot helper

### DIFF
--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -23,6 +23,9 @@ export GH_COPILOT_WORKSPACE=/path/to/gh_COPILOT
 ## 2. Generate From Templates
 - Use retrieved templates as the base for new scripts.
 - Log template usage in `template_usage_tracking` for auditing.
+- Templates may include placeholders such as `{workspace}` which will be
+  automatically replaced with the active workspace path by
+  `DatabaseFirstCopilotEnhancer`.
 
 ## 3. Documentation Generation
 - Documentation patterns are stored in `documentation.db`.


### PR DESCRIPTION
## Summary
- refine DatabaseFirstCopilotEnhancer to check backup root
- implement similarity scoring and environment adaptation
- clarify template placeholder usage in docs
- extend tests for similarity and environment adaptation

## Testing
- `ruff check scripts/database/database_first_copilot_enhancer.py tests/test_database_first_copilot_enhancer.py`
- `pytest tests/test_database_first_copilot_enhancer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e644f51f883318080663c5ee2ba21