### PR TITLE
feat: enhance WLC session logging and validation

### DIFF
--- a/tests/test_wlc_session_manager.py
+++ b/tests/test_wlc_session_manager.py
@@ -4,12 +4,24 @@ import sqlite3
 import scripts.wlc_session_manager as wsm
 
 
+class DummyValidator:
+    def __init__(self, logger=None):
+        self.called = False
+
+    def validate_corrections(self, files):
+        self.called = True
+        return True
+
+
 def test_main_inserts_session(tmp_path, monkeypatch):
     temp_db = tmp_path / "production.db"
     shutil.copy(wsm.DB_PATH, temp_db)
     monkeypatch.setattr(wsm, "DB_PATH", temp_db)
+    backup_root = tmp_path / "backups"
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
-    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+    dummy = DummyValidator()
+    monkeypatch.setattr(wsm, "SecondaryCopilotValidator", lambda: dummy)
     with sqlite3.connect(temp_db) as conn:
         cur = conn.cursor()
         cur.execute("SELECT COUNT(*) FROM unified_wrapup_sessions")
@@ -25,3 +37,6 @@ def test_main_inserts_session(tmp_path, monkeypatch):
         score = cur.fetchone()[0]
     assert after == before + 1
     assert abs(score - 1.0) < 1e-6
+    assert dummy.called
+    log_files = list((backup_root / "logs").glob("wlc_*.log"))
+    assert log_files


### PR DESCRIPTION
## Summary
- log WLC session activity outside the repo
- validate WLC sessions with the SecondaryCopilotValidator
- test WLC logging and validation flow

## Testing
- `pytest -q`
- `ruff check scripts/wlc_session_manager.py tests/test_wlc_session_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6881b4f290388331911125cef8dc7b9f