### PR TITLE
Add dual copilot test for documentation manager

### DIFF
--- a/enterprise_database_driven_documentation_manager.py
+++ b/enterprise_database_driven_documentation_manager.py
@@ -7,12 +7,15 @@ import json
 import logging
 import sqlite3
 import sys
-from dataclasses import dataclass
 import time
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from template_engine.auto_generator import TemplateAutoGenerator, calculate_etc
+
 from tqdm import tqdm
-from utils.log_utils import _log_event
+
+from template_engine.auto_generator import TemplateAutoGenerator, calculate_etc
+from utils.log_utils import DEFAULT_ANALYTICS_DB, _log_event
 
 RENDER_LOG_DIR = Path("logs/template_rendering")
 LOG_FILE = RENDER_LOG_DIR / "documentation_render.log"

--- a/tests/test_enterprise_database_driven_documentation_manager.py
+++ b/tests/test_enterprise_database_driven_documentation_manager.py
@@ -1,0 +1,77 @@
+"""Tests for :mod:`enterprise_database_driven_documentation_manager`."""
+
+import logging
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from enterprise_database_driven_documentation_manager import (
+    DocumentationManager,
+    dual_validate,
+)
+
+
+def test_dual_copilot_validation(tmp_path: Path, monkeypatch, caplog) -> None:
+    """Validate DUAL COPILOT pattern for documentation rendering."""
+
+    # Visual processing indicator start
+    start = datetime.now()
+    print("PROCESS STARTED: test_dual_copilot_validation")
+    print(f"Start Time: {start.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"Process ID: {os.getpid()}")
+
+    # Setup temporary databases
+    prod_db = tmp_path / "production.db"
+    analytics_db = tmp_path / "analytics.db"
+    completion_db = tmp_path / "template_completion.db"
+
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute(
+            "CREATE TABLE documentation (title TEXT, content TEXT, compliance_score INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO documentation VALUES ('Doc1', 'content', 75)"
+        )
+
+    with sqlite3.connect(completion_db) as conn:
+        conn.execute("CREATE TABLE templates (template_content TEXT)")
+        conn.execute("INSERT INTO templates VALUES ('{content}')")
+
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            "CREATE TABLE ml_pattern_optimization (replacement_template TEXT)"
+        )
+        conn.execute("INSERT INTO ml_pattern_optimization VALUES ('{content}')")
+
+    # Ensure environment variables are set for compliance
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
+
+    # Provide our custom manager to ``dual_validate``
+    manager = DocumentationManager(
+        database=prod_db,
+        analytics_db=analytics_db,
+        completion_db=completion_db,
+    )
+    monkeypatch.setattr(
+        "enterprise_database_driven_documentation_manager.DocumentationManager",
+        lambda: manager,
+    )
+
+    caplog.set_level(logging.INFO)
+    assert dual_validate(), "Primary render step failed"
+
+    # Secondary validation: confirm analytics log entry
+    with sqlite3.connect(analytics_db) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM render_events"
+        ).fetchone()[0]
+    assert count >= 1, "DUAL COPILOT validation failed"
+
+    # Visual processing indicator end
+    duration = (datetime.now() - start).total_seconds()
+    print(
+        f"TEST COMPLETED: test_dual_copilot_validation in {duration:.2f}s"
+    )
+


### PR DESCRIPTION
## Summary
- import `DEFAULT_ANALYTICS_DB` and `datetime` in `enterprise_database_driven_documentation_manager`
- add new test validating dual copilot pattern for the documentation manager

## Testing
- `ruff check enterprise_database_driven_documentation_manager.py tests/test_enterprise_database_driven_documentation_manager.py`
- `pytest -q tests/test_enterprise_database_driven_documentation_manager.py`
- `pytest -q` *(fails: 15 failed, 53 passed, 1 skipped, 44 warnings, 9 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883993718a48331968da51e566511ea