### PR TITLE
fix: cleanup template sync utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ template = gen.generate_template({"action": "print"})
 sync_count = template_synchronizer.synchronize_templates([Path("databases/production.db")])
 ```
 
+To perform a real synchronization with analytics logging, run:
+
+```bash
+python template_engine/template_synchronizer.py --real
+```
+
+Analytics events are stored in `analytics.db` when it resides outside the workspace.
+
 #### Unified Logging Helper
 The `_log_event` function records structured events with progress bars and
 real-time status. It accepts a dictionary payload, optional table name, and the

--- a/scripts/enterprise_compliance_monitor.py
+++ b/scripts/enterprise_compliance_monitor.py
@@ -51,24 +51,24 @@ with comprehensive validation, automated correction, and performance tracking.
 6. Performance (15%): Response times, throughput, resource efficiency
 """
 
-import os
-import sys
-import json
-import time
-import sqlite3
-import logging
 import argparse
+import json
+import logging
+import os
+import sqlite3
+import sys
 import threading
+import time
 import traceback
-from datetime import datetime, timedelta
-from pathlib import Path
-from typing import Dict, List, Any, Optional, Tuple, Union
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
+from datetime import datetime
 from enum import Enum
-from tqdm import tqdm
-import hashlib
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
 import psutil
-import subprocess
+from tqdm import tqdm
+
 
 # Enterprise Imports
 # Fallback implementation for DualCopilotValidator if import fails
@@ -369,8 +369,8 @@ class EnterpriseComplianceMonitor:
         self.logger.info("✅ ENTERPRISE COMPLIANCE MONITORING STARTED")
         self.logger.info(f"Monitor ID: {self.monitor_id}")
         self.logger.info(f"Setup Duration: {duration:.2f} seconds")
-        self.logger.info(f"Monitoring Status: ACTIVE")
-        self.logger.info(f"Background Thread: RUNNING")
+        self.logger.info("Monitoring Status: ACTIVE")
+        self.logger.info("Background Thread: RUNNING")
         self.logger.info("="*80)
         
         return {
@@ -1025,8 +1025,8 @@ class EnterpriseComplianceMonitor:
             if backup_folders:
                 self.logger.error(f"🚨 RECURSIVE FOLDERS DETECTED: {len(backup_folders)} folders")
                 return True
-        except Exception:
-            pass
+        except Exception as exc:
+            self.logger.error("Recursive folder check failed: %s", exc)
         return False
     
     def _check_database_corruption(self) -> bool:
@@ -1053,8 +1053,8 @@ class EnterpriseComplianceMonitor:
             if cpu_percent > 95 or memory.percent > 98:
                 self.logger.error(f"🚨 CRITICAL RESOURCE USAGE: CPU {cpu_percent:.1f}%, Memory {memory.percent:.1f}%")
                 return True
-        except Exception:
-            pass
+        except Exception as exc:
+            self.logger.error("Resource usage check failed: %s", exc)
         return False
     
     def _check_security_breach(self) -> bool:

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -23,7 +23,6 @@ import os
 import sqlite3
 import time
 from datetime import UTC, datetime
-import time
 from pathlib import Path
 
 from tqdm import tqdm

--- a/tests/test_template_synchronizer.py
+++ b/tests/test_template_synchronizer.py
@@ -69,3 +69,21 @@ def test_audit_logging_and_rollback(tmp_path: Path, monkeypatch) -> None:
         assert tables == [("other",)]
 
     assert not analytics.exists()
+
+
+def test_extract_templates(tmp_path: Path) -> None:
+    db = tmp_path / "temp.db"
+    create_db(db, {"n1": "c1"})
+    results = template_synchronizer._extract_templates(db)
+    assert results == [("n1", "c1")]
+
+
+def test_can_write_analytics(tmp_path: Path, monkeypatch) -> None:
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    outside = tmp_path.parent / "analytics.db"
+    monkeypatch.setattr(template_synchronizer, "ANALYTICS_DB", outside)
+    assert template_synchronizer._can_write_analytics()
+
+    inside = tmp_path / "analytics.db"
+    monkeypatch.setattr(template_synchronizer, "ANALYTICS_DB", inside)
+    assert not template_synchronizer._can_write_analytics()


### PR DESCRIPTION
## Summary
- fix import duplication in WLC session manager
- drop unused helper and update header in template synchronizer
- add --real CLI usage docs and analytics note
- guard DB rollback in template synchronization
- add tests for helper functions
- log errors in enterprise compliance monitor

## Testing
- `ruff check scripts/wlc_session_manager.py template_engine/template_synchronizer.py scripts/enterprise_compliance_monitor.py tests/test_template_synchronizer.py` *(fails: E501 etc.)*
- `PYTHONPATH=. pytest tests/test_template_synchronizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688434c2c548833186f89156f55a245f