### PR TITLE
Enhance WLC session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ workspace, maintaining anti-recursion compliance.
 ### Workspace Detection
 Most scripts read the workspace path from the `GH_COPILOT_WORKSPACE` environment variable. If the variable is not set, the current working directory is used by default.
 
+### WLC Session Manager
+The [WLC Session Manager](docs/WLC_SESSION_MANAGER.md) implements the **Wrapping, Logging, and Compliance** methodology. Run it with:
+```bash
+python scripts/wlc_session_manager.py --steps 2 --verbose
+```
+It records each session in `production.db` and writes logs under `$GH_COPILOT_BACKUP_ROOT/logs`.
+
 ---
 
 ## 🗄️ DATABASE-FIRST ARCHITECTURE

--- a/tests/test_wlc_session_manager.py
+++ b/tests/test_wlc_session_manager.py
@@ -26,14 +26,12 @@ def test_main_inserts_session(tmp_path, monkeypatch):
         cur = conn.cursor()
         cur.execute("SELECT COUNT(*) FROM unified_wrapup_sessions")
         before = cur.fetchone()[0]
-    wsm.main()
+    wsm.main([])
     with sqlite3.connect(temp_db) as conn:
         cur = conn.cursor()
         cur.execute("SELECT COUNT(*) FROM unified_wrapup_sessions")
         after = cur.fetchone()[0]
-        cur.execute(
-            "SELECT compliance_score FROM unified_wrapup_sessions ORDER BY rowid DESC LIMIT 1"
-        )
+        cur.execute("SELECT compliance_score FROM unified_wrapup_sessions ORDER BY rowid DESC LIMIT 1")
         score = cur.fetchone()[0]
     assert after == before + 1
     assert abs(score - 1.0) < 1e-6

--- a/tests/test_wlc_session_manager_cli.py
+++ b/tests/test_wlc_session_manager_cli.py
@@ -1,0 +1,59 @@
+import os
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "wlc_session_manager.py"
+
+
+def test_cli_execution(tmp_path):
+    temp_db = tmp_path / "production.db"
+    shutil.copy(Path("databases/production.db"), temp_db)
+    env = os.environ.copy()
+    env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    env["GH_COPILOT_BACKUP_ROOT"] = str(tmp_path / "backups")
+    env["PYTHONPATH"] = str(Path.cwd())
+    with sqlite3.connect(temp_db) as conn:
+        before = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
+
+    result = subprocess.run(
+        [
+            "python",
+            str(SCRIPT),
+            "--steps",
+            "1",
+            "--db-path",
+            str(temp_db),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    with sqlite3.connect(temp_db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
+    assert count == before + 1
+
+
+def test_cli_invalid_env(tmp_path):
+    env = os.environ.copy()
+    env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    env["PYTHONPATH"] = str(Path.cwd())
+    env.pop("GH_COPILOT_BACKUP_ROOT", None)
+    temp_db = tmp_path / "production.db"
+    shutil.copy(Path("databases/production.db"), temp_db)
+    # Missing GH_COPILOT_BACKUP_ROOT
+    result = subprocess.run(
+        [
+            "python",
+            str(SCRIPT),
+            "--db-path",
+            str(temp_db),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "environment variables" in result.stderr


### PR DESCRIPTION
## Summary
- add CLI to `wlc_session_manager.py` with step count, verbosity and db path
- update session tests to work with new CLI features
- add new CLI integration tests
- document WLC Session Manager usage in README

## Testing
- `ruff check scripts/wlc_session_manager.py tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b62cc98883318227afa049a72db6