### PR TITLE
feat: add obsolete table cleanup utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ Several small modules provide common helpers:
   optimizations and demonstrations.
 - `template_engine.pattern_clustering_sync.PatternClusteringSync` – cluster templates from `production.db` and synchronize them with compliance auditing.
 - `template_engine.workflow_enhancer.TemplateWorkflowEnhancer` – enhance template workflows using clustering, pattern mining and dashboard reports.
+- `tools.cleanup.cleanup_obsolete_entries` – remove rows from `obsolete_table` in `production.db`.
 
 ## Future Roadmap
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,21 @@
+import sqlite3
+from pathlib import Path
+
+from tools.cleanup import cleanup_obsolete_entries
+
+
+def test_cleanup_obsolete_entries(tmp_path: Path) -> None:
+    db = tmp_path / "test.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE obsolete_table(id INTEGER)")
+        conn.executemany("INSERT INTO obsolete_table(id) VALUES (?)", [(1,), (2,)])
+
+    deleted, valid = cleanup_obsolete_entries(db)
+
+    assert deleted == 2
+    assert valid
+
+    with sqlite3.connect(db) as conn:
+        remaining = conn.execute("SELECT COUNT(*) FROM obsolete_table").fetchone()[0]
+    assert remaining == 0
+

--- a/tools/cleanup.py
+++ b/tools/cleanup.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Remove obsolete records from :mod:`production.db`.
+
+This utility follows the Dual Copilot pattern with basic visual
+processing indicators. It deletes all rows from ``obsolete_table`` and
+verifies the cleanup in a secondary validation phase.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple
+
+from tqdm import tqdm
+
+DB_PATH = Path("databases/production.db")
+TABLE = "obsolete_table"
+
+
+def _primary_cleanup(conn: sqlite3.Connection) -> int:
+    """Delete all rows from :data:`TABLE`.
+
+    Returns the number of rows removed. If the table does not exist, no
+    rows are removed and zero is returned.
+    """
+
+    if not _table_exists(conn, TABLE):
+        logging.info("Table %s not present; nothing to clean", TABLE)
+        return 0
+
+    cur = conn.execute(f"DELETE FROM {TABLE}")
+    return cur.rowcount
+
+
+def _secondary_validation(conn: sqlite3.Connection) -> bool:
+    """Verify :data:`TABLE` has no remaining rows."""
+
+    if not _table_exists(conn, TABLE):
+        return True
+    remaining = conn.execute(f"SELECT COUNT(*) FROM {TABLE}").fetchone()[0]
+    return remaining == 0
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def cleanup_obsolete_entries(db_path: Path = DB_PATH) -> Tuple[int, bool]:
+    """Clean ``obsolete_table`` from ``db_path``.
+
+    Returns a tuple of ``(rows_deleted, validation_passed)``.
+    """
+
+    start = datetime.now()
+    logging.info("Start: %s", start.strftime("%Y-%m-%d %H:%M:%S"))
+    logging.info("PID: %s", os.getpid())
+
+    with sqlite3.connect(db_path) as conn:
+        with tqdm(total=1, desc="Cleaning", unit="step") as bar:
+            deleted = _primary_cleanup(conn)
+            bar.update(1)
+
+    with sqlite3.connect(db_path) as conn:
+        valid = _secondary_validation(conn)
+
+    logging.info("Rows deleted: %s", deleted)
+    logging.info("Validation: %s", "passed" if valid else "failed")
+    logging.info("Completed in %s", datetime.now() - start)
+    return deleted, valid
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    cleanup_obsolete_entries()
+


### PR DESCRIPTION
## Summary
- add tools/cleanup.py to remove obsolete_table rows from production.db
- document cleanup utility in README
- test cleanup_obsolete_entries in new unit test

## Testing
- `ruff check tools/cleanup.py tests/test_cleanup.py`
- `pytest -q tests/test_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_6883a39a9fac8331bcee27d3cc5bb872