### PR TITLE
Add environment checks for CLI wrappers

### DIFF
--- a/quantum_database_search.py
+++ b/quantum_database_search.py
@@ -1,18 +1,43 @@
 #!/usr/bin/env python3
 """Wrapper for :mod:`quantum.quantum_database_search` utilities."""
-from quantum.quantum_database_search import (
-    main,
-    quantum_search_hybrid,
-    quantum_search_nosql,
-    quantum_search_sql,
-)
+from utils.cross_platform_paths import verify_environment_variables
 
 __all__ = [
     "quantum_search_sql",
     "quantum_search_nosql",
     "quantum_search_hybrid",
-    "main",
+    "cli",
 ]
 
-if __name__ == "__main__":  # pragma: no cover
+
+def quantum_search_sql(*args, **kwargs):
+    """Lazy import and execute ``quantum_search_sql``."""
+    from quantum.quantum_database_search import quantum_search_sql as _func
+    return _func(*args, **kwargs)
+
+
+def quantum_search_nosql(*args, **kwargs):
+    """Lazy import and execute ``quantum_search_nosql``."""
+    from quantum.quantum_database_search import quantum_search_nosql as _func
+    return _func(*args, **kwargs)
+
+
+def quantum_search_hybrid(*args, **kwargs):
+    """Lazy import and execute ``quantum_search_hybrid``."""
+    from quantum.quantum_database_search import quantum_search_hybrid as _func
+    return _func(*args, **kwargs)
+
+
+def cli() -> None:
+    """Run :mod:`quantum.quantum_database_search` CLI after environment check."""
+    verify_environment_variables()
+    from quantum.quantum_database_search import (
+        main,
+        quantum_search_hybrid,
+        quantum_search_nosql,
+        quantum_search_sql,
+    )
     main()
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/session_protocol_validator.py
+++ b/session_protocol_validator.py
@@ -1,11 +1,13 @@
 """CLI wrapper for :mod:`validation.protocols.session`."""
 from validation.protocols.session import SessionProtocolValidator
+from utils.cross_platform_paths import verify_environment_variables
 
 __all__ = ["SessionProtocolValidator", "main"]
 
 
 def main() -> int:
     """Delegate to :class:`~validation.protocols.session.SessionProtocolValidator`."""
+    verify_environment_variables()
     return SessionProtocolValidator.main()
 
 

--- a/tests/test_wrapper_env_vars.py
+++ b/tests/test_wrapper_env_vars.py
@@ -1,0 +1,34 @@
+import sys
+import types
+import pytest
+
+from session_protocol_validator import main as spv_main
+
+# Provide minimal stub modules so importing the wrapper does not fail
+fake_qiskit = types.ModuleType("qiskit")
+fake_qiskit.QuantumCircuit = object
+sys.modules.setdefault("qiskit", fake_qiskit)
+sys.modules.setdefault("qiskit.circuit", types.ModuleType("circuit"))
+fake_library = types.ModuleType("library")
+fake_library.QFT = object
+sys.modules.setdefault("qiskit.circuit.library", fake_library)
+sys.modules.setdefault("qiskit.circuit.library.templates", types.ModuleType("templates"))
+fake_qi = types.ModuleType("quantum_info")
+fake_qi.Statevector = object
+sys.modules.setdefault("qiskit.quantum_info", fake_qi)
+
+from quantum_database_search import cli as qds_cli
+
+
+def test_session_protocol_requires_env(monkeypatch):
+    monkeypatch.delenv("GH_COPILOT_WORKSPACE", raising=False)
+    monkeypatch.delenv("GH_COPILOT_BACKUP_ROOT", raising=False)
+    with pytest.raises(EnvironmentError):
+        spv_main()
+
+
+def test_quantum_search_requires_env(monkeypatch):
+    monkeypatch.delenv("GH_COPILOT_WORKSPACE", raising=False)
+    monkeypatch.delenv("GH_COPILOT_BACKUP_ROOT", raising=False)
+    with pytest.raises(EnvironmentError):
+        qds_cli()

--- a/utils/cross_platform_paths.py
+++ b/utils/cross_platform_paths.py
@@ -147,3 +147,36 @@ def migrate_hard_coded_paths(file_path: Path) -> Dict[str, Any]:
         "changes_made": changes_made,
         "backup_created": str(backup_path) if changes_made else None,
     }
+
+
+def verify_environment_variables() -> None:
+    """Ensure ``GH_COPILOT_WORKSPACE`` and ``GH_COPILOT_BACKUP_ROOT`` are set.
+
+    Raises
+    ------
+    EnvironmentError
+        If required environment variables are missing or point to invalid paths.
+    """
+
+    workspace_env = os.getenv("GH_COPILOT_WORKSPACE")
+    backup_env = os.getenv("GH_COPILOT_BACKUP_ROOT")
+
+    if not workspace_env or not backup_env:
+        raise EnvironmentError(
+            "GH_COPILOT_WORKSPACE and GH_COPILOT_BACKUP_ROOT must be set"
+        )
+
+    workspace = CrossPlatformPathManager.get_workspace_path()
+    backup_root = CrossPlatformPathManager.get_backup_root()
+
+    if not workspace.exists():
+        raise EnvironmentError(f"Workspace does not exist: {workspace}")
+
+    if workspace == backup_root or workspace in backup_root.parents:
+        raise EnvironmentError("Backup root cannot reside within the workspace")
+
+    if not backup_root.parent.exists():
+        raise EnvironmentError(
+            f"Backup root parent does not exist: {backup_root.parent}"
+        )
+


### PR DESCRIPTION
## Summary
- enforce GH_COPILOT_WORKSPACE and GH_COPILOT_BACKUP_ROOT validation via new helper
- verify environment before running `session_protocol_validator` and `quantum_database_search`
- expose lazy wrappers for quantum search helpers
- test missing environment variable behavior

## Testing
- `ruff check session_protocol_validator.py quantum_database_search.py utils/cross_platform_paths.py tests/test_wrapper_env_vars.py`
- `pytest tests/test_wrapper_env_vars.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688575e256f48331977a491cbcbd9d5a