### PR TITLE
test: add dual copilot migration checks

### DIFF
--- a/tests/test_add_code_audit_log.py
+++ b/tests/test_add_code_audit_log.py
@@ -1,7 +1,13 @@
 import sqlite3
 from pathlib import Path
 
+import logging
+import time
+
+from tqdm import tqdm
+
 from scripts.database.add_code_audit_log import add_table, ensure_code_audit_log
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 
 def test_add_code_audit_log(tmp_path: Path) -> None:
@@ -25,7 +31,54 @@ def test_ensure_code_audit_log_wrapper(tmp_path: Path) -> None:
     db = tmp_path / "analytics.db"
     ensure_code_audit_log(db)
     with sqlite3.connect(db) as conn:
-        tables = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' and name='code_audit_log'"
-        ).fetchall()
+        tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table' and name='code_audit_log'").fetchall()
     assert tables
+
+
+def test_add_code_audit_log_dual_copilot(tmp_path: Path, caplog) -> None:
+    """Verify migration with dual copilot validation."""
+    db = tmp_path / "analytics.db"
+    caplog.set_level(logging.INFO)
+
+    # Primary copilot: run migration with visual indicators
+    start = time.time()
+    for _ in tqdm(range(1), desc="Simulating migration steps", unit="step"):
+        add_table(db)
+
+    # Secondary copilot: validate table exists and script passes flake8
+    with sqlite3.connect(db) as conn:
+        tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table' and name='code_audit_log'").fetchall()
+
+    validator = SecondaryCopilotValidator(logging.getLogger(__name__))
+    script = Path(__file__).resolve().parents[1] / "scripts" / "database" / "add_code_audit_log.py"
+    validation = validator.validate_corrections([str(script)])
+
+    elapsed = time.time() - start
+
+    assert tables
+    assert validation
+    assert "add_table" in caplog.text or "code_audit_log ensured" in caplog.text
+    assert elapsed >= 0
+
+
+def test_sql_migration_dual_copilot(tmp_path: Path) -> None:
+    """Run SQL migration with secondary validation."""
+    repo_root = Path(__file__).resolve().parents[1]
+    db = tmp_path / "analytics.db"
+
+    sql = (repo_root / "databases" / "migrations" / "add_code_audit_log.sql").read_text()
+
+    start_time = time.time()
+    with sqlite3.connect(db) as conn, tqdm(total=1, desc="apply-sql", unit="step") as bar:
+        conn.executescript(sql)
+        bar.update(1)
+        conn.commit()
+
+    with sqlite3.connect(db) as conn:
+        exists = conn.execute("SELECT name FROM sqlite_master WHERE type='table' and name='code_audit_log'").fetchall()
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+
+    duration = time.time() - start_time
+    assert exists
+    assert integrity == "ok"
+    assert duration >= 0


### PR DESCRIPTION
Adds unit tests for code audit log migrations using a dual copilot pattern. Tests run migrations on a temporary database with visual processing indicators and validate schema integrity. References prompt for analytics.db test-only protocol.

All new tests pass:
```
pytest tests/test_add_code_audit_log.py::test_add_code_audit_log_dual_copilot -q
pytest tests/test_add_code_audit_log.py::test_sql_migration_dual_copilot -q
```


------
https://chatgpt.com/codex/tasks/task_e_6883993718a48331968da51e566511ea