### PR TITLE
docs: clarify clw usage and WLC session logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,15 @@ Ensure the development environment is correctly configured **before** making any
   * *Optional variables:* **WORKSPACE\_ROOT** (alias for `GH_COPILOT_WORKSPACE`), **FLASK\_SECRET\_KEY** (for the optional Flask web UI, default `'your_secret_key'` – replace in production), **FLASK\_RUN\_PORT** (Flask dev server port, default 5000), **CONFIG\_PATH** (path to a custom config file if not using the default `config/enterprise.json`), **WEB\_DASHBOARD\_ENABLED** (`"1"` or `"0"` to toggle logging of performance metrics with `[DASHBOARD]` tags). Configure these as needed if using those features.
 * After installing dependencies and setting variables, **run the test suite** (see [Testing and Validation](#testing-and-validation)) to verify the environment is correctly set up.
 
+## Output Safety and `clw`
+
+The terminal enforces a **1600-byte per-line limit**. Lines longer than this will reset the session. To stay safe:
+
+* Always pipe potentially large output through `/usr/local/bin/clw`. The tool hard-wraps lines longer than the configured threshold (default 1550 bytes).
+* When unsure, redirect command output to a log file and inspect it using `clw` or chunked reads (`head`, `tail`).
+* If `clw` is missing, recreate it from `tools/clw.py`, place it at `/usr/local/bin/clw`, and make it executable.
+* On any line-length error, start a new session, re-run setup, and retry the command using `clw` or log chunking.
+
 ## Allowed Tools and Commands (Agent Behavior)
 
 When using the terminal or editing files, the agent must adhere to the following rules:

--- a/README.md
+++ b/README.md
@@ -705,8 +705,10 @@ The **Wrapping, Logging, and Compliance (WLC)** system ensures that long-running
 operations are recorded and validated for enterprise review. The session manager
 in [`scripts/wlc_session_manager.py`](scripts/wlc_session_manager.py) starts a
 session entry in `production.db`, logs progress to an external backup location,
-and finalizes the run with a compliance score. Detailed usage instructions are
-available in [docs/WLC_SESSION_MANAGER.md](docs/WLC_SESSION_MANAGER.md).
+and finalizes the run with a compliance score. Each run inserts a record into the
+`unified_wrapup_sessions` table with `session_id`, timestamps, status, compliance
+score, and optional error details. Detailed usage instructions are available in
+[docs/WLC_SESSION_MANAGER.md](docs/WLC_SESSION_MANAGER.md).
 
 ---
 

--- a/docs/REPOSITORY_GUIDELINES.md
+++ b/docs/REPOSITORY_GUIDELINES.md
@@ -55,6 +55,21 @@ Configurations should follow the standards outlined in `AGENTS.md`.
 
 ---
 
+## WLC Session Logging
+
+Use `scripts/wlc_session_manager.py` to execute tasks under the Wrapping, Logging,
+and Compliance methodology. Each run writes a row to the
+`production.db` table `unified_wrapup_sessions` capturing the session ID,
+start and end times, completion status, compliance score, and any errors.
+
+```bash
+python scripts/wlc_session_manager.py --steps 2 --verbose
+```
+
+Log files are stored under `$GH_COPILOT_BACKUP_ROOT/logs/`.
+
+---
+
 ## LOG MAINTENANCE
 
 To avoid unnecessary CI failures or clutter in Pull Requests, ensure that:


### PR DESCRIPTION
## Summary
- add concise output safety section about `clw` to AGENTS.md
- document `unified_wrapup_sessions` table in README
- outline WLC session logging in repository guidelines

## Testing
- `ruff check scripts/wlc_session_manager.py`
- `pyright scripts/wlc_session_manager.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a70911c8833189f43fa31f16486e