### PR TITLE
feat: add log message standardization and style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ are thin CLI wrappers. They delegate to the core implementations under
 - ``continuous_operation_monitor.py`` records uptime and resource usage to ``analytics.db``.
 Import these modules directly in your own scripts for easier maintenance.
 ### **Output Safety with `clw`**
-Commands that generate large output should be piped through `/usr/local/bin/clw` to avoid the 1600-byte line limit. If `clw` is missing, copy `tools/clw` to `/usr/local/bin/clw` and make it executable:
+Commands that generate large output **must** be piped through `/usr/local/bin/clw` to comply with the 1600-byte line limit. If `clw` is missing, copy `tools/clw` to `/usr/local/bin/clw` and make it executable:
 ```bash
 cp tools/clw /usr/local/bin/clw
 chmod +x /usr/local/bin/clw
@@ -259,7 +259,7 @@ optimization_metrics.db         # Continuous optimization data
 ```
 
 ### Analytics Database Test Protocol
-The `analytics.db` file should never be created or modified automatically.
+Never create or modify the `analytics.db` file automatically.
 To create or migrate the file manually, run:
 
 ```bash

--- a/docs/COMMUNICATION_STANDARDS.md
+++ b/docs/COMMUNICATION_STANDARDS.md
@@ -1,0 +1,9 @@
+# Communication Standards
+
+This project values concise, direct language. Follow these guidelines when writing documentation, code comments, and commit messages:
+
+- Use active voice and present tense whenever possible.
+- Avoid ambiguous phrases such as "maybe" or "should"; provide explicit instructions.
+- Prefix log messages with the emitting module name using `log_message()` from `utils.log_utils`.
+- Keep sentences short and focused on a single idea.
+- Wrap lines at 120 characters to improve readability.

--- a/scripts/cross_database_aggregation_system.py
+++ b/scripts/cross_database_aggregation_system.py
@@ -10,10 +10,11 @@ Enterprise Standards Compliance:
 """
 import sys
 
-import sqlite3
 import logging
+import sqlite3
 from pathlib import Path
 from datetime import datetime
+from utils.log_utils import log_message
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -72,9 +73,17 @@ def main():
     success = processor.execute_processing()
 
     if success:
-        print(f"{TEXT_INDICATORS['success']} Database processing completed")
+        log_message(
+            "cross_database_aggregation_system",
+            "Database processing completed",
+            level=logging.INFO,
+        )
     else:
-        print(f"{TEXT_INDICATORS['error']} Database processing failed")
+        log_message(
+            "cross_database_aggregation_system",
+            "Database processing failed",
+            level=logging.ERROR,
+        )
 
     return success
 

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -52,11 +52,30 @@ def _log_event(
     level: int = logging.INFO,
     test_mode: bool = True,  # Always True: never actually writes, only simulates
 ) -> bool:
-    """
-    Simulate logging a structured event to analytics SQLite DB.
-    - Does NOT actually create/write analytics.db.
-    - Returns True if analytics.db COULD be created at the given path.
-    - Shows all visual indicators, progress bars, and logs (test mode only).
+    """Log a structured event in a consistent format.
+
+    Parameters
+    ----------
+    event:
+        Dictionary describing the event to record.
+    table:
+        Destination table name within the analytics database.
+    db_path:
+        Path to the analytics database file (simulated).
+    fallback_file:
+        Optional path for writing events if the database is unavailable.
+    echo:
+        If ``True`` the formatted log line is echoed to the console.
+    level:
+        Logging level used for the echo output.
+    test_mode:
+        When ``True`` no database writes occur; the function only simulates the
+        operation.
+
+    Returns
+    -------
+    bool
+        ``True`` when the analytics database could be created at ``db_path``.
     """
     payload = dict(event)
     if "timestamp" not in payload:
@@ -114,8 +133,30 @@ def _log_audit_event(
     echo: bool = False,
     test_mode: bool = True,
 ) -> bool:
-    """
-    Simulate logging an audit event to analytics DB/audit_log table (no real writes).
+    """Record an audit event in the analytics log.
+
+    Parameters
+    ----------
+    description:
+        Brief text describing the audit entry.
+    details:
+        Optional dictionary containing extra information.
+    level:
+        Logging level for echo output.
+    db_path:
+        Path to the analytics database file (simulated).
+    table:
+        Table name within the analytics database.
+    echo:
+        If ``True`` the formatted log line is echoed to the console.
+    test_mode:
+        When ``True`` the function only simulates the operation and returns the
+        result of :func:`_log_event`.
+
+    Returns
+    -------
+    bool
+        ``True`` when the analytics database could be created at ``db_path``.
     """
     event = {
         "description": description,
@@ -141,6 +182,28 @@ def _log_plain(
         tqdm.write(f"[TEST] Would write to log file: {log_file}")
     if echo:
         print(line, file=sys.stderr if level >= logging.ERROR else sys.stdout)
+
+
+def log_message(module: str, message: str, *, level: int = logging.INFO) -> None:
+    """Emit a standardized log message.
+
+    Parameters
+    ----------
+    module:
+        Name of the calling module.
+    message:
+        Human readable log message.
+    level:
+        Logging severity level.
+
+    Expected Outcome
+    ----------------
+    A timestamped log line is printed using :func:`_log_plain` with the module
+    name prefixed to the message.
+    """
+
+    formatted = f"[{module}] {message}"
+    _log_plain(formatted, level=level)
 
 
 def _list_events(


### PR DESCRIPTION
## Summary
- clarify README instructions on clw usage and analytics db
- add `log_message` helper to `utils/log_utils`
- standardize session database tooling logs
- standardize database aggregation logs
- document project communication standards

## Testing
- `ruff check .` *(fails: 1474 errors)*
- `pytest -q` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688574ccab8083318dd1b37098ebbc7c