### PR TITLE
feat: document clw utility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 Ensure the development environment is correctly configured **before** making any changes or running code:
 
 * **Setup Script**: If a `setup.sh` script is present at the repository root, run it (e.g. `bash setup.sh`) to perform initial setup tasks (creating the virtual environment, installing dependencies, etc.). This project provides a `setup.sh` – use it to avoid missing any required steps.
-* **Verify `clw` Utility**: After setup, confirm `/usr/local/bin/clw` exists and is executable. Recreate it with the provided script if missing.
+* **Verify `clw` Utility**: After setup, confirm `/usr/local/bin/clw` exists and is executable. If the file is missing, recreate it using the Python wrapper shown in the README’s **Output Safety with `clw`** section and make it executable. The wrapper ensures long lines are hard-wrapped so no output exceeds the 1600‑byte limit.
 * **Python & Tools**: Use **Python 3.8+** (already provided in Codex). The setup will install necessary system packages (development headers, build tools, SQLite, etc.) and Python packages as specified by the project. Do **not** install additional packages beyond those listed in `requirements.txt` (and optional `requirements-web.txt`, `requirements-ml.txt`, etc.). **Only use** the dependencies declared by the project. If you believe a new package is required, **do not install it yourself** – instead, mention the need in the PR description for maintainers.
 * **Virtual Environment**: Always activate the Python virtual environment after running setup. For example, use `source .venv/bin/activate` to ensure you’re using the project’s isolated environment and packages.
 * **Environment Variables**: Certain environment variables must be set for the toolkit to function correctly. In particular:

--- a/tests/test_clw_wrapper.py
+++ b/tests/test_clw_wrapper.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+
+
+def test_clw_inserts_line_break():
+    env = os.environ.copy()
+    env["CLW_MAX_LINE_LENGTH"] = "1200"
+    proc = subprocess.run(
+        ["/usr/local/bin/clw"],
+        input=b"A" * 1300,
+        capture_output=True,
+        env=env,
+    )
+    assert proc.returncode == 0
+    out = proc.stdout
+    assert b"\xe2\x8f\x8e\n" in out
+    parts = out.split(b"\xe2\x8f\x8e\n")
+    assert len(parts) == 2
+    assert len(parts[0]) <= 1200


### PR DESCRIPTION
## Summary
- document creation of `/usr/local/bin/clw` and reference it in AGENTS and README
- add a test verifying that clw wraps long lines

## Testing
- `ruff check tests/test_clw_wrapper.py`
- `pytest tests/test_clw_wrapper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6881d7d537e883319189bbd40ddb5123