### PR TITLE
Implement validation logic

### DIFF
--- a/builds/final/production/builds/artifacts/validation/FINAL_COMPREHENSIVE_PRODUCTION_TEST.py
+++ b/builds/final/production/builds/artifacts/validation/FINAL_COMPREHENSIVE_PRODUCTION_TEST.py
@@ -12,15 +12,17 @@ Enterprise Standards Compliance:
 # import os
 import sys
 import logging
+import sqlite3
 from pathlib import Path
 from datetime import datetime
+from tqdm import tqdm
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
-    'start': '[START]',
-    'success': '[SUCCESS]',
-    'error': '[ERROR]',
-    'info': '[INFO]'
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "info": "[INFO]",
 }
 
 
@@ -42,9 +44,9 @@ class EnterpriseUtility:
 
             if success:
                 duration = (datetime.now() - start_time).total_seconds()
-                self.logger.info(f"{TEXT_INDICATORS['success']} Uti" \
-               " \
-                                  "                  "ity completed in {duration:.1f}s")
+                self.logger.info(
+                    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s"
+                )
                 return True
             else:
                 self.logger.error(f"{TEXT_INDICATORS['error']} Utility failed")
@@ -56,8 +58,54 @@ class EnterpriseUtility:
 
     def perform_utility_function(self) -> bool:
         """Perform the utility function"""
-        # Implementation placeholder
+        db_path = self.workspace_path / "databases" / "production.db"
+        if not db_path.exists():
+            self.logger.error(f"{TEXT_INDICATORS['error']} Database missing: {db_path}")
+            self._log_validation(False)
+            return False
+
+        try:
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.execute(
+                    "SELECT script_path FROM script_repository LIMIT 5"
+                )
+                scripts = [row[0] for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            self.logger.error(f"{TEXT_INDICATORS['error']} Database error: {e}")
+            self._log_validation(False)
+            return False
+
+        for script in tqdm(scripts, desc="[PROGRESS] Checking files", unit="file"):
+            if not (self.workspace_path / script).exists():
+                self.logger.error(f"{TEXT_INDICATORS['error']} Missing file: {script}")
+                self._log_validation(False)
+                return False
+
+        self._log_validation(True)
         return True
+
+    def _log_validation(self, success: bool) -> None:
+        """Record validation result in analytics.db."""
+        analytics_path = self.workspace_path / "analytics.db"
+        try:
+            with sqlite3.connect(analytics_path) as conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS validation_log (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        script_name TEXT,
+                        success BOOLEAN,
+                        ts DATETIME DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+                conn.execute(
+                    "INSERT INTO validation_log (script_name, success) VALUES (?, ?)",
+                    (Path(__file__).name, int(success)),
+                )
+                conn.commit()
+        except sqlite3.Error:
+            pass
 
 
 def main():
@@ -70,9 +118,8 @@ def main():
     else:
         print(f"{TEXT_INDICATORS['error']} Utility failed")
 
-
-
     return success
+
 
 if __name__ == "__main__":
     success = main()


### PR DESCRIPTION
## Summary
- expand validation utilities
- record validation results in analytics.db

## Testing
- `ruff check builds/final/production/builds/artifacts/validation/quantum_performance_integration_tester.py builds/final/production/builds/artifacts/validation/UNIFIED_DEPLOYMENT_ORCHESTRATOR_TEST_SUITE.py builds/final/production/builds/artifacts/validation/comprehensive_production_capability_tester.py builds/final/production/builds/artifacts/validation/FINAL_COMPREHENSIVE_PRODUCTION_TEST.py builds/final/production/builds/artifacts/validation/test_quantum_deploy.py`
- `ruff format builds/final/production/builds/artifacts/validation/quantum_performance_integration_tester.py builds/final/production/builds/artifacts/validation/UNIFIED_DEPLOYMENT_ORCHESTRATOR_TEST_SUITE.py builds/final/production/builds/artifacts/validation/comprehensive_production_capability_tester.py builds/final/production/builds/artifacts/validation/FINAL_COMPREHENSIVE_PRODUCTION_TEST.py builds/final/production/builds/artifacts/validation/test_quantum_deploy.py`
- `pytest -q` *(fails: 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687edf3680408331b9ae28053a592733