### PR TITLE
Add clw utility installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ bash setup.sh
 # dependencies and environment variables are correctly initialized.
 
 # 2b. Verify the line-wrapping utility is available
+if [ ! -x /usr/local/bin/clw ]; then
+    bash tools/install_clw.sh
+fi
 ls -l /usr/local/bin/clw
 
 # 3. Initialize databases

--- a/setup.sh
+++ b/setup.sh
@@ -16,6 +16,18 @@ if [ -f "$WORKSPACE/requirements-test.txt" ]; then
     pip install -r "$WORKSPACE/requirements-test.txt" >>/tmp/setup_install.log
 fi
 
+# install clw line wrapper if missing
+if [ ! -x /usr/local/bin/clw ]; then
+    if [ -f "$WORKSPACE/tools/clw" ]; then
+        ln -sf "$WORKSPACE/tools/clw" /usr/local/bin/clw 2>/dev/null || \
+            cp "$WORKSPACE/tools/clw" /usr/local/bin/clw
+        chmod +x /usr/local/bin/clw
+        echo "Installed clw to /usr/local/bin/clw"
+    else
+        echo "clw script not found in tools/" >&2
+    fi
+fi
+
 if [ -z "${GH_COPILOT_BACKUP_ROOT:-}" ]; then
     echo "GH_COPILOT_BACKUP_ROOT not set. Please set it outside the workspace." >&2
 fi

--- a/tools/clw
+++ b/tools/clw
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+INFO FOR HUMANS: This script solves this error:
+```
+Error: Output for session 'shell' contained a line exceeding the max of 1600 bytes (observed at least 12345 bytes).
+
+The byte sequence which exceeded the limit started with: b'\x1b[35m\x1b[K./node_modul'
+
+The exec session has been deleted. Please start a new session.
+
+Tip - rerun the command and extract only what you need, e.g.:
+  * grep -nE 'PATTERN' FILE | cut -c1-200
+  * grep -o 'PATTERN' FILE
+  * jq -r '.json.path' FILE
+  * grep -a PATTERN FILE
+```
+
+Add this to your custom instructions or AGENTS.md:
+```
+Inspect the source of /usr/local/bin/clw and use it as indicated.
+```
+
+Add this to your environment setup instructions:
+```
+curl -o /usr/local/bin/clw https://gist.githubusercontent.com/toriningen/722e0dd49a62db948d418907dcc57715/raw
+chmod +x /usr/local/bin/clw
+```
+
+IMPORTANT INFO FOR AGENTS (CODEX): Your terminal has a hard limitation of 1600 bytes per line. If any output exceeds
+it, the terminal will crash, and the environment would be reset to the blank state - this will render tools like node,
+corepack, pnpm etc. unavailable, which in turn will prevent you from solving the task at hand. You don't want this to
+happen.
+
+This utility solves this issue. It's available in your environment as /usr/local/bin/clw, and you can call it just as
+`clw`. Pipe all commands that potentially might have a long output, or pipe everything that doesn't need a tty to stay
+on the safe side.
+
+It will output lines shorter than 1550 bytes unchanged, and lines longer than that will be force-wrapped either at the
+last word boundary or at 1550 byte mark, whatever comes sooner. If the line is wrapped, it will be suffixed with "⏎\n".
+This wrap mark is always encoded as UTF-8 regardless of the output encoding - e.g. it will always be b"\xe2\x8f\x8e\n".
+"""
+
+import binascii
+import os
+import re
+import sys
+
+DEFAULT_MAX_LINE_LENGTH = 1550
+DEFAULT_WRAP_MARK = "⏎"
+
+
+def split_into_chunks(s, chunk_size):
+    rx_word_wrap = re.compile(rb"^.*(\b).+", re.DOTALL)
+
+    start = 0
+    while True:
+        end = start + chunk_size
+        chunk = s[start:end]
+        if len(chunk) < chunk_size:
+            yield False, chunk
+            return
+
+        m = rx_word_wrap.match(chunk)
+        if m and m.start(1):
+            # wrap on the last word boundary if it exists. otherwise, keep the full chunk
+            chunk = chunk[: m.start(1)]
+
+        yield True, chunk
+        start += len(chunk)
+
+
+def main():
+    env_max_line_length = os.environ.get("CLW_MAX_LINE_LENGTH")
+    if env_max_line_length:
+        max_line_length = int(env_max_line_length)
+    else:
+        max_line_length = DEFAULT_MAX_LINE_LENGTH
+
+    env_wrap_mark = os.environ.get("CLW_WRAP_MARK")
+    if env_wrap_mark:
+        wrap_mark = binascii.unhexlify(env_wrap_mark)
+    else:
+        wrap_mark = DEFAULT_WRAP_MARK.encode("utf-8")
+    wrap_mark = wrap_mark + b"\n"
+
+    chunk_size = max_line_length - len(wrap_mark)
+    assert chunk_size > 0
+
+    for line in sys.stdin.buffer:
+        for wrapped, chunk in split_into_chunks(line, chunk_size):
+            sys.stdout.buffer.write(chunk)
+            if wrapped:
+                sys.stdout.buffer.write(wrap_mark)
+            sys.stdout.buffer.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/install_clw.sh
+++ b/tools/install_clw.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLW_SRC="$SCRIPT_DIR/clw"
+CLW_DST="/usr/local/bin/clw"
+
+if [ ! -f "$CLW_SRC" ]; then
+    echo "clw source script not found: $CLW_SRC" >&2
+    exit 1
+fi
+
+if [ -L "$CLW_DST" ] || [ -f "$CLW_DST" ]; then
+    echo "clw already installed at $CLW_DST"
+else
+    ln -s "$CLW_SRC" "$CLW_DST" 2>/dev/null || cp "$CLW_SRC" "$CLW_DST"
+    chmod +x "$CLW_DST"
+    echo "Installed clw to $CLW_DST"
+fi


### PR DESCRIPTION
## Summary
- ship line-wrapping utility under `tools/clw`
- add installer helper `tools/install_clw.sh`
- install `clw` from `setup.sh` when missing
- document clw installation in README

## Testing
- `ruff check tools/clw`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881da1fb8bc833184cf6ddb9338654a