### PR TITLE
feat: enhance template sync logging

### DIFF
--- a/template_engine/template_synchronizer.py
+++ b/template_engine/template_synchronizer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 from typing import Iterable
 
@@ -16,19 +17,56 @@ DEFAULT_DATABASES = [
     Path("production.db"),
 ]
 
+ANALYTICS_DB = Path("databases") / "analytics.db"
+
+
 def _extract_templates(db: Path) -> list[tuple[str, str]]:
     if not db.exists():
         return []
     try:
         with sqlite3.connect(db) as conn:
-            rows = conn.execute("SELECT name, template_content FROM templates").fetchall()
+            rows = conn.execute(
+                "SELECT name, template_content FROM templates"
+            ).fetchall()
             return [(r[0], r[1]) for r in rows]
     except sqlite3.Error as exc:
         logger.warning("Failed to read templates from %s: %s", db, exc)
         return []
 
+
 def _validate_template(name: str, content: str) -> bool:
     return bool(name and content and content.strip())
+
+
+def _compliance_score(content: str) -> float:
+    """Return a simple compliance score for template content."""
+    return 50.0 if "TODO" in content.upper() else 100.0
+
+
+def _log_sync_event(source: str, target: str) -> None:
+    """Record a synchronization event."""
+    ANALYTICS_DB.parent.mkdir(exist_ok=True)
+    with sqlite3.connect(ANALYTICS_DB) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS sync_events (timestamp TEXT, source_db TEXT, target_db TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO sync_events (timestamp, source_db, target_db) VALUES (?, ?, ?)",
+            (datetime.utcnow().isoformat(), source, target),
+        )
+
+
+def _log_audit(db_name: str, details: str) -> None:
+    """Log synchronization failures."""
+    ANALYTICS_DB.parent.mkdir(exist_ok=True)
+    with sqlite3.connect(ANALYTICS_DB) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS audit_log (timestamp TEXT, db_name TEXT, details TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO audit_log (timestamp, db_name, details) VALUES (?, ?, ?)",
+            (datetime.utcnow().isoformat(), db_name, details),
+        )
 
 
 def synchronize_templates(source_dbs: Iterable[Path] | None = None) -> int:
@@ -43,6 +81,7 @@ def synchronize_templates(source_dbs: Iterable[Path] | None = None) -> int:
             else:
                 logger.warning("Invalid template from %s: %s", db, name)
 
+    source_names = ",".join(str(d) for d in databases)
     synced = 0
     for db in tqdm(databases, desc="Syncing DBs", unit="db"):
         if not db.exists():
@@ -53,18 +92,24 @@ def synchronize_templates(source_dbs: Iterable[Path] | None = None) -> int:
                 try:
                     cur.execute("BEGIN")
                     for name, content in all_templates.items():
+                        if _compliance_score(content) < 60.0:
+                            raise ValueError(f"Compliance failure for {name}")
                         cur.execute(
                             "INSERT OR REPLACE INTO templates (name, template_content) VALUES (?, ?)",
                             (name, content),
                         )
                     conn.commit()
                     synced += 1
-                except sqlite3.Error as exc:
+                    _log_sync_event(source_names, str(db))
+                except Exception as exc:
                     conn.rollback()
                     logger.error("Failed to synchronize %s: %s", db, exc)
+                    _log_audit(str(db), str(exc))
         except sqlite3.Error as exc:
             logger.error("Database error %s: %s", db, exc)
+            _log_audit(str(db), str(exc))
     return synced
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)

--- a/tests/test_template_synchronizer.py
+++ b/tests/test_template_synchronizer.py
@@ -1,7 +1,7 @@
 import sqlite3
 from pathlib import Path
 
-from template_engine.template_synchronizer import synchronize_templates
+from template_engine import template_synchronizer
 
 
 def create_db(path: Path, templates: dict[str, str]) -> None:
@@ -15,26 +15,70 @@ def create_db(path: Path, templates: dict[str, str]) -> None:
         )
 
 
-def test_synchronize_templates(tmp_path: Path) -> None:
+def test_synchronize_templates(tmp_path: Path, monkeypatch) -> None:
     db_a = tmp_path / "a.db"
     db_b = tmp_path / "b.db"
     create_db(db_a, {"t1": "foo"})
     create_db(db_b, {"t2": "bar"})
-    synchronize_templates([db_a, db_b])
+    analytics = tmp_path / "analytics.db"
+    monkeypatch.setattr(template_synchronizer, "ANALYTICS_DB", analytics)
+    template_synchronizer.synchronize_templates([db_a, db_b])
     for db in [db_a, db_b]:
         with sqlite3.connect(db) as conn:
-            rows = conn.execute("SELECT name, template_content FROM templates ORDER BY name").fetchall()
+            rows = conn.execute(
+                "SELECT name, template_content FROM templates ORDER BY name"
+            ).fetchall()
             assert rows == [("t1", "foo"), ("t2", "bar")]
 
+    with sqlite3.connect(analytics) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM sync_events").fetchone()[0]
+        assert count == 2
 
-def test_invalid_templates_ignored(tmp_path: Path) -> None:
+
+def test_invalid_templates_ignored(tmp_path: Path, monkeypatch) -> None:
     db_a = tmp_path / "a.db"
     db_b = tmp_path / "b.db"
     create_db(db_a, {"t1": "foo", "empty": ""})
     create_db(db_b, {})
 
-    synchronize_templates([db_a, db_b])
+    analytics = tmp_path / "analytics.db"
+    monkeypatch.setattr(template_synchronizer, "ANALYTICS_DB", analytics)
+
+    template_synchronizer.synchronize_templates([db_a, db_b])
 
     with sqlite3.connect(db_b) as conn:
         rows = conn.execute("SELECT name FROM templates ORDER BY name").fetchall()
-        assert rows == [("t1",),]
+        assert rows == [
+            ("t1",),
+        ]
+
+    with sqlite3.connect(analytics) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM sync_events").fetchone()[0]
+        assert count == 2
+
+
+def test_audit_logging_and_rollback(tmp_path: Path, monkeypatch) -> None:
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+    create_db(db_a, {"good": "foo"})
+    # create db_b without templates table to force failure
+    with sqlite3.connect(db_b) as conn:
+        conn.execute("CREATE TABLE other(id INTEGER)")
+
+    analytics = tmp_path / "analytics.db"
+    monkeypatch.setattr(template_synchronizer, "ANALYTICS_DB", analytics)
+
+    template_synchronizer.synchronize_templates([db_a, db_b])
+
+    # db_b should remain unchanged because sync rolled back
+    with sqlite3.connect(db_b) as conn:
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        assert tables == [("other",)]
+
+    with sqlite3.connect(analytics) as conn:
+        audit_count = conn.execute("SELECT COUNT(*) FROM audit_log").fetchone()[0]
+        event_count = conn.execute("SELECT COUNT(*) FROM sync_events").fetchone()[0]
+        assert audit_count == 1
+        assert event_count == 1


### PR DESCRIPTION
## Summary
- log template synchronization events to `analytics.db`
- validate templates with a compliance score check
- audit failures and roll back on database errors
- add tests for analytics logging and rollback behavior

## Testing
- `ruff format template_engine/template_synchronizer.py tests/test_template_synchronizer.py`
- `ruff check template_engine/template_synchronizer.py tests/test_template_synchronizer.py`
- `pytest tests/test_template_synchronizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e90a705e08331a2e8928a1945cd54