### PR TITLE
Add automated maintenance scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,9 @@ Tests verify this logging mechanism as part of the DUAL COPILOT pattern.
 - **Continuous Monitoring:** 24/7 system health tracking
 - **Data-Driven Metrics:** Health statistics are stored in `analytics.db` via
   `monitoring.health_monitor` for historical analysis
+- **Continuous Operation Scheduler:** Run `python scripts/automation/system_maintenance_scheduler.py` to
+  automate self-healing and monitoring cycles. Job history is recorded in
+  `analytics.db` and session entries in `production.db`.
 
 ### **Autonomous System Architecture**
 ```python

--- a/docs/CONTINUOUS_OPERATION_MODE.md
+++ b/docs/CONTINUOUS_OPERATION_MODE.md
@@ -1,0 +1,18 @@
+# Continuous Operation Mode
+
+The toolkit can run in a fully automated mode to ensure 24/7 monitoring and self‑healing.
+The new scheduler integrates the self‑healing system and operation monitor.
+
+## Running the Scheduler
+
+```bash
+python scripts/automation/system_maintenance_scheduler.py --interval 60
+```
+
+- `--interval` specifies minutes between maintenance cycles.
+- Each cycle runs the self‑healing logic and logs a health snapshot.
+- Job history is stored in `analytics.db` table `system_maintenance_jobs`.
+- Session entries are recorded in `production.db` via `unified_wrapup_sessions`.
+
+Ensure `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT` are set before launching.
+The scheduler runs indefinitely and should be used for continuous environments.

--- a/scripts/automation/system_maintenance_scheduler.py
+++ b/scripts/automation/system_maintenance_scheduler.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""System maintenance scheduler for continuous operation."""
+
+# pyright: reportMissingImports=false
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import schedule
+
+from scripts.monitoring.continuous_operation_monitor import (
+    ContinuousOperationMonitor,
+)
+from scripts.utilities import self_healing_self_learning_system as shs
+from scripts.wlc_session_manager import finalize_session_entry, start_session_entry
+
+
+def _ensure_job_table(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS system_maintenance_jobs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_name TEXT,
+                start_time TEXT,
+                end_time TEXT,
+                status TEXT
+            )
+            """
+        )
+        conn.commit()
+
+
+def _log_job(db_path: Path, job_name: str, start: datetime, end: datetime, status: str) -> None:
+    _ensure_job_table(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO system_maintenance_jobs (job_name, start_time, end_time, status) VALUES (?, ?, ?, ?)",
+            (job_name, start.isoformat(), end.isoformat(), status),
+        )
+        conn.commit()
+
+
+def _run_self_healing(workspace: Path) -> None:
+    shs.main()
+
+
+def _run_monitor_once(workspace: Path) -> None:
+    monitor = ContinuousOperationMonitor(
+        monitor_interval=60,
+        log_db=str(workspace / "analytics.db"),
+        verbose=False,
+    )
+    metrics = monitor._get_system_metrics()
+    monitor._write_metrics(metrics)
+
+
+def maintenance_cycle(workspace: Path) -> None:
+    analytics_db = workspace / "analytics.db"
+    production_db = workspace / "databases" / "production.db"
+    start = datetime.now(timezone.utc)
+    status = "SUCCESS"
+    entry_id = None
+    try:
+        with sqlite3.connect(production_db) as conn:
+            entry_id = start_session_entry(conn)
+        _run_self_healing(workspace)
+        _run_monitor_once(workspace)
+        if entry_id is not None:
+            with sqlite3.connect(production_db) as conn:
+                finalize_session_entry(conn, entry_id, 1.0)
+    except Exception as exc:  # noqa: BLE001
+        status = f"FAILED_{type(exc).__name__}"
+        if entry_id is not None:
+            with sqlite3.connect(production_db) as conn:
+                finalize_session_entry(conn, entry_id, 0.0, error=str(exc))
+    end = datetime.now(timezone.utc)
+    _log_job(analytics_db, "maintenance_cycle", start, end, status)
+
+
+def start_scheduler(interval_minutes: int = 60) -> None:
+    workspace = Path(os.environ.get("GH_COPILOT_WORKSPACE", ".")).resolve()
+    schedule.every(interval_minutes).minutes.do(maintenance_cycle, workspace)
+    print(f"[INFO] Maintenance scheduler running every {interval_minutes} minutes")
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run system maintenance scheduler")
+    parser.add_argument("--interval", type=int, default=60, help="Minutes between cycles")
+    args = parser.parse_args()
+    start_scheduler(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_system_maintenance_scheduler.py
+++ b/tests/test_system_maintenance_scheduler.py
@@ -1,0 +1,45 @@
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import scripts.automation.system_maintenance_scheduler as sms
+
+
+class DummyMonitor:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def _get_system_metrics(self) -> dict[str, Any]:
+        return {"uptime_seconds": 1}
+
+    def _write_metrics(self, metrics: dict[str, Any]) -> None:
+        pass
+
+
+def test_run_cycle(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path
+    (workspace / "databases").mkdir()
+    analytics_db = workspace / "analytics.db"
+    production_db = workspace / "databases" / "production.db"
+    with sqlite3.connect(production_db) as conn:
+        conn.execute(
+            (
+                "CREATE TABLE IF NOT EXISTS unified_wrapup_sessions ("
+                "session_id TEXT PRIMARY KEY, start_time TEXT, end_time TEXT, "
+                "status TEXT, compliance_score REAL, error_details TEXT)"
+            )
+        )
+        conn.commit()
+
+    monkeypatch.setattr(sms, "_run_self_healing", lambda w: None)
+    monkeypatch.setattr(sms, "ContinuousOperationMonitor", lambda *a, **k: DummyMonitor())
+
+    sms.maintenance_cycle(workspace)
+
+    with sqlite3.connect(analytics_db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM system_maintenance_jobs").fetchone()[0]
+    assert count == 1
+
+    with sqlite3.connect(production_db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
+    assert count == 1


### PR DESCRIPTION
## Summary
- add `system_maintenance_scheduler.py` under `scripts/automation`
- document continuous operation mode
- mention scheduler in README
- test maintenance cycle logic

## Testing
- `ruff check scripts/automation/system_maintenance_scheduler.py tests/test_system_maintenance_scheduler.py`
- `pyright scripts/automation/system_maintenance_scheduler.py tests/test_system_maintenance_scheduler.py`
- `pytest tests/test_system_maintenance_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_6885768d13bc833194a43bacd560c873