### PR TITLE
Clarify compliance in Database-First docs

### DIFF
--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -37,4 +37,10 @@ export GH_COPILOT_WORKSPACE=/path/to/gh_COPILOT
 ## 5. Compliance & Correction
 - All generation actions must be logged for compliance review.
 - When corrections occur, update `analytics.db:correction_patterns` for future reference.
+- Script generation events are recorded in `production.db:enhanced_script_tracking` with the
+  template version and a computed compliance score.
+- The `EnterpriseComplianceValidator` verifies that every generated script comes from an approved
+  template and meets the minimum compliance threshold (usually 80%).
+- Compliance summaries are exported to `analytics.db` so auditors can trace which templates were
+  used and whether any corrective actions occurred.
 


### PR DESCRIPTION
## Summary
- add detailed description of compliance workflow in Database-First model

## Testing
- `ruff check docs/DATABASE_FIRST_USAGE_GUIDE.md`
- `pytest tests/test_documentation_consolidator.py -q` *(fails: TypeError unsupported operand type(s) for +: 'PosixPath' and 'str')*

------
https://chatgpt.com/codex/tasks/task_e_687e67f5da5483319ce6e8b53d5c0a90