### PR TITLE
feat: implement analytics migration utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ ls -l /usr/local/bin/clw
 # 3. Initialize databases
 python scripts/database/database_initializer.py
 
+# Ensure analytics schema is up to date
+python scripts/database/add_code_audit_log.py
+
 # 3b. Synchronize databases
 python scripts/database/database_sync_scheduler.py \
     --workspace . \

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,5 +1,7 @@
 # Dashboard
 
 Compliance metrics and summaries.
-
-The `compliance` directory contains generated metrics (`metrics.json`) and correction summaries (`correction_summary.json`).
+The `compliance` directory contains generated metrics (`metrics.json`) and
+correction summaries (`correction_summary.json`). All data is sourced from
+`analytics.db` tables such as `placeholder_audit`, `code_audit_log` and
+`correction_history`.

--- a/databases/migrations/add_code_audit_log.sql
+++ b/databases/migrations/add_code_audit_log.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS code_audit_log (
+    id INTEGER PRIMARY KEY,
+    file_path TEXT NOT NULL,
+    line_number INTEGER NOT NULL,
+    placeholder_type TEXT NOT NULL,
+    context TEXT,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_code_audit_log_file_path ON code_audit_log(file_path);
+CREATE INDEX IF NOT EXISTS idx_code_audit_log_timestamp ON code_audit_log(timestamp);

--- a/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
+++ b/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
@@ -34,6 +34,8 @@ This document lists high-level tasks required to fully implement the database-fi
 - Create `code_templates`, `template_usage_tracking` and `template_registry` tables. Write migration scripts for existing databases.
 - Ensure `documentation` table stores `compliance_score` for each document.
 - Add `code_audit_log` table in `analytics.db` for placeholder scanning results.
+- Provide migration `databases/migrations/add_code_audit_log.sql` and helper
+  script `scripts/database/add_code_audit_log.py` to create the table.
 
 ## 7. Template Engine Upgrades
 - Replace the placeholder clustering in `template_engine/auto_generator.py` with `sklearn.cluster.KMeans`.

--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -45,6 +45,9 @@ export GH_COPILOT_WORKSPACE=/path/to/gh_COPILOT
 - All generation actions must be logged for compliance review.
 - When corrections occur, update `analytics.db:correction_patterns` for future reference.
 - Placeholder detection results are written to `analytics.db:placeholder_audit` and mirrored in `code_audit_log` for dashboard reporting.
+- Run `python scripts/database/add_code_audit_log.py` or apply
+  `databases/migrations/add_code_audit_log.sql` to ensure this table exists on
+  older analytics databases.
 - Script generation events are recorded in `production.db:enhanced_script_tracking` with the
   template version and a computed compliance score.
 - The `EnterpriseComplianceValidator` verifies that every generated script comes from an approved

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - gh_COPILOT Enterprise Toolkit
 
+## [4.1.0] - 2025-07-23 - Analytics Schema Update
+
+### Added
+- `code_audit_log` table migration (`add_code_audit_log.sql`)
+- Helper script `add_code_audit_log.py` for existing databases
+
 ## [4.0.0] - 2025-07-14 - ENTERPRISE READINESS 100% ACHIEVEMENT
 
 ### 🏆 Major Achievements
@@ -183,6 +189,7 @@
 
 | Version | Date | Key Achievement | Readiness Score |
 |---------|------|----------------|-----------------|
+| 4.1.0 | 2025-07-23 | Analytics Schema Update | 100.0% |
 | 4.0.0 | 2025-07-14 | 100% Enterprise Readiness | 100.0% |
 | 3.5.0 | 2025-07-13 | Phase 4 Completion | 94.95% |
 | 3.0.0 | 2025-07-12 | Enterprise Foundation | 85.0% |

--- a/scripts/database/add_code_audit_log.py
+++ b/scripts/database/add_code_audit_log.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Add the ``code_audit_log`` table to analytics.db.
+
+This utility creates the ``code_audit_log`` table if it does not
+already exist and verifies database size compliance after the
+operation. It follows the database-first pattern and can safely be
+run multiple times.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from .size_compliance_checker import check_database_sizes
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS code_audit_log (
+    id INTEGER PRIMARY KEY,
+    file_path TEXT NOT NULL,
+    line_number INTEGER NOT NULL,
+    placeholder_type TEXT NOT NULL,
+    context TEXT,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_code_audit_log_file_path
+    ON code_audit_log(file_path);
+CREATE INDEX IF NOT EXISTS idx_code_audit_log_timestamp
+    ON code_audit_log(timestamp);
+"""
+
+
+def add_table(db_path: Path) -> None:
+    """Create ``code_audit_log`` table in ``db_path``."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(SCHEMA_SQL)
+        conn.commit()
+    logger.info("code_audit_log ensured in %s", db_path)
+    check_database_sizes(db_path.parent)
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    db_path = root / "databases" / "analytics.db"
+    add_table(db_path)
+    logger.info("Migration completed at %s", datetime.utcnow().isoformat())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/scripts/database/documentation_db_analyzer.py
+++ b/scripts/database/documentation_db_analyzer.py
@@ -17,9 +17,7 @@ from tqdm import tqdm
 import importlib.util
 from template_engine.auto_generator import DEFAULT_ANALYTICS_DB
 
-_LOG_UTILS_PATH = (
-    Path(__file__).resolve().parents[2] / "template_engine" / "log_utils.py"
-)
+_LOG_UTILS_PATH = Path(__file__).resolve().parents[2] / "template_engine" / "log_utils.py"
 spec = importlib.util.spec_from_file_location("log_utils", _LOG_UTILS_PATH)
 _log_mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(_log_mod)
@@ -27,6 +25,24 @@ _log_event = _log_mod._log_event
 
 logger = logging.getLogger(__name__)
 ANALYTICS_DB = DEFAULT_ANALYTICS_DB
+
+CORRECTION_SQL = """
+CREATE TABLE IF NOT EXISTS correction_history (
+    session_id TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    violation_code TEXT NOT NULL,
+    fix_applied TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);
+"""
+
+
+def ensure_correction_history(db_path: Path) -> None:
+    """Create ``correction_history`` table if needed."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(CORRECTION_SQL)
+        conn.commit()
 
 
 def _calculate_etc(start_ts: float, current: int, total: int) -> str:
@@ -43,9 +59,7 @@ def _create_backup(db: Path) -> Optional[Path]:
     backup_root.mkdir(parents=True, exist_ok=True)
     if not db.exists():
         return None
-    backup = (
-        backup_root / f"{db.name}.{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.bak"
-    )
+    backup = backup_root / f"{db.name}.{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.bak"
     shutil.copy(db, backup)
     return backup
 
@@ -60,10 +74,7 @@ def rollback_db(db: Path, backup: Path) -> None:
         )
 
 
-CLEANUP_SQL = (
-    "DELETE FROM enterprise_documentation "
-    "WHERE doc_type='BACKUP_LOG' OR source_path LIKE '%backup%'"
-)
+CLEANUP_SQL = "DELETE FROM enterprise_documentation WHERE doc_type='BACKUP_LOG' OR source_path LIKE '%backup%'"
 
 DEDUP_SQL = (
     "DELETE FROM enterprise_documentation WHERE rowid NOT IN ("
@@ -101,9 +112,7 @@ def audit_placeholders(db_path: Path) -> int:
     return len(placeholders)
 
 
-def analyze_and_cleanup(
-    db_path: Path, backup_path: Path | None = None
-) -> dict[str, int]:
+def analyze_and_cleanup(db_path: Path, backup_path: Path | None = None) -> dict[str, int]:
     """Remove backups and duplicates from ``db_path`` and return a report.
     Optionally record removed entries for rollback.
     """
@@ -113,14 +122,10 @@ def analyze_and_cleanup(
     with sqlite3.connect(db_path) as conn:
         cur = conn.cursor()
         placeholders = _audit_placeholders_conn(conn)
-        before = cur.execute(
-            "SELECT COUNT(*) FROM enterprise_documentation"
-        ).fetchone()[0]
+        before = cur.execute("SELECT COUNT(*) FROM enterprise_documentation").fetchone()[0]
         removed_backups = cur.execute(CLEANUP_SQL).rowcount
         removed_dupes = cur.execute(DEDUP_SQL).rowcount
-        after = cur.execute("SELECT COUNT(*) FROM enterprise_documentation").fetchone()[
-            0
-        ]
+        after = cur.execute("SELECT COUNT(*) FROM enterprise_documentation").fetchone()[0]
         conn.commit()
         _log_event(
             {
@@ -134,6 +139,33 @@ def analyze_and_cleanup(
             table="doc_analysis",
             db_path=ANALYTICS_DB,
         )
+
+        ensure_correction_history(ANALYTICS_DB)
+        with sqlite3.connect(ANALYTICS_DB) as log_conn:
+            session = f"doc_cleanup_{datetime.utcnow().isoformat()}"
+            if removed_backups:
+                log_conn.execute(
+                    "INSERT INTO correction_history (session_id, file_path, violation_code, fix_applied, timestamp)"
+                    " VALUES (?, ?, 'DOC_BACKUP', ?, ?)",
+                    (
+                        session,
+                        str(db_path),
+                        f"{removed_backups}_removed",
+                        datetime.utcnow().isoformat(),
+                    ),
+                )
+            if removed_dupes:
+                log_conn.execute(
+                    "INSERT INTO correction_history (session_id, file_path, violation_code, fix_applied, timestamp)"
+                    " VALUES (?, ?, 'DOC_DUPLICATE', ?, ?)",
+                    (
+                        session,
+                        str(db_path),
+                        f"{removed_dupes}_removed",
+                        datetime.utcnow().isoformat(),
+                    ),
+                )
+            log_conn.commit()
 
         if backup_path:
             backup_path.write_text(json.dumps(placeholders, indent=2), encoding="utf-8")
@@ -170,9 +202,7 @@ def _log_report(report: dict) -> None:
     try:
         ANALYTICS_DB.parent.mkdir(exist_ok=True, parents=True)
         with sqlite3.connect(ANALYTICS_DB) as conn:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS doc_audit (timestamp TEXT, details TEXT)"
-            )
+            conn.execute("CREATE TABLE IF NOT EXISTS doc_audit (timestamp TEXT, details TEXT)")
             conn.execute(
                 "INSERT INTO doc_audit (timestamp, details) VALUES (?, ?)",
                 (datetime.utcnow().isoformat(), json.dumps(report)),
@@ -238,9 +268,7 @@ def main() -> None:
     for step in tqdm(["cleanup"], desc="[PROGRESS]", unit="step"):
         report = analyze_and_cleanup(db_path, backup)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    report_path = (
-        repo_root / "reports" / f"documentation_cleanup_report_{timestamp}.json"
-    )
+    report_path = repo_root / "reports" / f"documentation_cleanup_report_{timestamp}.json"
     report_path.parent.mkdir(parents=True, exist_ok=True)
     report_path.write_text(json.dumps(report, indent=2))
     _log_report(report)

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -67,11 +67,7 @@ TABLES: dict[str, str] = {
         ")"
     ),
     "enterprise_metadata": (
-        "CREATE TABLE IF NOT EXISTS enterprise_metadata ("
-        "id INTEGER PRIMARY KEY,"
-        "key TEXT NOT NULL,"
-        "value TEXT NOT NULL"
-        ")"
+        "CREATE TABLE IF NOT EXISTS enterprise_metadata (id INTEGER PRIMARY KEY,key TEXT NOT NULL,value TEXT NOT NULL)"
     ),
     "integration_tracking": (
         "CREATE TABLE IF NOT EXISTS integration_tracking ("
@@ -91,7 +87,18 @@ TABLES: dict[str, str] = {
         "timestamp TEXT NOT NULL"
         ")"
     ),
+    "code_audit_log": (
+        "CREATE TABLE IF NOT EXISTS code_audit_log ("
+        "id INTEGER PRIMARY KEY,"
+        "file_path TEXT NOT NULL,"
+        "line_number INTEGER NOT NULL,"
+        "placeholder_type TEXT NOT NULL,"
+        "context TEXT,"
+        "timestamp TEXT NOT NULL"
+        ")"
+    ),
 }
+
 
 def load_schema_from_production(tables: dict[str, str]) -> dict[str, str]:
     """Load CREATE TABLE statements from production.db if available."""
@@ -111,16 +118,16 @@ def load_schema_from_production(tables: dict[str, str]) -> dict[str, str]:
     # merge production schema with defaults
     return {**tables, **schema}
 
+
 def _load_production_schema(prod_db: Path) -> None:
     """Log schema information from ``production.db`` if available."""
     if not prod_db.exists():
         logger.warning("production.db not found at %s", prod_db)
         return
     with sqlite3.connect(prod_db) as conn:
-        tables = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'"
-        ).fetchall()
+        tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
         logger.info("Existing production tables: %s", [t[0] for t in tables])
+
 
 def initialize_database(db_path: Path) -> None:
     """
@@ -209,6 +216,7 @@ def initialize_database(db_path: Path) -> None:
     else:
         logger.error("DUAL COPILOT VALIDATION: FAILED")
 
+
 def main() -> None:
     root = Path(__file__).resolve().parents[1]
     db_path = root / "databases" / "enterprise_assets.db"
@@ -216,6 +224,7 @@ def main() -> None:
         logger.info("%s already exists", db_path)
         return
     initialize_database(db_path)
+
 
 if __name__ == "__main__":
     setup_enterprise_logging()

--- a/scripts/placeholder_audit_logger.py
+++ b/scripts/placeholder_audit_logger.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Iterable, List
 
 from tqdm import tqdm
+from scripts.database.add_code_audit_log import add_table as ensure_code_audit_log
 
 
 TEXT = {
@@ -61,9 +62,7 @@ def scan_files(workspace: Path, patterns: Iterable[str]) -> List[dict]:
     """Return a list of placeholder findings in ``workspace``."""
     results: List[dict] = []
     files = [p for p in workspace.rglob("*") if p.is_file()]
-    with tqdm(
-        total=len(files), desc=f"{TEXT['progress']} scanning", unit="file"
-    ) as bar:
+    with tqdm(total=len(files), desc=f"{TEXT['progress']} scanning", unit="file") as bar:
         for file in files:
             try:
                 lines = file.read_text(encoding="utf-8", errors="ignore").splitlines()
@@ -87,8 +86,8 @@ def scan_files(workspace: Path, patterns: Iterable[str]) -> List[dict]:
 
 def log_results(results: List[dict], db_path: Path) -> None:
     """Insert placeholder findings into ``analytics.db`` with progress bars."""
-
     db_path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_code_audit_log(db_path)
     with sqlite3.connect(db_path) as conn, tqdm(
         total=len(results), desc=f"{TEXT['progress']} logging", unit="item"
     ) as bar:
@@ -104,22 +103,9 @@ def log_results(results: List[dict], db_path: Path) -> None:
             )
             """,
         )
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS code_audit_log (
-                id INTEGER PRIMARY KEY,
-                file_path TEXT,
-                line_number INTEGER,
-                placeholder_type TEXT,
-                context TEXT,
-                timestamp TEXT
-            )
-            """,
-        )
         for row in results:
             conn.execute(
-                "INSERT INTO placeholder_audit (file_path, pattern, line, severity, ts)"
-                " VALUES (?, ?, ?, ?, ?)",
+                "INSERT INTO placeholder_audit (file_path, pattern, line, severity, ts) VALUES (?, ?, ?, ?, ?)",
                 (
                     row["file"],
                     row["pattern"],
@@ -150,9 +136,7 @@ def rollback_last_entry(db_path: Path) -> bool:
     removed = False
     with tqdm(total=1, desc=f"{TEXT['progress']} rollback", unit="entry") as bar:
         with sqlite3.connect(db_path) as conn:
-            cur = conn.execute(
-                "SELECT rowid FROM placeholder_audit ORDER BY rowid DESC LIMIT 1"
-            )
+            cur = conn.execute("SELECT rowid FROM placeholder_audit ORDER BY rowid DESC LIMIT 1")
             row = cur.fetchone()
             if row:
                 conn.execute("DELETE FROM placeholder_audit WHERE rowid = ?", (row[0],))
@@ -176,9 +160,7 @@ def update_dashboard(results: List[dict], dashboard_dir: Path) -> None:
         "compliance_score": compliance,
         "status": "complete" if count == 0 else "incomplete",
     }
-    (dashboard_dir / "placeholder_summary.json").write_text(
-        json.dumps(data, indent=2), encoding="utf-8"
-    )
+    (dashboard_dir / "placeholder_summary.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
 def main(
@@ -196,9 +178,7 @@ def main(
     production = Path(production_db or workspace / "databases" / "production.db")
     dashboard = Path(dashboard_dir or workspace / "dashboard" / "compliance")
 
-    patterns = ["TODO", "FIXME", "Implementation placeholder"] + fetch_db_patterns(
-        production
-    )
+    patterns = ["TODO", "FIXME", "Implementation placeholder"] + fetch_db_patterns(production)
 
     start = time.time()
     results = scan_files(workspace, patterns)

--- a/tests/test_add_code_audit_log.py
+++ b/tests/test_add_code_audit_log.py
@@ -1,0 +1,20 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.add_code_audit_log import add_table
+
+
+def test_add_code_audit_log(tmp_path: Path) -> None:
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE placeholder_audit (id INTEGER)")
+    # run migration twice to ensure idempotence
+    add_table(db)
+    add_table(db)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "INSERT INTO code_audit_log (file_path, line_number, placeholder_type, context, timestamp)"
+            " VALUES ('f', 1, 'TODO', 'ctx', 'ts')"
+        )
+        rows = conn.execute("SELECT file_path FROM code_audit_log").fetchall()
+    assert rows

--- a/tests/test_documentation_db_analyzer_new.py
+++ b/tests/test_documentation_db_analyzer_new.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from scripts.database.documentation_db_analyzer import audit_placeholders, rollback_cleanup
 
+
 def test_audit_placeholders(tmp_path: Path) -> None:
     db = tmp_path / "doc.db"
     with sqlite3.connect(db) as conn:
@@ -25,4 +26,32 @@ def test_rollback_cleanup(tmp_path: Path) -> None:
     assert rollback_cleanup(db, backup)
     with sqlite3.connect(db) as conn:
         val = conn.execute("SELECT a FROM t").fetchone()[0]
-    assert val == 'x'
+    assert val == "x"
+
+
+def test_analyze_and_cleanup_logs_corrections(tmp_path: Path) -> None:
+    db = tmp_path / "doc.db"
+    analytics = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE enterprise_documentation (doc_type TEXT, source_path TEXT, title TEXT, content TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO enterprise_documentation VALUES (?, ?, ?, ?)",
+            [
+                ("BACKUP_LOG", "x", "a", "foo"),
+                ("DOC", "y", "b", "bar"),
+                ("DOC", "y", "b", "bar"),
+            ],
+        )
+    import importlib
+    from scripts import database
+
+    module = importlib.import_module("scripts.database.documentation_db_analyzer")
+    module.ANALYTICS_DB = analytics
+    module.ensure_correction_history(analytics)
+    report = module.analyze_and_cleanup(db)
+    assert report["removed_duplicates"] or report["removed_backups"]
+    with sqlite3.connect(analytics) as conn:
+        rows = conn.execute("SELECT violation_code FROM correction_history").fetchall()
+    assert rows


### PR DESCRIPTION
## Summary
- add `add_code_audit_log.py` for creating analytics table and check DB size
- migrate analytics DB schema via `add_code_audit_log.sql`
- ensure initializer includes `code_audit_log` table
- log documentation cleanup to `correction_history`
- call analytics table helper from placeholder audit scripts
- document migration in README and usage guides
- update dashboard overview and changelog
- test analytics migration and cleanup logging

## Testing
- `ruff format scripts/database/add_code_audit_log.py scripts/audit_codebase_placeholders.py scripts/placeholder_audit_logger.py scripts/database/documentation_db_analyzer.py tests/test_add_code_audit_log.py tests/test_documentation_db_analyzer_new.py scripts/database/unified_database_initializer.py`
- `ruff check scripts/database/add_code_audit_log.py scripts/audit_codebase_placeholders.py scripts/placeholder_audit_logger.py scripts/database/documentation_db_analyzer.py tests/test_add_code_audit_log.py tests/test_documentation_db_analyzer_new.py scripts/database/unified_database_initializer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826d8075e08331843034b4dae92b36