### PR TITLE
Integrate orchestrator with WLC session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,13 @@ The [WLC Session Manager](docs/WLC_SESSION_MANAGER.md) implements the **Wrapping
 ```bash
 python scripts/wlc_session_manager.py --steps 2 --verbose
 ```
-It records each session in `production.db` and writes logs under `$GH_COPILOT_BACKUP_ROOT/logs`.
+Add `--orchestrate` to run the `UnifiedWrapUpOrchestrator` after the WLC steps:
+
+```bash
+python scripts/wlc_session_manager.py --steps 2 --orchestrate
+```
+
+Each run records a row in `production.db` and writes logs under `$GH_COPILOT_BACKUP_ROOT/logs`.
 
 ---
 

--- a/docs/WLC_SESSION_MANAGER.md
+++ b/docs/WLC_SESSION_MANAGER.md
@@ -27,6 +27,16 @@ python scripts/wlc_session_manager.py
 
 Log files will be written under `$GH_COPILOT_BACKUP_ROOT/logs/` and a new row is inserted into the `unified_wrapup_sessions` table of `production.db`.
 
+### Orchestrator Integration
+
+Pass `--orchestrate` to automatically run the `UnifiedWrapUpOrchestrator` after the WLC steps complete:
+
+```bash
+python scripts/wlc_session_manager.py --steps 2 --orchestrate
+```
+
+The orchestrator consolidates files and validates configuration. All actions are recorded in the same `unified_wrapup_sessions` table.
+
 ## Related Tests
 
 The behavior is validated by `tests/test_wlc_session_manager.py`, which verifies session logging and compliance score tracking.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+    "pythonVersion": "3.12",
+    "extraPaths": [".venv/lib/python3.12/site-packages"]
+}

--- a/tests/test_wlc_session_manager.py
+++ b/tests/test_wlc_session_manager.py
@@ -38,3 +38,29 @@ def test_main_inserts_session(tmp_path, monkeypatch):
     assert dummy.called
     log_files = list((backup_root / "logs").glob("wlc_*.log"))
     assert log_files
+
+
+class DummyOrchestrator:
+    def __init__(self, workspace_path=None):
+        self.called = False
+
+    def execute_unified_wrapup(self):
+        self.called = True
+        return None
+
+
+def test_orchestrator_called(tmp_path, monkeypatch):
+    temp_db = tmp_path / "production.db"
+    shutil.copy(wsm.DB_PATH, temp_db)
+    monkeypatch.setattr(wsm, "DB_PATH", temp_db)
+    backup_root = tmp_path / "backups"
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+    dummy_validator = DummyValidator()
+    monkeypatch.setattr(wsm, "SecondaryCopilotValidator", lambda: dummy_validator)
+    dummy_orch = DummyOrchestrator()
+    monkeypatch.setattr(wsm, "UnifiedWrapUpOrchestrator", lambda workspace_path=None: dummy_orch)
+
+    wsm.run_session(1, temp_db, False, run_orchestrator=True)
+
+    assert dummy_orch.called


### PR DESCRIPTION
## Summary
- extend `wlc_session_manager` to optionally invoke `UnifiedWrapUpOrchestrator`
- add `--orchestrate` CLI flag
- document orchestrator integration
- ensure type checking by adding `pyrightconfig.json`
- expand tests for orchestrator support

## Testing
- `ruff check scripts/wlc_session_manager.py tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py`
- `pyright scripts/wlc_session_manager.py tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_6883a8dbbd588331a096ef8dee690bdb