### PR TITLE
Add simulation mode for placeholder audit scripts

### DIFF
--- a/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
+++ b/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
@@ -6,6 +6,7 @@ Recent updates:
 * Session management wrappers and monitoring utilities implemented.
 * Template synchronizer uses database-driven logic with analytics logging.
 * Compliance metrics updater generates real metrics for the dashboard.
+* Placeholder audit logger supports test-mode simulations for compliance checks.
 
 ## 1. Database-First Integration
 - Expand `DatabaseFirstCopilotEnhancer` with anti-recursion checks and query similarity scoring.

--- a/scripts/placeholder_audit_logger.py
+++ b/scripts/placeholder_audit_logger.py
@@ -169,8 +169,15 @@ def main(
     analytics_db: str | None = None,
     production_db: str | None = None,
     dashboard_dir: str | None = None,
+    simulate: bool = False,
 ) -> bool:
-    """Run the placeholder audit logger."""
+    """Run the placeholder audit logger.
+
+    Parameters
+    ----------
+    simulate:
+        If ``True``, skip writing to the database and dashboard.
+    """
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     logging.info(f"{TEXT['start']} placeholder audit")
 
@@ -183,8 +190,11 @@ def main(
 
     start = time.time()
     results = scan_files(workspace, patterns)
-    log_results(results, analytics)
-    update_dashboard(results, dashboard)
+    if not simulate:
+        log_results(results, analytics)
+        update_dashboard(results, dashboard)
+    else:
+        logging.info("[TEST MODE] Simulation enabled: no database writes")
     elapsed = time.time() - start
     logging.info(f"{TEXT['success']} audit completed in {elapsed:.2f}s")
 


### PR DESCRIPTION
## Summary
- allow placeholder audit logger to run without writing to DB
- support simulation mode in audit_codebase_placeholders script
- document new test-mode feature in task suggestions

## Testing
- `ruff check scripts/placeholder_audit_logger.py scripts/audit_codebase_placeholders.py`
- `pytest tests/test_audit_codebase_placeholders.py tests/test_placeholder_audit_logger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883bdb88a1483318571204faf502da2