### PR TITLE
feat: support API_SECRET_KEY for enterprise API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ GH_COPILOT_BACKUP_ROOT=/path/to/backups
 # You can generate one using Python: `import secrets; print(secrets.token_hex(32))`
 # Do not commit real credentials or secret keys to the repository.
 FLASK_SECRET_KEY=your_secret_key
+API_SECRET_KEY=your_api_secret
 FLASK_RUN_PORT=5000
 
 # Other utilities

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Run the session manager after setting the workspace and backup paths:
 ```bash
 export GH_COPILOT_WORKSPACE=$(pwd)
 export GH_COPILOT_BACKUP_ROOT=/path/to/backups
+export API_SECRET_KEY=your_api_secret
 python scripts/wlc_session_manager.py
 ```
 

--- a/docs/REPOSITORY_GUIDELINES.md
+++ b/docs/REPOSITORY_GUIDELINES.md
@@ -44,6 +44,7 @@ Set the following environment variables in your shell configuration (or load the
 - **`GH_COPILOT_WORKSPACE`:** Specifies the repository workspace.
 - **`GH_COPILOT_BACKUP_ROOT`:** Ensures backups and logs are stored outside the workspace to prevent recursive violations. If unset, the system defaults to `/tmp/<user>/gh_COPILOT_Backups` on Linux.
 - **`CLW_MAX_LINE_LENGTH`:** Optional terminal output wrap length. Set to `1550` to avoid exceeding the 1600-byte console limit when using `clw`.
+- **`API_SECRET_KEY`:** Secret used by the Enterprise API. Set this or provide `api_secret_key` in your config file.
 
 Example:
 

--- a/scripts/enterprise/enterprise_api_infrastructure_framework.py
+++ b/scripts/enterprise/enterprise_api_infrastructure_framework.py
@@ -109,7 +109,21 @@ class EnterpriseAuthentication:
         self.users = {}
         self.api_keys = {}
         self.session_tokens = {}
-        self.secret_key = "enterprise_api_secret_2024"  # In production, use environment variable
+        # Secret key used for token generation and validation
+        # Priority: environment variable -> config file -> default
+        self.secret_key = os.getenv("API_SECRET_KEY")
+        if not self.secret_key:
+            config_path = os.getenv("CONFIG_PATH", "config/enterprise_master_config.json")
+            try:
+                with open(config_path, "r") as cfg_file:
+                    cfg = json.load(cfg_file)
+                    self.secret_key = cfg.get("api_secret_key")
+            except FileNotFoundError:
+                self.secret_key = None
+            except json.JSONDecodeError:
+                self.secret_key = None
+        if not self.secret_key:
+            self.secret_key = "enterprise_api_secret_2024"
         
         # Initialize default admin user
         self._create_default_users()

--- a/tests/test_enterprise_api_auth.py
+++ b/tests/test_enterprise_api_auth.py
@@ -1,0 +1,7 @@
+import os
+from scripts.enterprise.enterprise_api_infrastructure_framework import EnterpriseAuthentication
+
+def test_secret_loaded_from_env(monkeypatch):
+    monkeypatch.setenv("API_SECRET_KEY", "test_secret")
+    auth = EnterpriseAuthentication(workspace_path=".")
+    assert auth.secret_key == "test_secret"


### PR DESCRIPTION
## Summary
- read API secret from `API_SECRET_KEY` or config
- document new env var in guidelines and README
- update example env file with `API_SECRET_KEY`
- add unit test covering environment lookup

## Testing
- `ruff check .`
- `pytest -q` *(fails: ImportError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6885c760f6248331a57272e737a897e6