### PR TITLE
docs: add data backup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ python simplified_quantum_integration_orchestrator.py
 echo "def foo(): pass" | python scripts/template_matcher.py
 ```
 
+### Data Backup Feature
+The toolkit includes an enterprise-grade data backup feature. Set the
+`GH_COPILOT_BACKUP_ROOT` environment variable to an external directory and
+follow the steps in [docs/enterprise_backup_guide.md](docs/enterprise_backup_guide.md)
+to create and manage backups. This variable ensures backups never reside in the
+workspace, maintaining anti-recursion compliance.
+
 ---
 
 ## 🗄️ DATABASE-FIRST ARCHITECTURE

--- a/docs/enterprise_backup_guide.md
+++ b/docs/enterprise_backup_guide.md
@@ -1,0 +1,20 @@
+# Enterprise Backup Guide
+
+This guide describes how to use the data backup feature in the gh_COPILOT toolkit.
+
+## Prerequisites
+- Ensure the `GH_COPILOT_BACKUP_ROOT` environment variable points to an external directory outside the repository workspace.
+- Run `bash setup.sh` to create the `.venv` and install dependencies.
+
+## Performing a Backup
+1. Verify your environment variables:
+   ```bash
+   echo $GH_COPILOT_BACKUP_ROOT
+   ```
+2. Execute the backup command:
+   ```bash
+   python scripts/automation/enhanced_enterprise_continuation_processor_backup.py --source /path/to/data
+   ```
+3. Backups are stored within `$GH_COPILOT_BACKUP_ROOT` by default.
+
+For more details on advanced options and restoration procedures, see the documentation in `disaster_recovery/`.


### PR DESCRIPTION
## Summary
- add enterprise backup guide
- reference data backup feature and environment variable in README

## Testing
- `ruff check .`
- `ruff format .` *(fails: unterminated string)*
- `pytest -q` *(fails: import errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687e8451b3a88331a4eae71d6df71541