### PR TITLE
Add environment validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The toolkit includes an enterprise-grade data backup feature. Set the
 follow the steps in [docs/enterprise_backup_guide.md](docs/enterprise_backup_guide.md)
 to create and manage backups. This variable ensures backups never reside in the
 workspace, maintaining anti-recursion compliance.
+The `validate_enterprise_environment` helper enforces these settings at script startup.
 
 ### Wrapping, Logging, and Compliance (WLC)
 Run the session manager after setting the workspace and backup paths:

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -29,6 +29,7 @@ from tqdm import tqdm
 
 from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 from utils.cross_platform_paths import CrossPlatformPathManager
+from utils.validation_utils import validate_enterprise_environment
 
 try:
     from scripts.orchestrators.unified_wrapup_orchestrator import (
@@ -90,11 +91,9 @@ def finalize_session_entry(
 
 
 def validate_environment() -> bool:
-    workspace = os.getenv("GH_COPILOT_WORKSPACE")
-    backup_root = os.getenv("GH_COPILOT_BACKUP_ROOT")
-    if not (workspace and backup_root):
-        return False
-    return Path(workspace).exists() and Path(backup_root).parent.exists()
+    """Validate enterprise workspace and backup paths."""
+    validate_enterprise_environment()
+    return True
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/utils/validation_utils.py
+++ b/utils/validation_utils.py
@@ -1,7 +1,7 @@
 """Validation utilities for gh_COPILOT Enterprise Toolkit"""
 
-import os
 import json
+import os
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -93,6 +93,26 @@ def validate_path(path: Path) -> bool:
     except FileNotFoundError:
         return False
     return workspace in resolved.parents and backup_root not in resolved.parents
+
+
+def validate_enterprise_environment() -> bool:
+    """Ensure workspace and backup paths are set and non-recursive."""
+    workspace = CrossPlatformPathManager.get_workspace_path().resolve()
+    backup_root_env = os.getenv("GH_COPILOT_BACKUP_ROOT")
+    if not backup_root_env:
+        raise EnvironmentError("GH_COPILOT_BACKUP_ROOT is not set")
+    backup_root = Path(backup_root_env).resolve()
+
+    if not workspace.exists():
+        raise EnvironmentError("GH_COPILOT_WORKSPACE does not exist")
+
+    if backup_root.exists() and workspace in backup_root.parents:
+        raise EnvironmentError("Backup root must be outside the workspace")
+
+    if not backup_root.parent.exists():
+        raise EnvironmentError("Backup root parent directory is missing")
+
+    return True
 
 
 def operations_validate_workspace() -> None:


### PR DESCRIPTION
## Summary
- add `validate_enterprise_environment` utility for workspace checks
- use helper in `wlc_session_manager.py` and maintenance scheduler
- document helper usage in README
- test helper behavior for allowed and disallowed backup locations

## Testing
- `ruff check scripts/wlc_session_manager.py scripts/database/maintenance_scheduler.py utils/validation_utils.py tests/test_new_utils.py --select I001,E501`
- `pytest -q tests/test_new_utils.py tests/test_wlc_session_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688575fbd6f48331b1f5a637c72aca8f