### PR TITLE
Fix Ruff errors and constant imports

### DIFF
--- a/archive/consolidated_scripts/documentation_manager_refactor.py
+++ b/archive/consolidated_scripts/documentation_manager_refactor.py
@@ -18,7 +18,7 @@ import logging
 import os
 import sqlite3
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, Optional
 
@@ -71,7 +71,7 @@ class EnterpriseDocumentationManager:
         self.status = "INITIALIZED"
         validate_no_recursive_folders()
         validate_environment_root()
-        logging.info(f"PROCESS STARTED: Documentation Rendering")
+        logging.info("PROCESS STARTED: Documentation Rendering")
         logging.info(f"Start Time: {self.start_time.strftime('%Y-%m-%d %H:%M:%S')}")
         logging.info(f"Process ID: {self.process_id}")
 

--- a/scripts/database/documentation_db_analyzer.py
+++ b/scripts/database/documentation_db_analyzer.py
@@ -10,6 +10,7 @@ import shutil
 import sqlite3
 import time
 from datetime import datetime, timezone
+from template_engine.placeholder_utils import DEFAULT_ANALYTICS_DB
 from pathlib import Path
 from typing import List, Tuple, Optional
 from tqdm import tqdm


### PR DESCRIPTION
## Summary
- remove unused `timedelta` import and extraneous `f` prefix in documentation manager
- import `DEFAULT_ANALYTICS_DB` in documentation DB analyzer

## Testing
- `ruff check archive/consolidated_scripts/documentation_manager_refactor.py`
- `ruff check scripts/database/documentation_db_analyzer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68807f7ae7b083318c04231ef3e03448