### PR TITLE
Fix audit log helper, idempotent migration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Autonomous Systems:** early self-healing scripts included
 - **Placeholder Auditing:** detection script logs findings to `analytics.db:code_audit_log`
 - **Analytics Migrations:** run `add_code_audit_log.sql` or the initializer to add the table
+- **Correction History:** migration `add_correction_history.sql` adds audit trail table
 - **Quantum features:** planned, not yet implemented
 
 ---
@@ -70,6 +71,8 @@ cp .env.example .env
 bash setup.sh
 # Always run this script before executing tests or automation tasks to ensure
 # dependencies and environment variables are correctly initialized.
+# Some environments block network access. If package installs fail,
+# ensure required domains are allowed for setup.
 
 # 2b. Install the line-wrapping utility
 bash tools/install_clw.sh
@@ -77,11 +80,12 @@ bash tools/install_clw.sh
 ls -l /usr/local/bin/clw
 
 # 3. Initialize databases
-python scripts/database/database_initializer.py
+python scripts/database/unified_database_initializer.py
 
 # Add analytics tables and run migrations
 python scripts/database/add_code_audit_log.py
 sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
+sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
 python scripts/database/size_compliance_checker.py
 
 # 3b. Synchronize databases

--- a/databases/migrations/README.md
+++ b/databases/migrations/README.md
@@ -1,0 +1,17 @@
+# Database Migrations Guide
+
+## Migration Files & Order
+- `add_code_audit_log.sql`: Adds `code_audit_log` table.
+- `add_correction_history.sql`: Adds `correction_history` table (idempotent).
+
+## Applying Migrations
+Run each migration using:
+```bash
+sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
+sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
+```
+
+## Notes
+- All migrations are idempotent and safe to re-run.
+- For compliance details see `scripts/database/add_code_audit_log.py`.
+- Audit logging is integrated via `scripts/placeholder_audit_logger.py`.

