### PR TITLE
Improve documentation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Multiple SQLite Databases:** `production.db`, `analytics.db`, `monitoring.db`
 - **Flask Enterprise Dashboard:** basic endpoints and templates
 - **Template Intelligence Platform:** tracks generated scripts
+- **Documentation logs:** rendered templates saved under `logs/template_rendering/`
 - **Script Validation**: automated checks available
 - **Self-Healing Systems:** experimental correction scripts
 - **Continuous Operation Mode:** optional monitoring utilities

--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -34,6 +34,7 @@ export GH_COPILOT_WORKSPACE=/path/to/gh_COPILOT
 ## 3. Documentation Generation
 - Documentation patterns are stored in `documentation.db`.
 - Use `scripts/documentation/enterprise_documentation_manager.py` to render Markdown files from these entries and record the generation event.
+- Rendered output is also saved to `logs/template_rendering/` with timestamped filenames for auditing.
 
 ## 4. Synchronization
 - Run `template_engine.template_synchronizer.synchronize_templates()` to ensure


### PR DESCRIPTION
## Summary
- enhance EnterpriseDocumentationManager with compliance-based template selection
- log rendered docs to `logs/template_rendering`
- document new logging path in the README and usage guide

## Testing
- `ruff check documentation/enterprise_documentation_manager.py`
- `pytest -q tests/test_enterprise_documentation_manager_module.py`
- `ruff check .` *(fails: 2293 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ebc7dbd748331b126d38451816bb1