### PR TITLE
feat: add file audit checklist script

### DIFF
--- a/scripts/files_and_actions_checklist.py
+++ b/scripts/files_and_actions_checklist.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Database-first file audit and checklist generator.
+
+This script audits key repository files using patterns pulled from
+``production.db``. Findings are logged to ``analytics.db`` and a JSON
+report is written to ``reports``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from tqdm import tqdm
+
+from scripts.continuous_operation_orchestrator import validate_enterprise_operation
+
+DEFAULT_FILES = [
+    "DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md",
+    "DUAL_COPILOT_PATTERN.instructions.md",
+    "auto_generator.py",
+]
+
+
+def fetch_checklist_patterns(production_db: Path) -> List[str]:
+    """Return additional file patterns from the production database."""
+    if not production_db.exists():
+        return []
+    with sqlite3.connect(production_db) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS checklist_patterns (pattern TEXT)"
+        )
+        rows = conn.execute("SELECT pattern FROM checklist_patterns").fetchall()
+        return [row[0] for row in rows]
+
+
+def audit_files(files: List[str], workspace: Path) -> List[Dict[str, str]]:
+    """Check whether each file exists in the workspace."""
+    results: List[Dict[str, str]] = []
+    with tqdm(total=len(files), desc="Auditing files", unit="file") as bar:
+        for name in files:
+            path = workspace / name
+            status = "present" if path.exists() else "missing"
+            results.append({"file": str(path), "status": status})
+            bar.update(1)
+    return results
+
+
+def log_audit(results: List[Dict[str, str]], analytics_db: Path) -> None:
+    """Store audit results in ``analytics.db``."""
+    analytics_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS file_audit (file_path TEXT, status TEXT, ts TEXT)"
+        )
+        for row in results:
+            conn.execute(
+                "INSERT INTO file_audit (file_path, status, ts) VALUES (?, ?, ?)",
+                (row["file"], row["status"], datetime.now().isoformat()),
+            )
+        conn.commit()
+
+
+def validate_audit(expected_count: int, analytics_db: Path) -> bool:
+    """Validate audit count using dual-copilot pattern."""
+    with sqlite3.connect(analytics_db) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM file_audit")
+        count = cur.fetchone()[0]
+    return count >= expected_count
+
+
+def generate_report(results: List[Dict[str, str]], report_file: Path) -> None:
+    """Write audit summary report."""
+    report_file.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"timestamp": datetime.now().isoformat(), "files": results}
+    report_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def main(
+    workspace: str | None = None,
+    production_db: str | None = None,
+    analytics_db: str | None = None,
+    report_path: str | None = None,
+) -> bool:
+    """Run the file audit workflow."""
+    if os.getenv("GH_COPILOT_DISABLE_VALIDATION") != "1":
+        validate_enterprise_operation()
+
+    workspace_path = Path(workspace or os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    prod_db = Path(production_db or workspace_path / "databases" / "production.db")
+    analytics = Path(analytics_db or workspace_path / "databases" / "analytics.db")
+    report = Path(report_path or workspace_path / "reports" / "file_audit_report.json")
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logging.info("[START] file checklist audit")
+
+    patterns = fetch_checklist_patterns(prod_db)
+    files = DEFAULT_FILES + patterns
+    results = audit_files(files, workspace_path)
+    log_audit(results, analytics)
+    generate_report(results, report)
+
+    valid = validate_audit(len(results), analytics)
+    if valid:
+        logging.info("[SUCCESS] checklist audit complete")
+    else:
+        logging.error("[ERROR] validation mismatch")
+    return valid
+
+
+if __name__ == "__main__":
+    raise SystemExit(0 if main() else 1)

--- a/tests/test_files_and_actions_checklist.py
+++ b/tests/test_files_and_actions_checklist.py
@@ -1,0 +1,34 @@
+import os
+import sqlite3
+from scripts.files_and_actions_checklist import main
+
+
+def test_files_and_actions_checklist(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    # create one expected file
+    (workspace / "DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md").write_text("x")
+
+    prod_db = tmp_path / "prod.db"
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute("CREATE TABLE checklist_patterns (pattern TEXT)")
+        conn.execute("INSERT INTO checklist_patterns (pattern) VALUES ('extra.txt')")
+        conn.commit()
+    (workspace / "extra.txt").write_text("y")
+
+    analytics = tmp_path / "analytics.db"
+    report = tmp_path / "report.json"
+
+    os.environ["GH_COPILOT_WORKSPACE"] = str(workspace)
+    os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+    assert main(
+        workspace=str(workspace),
+        production_db=str(prod_db),
+        analytics_db=str(analytics),
+        report_path=str(report),
+    )
+
+    with sqlite3.connect(analytics) as conn:
+        rows = conn.execute("SELECT file_path FROM file_audit").fetchall()
+    assert len(rows) == 4
+    assert report.exists()


### PR DESCRIPTION
## Summary
- implement `files_and_actions_checklist.py` to audit required files based on DB patterns
- log checklist results to `analytics.db` and output report
- add unit test `test_files_and_actions_checklist`

## Testing
- `ruff check scripts/files_and_actions_checklist.py tests/test_files_and_actions_checklist.py`
- `pytest tests/test_files_and_actions_checklist.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f98b4ddf883318ee48e7293b87f62