### PR TITLE
Update template_engine documentation and CI import check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run tests
         run: make test
 
+      - name: Verify template_engine import
+        run: python -c "import template_engine"
+
   docker-build:
     needs: lint-test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -295,6 +295,10 @@ compliance logging:
   events to `sync_events_log`, `sync_status`, or `doc_analysis` tables in
   `analytics.db` with visual indicators and DUAL COPILOT validation.
 
+All public APIs surface `RuntimeError` for validation issues and propagate
+`sqlite3.Error` for database operations. Consumers should wrap calls in `try` /
+`except` blocks to handle these errors gracefully.
+
 #### Unified Logging Helper
 The `_log_event` function records structured events with progress bars and
 real-time status. It accepts a dictionary payload, optional table name, and the

--- a/template_engine/pattern_mining_engine.py
+++ b/template_engine/pattern_mining_engine.py
@@ -1,3 +1,15 @@
+
+"""Pattern mining utilities for extracting and logging templates.
+
+This module provides helper functions used by :mod:`template_engine` for
+mining patterns from stored templates. Functions log operations to
+``analytics.db`` and implement safety checks, including anti-recursion
+validation via :func:`validate_no_recursive_folders`.
+
+All public functions raise ``RuntimeError`` on validation failure and
+``sqlite3.Error`` for database issues so callers can react accordingly.
+"""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- add import verification step in CI workflow
- document template_engine error handling in README
- add module docs to pattern_mining_engine

## Testing
- `ruff check .` *(fails: Found 1483 errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qiskit.circuit.library.templates')*

------
https://chatgpt.com/codex/tasks/task_e_6883f9c257188331bc170c2a7545035c