### PR TITLE
feat: log placeholder severity

### DIFF
--- a/scripts/intelligent_code_analysis_placeholder_detection.py
+++ b/scripts/intelligent_code_analysis_placeholder_detection.py
@@ -121,16 +121,32 @@ class EnterpriseUtility:
                 conn.execute(
                     "CREATE TABLE IF NOT EXISTS placeholder_audit ("
                     "id INTEGER PRIMARY KEY, file_path TEXT, pattern TEXT, "
-                    "position INTEGER, ts TEXT)"
+                    "position INTEGER, severity TEXT, ts TEXT)"
                 )
                 conn.execute(
-                    "INSERT INTO placeholder_audit (file_path, pattern, position, ts) "
-                    "VALUES (?, ?, ?, ?)",
-                    (file_path, pattern, position, datetime.now().isoformat()),
+                    "INSERT INTO placeholder_audit (file_path, pattern, position, severity, ts) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        file_path,
+                        pattern,
+                        position,
+                        self._severity_for_pattern(pattern),
+                        datetime.now().isoformat(),
+                    ),
                 )
                 conn.commit()
         except sqlite3.Error as exc:
             self.logger.error(f"{TEXT_INDICATORS['error']} DB log failed: {exc}")
+
+
+    def _severity_for_pattern(self, pattern: str) -> str:
+        """Return a severity level for the given placeholder pattern."""
+        normalized = pattern.lower()
+        if normalized in {"todo", "pass"}:
+            return "low"
+        if normalized == "fixme":
+            return "medium"
+        return "high"
 
 
 def main():

--- a/tests/test_placeholder_audit.py
+++ b/tests/test_placeholder_audit.py
@@ -15,8 +15,9 @@ def test_placeholder_logging(tmp_path):
 
     with sqlite3.connect(db_path) as conn:
         row = conn.execute(
-            "SELECT file_path, pattern FROM placeholder_audit"
+            "SELECT file_path, pattern, severity FROM placeholder_audit"
         ).fetchone()
     assert row[0].endswith("comprehensive_production_deployer.py")
     assert row[1] == "TODO"
+    assert row[2] == "low"
 


### PR DESCRIPTION
## Summary
- record severity when logging TODO/FIXME placeholders
- test placeholder audit severity levels

## Testing
- `ruff check scripts/intelligent_code_analysis_placeholder_detection.py tests/test_placeholder_audit.py`
- `pytest tests/test_placeholder_audit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687efc9cc16883318f894e97a59ebf84