### PR TITLE
feat: placeholder audit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,12 @@ python scripts/validation/enterprise_dual_copilot_validator.py --validate-all
 # Placeholder audit (with progress display)
 python scripts/intelligent_code_analysis_placeholder_detection.py \
     --workspace $GH_COPILOT_WORKSPACE --db analytics.db
+
+# Repository-wide placeholder audit
+python scripts/audit_codebase_placeholders.py \
+    --workspace $GH_COPILOT_WORKSPACE \
+    --analytics-db databases/analytics.db \
+    --production-db databases/production.db
 ```
 
 ### **Contact & Support**

--- a/scripts/audit_codebase_placeholders.py
+++ b/scripts/audit_codebase_placeholders.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Audit repository for TODO/FIXME and placeholders.
+
+This script traverses the workspace and logs any occurrence of
+code placeholders or legacy template markers. Findings are stored
+in ``analytics.db`` under the ``todo_fixme_tracking`` table and a
+summary JSON file is written to ``dashboard/compliance``.
+
+Features
+--------
+* Database-first: placeholder patterns are pulled from ``production.db``.
+* Dual copilot validation: results are verified after insertion.
+* Visual indicators via ``tqdm`` progress bars.
+* Anti-recursion validation using ``validate_enterprise_operation``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from tqdm import tqdm
+
+from scripts.continuous_operation_orchestrator import validate_enterprise_operation
+
+TEXT = {
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "info": "[INFO]",
+}
+
+DEFAULT_PATTERNS = [r"TODO", r"FIXME", r"Implementation placeholder", r"legacy template logic"]
+
+
+def fetch_db_placeholders(production_db: Path) -> List[str]:
+    """Return placeholder strings stored in ``production.db``."""
+    if not production_db.exists():
+        return []
+    with sqlite3.connect(production_db) as conn:
+        cur = conn.execute("SELECT placeholder_name FROM template_placeholders")
+        return [row[0] for row in cur.fetchall()]
+
+
+def log_findings(results: List[dict], analytics_db: Path) -> None:
+    """Insert findings into ``analytics.db``."""
+    analytics_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS todo_fixme_tracking (
+            id INTEGER PRIMARY KEY,
+            file_path TEXT,
+            line_number INTEGER,
+            pattern TEXT,
+            context TEXT,
+            ts TEXT
+        )"""
+        )
+        for row in results:
+            conn.execute(
+                "INSERT INTO todo_fixme_tracking (file_path, line_number, pattern, context, ts) VALUES (?, ?, ?, ?, ?)",
+                (
+                    row["file"],
+                    row["line"],
+                    row["pattern"],
+                    row["context"],
+                    datetime.now().isoformat(),
+                ),
+            )
+        conn.commit()
+
+
+def update_dashboard(count: int, dashboard_dir: Path) -> None:
+    """Write summary JSON to dashboard directory."""
+    dashboard_dir.mkdir(parents=True, exist_ok=True)
+    data = {"timestamp": datetime.now().isoformat(), "findings": count}
+    summary_file = dashboard_dir / "placeholder_summary.json"
+    summary_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def scan_files(workspace: Path, patterns: Iterable[str]) -> List[dict]:
+    """Scan files for given patterns."""
+    results: List[dict] = []
+    files = [f for f in workspace.rglob("*") if f.is_file()]
+    with tqdm(total=len(files), desc=f"{TEXT['info']} scanning", unit="file") as bar:
+        for file in files:
+            try:
+                lines = file.read_text(encoding="utf-8", errors="ignore").splitlines()
+            except OSError:
+                bar.update(1)
+                continue
+            for idx, line in enumerate(lines, 1):
+                for pat in patterns:
+                    if re.search(pat, line):
+                        results.append({
+                            "file": str(file),
+                            "line": idx,
+                            "pattern": pat,
+                            "context": line.strip()[:200],
+                        })
+            bar.update(1)
+    return results
+
+
+def validate_results(expected_count: int, analytics_db: Path) -> bool:
+    """Secondary validation step for dual copilot pattern."""
+    with sqlite3.connect(analytics_db) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM todo_fixme_tracking")
+        db_count = cur.fetchone()[0]
+    return db_count >= expected_count
+
+
+def main(
+    workspace_path: Optional[str] = None,
+    analytics_db: Optional[str] = None,
+    production_db: Optional[str] = None,
+    dashboard_dir: Optional[str] = None,
+) -> bool:
+    """Entry point for placeholder auditing."""
+    if os.getenv("GH_COPILOT_DISABLE_VALIDATION") != "1":
+        validate_enterprise_operation()
+    workspace = Path(workspace_path or os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    analytics = Path(analytics_db or workspace / "databases" / "analytics.db")
+    production = Path(production_db or workspace / "databases" / "production.db")
+    dashboard = Path(dashboard_dir or workspace / "dashboard" / "compliance")
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logging.info(f"{TEXT['start']} auditing {workspace}")
+
+    patterns = DEFAULT_PATTERNS + fetch_db_placeholders(production)
+    results = scan_files(workspace, patterns)
+    log_findings(results, analytics)
+    update_dashboard(len(results), dashboard)
+
+    valid = validate_results(len(results), analytics)
+    if valid:
+        logging.info(f"{TEXT['success']} audit logged {len(results)} findings")
+    else:
+        logging.error(f"{TEXT['error']} validation mismatch")
+    return valid
+
+
+if __name__ == "__main__":
+    success = main()
+    raise SystemExit(0 if success else 1)

--- a/tests/test_audit_codebase_placeholders.py
+++ b/tests/test_audit_codebase_placeholders.py
@@ -1,0 +1,35 @@
+import os
+import sqlite3
+
+from scripts.audit_codebase_placeholders import main
+
+
+def test_audit_places(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    target = workspace / "demo.py"
+    target.write_text("def x():\n    pass  # TODO\n    # Implementation placeholder\n")
+
+    prod_db = tmp_path / "production.db"
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute(
+            "CREATE TABLE template_placeholders (id INTEGER PRIMARY KEY, placeholder_name TEXT)"
+        )
+        conn.execute("INSERT INTO template_placeholders (placeholder_name) VALUES ('legacy template logic')")
+        conn.commit()
+
+    analytics = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dashboard" / "compliance"
+
+    os.environ["GH_COPILOT_WORKSPACE"] = str(workspace)
+    assert main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=str(prod_db),
+        dashboard_dir=str(dash_dir),
+    )
+
+    with sqlite3.connect(analytics) as conn:
+        rows = conn.execute("SELECT pattern FROM todo_fixme_tracking").fetchall()
+    assert len(rows) >= 2
+    assert dash_dir.joinpath("placeholder_summary.json").exists()


### PR DESCRIPTION
## Summary
- implement `scripts/audit_codebase_placeholders.py` for repository-wide placeholder scanning
- log results to `analytics.db` and update compliance dashboard
- disable validation via env variable for tests
- add unit test
- document new script usage in README

## Testing
- `ruff check scripts/audit_codebase_placeholders.py tests/test_audit_codebase_placeholders.py`
- `pytest -q` *(fails: 33 errors)*
- `pytest tests/test_audit_codebase_placeholders.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f499fbd648331951add2efdc4ee85