### PR TITLE
feat: update compose entry and startup logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Validate docker-compose config
+        run: docker compose -f docker-compose.yml config
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -7,15 +7,31 @@ listens on ``FLASK_RUN_PORT`` when set, falling back to port ``5000``.
 
 from __future__ import annotations
 
+import logging
 import os
+from datetime import datetime
 
 from web_gui.scripts.flask_apps.enterprise_dashboard import app
 
 __all__ = ["app", "main"]
 
 
+def _validate_environment() -> None:
+    """Validate required environment variables and log them."""
+    required = ["GH_COPILOT_WORKSPACE"]
+    for var in required:
+        value = os.getenv(var)
+        if not value:
+            logging.warning("%s not set", var)
+        else:
+            logging.info("%s=%s", var, value)
+
+
 def main() -> None:
-    """Run the wrapped Flask app."""
+    """Run the wrapped Flask app with startup logging."""
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Dashboard starting at %s", datetime.utcnow().isoformat())
+    _validate_environment()
     port = int(os.getenv("FLASK_RUN_PORT", "5000"))
     app.run(host="0.0.0.0", port=port, debug=bool(__name__ == "__main__"))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   app:
     build: .
-    command: python main.py
+    command: python dashboard/enterprise_dashboard.py
     environment:
       - GH_COPILOT_WORKSPACE=/app
     volumes:


### PR DESCRIPTION
Resolves user request to align container entry script and add compose validation.

## Summary
- run enterprise dashboard from compose
- log start time and env validation in dashboard wrapper
- verify docker-compose config during CI

## Testing
- `ruff check dashboard/enterprise_dashboard.py --exit-zero`
- `pyright dashboard/enterprise_dashboard.py`
- `pytest tests/test_enterprise_assets_backup_compressor.py::test_compress_assets_backup_creates_zip -q` *(fails: CRITICAL: Recursive violations prevented execution)*

------
https://chatgpt.com/codex/tasks/task_e_6886d1f442f08331a16a8268fa05e650