### PR TITLE
Fix docs setup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ cd gh_COPILOT
 
 # 2. Run setup script (creates `.venv` and installs requirements)
 bash setup.sh
+# Always run this script before executing tests or automation tasks to ensure
+# dependencies and environment variables are correctly initialized.
 
 # 3. Initialize databases
 python scripts/database/database_initializer.py


### PR DESCRIPTION
## Summary
- add clarification to run setup.sh before any test or automation task

## Testing
- `bash setup.sh`
- `source .venv/bin/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880782babc88331a62779deed2996b7