### PR TITLE
Fix dashboard endpoints and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,11 +427,18 @@ validate_enterprise_standards(final_result)
 
 ### **Testing & Validation**
 ```bash
+# Ensure environment setup
+bash setup.sh
+source .venv/bin/activate
+
 # Install test dependencies
 pip install -r requirements-test.txt
 
 # Run comprehensive test suite
 make test
+
+# Run linter
+ruff check .
 
 # Enterprise validation
 python -m pytest tests/enterprise/ -v

--- a/template_engine/template_synchronizer.py
+++ b/template_engine/template_synchronizer.py
@@ -16,7 +16,7 @@ from typing import Iterable
 from tqdm import tqdm
 
 def _log_event(event: str, details: str) -> None:
-    """Generic event logger for analytics DB."""
+    """Generic event logger for synchronization steps."""
     try:
         ANALYTICS_DB.parent.mkdir(exist_ok=True, parents=True)
         with sqlite3.connect(ANALYTICS_DB) as conn:
@@ -106,20 +106,6 @@ def _log_audit(db_name: str, details: str) -> None:
         logger.error("Failed to log audit event: %s", exc)
 
 
-def _log_event(name: str, details: str) -> None:
-    """Generic event logger for synchronization steps."""
-    try:
-        ANALYTICS_DB.parent.mkdir(exist_ok=True, parents=True)
-        with sqlite3.connect(ANALYTICS_DB) as conn:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS sync_status (timestamp TEXT, name TEXT, details TEXT)"
-            )
-            conn.execute(
-                "INSERT INTO sync_status (timestamp, name, details) VALUES (?, ?, ?)",
-                (datetime.utcnow().isoformat(), name, details),
-            )
-    except sqlite3.Error as exc:
-        logger.error("Failed to log event: %s", exc)
 
 
 def _compliance_check(conn: sqlite3.Connection) -> bool:

--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -14,11 +14,37 @@ def test_metrics_endpoint():
     resp = client.get('/metrics')
     assert resp.status_code == 200
     data = resp.get_json()
-    assert isinstance(data, list)
+    assert isinstance(data, dict)
 
 
 def test_compliance_endpoint():
     client = app.test_client()
     resp = client.get('/compliance')
     assert resp.status_code == 200
-    assert isinstance(resp.get_json(), list)
+    assert isinstance(resp.get_json(), dict)
+
+
+def test_rollback_alerts_endpoint():
+    client = app.test_client()
+    resp = client.get('/rollback_alerts')
+    assert resp.status_code == 200
+
+
+def test_dashboard_info_endpoint():
+    client = app.test_client()
+    resp = client.get('/dashboard_info')
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json(), dict)
+
+
+def test_health_endpoint():
+    client = app.test_client()
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == 'ok'
+
+
+def test_reports_endpoint():
+    client = app.test_client()
+    resp = client.get('/reports')
+    assert resp.status_code == 200

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -79,19 +79,46 @@ def metrics() -> Any:
     return jsonify(data)
 
 
-@app.get("/compliance")
-def compliance() -> Any:
-    start = time.time()
-    metrics = _fetch_metrics()
-    rollbacks = _fetch_rollbacks()
-    etc = f"ETC: {calculate_etc(start, 1, 1)}"
-    logging.info("Compliance data served | %s", etc)
-    return jsonify({"metrics": metrics, "rollbacks": rollbacks})
 
 
 @app.get("/rollback_alerts")
 def rollback_alerts() -> Any:
     data = _fetch_rollbacks()
+    return jsonify(data)
+
+
+@app.get("/dashboard_info")
+def dashboard_info() -> Any:
+    start = time.time()
+    with tqdm(total=1, desc="dashboard_info", unit="step") as pbar:
+        data = {
+            "metrics": _fetch_metrics(),
+            "rollbacks": _fetch_rollbacks(),
+        }
+        pbar.update(1)
+    etc = f"ETC: {calculate_etc(start, 1, 1)}"
+    logging.info("Dashboard info served | %s", etc)
+    return jsonify(data)
+
+
+@app.get("/health")
+def health() -> Any:
+    start = time.time()
+    with tqdm(total=1, desc="health", unit="step") as pbar:
+        pbar.update(1)
+    etc = f"ETC: {calculate_etc(start, 1, 1)}"
+    logging.info("Health check served | %s", etc)
+    return jsonify({"status": "ok"})
+
+
+@app.get("/reports")
+def reports() -> Any:
+    start = time.time()
+    with tqdm(total=1, desc="reports", unit="step") as pbar:
+        data = _fetch_rollbacks()
+        pbar.update(1)
+    etc = f"ETC: {calculate_etc(start, 1, 1)}"
+    logging.info("Reports served | %s", etc)
     return jsonify(data)
 
 

--- a/web_gui/templates/backup_restore.html
+++ b/web_gui/templates/backup_restore.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>Backup & Restore</title>
+<h1>Backup and Restore</h1>
+<p>Manage backups here.</p>

--- a/web_gui/templates/database.html
+++ b/web_gui/templates/database.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>Database Info</title>
+<h1>Database Status</h1>
+<div id="status">Loading...</div>

--- a/web_gui/templates/deployment.html
+++ b/web_gui/templates/deployment.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>Deployment</title>
+<h1>Deployment Overview</h1>
+<p>Deployment status information.</p>

--- a/web_gui/templates/migration.html
+++ b/web_gui/templates/migration.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>Migration</title>
+<h1>Migration Process</h1>
+<p>Details about database migrations.</p>


### PR DESCRIPTION
## Summary
- add new health and reporting endpoints for the dashboard
- consolidate duplicate event logger in template_synchronizer
- extend endpoint tests
- add missing web GUI templates
- document setup for tests and linting

## Testing
- `pytest -q`
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py template_engine/template_synchronizer.py tests/test_dashboard_endpoints.py`

------
https://chatgpt.com/codex/tasks/task_e_68803f072ab483319534047f92040f8a