### PR TITLE
Implement analytics db queries in validation scripts

### DIFF
--- a/builds/final/production/builds/artifacts/validation/FINAL_COMPREHENSIVE_PRODUCTION_TEST.py
+++ b/builds/final/production/builds/artifacts/validation/FINAL_COMPREHENSIVE_PRODUCTION_TEST.py
@@ -12,15 +12,16 @@ Enterprise Standards Compliance:
 # import os
 import sys
 import logging
+import sqlite3
 from pathlib import Path
 from datetime import datetime
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
-    'start': '[START]',
-    'success': '[SUCCESS]',
-    'error': '[ERROR]',
-    'info': '[INFO]'
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "info": "[INFO]",
 }
 
 
@@ -42,9 +43,9 @@ class EnterpriseUtility:
 
             if success:
                 duration = (datetime.now() - start_time).total_seconds()
-                self.logger.info(f"{TEXT_INDICATORS['success']} Uti" \
-               " \
-                                  "                  "ity completed in {duration:.1f}s")
+                self.logger.info(
+                    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s"
+                )
                 return True
             else:
                 self.logger.error(f"{TEXT_INDICATORS['error']} Utility failed")
@@ -55,9 +56,21 @@ class EnterpriseUtility:
             return False
 
     def perform_utility_function(self) -> bool:
-        """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        """Perform the utility function.
+
+        Fetch the count of placeholder usages from ``archives/analytics.db`` and
+        log it. This aligns with the project's database-first policy.
+        """
+        try:
+            db_path = self.workspace_path / "archives" / "analytics.db"
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.execute("SELECT COUNT(*) FROM placeholder_usage")
+                count = cursor.fetchone()[0]
+            self.logger.info(f"{TEXT_INDICATORS['info']} Placeholder records: {count}")
+            return True
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} DB query failed: {exc}")
+            return False
 
 
 def main():
@@ -70,9 +83,8 @@ def main():
     else:
         print(f"{TEXT_INDICATORS['error']} Utility failed")
 
-
-
     return success
+
 
 if __name__ == "__main__":
     success = main()

--- a/builds/final/production/builds/artifacts/validation/UNIFIED_DEPLOYMENT_ORCHESTRATOR_TEST_SUITE.py
+++ b/builds/final/production/builds/artifacts/validation/UNIFIED_DEPLOYMENT_ORCHESTRATOR_TEST_SUITE.py
@@ -10,15 +10,17 @@ Enterprise Standards Compliance:
 """
 
 import logging
+import sqlite3
+import sys
 from pathlib import Path
 from datetime import datetime
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
-    'start': '[START]',
-    'success': '[SUCCESS]',
-    'error': '[ERROR]',
-    'info': '[INFO]'
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "info": "[INFO]",
 }
 
 
@@ -41,7 +43,8 @@ class EnterpriseUtility:
             if success:
                 duration = (datetime.now() - start_time).total_seconds()
                 self.logger.info(
-    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s")
+                    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s"
+                )
                 return True
             else:
                 self.logger.error(f"{TEXT_INDICATORS['error']} Utility failed")
@@ -52,9 +55,21 @@ class EnterpriseUtility:
             return False
 
     def perform_utility_function(self) -> bool:
-        """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        """Perform the utility function.
+
+        Query ``archives/analytics.db`` for the number of placeholder usages and
+        log the result for reporting.
+        """
+        try:
+            db_path = self.workspace_path / "archives" / "analytics.db"
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.execute("SELECT COUNT(*) FROM placeholder_usage")
+                count = cursor.fetchone()[0]
+            self.logger.info(f"{TEXT_INDICATORS['info']} Placeholder records: {count}")
+            return True
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} DB query failed: {exc}")
+            return False
 
 
 def main():
@@ -69,8 +84,7 @@ def main():
 
     return success
 
+
 if __name__ == "__main__":
-
-
     success = main()
     sys.exit(0 if success else 1)

--- a/builds/final/production/builds/artifacts/validation/comprehensive_production_capability_tester.py
+++ b/builds/final/production/builds/artifacts/validation/comprehensive_production_capability_tester.py
@@ -10,15 +10,17 @@ Enterprise Standards Compliance:
 """
 
 import logging
+import sqlite3
+import sys
 from pathlib import Path
 from datetime import datetime
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
-    'start': '[START]',
-    'success': '[SUCCESS]',
-    'error': '[ERROR]',
-    'info': '[INFO]'
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "info": "[INFO]",
 }
 
 
@@ -41,7 +43,8 @@ class EnterpriseUtility:
             if success:
                 duration = (datetime.now() - start_time).total_seconds()
                 self.logger.info(
-    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s")
+                    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s"
+                )
                 return True
             else:
                 self.logger.error(f"{TEXT_INDICATORS['error']} Utility failed")
@@ -52,9 +55,21 @@ class EnterpriseUtility:
             return False
 
     def perform_utility_function(self) -> bool:
