### PR TITLE
Add analytics test protocol documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Placeholder Auditing:** detection script logs findings to `analytics.db:code_audit_log`
 - **Correction History:** cleanup and fix events recorded in `analytics.db:correction_history`
 - **Analytics Migrations:** run `add_code_audit_log.sql` and `add_correction_history.sql` (use `sqlite3` manually if `analytics.db` shipped without the table) or use the initializer. The `correction_history` table tracks file corrections with session ID, action, timestamp, and optional details.
+- **Analytics DB Test Protocol:** see [docs/ANALYTICS_DB_TEST_PROTOCOL.md](docs/ANALYTICS_DB_TEST_PROTOCOL.md) for manual migration commands and testing guidelines.
 - **Quantum features:** planned, not yet implemented
 - **Quantum Utilities:** see [quantum/README.md](quantum/README.md) for
   optimizer and search helpers.

--- a/docs/ANALYTICS_DB_TEST_PROTOCOL.md
+++ b/docs/ANALYTICS_DB_TEST_PROTOCOL.md
@@ -1,0 +1,43 @@
+# Analytics DB Test-Only Protocol
+
+This document describes the procedure for validating the `analytics.db` migrations without automatically creating or modifying the database file. All automation must operate in **test mode** only.
+
+## Manual Migration
+
+Run the following commands manually if `analytics.db` needs the new tables:
+
+```bash
+sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
+sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
+```
+
+The database file is not generated automatically. A human operator must execute these commands to create the `code_audit_log` and `correction_history` tables.
+
+## Testing Guidance
+
+Tests run the migration SQL against an in-memory SQLite instance to confirm the schema applies cleanly. Progress indicators and dual validation ensure compliance.
+
+```python
+# Example from tests/test_analytics_migration_simulation.py
+from pathlib import Path
+import sqlite3
+from tqdm import tqdm
+
+with sqlite3.connect(":memory:") as conn:
+    for sql in tqdm([
+        Path("databases/migrations/add_code_audit_log.sql"),
+        Path("databases/migrations/add_correction_history.sql"),
+    ], desc="Simulating migration steps", unit="step"):
+        conn.executescript(sql.read_text())
+```
+
+No `analytics.db` file is created during testing.
+
+## Visual Processing Indicators
+
+All test scripts log the start time, use a progress bar, and provide status updates to comply with the Visual Processing Indicators standard.
+
+## Dual Copilot Validation
+
+Primary migration logic is verified by a secondary check ensuring both new tables exist before the simulation succeeds.
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.1.4] - 2025-07-28
+- Documented test-only protocol for `analytics.db` migrations.
+- Added `ANALYTICS_DB_TEST_PROTOCOL.md` with manual commands and testing notes.
+
 ## [4.1.3] - 2025-07-27
 - Verified presence of new session and monitoring modules.
 - Refreshed documentation for wrappers and utilities.


### PR DESCRIPTION
## Summary
- document manual analytics DB migration protocol
- reference new protocol in README
- update changelog

## Testing
- `ruff check scripts/database/add_code_audit_log.py`
- `pytest -q tests/test_analytics_migration_simulation.py tests/test_analytics_migrations.py tests/test_add_code_audit_log.py`

------
https://chatgpt.com/codex/tasks/task_e_6883a03c815c8331a029a8b35ca700f4