### PR TITLE
fix: resolve circular import in sync logger

### DIFF
--- a/scripts/database/cross_database_sync_logger.py
+++ b/scripts/database/cross_database_sync_logger.py
@@ -15,11 +15,8 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
-from scripts.continuous_operation_orchestrator import \
-    validate_enterprise_operation
+from scripts.continuous_operation_orchestrator import validate_enterprise_operation
 from utils.logging_utils import setup_enterprise_logging
-
-from .unified_database_initializer import initialize_database
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +47,7 @@ def log_sync_operation(
     validate_enterprise_operation()
 
     if not db_path.exists():
+        from .unified_database_initializer import initialize_database
         initialize_database(db_path)
 
     start_dt = start_time or datetime.now(timezone.utc)
@@ -60,6 +58,7 @@ def log_sync_operation(
     with sqlite3.connect(db_path) as conn:
         if not _table_exists(conn, "cross_database_sync_operations"):
             conn.close()
+            from .unified_database_initializer import initialize_database
             initialize_database(db_path)
             conn = sqlite3.connect(db_path)
         with conn:


### PR DESCRIPTION
## Summary
- avoid circular import by lazily importing `initialize_database` in `cross_database_sync_logger`

## Testing
- `ruff check scripts/database/cross_database_sync_logger.py`
- `pytest tests/test_documentation_ingestor.py::test_ingest_documentation -q` *(fails: Recursive violations prevented execution)*

------
https://chatgpt.com/codex/tasks/task_e_68824d910a3083319eeab5eef2cad04a