### PR TITLE
Add EnterpriseDocumentationManager

### DIFF
--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -33,7 +33,7 @@ export GH_COPILOT_WORKSPACE=/path/to/gh_COPILOT
 
 ## 3. Documentation Generation
 - Documentation patterns are stored in `documentation.db`.
-- Render Markdown files from these entries and record the generation event.
+- Use `scripts/documentation/enterprise_documentation_manager.py` to render Markdown files from these entries and record the generation event.
 
 ## 4. Synchronization
 - Run `template_engine.template_synchronizer.synchronize_templates()` to ensure

--- a/docs/DATABASE_QUERY_GUIDE.md
+++ b/docs/DATABASE_QUERY_GUIDE.md
@@ -45,6 +45,7 @@ with sqlite3.connect(workspace / "databases" / "documentation.db") as conn:
 
 - `scripts/documentation_generation_system.py`
 - `scripts/documentation_consolidator.py`
+- `scripts/documentation/enterprise_documentation_manager.py`
 - `scripts/utilities/complete_template_generator.py`
 
 These utilities rely on the databases above to generate scripts and docs.

--- a/scripts/documentation/enterprise_documentation_manager.py
+++ b/scripts/documentation/enterprise_documentation_manager.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from pathlib import Path
+from typing import Iterable, List
+
+from tqdm import tqdm
+
+from template_engine.auto_generator import (
+    DEFAULT_ANALYTICS_DB,
+    DEFAULT_COMPLETION_DB,
+    TemplateAutoGenerator,
+)
+
+TEXT_INDICATORS = {
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "progress": "[PROGRESS]",
+    "info": "[INFO]",
+}
+
+
+class EnterpriseDocumentationManager:
+    """Generate documentation files from ``documentation.db``."""
+
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        db_path: Path | None = None,
+        analytics_db: Path = DEFAULT_ANALYTICS_DB,
+        completion_db: Path = DEFAULT_COMPLETION_DB,
+    ) -> None:
+        self.workspace = Path(
+            workspace
+            or os.getenv("GH_COPILOT_WORKSPACE", Path(__file__).resolve().parents[2])
+        )
+        self.db_path = Path(
+            db_path
+            or os.getenv(
+                "DOCUMENTATION_DB_PATH",
+                self.workspace / "archives" / "documentation.db",
+            )
+        )
+        self.output_dir = (
+            self.workspace / "documentation" / "generated" / "enterprise_docs"
+        )
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.logger = logging.getLogger(__name__)
+        self.generator = TemplateAutoGenerator(analytics_db, completion_db)
+
+    # ------------------------------------------------------------------
+    def query_documentation(self, doc_type: str) -> list[tuple[str, str]]:
+        """Return ``doc_id`` and ``content`` for the given ``doc_type``."""
+        if not self.db_path.exists():
+            self.logger.error(
+                f"{TEXT_INDICATORS['error']} Missing database {self.db_path}"
+            )
+            return []
+        query = (
+            "SELECT doc_id, content FROM enterprise_documentation WHERE doc_type=?"
+        )
+        with sqlite3.connect(self.db_path) as conn:
+            return conn.execute(query, (doc_type,)).fetchall()
+
+    # ------------------------------------------------------------------
+    def select_template(self, doc_type: str) -> str:
+        """Return best template for ``doc_type`` using ``TemplateAutoGenerator``."""
+        template = self.generator.select_best_template(doc_type)
+        if not template:
+            self.logger.info(
+                f"{TEXT_INDICATORS['info']} No template found for {doc_type}"
+            )
+        return template
+
+    # ------------------------------------------------------------------
+    def generate_files(self, doc_type: str) -> List[Path]:
+        """Generate documentation files for ``doc_type``."""
+        docs = self.query_documentation(doc_type)
+        if not docs:
+            return []
+        template = self.select_template(doc_type)
+        generated: List[Path] = []
+        self.logger.info(
+            f"{TEXT_INDICATORS['start']} Generating {doc_type} documentation"
+        )
+        with tqdm(total=len(docs), desc=f"{TEXT_INDICATORS['progress']} docs", unit="doc") as bar:
+            for doc_id, content in docs:
+                text = template.replace("{content}", content) if template else content
+                path = self.output_dir / f"{doc_id}.md"
+                path.write_text(text)
+                generated.append(path)
+                bar.update(1)
+        self.logger.info(
+            f"{TEXT_INDICATORS['success']} Generated {len(generated)} {doc_type} files"
+        )
+        return generated
+
+
+__all__ = ["EnterpriseDocumentationManager"]

--- a/tests/test_documentation_manager.py
+++ b/tests/test_documentation_manager.py
@@ -1,0 +1,56 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.documentation.enterprise_documentation_manager import (
+    EnterpriseDocumentationManager,
+)
+from template_engine.auto_generator import TemplateAutoGenerator
+
+
+def create_template_dbs(tmp_path: Path):
+    analytics_db = tmp_path / "analytics.db"
+    completion_db = tmp_path / "template_completion.db"
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            "CREATE TABLE ml_pattern_optimization (replacement_template TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO ml_pattern_optimization VALUES ('{content}')"
+        )
+    with sqlite3.connect(completion_db) as conn:
+        conn.execute(
+            "CREATE TABLE templates (template_content TEXT)"
+        )
+        conn.execute("INSERT INTO templates VALUES ('{content}')")
+    return analytics_db, completion_db
+
+
+def test_generate_files(tmp_path, monkeypatch):
+    workspace = tmp_path
+    db_dir = workspace / "databases"
+    doc_dir = workspace / "documentation"
+    db_dir.mkdir()
+    doc_dir.mkdir()
+    db_path = db_dir / "documentation.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE enterprise_documentation (doc_id TEXT, doc_type TEXT, content TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO enterprise_documentation VALUES (?,?,?)",
+            [("1", "README", "alpha"), ("2", "README", "beta")],
+        )
+    analytics_db, completion_db = create_template_dbs(tmp_path)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("DOCUMENTATION_DB_PATH", str(db_path))
+    manager = EnterpriseDocumentationManager(
+        workspace=workspace,
+        db_path=db_path,
+        analytics_db=analytics_db,
+        completion_db=completion_db,
+    )
+    files = manager.generate_files("README")
+    assert len(files) == 2
+    for f in files:
+        assert f.exists()
+        assert f.read_text() in {"alpha", "beta"}


### PR DESCRIPTION
## Summary
- implement EnterpriseDocumentationManager for generating docs
- document new utility in DATABASE_* guides
- test documentation manager functionality

## Testing
- `ruff check scripts/documentation/enterprise_documentation_manager.py tests/test_documentation_manager.py docs/DATABASE_QUERY_GUIDE.md docs/DATABASE_FIRST_USAGE_GUIDE.md`
- `pytest tests/test_documentation_manager.py -q`
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687e90a309c48331ab6019d6f0724379