### PR TITLE
Fix template sync logic

### DIFF
--- a/template_engine/__init__.py
+++ b/template_engine/__init__.py
@@ -8,22 +8,20 @@ The package exposes several lazily imported modules:
 
 Unknown attribute access raises ``AttributeError``.
 """
+
 from importlib import import_module
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from utils import log_utils
 
-The package exposes several submodules used throughout the project. Public APIs
-include :mod:`auto_generator`, :mod:`db_first_code_generator`,
-:mod:`pattern_mining_engine` and :mod:`template_synchronizer`. Importing a
-submodule will automatically load it on first access.
-
-Error handling is performed via ``RuntimeError`` for unrecoverable states (like
-recursive folder detection) and ``ValueError`` for malformed templates. Logging
-is routed through :mod:`utils.log_utils`.
-"""
-from importlib import import_module
-from typing import TYPE_CHECKING
+# The package exposes several submodules used throughout the project. Public APIs
+# include :mod:`auto_generator`, :mod:`db_first_code_generator`,
+# :mod:`pattern_mining_engine` and :mod:`template_synchronizer`. Importing a
+# submodule will automatically load it on first access.
+#
+# Error handling is performed via ``RuntimeError`` for unrecoverable states (like
+# recursive folder detection) and ``ValueError`` for malformed templates. Logging
+# is routed through :mod:`utils.log_utils`.
 
 __all__ = ["template_synchronizer"]


### PR DESCRIPTION
## Summary
- refine analytics path validation and dry-run behavior in template_synchronizer
- clean up template engine package docs

## Testing
- `pytest tests/test_template_synchronizer.py tests/test_template_synchronizer_real.py tests/test_database_first_copilot_enhancer.py tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_688408b357348331872177a64e5b8b48