### PR TITLE
feat: add backup archiver and validation

### DIFF
--- a/db_tools/utils/__init__.py
+++ b/db_tools/utils/__init__.py
@@ -2,5 +2,10 @@
 
 from .query_builder import QueryBuilder
 from .validators import DataValidator
+from .enterprise_validation import validate_enterprise_operation
 
-__all__ = ['QueryBuilder', 'DataValidator']
+__all__ = [
+    'QueryBuilder',
+    'DataValidator',
+    'validate_enterprise_operation',
+]

--- a/db_tools/utils/enterprise_validation.py
+++ b/db_tools/utils/enterprise_validation.py
@@ -1,0 +1,25 @@
+"""Enterprise operation validation helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def validate_enterprise_operation(path: str | None = None) -> bool:
+    """Validate operations to prevent internal backup access."""
+
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())).resolve()
+    target = Path(path or workspace).resolve()
+    backup_root = Path(
+        os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups")
+    ).resolve()
+
+    if backup_root == workspace or backup_root.is_relative_to(workspace):
+        raise RuntimeError("Backup root cannot be inside the workspace")
+
+    if target.is_relative_to(workspace) and "backup" in target.name.lower():
+        raise RuntimeError("Operations targeting internal backups are forbidden")
+
+    return True
+

--- a/docs/enterprise_backup_guide.md
+++ b/docs/enterprise_backup_guide.md
@@ -11,10 +11,17 @@ This guide describes how to use the data backup feature in the gh_COPILOT toolki
    ```bash
    echo $GH_COPILOT_BACKUP_ROOT
    ```
+   The path **must** be located outside the repository workspace.
 2. Execute the backup command:
    ```bash
    python scripts/automation/enhanced_enterprise_continuation_processor_backup.py --source /path/to/data
    ```
-3. Backups are stored within `$GH_COPILOT_BACKUP_ROOT` by default.
+3. After backups are created, run the archiver:
+   ```bash
+   python scripts/backup_archiver.py
+   ```
+   This compresses all files under `$GH_COPILOT_BACKUP_ROOT` into a `.7z` file
+   placed in `archive/` at the repository root.
+4. Backups remain stored within `$GH_COPILOT_BACKUP_ROOT` by default.
 
 For more details on advanced options and restoration procedures, see the documentation in `disaster_recovery/`.

--- a/scripts/backup_archiver.py
+++ b/scripts/backup_archiver.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Archive backups using 7z compression."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+
+import py7zr
+
+from enterprise_modules.compliance import validate_enterprise_operation
+from utils.cross_platform_paths import CrossPlatformPathManager
+
+
+def archive_backups() -> Path:
+    """Compress backup files and store the archive under ``archive/``."""
+
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())).resolve()
+    backup_root = CrossPlatformPathManager.get_backup_root().resolve()
+
+    if backup_root == workspace or backup_root.is_relative_to(workspace):
+        raise RuntimeError("Backup root cannot be inside the workspace")
+
+    validate_enterprise_operation(str(workspace))
+
+    archive_dir = workspace / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    archive_path = archive_dir / f"backups_{timestamp}.7z"
+
+    with py7zr.SevenZipFile(archive_path, "w") as zf:
+        for item in backup_root.rglob("*"):
+            if item.is_file():
+                zf.write(item, item.relative_to(backup_root))
+
+    logging.info("Archived backups to %s", archive_path)
+    return archive_path
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    archive_backups()
+

--- a/tests/test_backup_archiver.py
+++ b/tests/test_backup_archiver.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+
+import py7zr
+import pytest
+
+
+def test_archive_backups_creates_archive(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = tmp_path / "bk"
+    backup_root.mkdir()
+    (backup_root / "file.txt").write_text("x")
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    from scripts import backup_archiver
+
+    archive_path = backup_archiver.archive_backups()
+
+    assert archive_path.exists()
+    with py7zr.SevenZipFile(archive_path) as zf:
+        assert "file.txt" in zf.getnames()
+
+
+def test_archive_backups_disallows_internal_backup(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = workspace / "bk"
+    backup_root.mkdir()
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    from scripts import backup_archiver
+
+    with pytest.raises(RuntimeError):
+        backup_archiver.archive_backups()
+

--- a/tests/test_enterprise_validation.py
+++ b/tests/test_enterprise_validation.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_validate_enterprise_operation_rejects_internal_backup(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = workspace / "bk"
+    backup_root.mkdir()
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    from db_tools.utils.enterprise_validation import validate_enterprise_operation
+
+    with pytest.raises(RuntimeError):
+        validate_enterprise_operation(str(backup_root))
+
+
+def test_validate_enterprise_operation_allows_external_backup(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = tmp_path / "bk"
+    backup_root.mkdir()
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    from db_tools.utils.enterprise_validation import validate_enterprise_operation
+
+    assert validate_enterprise_operation(str(workspace / "data")) is True
+


### PR DESCRIPTION
## Summary
- ensure db_tools exposes new `validate_enterprise_operation`
- archive external backups to `archive/` folder using 7z compression
- document new backup workflow in `enterprise_backup_guide.md`
- test archive function and validation helpers

## Testing
- `ruff check scripts/backup_archiver.py db_tools/utils/enterprise_validation.py tests/test_backup_archiver.py tests/test_enterprise_validation.py`
- `pytest tests/test_backup_archiver.py tests/test_enterprise_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688575af235c83319e1033797c6eb2ae