### PR TITLE
docs: clarify analytics.db dry-run test

### DIFF
--- a/docs/validation/Analytics_DB_Creation_Test.md
+++ b/docs/validation/Analytics_DB_Creation_Test.md
@@ -14,6 +14,14 @@ sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
 sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
 ```
 
+For a fully compliant dry‑run, execute the in‑memory test which logs the start
+time, shows a progress bar, and reports completion. This demonstrates the
+migrations without creating the database file:
+
+```bash
+python -m pytest tests/test_analytics_migration_simulation.py -q
+```
+
 If these commands complete without error, the migrations succeed. The
 database is **not** created automatically during normal operation; a
 human must trigger the command to comply with database‑first and

--- a/tests/test_analytics_migration_simulation.py
+++ b/tests/test_analytics_migration_simulation.py
@@ -9,6 +9,7 @@ such as a progress bar and duration logging.
 from __future__ import annotations
 
 import datetime as dt
+import os
 import sqlite3
 from pathlib import Path
 
@@ -26,9 +27,7 @@ def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
 
 
 def _primary_validation(conn: sqlite3.Connection) -> bool:
-    return all(
-        _table_exists(conn, tbl) for tbl in ["code_audit_log", "correction_history"]
-    )
+    return all(_table_exists(conn, tbl) for tbl in ["code_audit_log", "correction_history"])
 
 
 def _secondary_validation(conn: sqlite3.Connection) -> bool:
@@ -39,6 +38,8 @@ def _secondary_validation(conn: sqlite3.Connection) -> bool:
 def test_analytics_migration_simulation(capsys) -> None:
     """Run migrations in-memory with progress indicators."""
     print("Test: Simulate analytics.db migration (dry-run)")
+    print(f"Start: {dt.datetime.now()}")
+    print(f"PID: {os.getpid()}")
     start = dt.datetime.now()
 
     migration_files = [
@@ -56,4 +57,3 @@ def test_analytics_migration_simulation(capsys) -> None:
     print(f"Completed simulation in {dt.datetime.now() - start}")
     captured = capsys.readouterr()
     assert "Completed simulation" in captured.out
-


### PR DESCRIPTION
## Summary
- update Analytics_DB_Creation_Test doc with dry-run test instructions
- add start time and PID logging to analytics migration simulation test

## Testing
- `ruff check tests/test_analytics_migration_simulation.py tests/test_analytics_db_creation.py`
- `pytest tests/test_analytics_migration_simulation.py tests/test_analytics_db_creation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a39a9fac8331bcee27d3cc5bb872