### PR TITLE
feat: add data-driven health monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ TEXT_INDICATORS = {
 - **Anomaly Detection Models:** StandardScaler preprocessing with IsolationForest
 - **Model Persistence:** ML models are serialized to `models/autonomous/`
 - **Continuous Monitoring:** 24/7 system health tracking
+- **Data-Driven Metrics:** Health statistics are stored in `analytics.db` via
+  `monitoring.health_monitor` for historical analysis
 
 ### **Autonomous System Architecture**
 ```python

--- a/monitoring/health_monitor.py
+++ b/monitoring/health_monitor.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""System health monitoring utilities stored in analytics.db."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Dict, Optional
+
+import psutil
+
+WORKSPACE_ROOT = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+DB_PATH = WORKSPACE_ROOT / "analytics.db"
+
+__all__ = [
+    "record_system_health",
+    "recent_average",
+    "gather_metrics",
+    "ensure_table",
+]
+
+
+def ensure_table(conn: sqlite3.Connection) -> None:
+    """Ensure the system_health table exists."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS system_health (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            cpu_percent REAL,
+            memory_percent REAL,
+            disk_percent REAL,
+            net_bytes_sent INTEGER,
+            net_bytes_recv INTEGER
+        )
+        """
+    )
+
+
+def gather_metrics() -> Dict[str, float]:
+    """Collect current system metrics."""
+    return {
+        "cpu_percent": psutil.cpu_percent(interval=1),
+        "memory_percent": psutil.virtual_memory().percent,
+        "disk_percent": psutil.disk_usage("/").percent,
+        "net_bytes_sent": psutil.net_io_counters().bytes_sent,
+        "net_bytes_recv": psutil.net_io_counters().bytes_recv,
+    }
+
+
+def record_system_health(db_path: Optional[Path] = None) -> Dict[str, float]:
+    """Record current system health metrics and return them."""
+    metrics = gather_metrics()
+    path = db_path or DB_PATH
+    with sqlite3.connect(path) as conn:
+        ensure_table(conn)
+        conn.execute(
+            """
+            INSERT INTO system_health (
+                cpu_percent,
+                memory_percent,
+                disk_percent,
+                net_bytes_sent,
+                net_bytes_recv
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                metrics["cpu_percent"],
+                metrics["memory_percent"],
+                metrics["disk_percent"],
+                metrics["net_bytes_sent"],
+                metrics["net_bytes_recv"],
+            ),
+        )
+        conn.commit()
+    return metrics
+
+
+def recent_average(n: int = 10, db_path: Optional[Path] = None) -> Dict[str, float]:
+    """Return averages for the most recent ``n`` health records."""
+    path = db_path or DB_PATH
+    with sqlite3.connect(path) as conn:
+        ensure_table(conn)
+        cur = conn.execute(
+            """
+            SELECT AVG(cpu_percent),
+                   AVG(memory_percent),
+                   AVG(disk_percent),
+                   AVG(net_bytes_sent),
+                   AVG(net_bytes_recv)
+            FROM (
+                SELECT * FROM system_health ORDER BY id DESC LIMIT ?
+            )
+            """,
+            (n,),
+        )
+        row = cur.fetchone() or (0, 0, 0, 0, 0)
+        return {
+            "avg_cpu_percent": row[0] or 0.0,
+            "avg_memory_percent": row[1] or 0.0,
+            "avg_disk_percent": row[2] or 0.0,
+            "avg_net_bytes_sent": row[3] or 0.0,
+            "avg_net_bytes_recv": row[4] or 0.0,
+        }
+
+
+if __name__ == "__main__":
+    results = record_system_health()
+    print(results)

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import sqlite3
+from pathlib import Path
+
+from monitoring.health_monitor import (
+    ensure_table,
+    record_system_health,
+    recent_average,
+)
+
+
+def _prepare_db(tmp_path: Path) -> Path:
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        ensure_table(conn)
+    return db
+
+
+def test_record_system_health_inserts_row(tmp_path, monkeypatch):
+    db = _prepare_db(tmp_path)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    metrics = record_system_health(db_path=db)
+    assert "cpu_percent" in metrics
+    with sqlite3.connect(db) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM system_health")
+        assert cur.fetchone()[0] == 1
+
+
+def test_recent_average_computes_values(tmp_path):
+    db = _prepare_db(tmp_path)
+    with sqlite3.connect(db) as conn:
+        conn.executemany(
+            "INSERT INTO system_health (cpu_percent, memory_percent, disk_percent, net_bytes_sent, net_bytes_recv) VALUES (?, ?, ?, ?, ?)",
+            [(10, 20, 30, 40, 50), (20, 30, 40, 50, 60)],
+        )
+        conn.commit()
+    avg = recent_average(2, db_path=db)
+    assert round(avg["avg_cpu_percent"], 1) == 15.0
+    assert round(avg["avg_memory_percent"], 1) == 25.0


### PR DESCRIPTION
## Summary
- implement `monitoring.health_monitor` for storing system metrics in analytics.db
- test health monitor utilities
- document health monitor in README

## Testing
- `ruff check monitoring/health_monitor.py tests/test_health_monitor.py`
- `pytest tests/test_health_monitor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687e772988648331ad5e482591b59583