### PR TITLE
Ensure test requirements installed via setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ensure .env file
-        run: cp .env.example .env
+        run: |
+          if [ -f .env.example ]; then
+            cp .env.example .env
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install test dependencies
-        run: |
-          pip install -r requirements-test.txt
-          pip install qiskit-machine-learning
+      - name: Setup project
+        run: bash setup.sh
 
       - name: Lint src
         run: |

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-import logging
+from typing import Iterable
 
 
 def ensure_env() -> None:
@@ -25,6 +25,14 @@ def ensure_env() -> None:
         raise FileNotFoundError("Missing .env.example")
 
 
+def _parse_requirements(path: Path) -> Iterable[str]:
+    """Return a list of requirement strings from ``requirements-test.txt``."""
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            yield stripped
+
+
 def install_test_requirements() -> None:
     """Install dependencies required for running tests."""
     repo_root = Path(__file__).resolve().parents[1]
@@ -34,10 +42,18 @@ def install_test_requirements() -> None:
         print("requirements-test.txt not found; skipping test dependency installation")
         return
 
+    packages = list(_parse_requirements(requirements))
+
     subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "-r", str(requirements)]
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            *packages,
+        ]
     )
-    print("Installed test dependencies")
+    print("Installed test dependencies: " + ", ".join(packages))
 
 
 def main() -> None:

--- a/setup.sh
+++ b/setup.sh
@@ -12,9 +12,8 @@ source "$WORKSPACE/.venv/bin/activate"
 pip install --upgrade pip >/tmp/setup_install.log
 
 pip install -r "$WORKSPACE/requirements.txt" >>/tmp/setup_install.log
-if [ -f "$WORKSPACE/requirements-test.txt" ]; then
-    pip install -r "$WORKSPACE/requirements-test.txt" >>/tmp/setup_install.log
-fi
+
+python "$WORKSPACE/scripts/setup_environment.py" >>/tmp/setup_install.log
 
 if [ -z "${GH_COPILOT_BACKUP_ROOT:-}" ]; then
     echo "GH_COPILOT_BACKUP_ROOT not set. Please set it outside the workspace." >&2


### PR DESCRIPTION
## Summary
- install each package from `requirements-test.txt` via `setup_environment.py`
- call test setup script from `setup.sh`
- make CI run `setup.sh` before tests

## Testing
- `ruff check scripts/setup_environment.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d84f50508331a4d4f8b4b813b0ae