### PR TITLE
Add communication guide and update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,16 +577,16 @@ gh_COPILOT/
 The project tracks several learning patterns. Current integration status:
 
 - **Database-First Architecture:** 98.5% implementation score
-- **DUAL COPILOT Pattern:** 96.8% implementation score  
-- **Visual Processing Indicators:** 94.7% implementation score
-- **Autonomous Systems:** 97.2% implementation score
-- **Enterprise Compliance:** 99.1% implementation score
+- **DUAL COPILOT Pattern:** 96.8% implementation score
+- **Visual Processing Indicators:** 94.7% implementation score [[docs](docs/GITHUB_COPILOT_INTEGRATION_NOTES.md#visual-processing)]
+- **Autonomous Systems:** 97.2% implementation score [[scheduler](documentation/SYSTEM_OVERVIEW.md#database-synchronization)]
+- **Enterprise Compliance:** 99.1% implementation score [[validation helper](docs/DATABASE_FIRST_USAGE_GUIDE.md#database-first-enforcement)]
 
 **Overall Integration Score: 97.4%** ✅
 
 ### **Learning Pattern Categories**
 1. **Process Learning Patterns** (90% effectiveness)
-2. **Communication Excellence** (85% effectiveness) 
+2. **Communication Excellence** (85% effectiveness) – see [Communication Excellence Guide](docs/COMMUNICATION_EXCELLENCE_GUIDE.md)
 3. **Technical Implementation** (88% effectiveness)
 4. **Enterprise Standards** (95% effectiveness)
 5. **Autonomous Operations** (92% effectiveness)

--- a/docs/COMMUNICATION_EXCELLENCE_GUIDE.md
+++ b/docs/COMMUNICATION_EXCELLENCE_GUIDE.md
@@ -1,0 +1,19 @@
+# Communication Excellence Guide
+
+This guide summarizes how to communicate changes effectively in the gh_COPILOT project.
+
+## Commit Message Conventions
+- Use **Conventional Commits** prefixes (`feat:`, `fix:`, `docs:`, `chore:`, etc.).
+- Keep messages concise and explain the reason for the change.
+- Run `ruff check .` and `pytest -q` before committing to ensure code quality.
+
+## Pull Request Template
+1. **Summary** – brief description of the change.
+2. **Testing** – mention linting and test results.
+3. **Related Docs** – list updated or referenced documentation.
+4. **Prompt Reference** – include the original request or issue link.
+
+## Example Prompts
+- "Add visual indicators to `maintenance_scheduler` progress bars."
+- "Implement validation helper for database-first operations."
+- "Revise README integration score and link to scheduler docs."

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,11 @@ location. The command exits with an error if any values are inconsistent.
 This workflow ensures that documentation statistics accurately reflect the
 contents of the production database.
 
+### Related Requirements
+- **Database Maintenance Scheduler:** see [SYSTEM_OVERVIEW.md](../documentation/SYSTEM_OVERVIEW.md#database-synchronization).
+- **Validation Helper:** see [DATABASE_FIRST_USAGE_GUIDE.md](DATABASE_FIRST_USAGE_GUIDE.md#database-first-enforcement).
+- **Visual Indicator Standards:** see [GITHUB_COPILOT_INTEGRATION_NOTES.md](GITHUB_COPILOT_INTEGRATION_NOTES.md#visual-processing).
+
 ## Resetting Benchmark Baselines
 
 Benchmark results are stored in ``benchmark_metrics.db``. Remove this file to


### PR DESCRIPTION
## Summary
- document commit and PR conventions in new Communication Excellence guide
- cross-link scheduler, validation helper, and visual indicator docs
- mention guide from integration score section

## Testing
- `ruff check docs/COMMUNICATION_EXCELLENCE_GUIDE.md README.md docs/README.md`
- `pytest -q` *(fails: ModuleNotFoundError for qiskit modules)*

------
https://chatgpt.com/codex/tasks/task_e_688575f4e0348331b8afb7a976ab9c19