### PR TITLE
Update logging and metrics utilities

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -96,7 +96,7 @@ Visit [http://localhost:5000](http://localhost:5000) in your browser. The dashbo
 
 The `/dashboard/compliance` endpoint returns compliance information as JSON, combining live metrics from `analytics.db` and correction/rollback summaries from `dashboard/compliance/correction_summary.json`.
 
-`metrics.json` uses the following schema:
+`metrics.json` uses the following schema (applies to both `dashboard/metrics.json` and `dashboard/compliance/metrics.json`):
 
 ```json
 {
@@ -130,6 +130,7 @@ The `/dashboard/compliance` endpoint returns compliance information as JSON, com
 
 - `metrics` — Aggregated compliance metrics (e.g., placeholder removal count, compliance score)
 - `rollbacks` — List of correction and rollback events
+- `notes` — Array of status messages using text tags like `[SUCCESS]`
 
 The endpoint is used by the dashboard UI and can be queried by external tools for compliance reporting and audit automation.
 

--- a/dashboard/compliance/metrics.json
+++ b/dashboard/compliance/metrics.json
@@ -1,11 +1,11 @@
 {
   "metrics": {
-    "placeholder_removal": 0,
-    "compliance_score": 0.0,
-    "violation_count": 0,
-    "rollback_count": 0,
-    "last_update": "2025-07-25T03:43:39.942598"
+    "placeholder_removal": 14,
+    "compliance_score": 0.98,
+    "violation_count": 5,
+    "rollback_count": 1,
+    "last_update": "2025-07-25T08:59:07.599616"
   },
   "status": "updated",
-  "timestamp": "2025-07-25T03:43:39.946461"
+  "timestamp": "2025-07-25T08:59:07.599616"
 }

--- a/dashboard/metrics.json
+++ b/dashboard/metrics.json
@@ -9,6 +9,6 @@
   "status": "updated",
   "timestamp": "2025-07-24T00:47:55.320341",
   "notes": [
-    "\ud83c\udfc1 Test suite completed."
+    "[SUCCESS] Test suite completed."
   ]
 }

--- a/scripts/database/documentation_db_analyzer.py
+++ b/scripts/database/documentation_db_analyzer.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import logging
 import os
@@ -17,12 +16,7 @@ from typing import List, Optional, Tuple
 from tqdm import tqdm
 
 from template_engine.placeholder_utils import DEFAULT_ANALYTICS_DB
-
-_LOG_UTILS_PATH = Path(__file__).resolve().parents[2] / "template_engine" / "log_utils.py"
-spec = importlib.util.spec_from_file_location("log_utils", _LOG_UTILS_PATH)
-_log_mod = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(_log_mod)
-_log_event = _log_mod._log_event
+from utils.log_utils import _log_event
 
 logger = logging.getLogger(__name__)
 ANALYTICS_DB = DEFAULT_ANALYTICS_DB

--- a/simplified_quantum_integration_orchestrator.py
+++ b/simplified_quantum_integration_orchestrator.py
@@ -1,7 +1,5 @@
-"""Thin wrapper for :mod:`archive.consolidated_scripts.simplified_quantum_integration_orchestrator`."""
-from archive.consolidated_scripts.simplified_quantum_integration_orchestrator import (
-    EnterpriseUtility,
-)
+"""Thin wrapper for :mod:`session_management_consolidation_executor`."""
+from session_management_consolidation_executor import EnterpriseUtility
 
 __all__ = ["EnterpriseUtility", "hello_world"]
 

--- a/tests/test_simplified_quantum_integration_orchestrator.py
+++ b/tests/test_simplified_quantum_integration_orchestrator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from archive.consolidated_scripts.simplified_quantum_integration_orchestrator import EnterpriseUtility
+from session_management_consolidation_executor import EnterpriseUtility
 from simplified_quantum_integration_orchestrator import hello_world
 
 

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import sqlite3
 from datetime import datetime
 from pathlib import Path
 
@@ -31,14 +30,20 @@ def log_enterprise_operation(operation: str, status: str, details: str = "") -> 
     """Log enterprise operation with standard format"""
     logger = logging.getLogger("gh_COPILOT")
 
-    if status.upper() == "SUCCESS":
-        logger.info(f"✅ {operation}: {details}")
+    tag_map = {
+        "SUCCESS": "[SUCCESS]",
+        "WARNING": "[WARNING]",
+        "ERROR": "[ERROR]",
+        "INFO": "[INFO]",
+    }
+    prefix = tag_map.get(status.upper(), "[INFO]")
+
+    if status.upper() == "ERROR":
+        logger.error(f"{prefix} {operation}: {details}")
     elif status.upper() == "WARNING":
-        logger.warning(f"⚠️ {operation}: {details}")
-    elif status.upper() == "ERROR":
-        logger.error(f"❌ {operation}: {details}")
+        logger.warning(f"{prefix} {operation}: {details}")
     else:
-        logger.info(f"📊 {operation}: {details}")
+        logger.info(f"{prefix} {operation}: {details}")
 
 
 ANALYTICS_DB = Path("databases") / "analytics.db"

--- a/web_gui/database_driven_web_gui_generator.py
+++ b/web_gui/database_driven_web_gui_generator.py
@@ -8,12 +8,11 @@ Enterprise Standards Compliance:
 - Emoji-free code (text-based indicators only)
 - Database-first architecture
 """
-import sys
-
-import sqlite3
 import logging
-from pathlib import Path
+import sqlite3
+import sys
 from datetime import datetime
+from pathlib import Path
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {

--- a/web_gui/scripts/__init__.py
+++ b/web_gui/scripts/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 # Web GUI Scripts Module
 """
 Web interface scripts for gh_COPILOT Toolkit


### PR DESCRIPTION
## Summary
- simplify documentation analyzer logging import
- switch log_enterprise_operation to text tags
- calculate placeholder removals from correction history
- refresh metrics data and docs
- fix quantum orchestrator module path and tests
- apply ruff fixes to web gui utils

## Testing
- `pytest tests/test_documentation_db_analyzer_new.py tests/test_simplified_quantum_integration_orchestrator.py tests/test_compliance_metrics_updater.py -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_688345371f748331842e268441fcff97