### PR TITLE
Improve KMeans config

### DIFF
--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -58,7 +58,7 @@ class TemplateAutoGenerator:
         vectorizer = TfidfVectorizer()
         matrix = vectorizer.fit_transform(data)
         n_clusters = min(len(data), 2)
-        model = KMeans(n_clusters=n_clusters, n_init="auto", random_state=0)
+        model = KMeans(n_clusters=n_clusters, n_init=10, random_state=0)
         model.fit(matrix)
         self._vectorizer = vectorizer
         self._matrix = matrix


### PR DESCRIPTION
## Summary
- tweak `TemplateAutoGenerator`'s KMeans init params

## Testing
- `ruff check template_engine/auto_generator.py`
- `pytest tests/test_template_engine.py tests/test_template_synchronizer.py -q`
- `pytest -q` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687e8a579bd883319e16989163ea1332