### PR TITLE
docs: clarify clw usage and WLC table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Ensure the development environment is correctly configured **before** making any
 
 * **Setup Script**: If a `setup.sh` script is present at the repository root, run it (e.g. `bash setup.sh`) to perform initial setup tasks (creating the virtual environment, installing dependencies, etc.). This project provides a `setup.sh` – use it to avoid missing any required steps.
 * **Verify `clw` Utility**: After setup, confirm `/usr/local/bin/clw` exists and is executable. If missing, copy `tools/clw.py` to `/usr/local/bin/clw` and make it executable. Run `clw --help` to verify it works.
-* **Hard Output Limit**: The Codex terminal enforces a **1600-byte** maximum per line. Always pipe potentially long output through `clw` (e.g., `command | clw`) or redirect to a log file and read it in chunks. Adjust the limit with `CLW_MAX_LINE_LENGTH` if needed.
+* **Hard Output Limit**: The Codex terminal enforces a **1600-byte** maximum per line. Always pipe potentially long output through `clw` (e.g., `command | clw`) or redirect to a log file and read it in chunks.
+* **Recommended `CLW_MAX_LINE_LENGTH`**: Set the environment variable `CLW_MAX_LINE_LENGTH=1550` to keep wrapped output safely below the 1600-byte limit.
 * **Sample Usage of `clw`**: When inspecting large files or performing recursive searches, pipe the output through `clw`:
   ```bash
   grep -R "pattern" . | /usr/local/bin/clw

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ validation through the `SecondaryCopilotValidator`. It records each session in
 Each run inserts a row into the `unified_wrapup_sessions` table with a
 compliance score for audit purposes. Ensure all command output is piped through
 `/usr/local/bin/clw` to avoid exceeding the line length limit.
+The table stores `session_id`, timestamps, status, compliance score, and
+optional error details so administrators can audit every session.
 The test suite includes `tests/test_wlc_session_manager.py` to verify this behavior.
 
 ---

--- a/docs/REPOSITORY_GUIDELINES.md
+++ b/docs/REPOSITORY_GUIDELINES.md
@@ -66,7 +66,8 @@ python scripts/wlc_session_manager.py --steps 2 --verbose
 ```
 
 Use `/usr/local/bin/clw` when reviewing output to avoid long terminal lines.
-Set `CLW_MAX_LINE_LENGTH=1550` if required.
+Set `CLW_MAX_LINE_LENGTH=1550` if required. The console enforces a strict 1600-byte
+limit per line, so piping through `clw` is mandatory for any large output.
 
 The test `tests/test_wlc_session_manager.py` verifies that a new session record
 is inserted and logs are written under `$GH_COPILOT_BACKUP_ROOT/logs/`.


### PR DESCRIPTION
## Summary
- highlight `CLW_MAX_LINE_LENGTH` guidance in `AGENTS.md`
- expand `unified_wrapup_sessions` notes in `README.md`
- document strict console line limit in repository guidelines

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b67f869083319b831a80a46636b7