### PR TITLE
feat: add validator and progress bar

### DIFF
--- a/scripts/automation/quantum_integration_orchestrator.py
+++ b/scripts/automation/quantum_integration_orchestrator.py
@@ -16,14 +16,17 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Tuple
 
+from tqdm import tqdm
+
 from advanced_qubo_optimization import solve_qubo_bruteforce
+from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 
 
 def integrate_qubo_problems(qubos: List[List[List[float]]]) -> Tuple[List[int], float]:
     """Solve multiple QUBO problems and return the best solution."""
     best_solution: List[int] | None = None
     best_energy = float("inf")
-    for matrix in qubos:
+    for matrix in tqdm(qubos, desc="Integrating QUBO", unit="qubo"):
         solution, energy = solve_qubo_bruteforce(matrix)
         if energy < best_energy:
             best_solution, best_energy = solution, energy
@@ -97,6 +100,9 @@ def main() -> bool:
     """Main execution function"""
     utility = EnterpriseUtility()
     success = utility.execute_utility()
+
+    validator = SecondaryCopilotValidator()
+    validator.validate_corrections([__file__])
 
     if success:
         print(f"{TEXT_INDICATORS['success']} Utility completed")

--- a/tests/test_quantum_integration_orchestrator.py
+++ b/tests/test_quantum_integration_orchestrator.py
@@ -1,0 +1,23 @@
+from scripts.automation import quantum_integration_orchestrator as qio
+
+
+class DummyValidator:
+    def __init__(self):
+        self.called = False
+
+    def validate_corrections(self, files):
+        self.called = True
+        return True
+
+
+class DummyUtility:
+    def execute_utility(self):
+        return True
+
+
+def test_validator_called(monkeypatch):
+    dummy_validator = DummyValidator()
+    monkeypatch.setattr(qio, "SecondaryCopilotValidator", lambda: dummy_validator)
+    monkeypatch.setattr(qio, "EnterpriseUtility", lambda: DummyUtility())
+    assert qio.main() is True
+    assert dummy_validator.called

--- a/tests/test_qubo_integration.py
+++ b/tests/test_qubo_integration.py
@@ -3,6 +3,19 @@ import logging
 
 from scripts.automation.quantum_integration_orchestrator import integrate_qubo_problems
 
+
+class DummyTqdm:
+    """Minimal iterable tqdm replacement for testing."""
+
+    def __init__(self, iterable, *args, **kwargs):
+        self.iterable = list(iterable)
+        self.updates = 0
+
+    def __iter__(self):
+        for item in self.iterable:
+            self.updates += 1
+            yield item
+
 logging.getLogger().setLevel(logging.CRITICAL)
 
 
@@ -14,3 +27,23 @@ def test_integrate_qubo_problems():
     solution, energy = integrate_qubo_problems(qubos)
     assert solution == [1, 1]
     assert energy == -2.0
+
+
+def test_progress_bar(monkeypatch):
+    qubos = [
+        [[1.0, -2.0], [-2.0, 1.0]],
+        [[2.0, -1.0], [-1.0, 2.0]],
+    ]
+
+    bars = []
+
+    def dummy_tqdm(iterable, *args, **kwargs):
+        bar = DummyTqdm(iterable, *args, **kwargs)
+        bars.append(bar)
+        return bar
+
+    monkeypatch.setattr(
+        "scripts.automation.quantum_integration_orchestrator.tqdm", dummy_tqdm
+    )
+    integrate_qubo_problems(qubos)
+    assert bars and bars[0].updates == len(qubos)


### PR DESCRIPTION
## Summary
- validate quantum orchestrator via `SecondaryCopilotValidator`
- show progress when integrating QUBO problems
- test progress bar and validator invocation

## Testing
- `ruff check scripts/automation/quantum_integration_orchestrator.py tests/test_qubo_integration.py tests/test_quantum_integration_orchestrator.py`
- `pytest -q tests/test_qubo_integration.py tests/test_quantum_integration_orchestrator.py`
- `pytest -q` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688576b2c97483318a2ac8f572a0b844