### PR TITLE
Fix placeholder scanner encoding

### DIFF
--- a/scripts/intelligent_code_analysis_placeholder_detection.py
+++ b/scripts/intelligent_code_analysis_placeholder_detection.py
@@ -78,7 +78,7 @@ class EnterpriseUtility:
             placeholder_found = False
             for py_file in self.workspace_path.rglob("*.py"):
                 try:
-                    text = py_file.read_text(encoding="utf-8")
+                    text = py_file.read_text(encoding="utf-8", errors="ignore")
                 except OSError:
                     continue
                 for pat in patterns:


### PR DESCRIPTION
## Summary
- adjust placeholder scanner to ignore decoding errors

## Testing
- `pytest tests/test_template_engine.py`
- `ruff check scripts/intelligent_code_analysis_placeholder_detection.py`

------
https://chatgpt.com/codex/tasks/task_e_687eb5fa4e0c83319ed19c0c49c239b7