### PR TITLE
Add analytics.db creation test

### DIFF
--- a/docs/validation/Analytics_DB_Creation_Test.md
+++ b/docs/validation/Analytics_DB_Creation_Test.md
@@ -1,0 +1,21 @@
+# Analytics DB Creation Test
+
+This validation ensures that `databases/analytics.db` can be created and
+migrated on demand. The file is tracked in the repository for testing
+purposes, but new environments may need to recreate it.
+
+## Test‑Only Creation Command
+
+Run the following commands manually from the repository root to verify
+that a fresh analytics database can be initialized:
+
+```bash
+sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
+sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
+```
+
+If these commands complete without error, the migrations succeed. The
+database is **not** created automatically during normal operation; a
+human must trigger the command to comply with database‑first and
+enterprise standards.
+

--- a/tests/test_analytics_db_creation.py
+++ b/tests/test_analytics_db_creation.py
@@ -1,0 +1,40 @@
+"""Validate analytics.db migrations can run in a fresh database.
+
+This test ensures the migrations in ``databases/migrations`` can be
+applied to create the ``analytics.db`` schema. The repository includes an
+``analytics.db`` file, but it should be possible to recreate it from the
+SQL migrations when needed. The test does not rely on the existing file
+and runs entirely in a temporary directory.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def test_analytics_db_creation(tmp_path: Path) -> None:
+    """Run migrations and verify required tables exist."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    analytics = tmp_path / "analytics.db"
+
+    migration_dir = repo_root / "databases" / "migrations"
+    code_audit_sql = (migration_dir / "add_code_audit_log.sql").read_text()
+    correction_history_sql = (migration_dir / "add_correction_history.sql").read_text()
+
+    with sqlite3.connect(analytics) as conn:
+        conn.executescript(code_audit_sql)
+        conn.executescript(correction_history_sql)
+
+    with sqlite3.connect(analytics) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+
+    assert "code_audit_log" in tables
+    assert "correction_history" in tables
+


### PR DESCRIPTION
## Summary
- add validation for generating analytics.db from migrations
- document manual creation command

## Testing
- `ruff check tests/test_analytics_db_creation.py`
- `pytest tests/test_analytics_db_creation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68839d0c33e083318730ca31fa5587b8