### PR TITLE
Fix analytics DB creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
 sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
 # Verify creation
 sqlite3 databases/analytics.db ".schema code_audit_log"
+# Manual creation is required; see `docs/ANALYTICS_DB_TEST_PROTOCOL.md`
+# for the test-only procedure ensuring migrations succeed without
+# automatically generating `analytics.db`.
 python scripts/database/size_compliance_checker.py
 
 # 3b. Synchronize databases

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Documented test-only protocol for `analytics.db` migrations.
 - Added `ANALYTICS_DB_TEST_PROTOCOL.md` with manual commands and testing notes.
 
+## [4.1.5] - 2025-07-29
+- `log_quantum_event` no longer auto-creates `analytics.db`; added test to
+  verify this behavior.
+
 ## [4.1.3] - 2025-07-27
 - Verified presence of new session and monitoring modules.
 - Refreshed documentation for wrappers and utilities.

--- a/quantum_algorithm_library_expansion.py
+++ b/quantum_algorithm_library_expansion.py
@@ -7,10 +7,10 @@ only and are simplified versions of their quantum counterparts.
 
 from __future__ import annotations
 
-from typing import Iterable, List
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+from typing import Iterable, List
 
 import numpy as np
 from sklearn.cluster import KMeans
@@ -19,9 +19,12 @@ from tqdm import tqdm
 ANALYTICS_DB = Path("databases/analytics.db")
 
 def log_quantum_event(name: str, details: str) -> None:
-    """Log quantum algorithm usage."""
+    """Log quantum algorithm usage if ``analytics.db`` exists."""
+    if not ANALYTICS_DB.exists():
+        # Manual creation required; skip logging if database is absent
+        return
+
     try:
-        ANALYTICS_DB.parent.mkdir(parents=True, exist_ok=True)
         with sqlite3.connect(ANALYTICS_DB) as conn:
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS quantum_events (timestamp TEXT, name TEXT, details TEXT)"
@@ -32,6 +35,7 @@ def log_quantum_event(name: str, details: str) -> None:
             )
             conn.commit()
     except sqlite3.Error:
+        # Logging should not raise during optional analytics collection
         pass
 
 

--- a/tests/test_log_quantum_event_no_auto_create.py
+++ b/tests/test_log_quantum_event_no_auto_create.py
@@ -1,0 +1,13 @@
+import quantum_algorithm_library_expansion as qale
+
+
+def test_log_quantum_event_does_not_create_db(tmp_path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    monkeypatch.setattr(qale, "ANALYTICS_DB", db)
+
+    if db.exists():
+        db.unlink()
+
+    qale.log_quantum_event("test", "desc")
+    assert not db.exists(), "analytics.db should not be created automatically"
+


### PR DESCRIPTION
## Summary
- avoid auto creating analytics.db in quantum analytics logger
- document manual creation steps in README
- note behaviour in changelog
- add test to ensure analytics.db is not created automatically

## Testing
- `ruff check quantum_algorithm_library_expansion.py tests/test_log_quantum_event_no_auto_create.py`
- `pytest tests/test_log_quantum_event_no_auto_create.py tests/test_analytics_db_creation.py tests/test_analytics_migration_simulation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a74c501883319314a8cd50894317