### PR TITLE
Add backward compatibility wrapper for log utils

### DIFF
--- a/template_engine/log_utils.py
+++ b/template_engine/log_utils.py
@@ -1,0 +1,10 @@
+"""Backward-compatibility wrapper for :mod:`utils.log_utils`.
+
+This module re-exports :func:`utils.log_utils._log_event` for older imports.
+All new code should import from ``utils.log_utils`` instead.
+"""
+
+from utils.log_utils import _log_event
+
+__all__ = ["_log_event"]
+


### PR DESCRIPTION
## Summary
- provide `template_engine.log_utils` re-export wrapper for migration
- ensure new module passes lint and tests

## Testing
- `ruff check template_engine/log_utils.py`
- `pytest tests/test_quantum_optimizer.py::test_simulated_annealing_runs -q`

------
https://chatgpt.com/codex/tasks/task_e_68833b8c60f08331a229aaa9accfe0d3