### PR TITLE
Add env example with setup warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Example environment configuration for GH_COPILOT
+
+# Workspace root used by scripts and tests
+# Workspace root used by all scripts, tests, and utilities
+WORKSPACE_ROOT=/path/to/workspace
+GH_COPILOT_WORKSPACE=/path/to/workspace
+
+# Approved backup directory
+GH_COPILOT_BACKUP_ROOT=/path/to/backups
+
+# Flask configuration
+# IMPORTANT: Replace 'your_secret_key' with a strong, random secret key.
+# You can generate one using Python: `import secrets; print(secrets.token_hex(32))`
+# Do not commit real credentials or secret keys to the repository.
+FLASK_SECRET_KEY=your_secret_key
+FLASK_RUN_PORT=5000
+
+# Other utilities
+CONFIG_PATH=/path/to/config.yml

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 git clone https://github.com/your-org/gh_COPILOT.git
 cd gh_COPILOT
 
+# 1b. Copy environment template
+cp .env.example .env
+
 # 2. Run setup script (creates `.venv` and installs requirements)
 bash setup.sh
 # Always run this script before executing tests or automation tasks to ensure

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -22,7 +22,9 @@ def ensure_env() -> None:
         shutil.copy(example_file, env_file)
         print("Created .env from .env.example")
     else:
-        raise FileNotFoundError("Missing .env.example")
+        msg = ".env.example not found. Please create it from documentation."
+        logging.warning(msg)
+        raise FileNotFoundError(msg)
 
 
 def install_test_requirements() -> None:

--- a/tests/test_env_example.py
+++ b/tests/test_env_example.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_env_example_exists():
+    repo_root = Path(__file__).resolve().parents[1]
+    env_example = repo_root / ".env.example"
+    assert env_example.exists(), ".env.example should be present at repository root"


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders
- update setup instructions to copy `.env.example` to `.env`
- warn if `.env.example` is missing when bootstrapping
- ensure example file exists with new test

## Testing
- `ruff check README.md scripts/setup_environment.py tests/test_env_example.py`
- `pytest tests/test_env_example.py`

------
https://chatgpt.com/codex/tasks/task_e_6881da0349508331af958ef70dfd69ca