### PR TITLE
feat: add compliance dashboard and report generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ gh_COPILOT/
 - **`scripts/validation/enterprise_dual_copilot_validator.py`** - DUAL COPILOT validation
 - **`scripts/utilities/unified_script_generation_system.py`** - Database-first generation
 - **`web_gui/scripts/flask_apps/enterprise_dashboard.py`** - Enterprise dashboard
+- **`validation/compliance_report_generator.py`** - Summarize lint and test results
+- **`web_gui/dashboard_actionable_gui.py`** - Actionable compliance dashboard
 
 ---
 

--- a/docs/EXTERNAL_DEPENDENCIES.md
+++ b/docs/EXTERNAL_DEPENDENCIES.md
@@ -4,7 +4,7 @@ The project relies on several external packages and services:
 
 - **SQLite**: used for local data persistence. Databases are stored in the `databases/` folder.
 - **psutil**: required for performance monitoring scripts.
-- **Flask** and related packages: used by the optional web dashboard in `web_gui/`.
+- **Flask** and related packages: used by the optional web dashboard in `web_gui/` (e.g., `dashboard_actionable_gui.py`).
 - **tqdm** and **rich**: provide progress bars and colored console output.
 - **qiskit-machine-learning**: enables quantum-enhanced ML demos and tests.
 

--- a/tests/test_compliance_report_generator.py
+++ b/tests/test_compliance_report_generator.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import json
+import sqlite3
+from validation.compliance_report_generator import generate_compliance_report
+
+
+def test_generate_compliance_report(tmp_path: Path) -> None:
+    ruff_file = tmp_path / "ruff.txt"
+    ruff_file.write_text("file.py:1:1 F401 unused\n", encoding="utf-8")
+    pytest_file = tmp_path / "pytest.json"
+    pytest_file.write_text(
+        json.dumps({"summary": {"total": 2, "passed": 2, "failed": 0}})
+    )
+    output_dir = tmp_path / "out"
+    db = tmp_path / "analytics.db"
+    summary = generate_compliance_report(ruff_file, pytest_file, output_dir, db)
+    assert (output_dir / "compliance_report.json").exists()
+    assert (output_dir / "compliance_report.md").exists()
+    with sqlite3.connect(db) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM code_quality_metrics")
+        assert cur.fetchone()[0] == 1
+    assert summary["ruff"]["issues"] == 1

--- a/tests/test_dashboard_actionable_gui.py
+++ b/tests/test_dashboard_actionable_gui.py
@@ -1,0 +1,33 @@
+import json
+import os
+
+os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+from web_gui import dashboard_actionable_gui as gui
+
+
+class DummyRollback:
+    def __init__(self, db):
+        pass
+
+    def auto_rollback(self, target, backup=None):
+        return True
+
+
+def test_dashboard_endpoints(tmp_path, monkeypatch):
+    metrics = tmp_path / "metrics.json"
+    metrics.write_text(json.dumps({"metrics": {"issues": 5}}))
+    comp_dir = tmp_path / "compliance"
+    comp_dir.mkdir()
+    comp_dir.joinpath("correction_summary.json").write_text(
+        json.dumps({"corrections": []})
+    )
+    monkeypatch.setattr(gui, "METRICS_PATH", metrics)
+    monkeypatch.setattr(gui, "CORRECTIONS_DIR", comp_dir)
+    monkeypatch.setattr(gui, "ANALYTICS_DB", tmp_path / "analytics.db")
+    monkeypatch.setattr(gui, "CorrectionLoggerRollback", DummyRollback)
+    client = gui.app.test_client()
+    assert client.get("/metrics").status_code == 200
+    assert client.get("/corrections").status_code == 200
+    resp = client.post("/rollback", json={"target": str(tmp_path / "file.txt")})
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "ok"

