### PR TITLE
Add test for workspace validation on disallowed paths

### DIFF
--- a/tests/test_disallowed_paths.py
+++ b/tests/test_disallowed_paths.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+with patch.dict(os.environ, {"GH_COPILOT_DISABLE_VALIDATION": "1"}):
+    from scripts.continuous_operation_orchestrator import validate_enterprise_operation
+
+
+def test_validate_enterprise_operation_disallowed_path(tmp_path: Path) -> None:
+    disallowed_dir = tmp_path / "temp"
+    disallowed_dir.mkdir()
+    (disallowed_dir / "dummy.txt").write_text("data")
+
+    with patch.dict(os.environ, {"GH_COPILOT_WORKSPACE": str(tmp_path)}):
+        with patch("os.getcwd", return_value=str(tmp_path)):
+            with pytest.raises(RuntimeError):
+                validate_enterprise_operation()
+
+    assert not disallowed_dir.exists()


### PR DESCRIPTION
## Summary
- ensure `validate_enterprise_operation` guards against disallowed path usage
- new unit test `test_validate_enterprise_operation_disallowed_path`

## Testing
- `ruff check tests/test_disallowed_paths.py`
- `pytest -q tests/test_disallowed_paths.py`

------
https://chatgpt.com/codex/tasks/task_e_68819ba50e9483319bf9d36887428a87