-        """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        """Perform the utility function.
+
+        Query ``archives/analytics.db`` for placeholder usage and log the total
+        count.
+        """
+        try:
+            db_path = self.workspace_path / "archives" / "analytics.db"
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.execute("SELECT COUNT(*) FROM placeholder_usage")
+                count = cursor.fetchone()[0]
+            self.logger.info(f"{TEXT_INDICATORS['info']} Placeholder records: {count}")
+            return True
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} DB query failed: {exc}")
+            return False
 
 
 def main():
@@ -69,8 +84,7 @@ def main():
 
     return success
 
+
 if __name__ == "__main__":
-
-
     success = main()
     sys.exit(0 if success else 1)

--- a/builds/final/production/builds/artifacts/validation/quantum_performance_integration_tester.py
+++ b/builds/final/production/builds/artifacts/validation/quantum_performance_integration_tester.py
@@ -10,15 +10,17 @@ Enterprise Standards Compliance:
 """
 
 import logging
+import sqlite3
+import sys
 from pathlib import Path
 from datetime import datetime
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
-    'start': '[START]',
-    'success': '[SUCCESS]',
-    'error': '[ERROR]',
-    'info': '[INFO]'
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "info": "[INFO]",
 }
 
 
@@ -41,7 +43,8 @@ class EnterpriseUtility:
             if success:
                 duration = (datetime.now() - start_time).total_seconds()
                 self.logger.info(
-    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s")
+                    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s"
+                )
                 return True
             else:
                 self.logger.error(f"{TEXT_INDICATORS['error']} Utility failed")
@@ -52,9 +55,21 @@ class EnterpriseUtility:
             return False
 
     def perform_utility_function(self) -> bool:
-        """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        """Perform the utility function.
+
+        Retrieve placeholder usage count from ``archives/analytics.db`` and log
+        the information.
+        """
+        try:
+            db_path = self.workspace_path / "archives" / "analytics.db"
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.execute("SELECT COUNT(*) FROM placeholder_usage")
+                count = cursor.fetchone()[0]
+            self.logger.info(f"{TEXT_INDICATORS['info']} Placeholder records: {count}")
+            return True
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} DB query failed: {exc}")
+            return False
 
 
 def main():
@@ -69,8 +84,7 @@ def main():
 
     return success
 
+
 if __name__ == "__main__":
-
-
     success = main()
     sys.exit(0 if success else 1)

--- a/builds/final/production/builds/artifacts/validation/test_quantum_deploy.py
+++ b/builds/final/production/builds/artifacts/validation/test_quantum_deploy.py
@@ -10,15 +10,17 @@ Enterprise Standards Compliance:
 """
 
 import logging
+import sqlite3
+import sys
 from pathlib import Path
 from datetime import datetime
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
-    'start': '[START]',
-    'success': '[SUCCESS]',
-    'error': '[ERROR]',
-    'info': '[INFO]'
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "info": "[INFO]",
 }
 
 
@@ -41,7 +43,8 @@ class EnterpriseUtility:
             if success:
                 duration = (datetime.now() - start_time).total_seconds()
                 self.logger.info(
-    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s")
+                    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s"
+                )
                 return True
             else:
                 self.logger.error(f"{TEXT_INDICATORS['error']} Utility failed")
@@ -52,9 +55,21 @@ class EnterpriseUtility:
             return False
 
     def perform_utility_function(self) -> bool:
-        """Perform the utility function"""
-        # Implementation placeholder
-        return True
+        """Perform the utility function.
+
+        Query ``archives/analytics.db`` for placeholder usage statistics and log
+        the total count. This demonstrates the database-first approach.
+        """
+        try:
+            db_path = self.workspace_path / "archives" / "analytics.db"
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.execute("SELECT COUNT(*) FROM placeholder_usage")
+                count = cursor.fetchone()[0]
+            self.logger.info(f"{TEXT_INDICATORS['info']} Placeholder records: {count}")
+            return True
+        except sqlite3.Error as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} DB query failed: {exc}")
+            return False
 
 
 def main():
@@ -69,8 +84,7 @@ def main():
 
     return success
 
+
 if __name__ == "__main__":
-
-
     success = main()
     sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- replace implementation placeholders in validation scripts
- query archives/analytics.db for placeholder usage counts
- add missing imports and format with ruff

## Testing
- `ruff check builds/final/production/builds/artifacts/validation/test_quantum_deploy.py builds/final/production/builds/artifacts/validation/FINAL_COMPREHENSIVE_PRODUCTION_TEST.py builds/final/production/builds/artifacts/validation/UNIFIED_DEPLOYMENT_ORCHESTRATOR_TEST_SUITE.py builds/final/production/builds/artifacts/validation/quantum_performance_integration_tester.py builds/final/production/builds/artifacts/validation/comprehensive_production_capability_tester.py`
- `pytest tests/test_quantum_performance_integration_tester.py -q` *(fails: IndentationError in archived script)*

------
https://chatgpt.com/codex/tasks/task_e_687eb5fa4e0c83319ed19c0c49c239b7