--- a/validation/compliance_report_generator.py
+++ b/validation/compliance_report_generator.py
@@ -1,0 +1,121 @@
+"""
+Compliance Report Generator - Summarize lint and test results.
+
+Enterprise Standards Compliance:
+- Flake8/PEP 8 Compliant
+- Emoji-free code (text-based indicators only)
+- Database-first architecture
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+TEXT_INDICATORS = {
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+}
+
+
+def parse_ruff_output(output: str) -> Dict[str, int]:
+    """Parse ruff output and count issues."""
+    lines = [line for line in output.splitlines() if line.strip() and ":" in line]
+    return {"issues": len(lines)}
+
+
+def parse_pytest_report(path: Path) -> Dict[str, int]:
+    """Parse pytest JSON report."""
+    if not path.exists():
+        return {"tests": 0, "passed": 0, "failed": 0}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        summary = data.get("summary", {})
+        return {
+            "tests": summary.get("total", 0),
+            "passed": summary.get("passed", 0),
+            "failed": summary.get("failed", 0),
+        }
+    except Exception:
+        return {"tests": 0, "passed": 0, "failed": 0}
+
+
+def generate_compliance_report(
+    ruff_file: Path,
+    pytest_file: Path,
+    output_dir: Path,
+    analytics_db: Path,
+) -> Dict[str, Any]:
+    """Generate JSON and Markdown compliance reports."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ruff_metrics = (
+        parse_ruff_output(ruff_file.read_text(encoding="utf-8"))
+        if ruff_file.exists()
+        else {"issues": 0}
+    )
+    pytest_metrics = parse_pytest_report(pytest_file)
+    timestamp = datetime.now().isoformat()
+    summary = {
+        "timestamp": timestamp,
+        "ruff": ruff_metrics,
+        "pytest": pytest_metrics,
+    }
+
+    json_path = output_dir / "compliance_report.json"
+    json_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    md_path = output_dir / "compliance_report.md"
+    with open(md_path, "w", encoding="utf-8") as md:
+        md.write("# Compliance Report\n\n")
+        md.write(f"Generated: {timestamp}\n\n")
+        md.write("## Ruff\n")
+        md.write(f"- Issues: {ruff_metrics['issues']}\n")
+        md.write("\n## Pytest\n")
+        md.write(f"- Total: {pytest_metrics['tests']}\n")
+        md.write(f"- Passed: {pytest_metrics['passed']}\n")
+        md.write(f"- Failed: {pytest_metrics['failed']}\n")
+
+    analytics_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS code_quality_metrics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                operation TEXT,
+                timestamp TEXT,
+                metrics TEXT,
+                recorded_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO code_quality_metrics (operation, timestamp, metrics) VALUES (?, ?, ?)",
+            ("compliance_report", timestamp, json.dumps(summary)),
+        )
+        conn.commit()
+
+    return summary
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate compliance report")
+    parser.add_argument("--ruff", type=Path, required=True, help="Ruff output file")
+    parser.add_argument("--pytest", type=Path, required=True, help="Pytest JSON report")
+    parser.add_argument(
+        "--output", type=Path, default=Path("validation"), help="Output directory"
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path("databases") / "analytics.db",
+        help="Analytics database path",
+    )
+    args = parser.parse_args()
+
+    print(TEXT_INDICATORS["start"], "Generating compliance report")
+    result = generate_compliance_report(args.ruff, args.pytest, args.output, args.db)
+    print(TEXT_INDICATORS["success"], json.dumps(result, indent=2))

--- a/web_gui/dashboard_actionable_gui.py
+++ b/web_gui/dashboard_actionable_gui.py
@@ -1,0 +1,67 @@
+"""Minimal Flask dashboard displaying compliance metrics and rollback controls."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, List
+
+from flask import Flask, jsonify, render_template, request, Response
+
+from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
+
+APP_DIR = Path(__file__).resolve().parent
+TEMPLATES_DIR = APP_DIR / "templates"
+METRICS_PATH = Path("dashboard/metrics.json")
+CORRECTIONS_DIR = Path("dashboard/compliance")
+ANALYTICS_DB = Path("databases/analytics.db")
+
+app = Flask(__name__, template_folder=str(TEMPLATES_DIR))
+
+
+def _load_json(path: Path) -> Any:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def get_metrics() -> Any:
+    return _load_json(METRICS_PATH)
+
+
+def get_corrections() -> List[dict]:
+    summary = _load_json(CORRECTIONS_DIR / "correction_summary.json")
+    return summary.get("corrections", [])
+
+
+@app.route("/")
+def dashboard() -> str:
+    metrics = get_metrics().get("metrics", {})
+    corrections = get_corrections()
+    return render_template("dashboard.html", metrics=metrics, corrections=corrections)
+
+
+@app.route("/metrics")
+def metrics() -> Response:
+    return jsonify(get_metrics())
+
+
+@app.route("/corrections")
+def corrections() -> Response:
+    return jsonify(get_corrections())
+
+
+@app.route("/rollback", methods=["POST"])
+def trigger_rollback():
+    data = request.get_json(silent=True) or request.form
+    target = data.get("target")
+    backup = data.get("backup")
+    if not target:
+        return jsonify({"status": "error", "message": "target required"}), 400
+    log = CorrectionLoggerRollback(ANALYTICS_DB)
+    success = log.auto_rollback(Path(target), Path(backup) if backup else None)
+    return jsonify({"status": "ok" if success else "failed"})
+
+
+if __name__ == "__main__":
+    app.run(debug=False, port=5000)

--- a/web_gui/templates/dashboard.html
+++ b/web_gui/templates/dashboard.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>Compliance Dashboard</title>
+<h1>Compliance Dashboard</h1>
+<h2>Metrics</h2>
+<ul>
+{% for key, value in metrics.items() %}
+<li>{{ key }}: {{ value }}</li>
+{% endfor %}
+</ul>
+<h2>Corrections</h2>
+<ul>
+{% for c in corrections %}
+<li>{{ c.file_path }} - {{ c.rationale }}</li>
+{% endfor %}
+</ul>
+<form method="post" action="{{ url_for('trigger_rollback') }}">
+<input type="text" name="target" placeholder="File path">
+<button type="submit">Rollback</button>
+</form>


### PR DESCRIPTION
## Summary
- implement `compliance_report_generator.py` for lint/test summaries
- build actionable Flask dashboard with rollback controls
- provide basic dashboard template
- add unit tests for new modules
- document new utilities

## Testing
- `ruff check validation/compliance_report_generator.py web_gui/dashboard_actionable_gui.py tests/test_compliance_report_generator.py tests/test_dashboard_actionable_gui.py`
- `pytest tests/test_compliance_report_generator.py tests/test_dashboard_actionable_gui.py -q`
- `ruff check .` *(fails: Found 1446 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fe287ac9c8331a33295b7f42924d6