### PR TITLE
Add template synchronization utility

### DIFF
--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -36,7 +36,9 @@ export GH_COPILOT_WORKSPACE=/path/to/gh_COPILOT
 - Render Markdown files from these entries and record the generation event.
 
 ## 4. Synchronization
-- Run `synchronize_templates()` to ensure templates are consistent across all databases.
+- Run `template_engine.template_synchronizer.synchronize_templates()` to ensure
+  templates are consistent across development, staging, and production
+  databases.
 
 ## 5. Compliance & Correction
 - All generation actions must be logged for compliance review.

--- a/template_engine/template_synchronizer.py
+++ b/template_engine/template_synchronizer.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATABASES = [
+    Path("development.db"),
+    Path("staging.db"),
+    Path("production.db"),
+]
+
+def _extract_templates(db: Path) -> list[tuple[str, str]]:
+    if not db.exists():
+        return []
+    try:
+        with sqlite3.connect(db) as conn:
+            rows = conn.execute("SELECT name, template_content FROM templates").fetchall()
+            return [(r[0], r[1]) for r in rows]
+    except sqlite3.Error as exc:
+        logger.warning("Failed to read templates from %s: %s", db, exc)
+        return []
+
+def synchronize_templates(source_dbs: Iterable[Path] | None = None) -> int:
+    """Synchronize templates across multiple databases."""
+    databases = list(source_dbs) if source_dbs else DEFAULT_DATABASES
+    all_templates: dict[str, str] = {}
+    for db in databases:
+        for name, content in _extract_templates(db):
+            all_templates[name] = content
+    synced = 0
+    for db in databases:
+        if not db.exists():
+            continue
+        try:
+            with sqlite3.connect(db) as conn:
+                for name, content in all_templates.items():
+                    conn.execute(
+                        "INSERT OR REPLACE INTO templates (name, template_content) VALUES (?, ?)",
+                        (name, content),
+                    )
+                conn.commit()
+            synced += 1
+        except sqlite3.Error as exc:
+            logger.error("Failed to synchronize %s: %s", db, exc)
+    return synced
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    count = synchronize_templates()
+    logger.info("Synchronized %d databases", count)

--- a/tests/test_template_synchronizer.py
+++ b/tests/test_template_synchronizer.py
@@ -1,0 +1,27 @@
+import sqlite3
+from pathlib import Path
+
+from template_engine.template_synchronizer import synchronize_templates
+
+
+def create_db(path: Path, templates: dict[str, str]) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE templates (name TEXT PRIMARY KEY, template_content TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO templates (name, template_content) VALUES (?, ?)",
+            list(templates.items()),
+        )
+
+
+def test_synchronize_templates(tmp_path: Path) -> None:
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+    create_db(db_a, {"t1": "foo"})
+    create_db(db_b, {"t2": "bar"})
+    synchronize_templates([db_a, db_b])
+    for db in [db_a, db_b]:
+        with sqlite3.connect(db) as conn:
+            rows = conn.execute("SELECT name, template_content FROM templates ORDER BY name").fetchall()
+            assert rows == [("t1", "foo"), ("t2", "bar")]


### PR DESCRIPTION
## Summary
- implement `template_engine.template_synchronizer` for syncing template DBs
- document synchronization usage in the database-first usage guide
- add unit test for the synchronizer

## Testing
- `pytest tests/test_template_engine.py tests/test_template_synchronizer.py -q`
- `ruff check .` *(fails: Found 2295 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e783c5bdc8331b2209dd9ed987cb5