### PR TITLE
Add database-first validation docs

### DIFF
--- a/.github/docs/Database_First_Copilot.md
+++ b/.github/docs/Database_First_Copilot.md
@@ -1,0 +1,8 @@
+# Database-First Copilot Notes
+
+The Copilot integration relies on templates stored in `production.db`.
+When generating new code or documentation, the system queries the database
+for existing patterns before writing to the filesystem.
+
+Developers can update templates through the planned CRUD API to extend
+Copilot's capabilities.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,3 +33,5 @@ See [DATABASE_FIRST_USAGE_GUIDE.md](DATABASE_FIRST_USAGE_GUIDE.md) for database-
 For upcoming work items, refer to [DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md](DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md).
 Consult [DATABASE_QUERY_GUIDE.md](DATABASE_QUERY_GUIDE.md) for examples on querying the databases before implementing new features.
 The `template_engine.auto_generator` module clusters stored patterns using KMeans and can return representative templates for automation tasks.
+
+For validation details see [validation/Database_First_Validation.md](validation/Database_First_Validation.md). Copilot-specific notes are available under [.github/docs/Database_First_Copilot.md](../.github/docs/Database_First_Copilot.md).

--- a/docs/validation/Database_First_Validation.md
+++ b/docs/validation/Database_First_Validation.md
@@ -1,0 +1,12 @@
+# Database-First Validation Guide
+
+This document describes how to verify that automation follows the database-first workflow.
+
+## Checklist
+
+1. **Environment Setup** – Ensure `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT` are set.
+2. **Initial Query** – Confirm each script queries `production.db` before creating files.
+3. **Record Keeping** – Validation results should be stored in `validation_logs.db`.
+4. **Dual Copilot Review** – After primary execution, run the secondary validator to cross-check results.
+
+Use these steps whenever new modules or templates are introduced.


### PR DESCRIPTION
## Summary
- document how to validate database-first workflow
- add Copilot notes on using database templates
- reference the new docs in docs/README

## Testing
- `ruff check .`
- `pytest -q` *(fails: 25 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e772988648331ad5e482591b59583