--- a/databases/migrations/add_correction_history.sql
+++ b/databases/migrations/add_correction_history.sql
@@ -1,5 +1,4 @@
-DROP TABLE IF EXISTS correction_history;
-CREATE TABLE correction_history (
+CREATE TABLE IF NOT EXISTS correction_history (
     session_id TEXT NOT NULL,
     file_path TEXT NOT NULL,
     violation_code TEXT NOT NULL,

--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -65,13 +65,8 @@ metrics and shows real-time placeholder removal progress. When a placeholder is 
 ### Placeholder Correction Workflow
 1. Run `scripts/audit_codebase_placeholders.py` to log all TODOs.
 2. Review entries in `analytics.db:placeholder_audit` and fix the code.
-3. Record completed fixes with `scripts/placeholder_audit_logger.py`.
-4. Monitor `/dashboard/compliance` to verify the compliance score improves.
-
-### Placeholder Correction Workflow
-1. Scan the repository using `scripts/placeholder_audit_logger.py`.
-2. Review entries in `analytics.db:code_audit_log` and fix placeholders.
 3. Record corrections with `scripts/correction_logger_and_rollback.py` for audit.
+4. Monitor `/dashboard/compliance` to verify the compliance score improves.
 
 ## 6. Database Maintenance
 
@@ -89,7 +84,7 @@ reference.
 - Initialize all databases with `scripts/database/unified_database_initializer.py`.
 - To add new analytics tables run `scripts/database/add_code_audit_log.py` then
   execute any SQL files in `databases/migrations/` such as
-  `add_code_audit_log.sql` using `sqlite3` or your preferred migration tool.
+  `add_code_audit_log.sql` and `add_correction_history.sql` using `sqlite3` or your preferred migration tool.
 - After every migration, run `scripts/database/size_compliance_checker.py` to
   verify the 99.9 MB limit is maintained.
 

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -8,6 +8,11 @@
 - moved `_log_event` to `utils.log_utils`
 - updated `intelligent_database_merger` logging
 
+## [4.1.1] - 2025-07-25
+### Changed
+- `add_correction_history.sql` made idempotent
+- `README.md` now references `unified_database_initializer.py`
+
 ## [4.1.0] - 2025-07-22 - WRAPPER AND MONITORING UPDATES
 
 ### Added

--- a/scripts/audit_codebase_placeholders.py
+++ b/scripts/audit_codebase_placeholders.py
@@ -28,7 +28,7 @@ from tqdm import tqdm
 from scripts.continuous_operation_orchestrator import (
     validate_enterprise_operation,
 )
-from scripts.database.add_code_audit_log import add_table as ensure_code_audit_log
+from scripts.database.add_code_audit_log import ensure_code_audit_log
 
 # Visual processing indicator constants
 TEXT = {

--- a/scripts/database/add_code_audit_log.py
+++ b/scripts/database/add_code_audit_log.py
@@ -44,6 +44,14 @@ def add_table(db_path: Path) -> None:
     check_database_sizes(db_path.parent)
 
 
+def ensure_code_audit_log(db_path: Path) -> None:
+    """Ensure ``code_audit_log`` table exists."""
+    add_table(db_path)
+
+
+__all__ = ["add_table", "ensure_code_audit_log"]
+
+
 def main() -> None:
     root = Path(__file__).resolve().parents[1]
     db_path = root / "databases" / "analytics.db"

--- a/scripts/database/database_purification_engine.py
+++ b/scripts/database/database_purification_engine.py
@@ -259,8 +259,9 @@ class DatabasePurificationEngine:
         for db_path in self.databases:
             try:
                 # Create backup before repair
-                backup_path = f"{db_path}.backup_{datetime.datetime.now(
-                ).strftime('%Y%m%d_%H%M%S')}"
+                backup_path = (
+                    f"{db_path}.backup_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
+                )
                 shutil.copy2(str(db_path), backup_path)
                 self.logger.info(f"[INFO] Backup created: {backup_path}")
 

--- a/scripts/placeholder_audit_logger.py
+++ b/scripts/placeholder_audit_logger.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from typing import Iterable, List
 
 from tqdm import tqdm
-from scripts.database.add_code_audit_log import add_table as ensure_code_audit_log
 
 from scripts.database.add_code_audit_log import ensure_code_audit_log
 

--- a/tests/test_add_code_audit_log.py
+++ b/tests/test_add_code_audit_log.py
@@ -1,7 +1,7 @@
 import sqlite3
 from pathlib import Path
 
-from scripts.database.add_code_audit_log import add_table
+from scripts.database.add_code_audit_log import add_table, ensure_code_audit_log
 
 
 def test_add_code_audit_log(tmp_path: Path) -> None:
@@ -18,3 +18,14 @@ def test_add_code_audit_log(tmp_path: Path) -> None:
         )
         rows = conn.execute("SELECT file_path FROM code_audit_log").fetchall()
     assert rows
+
+
+def test_ensure_code_audit_log_wrapper(tmp_path: Path) -> None:
+    """Ensure wrapper delegates to ``add_table``."""
+    db = tmp_path / "analytics.db"
+    ensure_code_audit_log(db)
+    with sqlite3.connect(db) as conn:
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' and name='code_audit_log'"
+        ).fetchall()
+    assert tables


### PR DESCRIPTION
## Summary
- add `ensure_code_audit_log` wrapper
- update imports to use new helper
- make `add_correction_history.sql` idempotent
- create migrations README and update guides
- fix backup path string in database purifier
- add tests for wrapper

## Testing
- `ruff check scripts/database/add_code_audit_log.py scripts/audit_codebase_placeholders.py scripts/placeholder_audit_logger.py scripts/database/unified_database_initializer.py scripts/database/database_purification_engine.py tests/test_add_code_audit_log.py`
- `pytest tests/test_add_code_audit_log.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882de5805e8833198f16a9c1df22df9