### PR TITLE
feat: add dashboard port config

### DIFF
--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -1,4 +1,13 @@
-"""Thin wrapper for the enterprise Flask app."""
+"""Start the enterprise Flask dashboard.
+
+This wrapper loads ``app`` from :mod:`web_gui.scripts.flask_apps.enterprise_dashboard`
+and exposes a ``main`` entry point for command-line execution. The dashboard
+listens on ``FLASK_RUN_PORT`` when set, falling back to port ``5000``.
+"""
+
+from __future__ import annotations
+
+import os
 
 from web_gui.scripts.flask_apps.enterprise_dashboard import app
 
@@ -6,7 +15,9 @@ __all__ = ["app", "main"]
 
 
 def main() -> None:
-    app.run(host="0.0.0.0", port=5000, debug=bool(__name__ == "__main__"))
+    """Run the wrapped Flask app."""
+    port = int(os.getenv("FLASK_RUN_PORT", "5000"))
+    app.run(host="0.0.0.0", port=port, debug=bool(__name__ == "__main__"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add FLASK_RUN_PORT support to enterprise_dashboard

## Testing
- `ruff check dashboard/enterprise_dashboard.py`
- `pyright dashboard/enterprise_dashboard.py`
- `pytest tests/test_dashboard_endpoints.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883951a30888331b50f35c0cccb2236