### PR TITLE
Fix placeholder audit wrapper and update audit workflow

### DIFF
--- a/.github/workflows/compliance-audit.yml
+++ b/.github/workflows/compliance-audit.yml
@@ -12,9 +12,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: bash setup.sh

--- a/scripts/intelligent_code_analysis_placeholder_detection.py
+++ b/scripts/intelligent_code_analysis_placeholder_detection.py
@@ -1,7 +1,7 @@
 """Deprecated wrapper for :mod:`scripts.code_placeholder_audit`."""
 from __future__ import annotations
 
-from scripts.code_placeholder_audit import main
+from .code_placeholder_audit import main
 
 __all__ = ["main"]
 


### PR DESCRIPTION
## Summary
- use relative import in the placeholder detection module
- update compliance-audit workflow to Python 3.11 using `actions/setup-python@v5`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ImportError in template_engine tests)*

------
https://chatgpt.com/codex/tasks/task_e_6885c6c8d6388331b742337c9cd5210d