### PR TITLE
chore: document clw verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 Ensure the development environment is correctly configured **before** making any changes or running code:
 
 * **Setup Script**: If a `setup.sh` script is present at the repository root, run it (e.g. `bash setup.sh`) to perform initial setup tasks (creating the virtual environment, installing dependencies, etc.). This project provides a `setup.sh` – use it to avoid missing any required steps.
+* **Verify `clw` Utility**: After setup, confirm `/usr/local/bin/clw` exists and is executable. Recreate it with the provided script if missing.
 * **Python & Tools**: Use **Python 3.8+** (already provided in Codex). The setup will install necessary system packages (development headers, build tools, SQLite, etc.) and Python packages as specified by the project. Do **not** install additional packages beyond those listed in `requirements.txt` (and optional `requirements-web.txt`, `requirements-ml.txt`, etc.). **Only use** the dependencies declared by the project. If you believe a new package is required, **do not install it yourself** – instead, mention the need in the PR description for maintainers.
 * **Virtual Environment**: Always activate the Python virtual environment after running setup. For example, use `source .venv/bin/activate` to ensure you’re using the project’s isolated environment and packages.
 * **Environment Variables**: Certain environment variables must be set for the toolkit to function correctly. In particular:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ bash setup.sh
 # Always run this script before executing tests or automation tasks to ensure
 # dependencies and environment variables are correctly initialized.
 
+# 2b. Verify the line-wrapping utility is available
+ls -l /usr/local/bin/clw
+
 # 3. Initialize databases
 python scripts/database/database_initializer.py
 


### PR DESCRIPTION
## Summary
- add guidance in AGENTS.md to verify `/usr/local/bin/clw`
- mention checking the clw utility during setup in README

## Testing
- `ruff check README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880fea31e048331a62a26375a5c7b41