### PR TITLE
docs: recommend concluding scripts with WLC session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ export GH_COPILOT_BACKUP_ROOT=/path/to/backups
 python scripts/wlc_session_manager.py
 ```
 
+Major scripts should conclude by invoking the session manager to record
+final compliance results and generate a log file:
+
+```bash
+python <your_script>.py
+python scripts/wlc_session_manager.py --db-path databases/production.db
+```
+
+Each run writes a timestamped log to `$GH_COPILOT_BACKUP_ROOT/logs/`.
+
 For more information see [docs/WLC_SESSION_MANAGER.md](docs/WLC_SESSION_MANAGER.md).
 See [docs/WLC_QUICKSTART.md](docs/WLC_QUICKSTART.md) for a quickstart guide.
 

--- a/docs/WLC_SESSION_MANAGER.md
+++ b/docs/WLC_SESSION_MANAGER.md
@@ -31,6 +31,16 @@ Run the session manager directly to start a WLC session with explicit CLI parame
 python scripts/wlc_session_manager.py --steps 2 --db-path databases/production.db --verbose
 ```
 
+For any major workflow, end with the session manager to capture compliance data:
+
+```bash
+python my_long_running_script.py
+python scripts/wlc_session_manager.py --db-path databases/production.db
+```
+
+Logs are saved under `$GH_COPILOT_BACKUP_ROOT/logs/` with a timestamped filename
+like `wlc_20250101_120000.log`.
+
 Log files will be written under `$GH_COPILOT_BACKUP_ROOT/logs/` and a new row is inserted into the `unified_wrapup_sessions` table of `production.db`.
 
 The WLC session manager is also invoked automatically by the


### PR DESCRIPTION
## Summary
- document using `scripts/wlc_session_manager.py` after major scripts
- add example invocation and log locations

## Testing
- `ruff check .`
- `pytest -q tests/test_wlc_session_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_688575d34208833180e0c38994abbfa5