### PR TITLE
Fix imports for quantum tests

### DIFF
--- a/scripts/validation/performance_validation_framework.py
+++ b/scripts/validation/performance_validation_framework.py
@@ -19,7 +19,7 @@ from tqdm import tqdm
 
 from database_driven_flake8_corrector_functional import \
     DatabaseDrivenFlake8CorrectorFunctional
-from quantum_algorithms_functional import (
+from scripts.utilities.quantum_algorithms_functional import (
     run_grover_search,
     run_kmeans_clustering,
     run_simple_qnn,

--- a/tests/test_objective_similarity_scorer.py
+++ b/tests/test_objective_similarity_scorer.py
@@ -2,6 +2,7 @@ import os
 import sqlite3
 from pathlib import Path
 
+from datetime import datetime
 from template_engine.objective_similarity_scorer import (
     compute_similarity_scores,
     validate_scores,
@@ -29,53 +30,14 @@ def test_compute_similarity_scores(tmp_path: Path) -> None:
         )
 
     # Visual processing indicator: progress bar for scoring
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     objective = "hello world"
-    scores = compute_similarity_scores(objective, prod, analytics, timeout_minutes=1)
-    assert scores, "No similarity scores returned"
-
-    # Validate DUAL COPILOT pattern: check analytics for score records
-    assert validate_scores(objective, expected_count=len(scores), analytics_db=analytics), "DUAL COPILOT validation failed"
-
-    # Completion summary
-    end_time = datetime.now()
-    duration = (end_time - start_time).total_seconds()
-    print(f"TEST COMPLETED: test_compute_similarity_scores in {duration:.2f}s")
-
-```# filepath: tests/test_objective_similarity_scorer.py
-
-import os
-import sqlite3
-from pathlib import Path
-
-from template_engine.objective_similarity_scorer import (
-    compute_similarity_scores,
-    validate_scores,
-)
-
-def test_compute_similarity_scores(tmp_path: Path) -> None:
-    # Start time logging for test
-    start_time = datetime.now()
-    print(f"PROCESS STARTED: test_compute_similarity_scores")
-    print(f"Start Time: {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
-    print(f"Process ID: {os.getpid()}")
-
-    # Setup test databases
-    prod = tmp_path / "production.db"
-    analytics = tmp_path / "analytics.db"
-    with sqlite3.connect(prod) as conn:
-        conn.execute(
-            "CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)"
-        )
-        conn.execute(
-            "INSERT INTO code_templates (template_code) VALUES ('print(\"hello\")')"
-        )
-        conn.execute(
-            "INSERT INTO code_templates (template_code) VALUES ('def greet(): return \"hello world\"')"
-        )
-
-    # Visual processing indicator: progress bar for scoring
-    objective = "hello world"
-    scores = compute_similarity_scores(objective, prod, analytics, timeout_minutes=1)
+    scores = compute_similarity_scores(
+        objective,
+        prod,
+        analytics,
+        timeout_minutes=1,
+    )
     assert scores, "No similarity scores returned"
 
     # Validate DUAL COPILOT pattern: check analytics for score records


### PR DESCRIPTION
## Summary
- use wrappers from `scripts.utilities.quantum_algorithms_functional`
- repair `test_objective_similarity_scorer` duplication and missing env

## Testing
- `ruff check tests/test_objective_similarity_scorer.py`
- `pytest tests/test_objective_similarity_scorer.py::test_compute_similarity_scores -q`
- `pytest -q` *(fails: 14 failed, 53 passed, 44 warnings, 9 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688340aa0a18833180fb12723d721f2f