### PR TITLE
Fix monitoring imports

### DIFF
--- a/scripts/monitoring/continuous_monitoring_system.py
+++ b/scripts/monitoring/continuous_monitoring_system.py
@@ -5,17 +5,18 @@ Enterprise-grade continuous monitoring for 12,635+ violations
 Real-time tracking, alerting, and automated correction monitoring
 """
 
-import sqlite3
+import json
+import logging
 import os
+import sqlite3
 import sys
-import time
 import threading
+import time
+from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Any, Tuple
-from dataclasses import dataclass, asdict
-import logging
-import json
+from typing import Any, Dict, List, Tuple
+
 from tqdm import tqdm
 
 # MANDATORY: Anti-recursion validation


### PR DESCRIPTION
## Summary
- sort imports in continuous_monitoring_system

## Testing
- `ruff check scripts/monitoring/continuous_monitoring_system.py`
- `pytest -k "archive_scripts or documentation_db_analyzer or quantum_performance_integration_tester" -q` *(fails: ImportError: cannot import name 'run_kmeans_clustering')*

------
https://chatgpt.com/codex/tasks/task_e_688356cf3d788331b0fd59fd0a715cbe