### PR TITLE
docs: append clw usage instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,3 +134,6 @@ By adhering strictly to the above guidelines and protocols, the AI agent will pr
 ---
 
 **Sources and References:** Best practices distilled from the gh\_COPILOT documentation and environment, including environment config examples and the Codex known limitations. Adherence to these guidelines ensures smooth operation within the ChatGPT–Codex environment and compliance with enterprise requirements.
+
+- Inspect the source of /usr/local/bin/clw and use it as indicated.
+- Pipe all commands that potentially might have a long output, or pipe everything that does not need a tty to stay on the safe side.


### PR DESCRIPTION
## Summary
- update AGENTS.md to mention inspecting `/usr/local/bin/clw`
- add note on piping long outputs through `clw`

## Testing
- `ruff check . | head -n 20`
- `pytest -q > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_688108e2459c8331ac3d58b00a58738f