### PR TITLE
Add analytics.db test protocol dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,18 @@ monitoring.db                   # Real-time system monitoring
 optimization_metrics.db         # Continuous optimization data
 ```
 
+### Analytics Database Test Protocol
+The `analytics.db` file should never be created or modified automatically.
+To create or migrate the file manually, run:
+
+```bash
+sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
+sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
+```
+
+Automated tests perform these migrations in-memory with progress bars and DUAL
+COPILOT validation, leaving the on-disk database untouched.
+
 ### **Database-First Workflow**
 1. **Query First:** Check production.db for existing solutions
 2. **Pattern Match:** Identify reusable templates and components

--- a/tests/test_analytics_protocol.py
+++ b/tests/test_analytics_protocol.py
@@ -1,0 +1,53 @@
+import datetime as dt
+import os
+import sqlite3
+from pathlib import Path
+
+from tqdm import tqdm
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _primary_validation(conn: sqlite3.Connection) -> bool:
+    return all(
+        _table_exists(conn, tbl) for tbl in ["code_audit_log", "correction_history"]
+    )
+
+
+def _secondary_validation(conn: sqlite3.Connection) -> bool:
+    return _primary_validation(conn)
+
+
+def test_analytics_protocol_dry_run(capsys) -> None:
+    analytics_db = Path("databases/analytics.db")
+    mtime = analytics_db.stat().st_mtime
+
+    print("Test: Dry-run analytics.db migrations")
+    print(f"Start: {dt.datetime.now()}")
+    print(f"PID: {os.getpid()}")
+    start = dt.datetime.now()
+
+    migration_files = [
+        Path("databases/migrations/add_code_audit_log.sql"),
+        Path("databases/migrations/add_correction_history.sql"),
+    ]
+
+    with sqlite3.connect(":memory:") as conn:
+        for sql in tqdm(migration_files, desc="Simulating migration steps", unit="step"):
+            conn.executescript(sql.read_text())
+
+        assert _primary_validation(conn)
+        assert _secondary_validation(conn)
+
+    print(f"Completed simulation in {dt.datetime.now() - start}")
+    captured = capsys.readouterr()
+    assert "Completed simulation" in captured.out
+    assert analytics_db.stat().st_mtime == mtime


### PR DESCRIPTION
## Summary
- add `test_analytics_protocol.py` to verify analytics migrations run only in-memory
- document manual analytics.db workflow in README

## Testing
- `ruff check tests/test_analytics_migration_simulation.py tests/test_analytics_migrations.py tests/test_analytics_db_creation.py tests/test_analytics_protocol.py`
- `pytest -q tests/test_analytics_db_creation.py tests/test_analytics_migration_simulation.py tests/test_analytics_migrations.py tests/test_analytics_protocol.py`

------
https://chatgpt.com/codex/tasks/task_e_6883a7650ad08331a2ffb68f0ec3de32