### PR TITLE
Enforce API secret config and update defaults

### DIFF
--- a/.env
+++ b/.env
@@ -12,8 +12,9 @@ GH_COPILOT_BACKUP_ROOT=/tmp/gh_COPILOT_Backups
 # IMPORTANT: Replace 'your_secret_key' with a strong, random secret key.
 # You can generate one using Python: `import secrets; print(secrets.token_hex(32))`
 # Do not commit real credentials or secret keys to the repository.
-FLASK_SECRET_KEY=your_secret_key
+FLASK_SECRET_KEY=
 FLASK_RUN_PORT=5000
+API_SECRET_KEY=
 
 # Other utilities
 CONFIG_PATH=/path/to/config.yml

--- a/.env.example
+++ b/.env.example
@@ -9,15 +9,12 @@ GH_COPILOT_WORKSPACE=/path/to/workspace
 GH_COPILOT_BACKUP_ROOT=/path/to/backups
 
 # Flask configuration
-# IMPORTANT: Replace 'your_secret_key' with a strong, random secret key.
-# You can generate one using Python: `import secrets; print(secrets.token_hex(32))`
-# Do not commit real credentials or secret keys to the repository.
-FLASK_SECRET_KEY=your_secret_key
-API_SECRET_KEY=your_api_secret
+# IMPORTANT: Generate secrets securely:
+# `import secrets; print(secrets.token_hex(32))`
+# Do not commit real credentials.
+FLASK_SECRET_KEY=
+API_SECRET_KEY=
 FLASK_RUN_PORT=5000
-
-# Secret used for JWT signing in EnterpriseAuthentication
-API_SECRET_KEY=change_me
 
 # Other utilities
 CONFIG_PATH=/path/to/config.yml

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ cd gh_COPILOT
 
 # 1b. Copy environment template
 cp .env.example .env
+# Edit `.env` to add `FLASK_SECRET_KEY` and `API_SECRET_KEY` values.
+# Generate strong secrets with `python -c "import secrets; print(secrets.token_hex(32))"`.
 
 # 2. Run setup script (creates `.venv` and installs requirements)
 bash setup.sh
@@ -203,7 +205,7 @@ Run the session manager after setting the workspace and backup paths:
 ```bash
 export GH_COPILOT_WORKSPACE=$(pwd)
 export GH_COPILOT_BACKUP_ROOT=/path/to/backups
-export API_SECRET_KEY=your_api_secret
+export API_SECRET_KEY=<generated_secret>
 python scripts/wlc_session_manager.py
 ```
 
@@ -237,6 +239,7 @@ Before running, set the required environment variables so session data is logged
 ```bash
 export GH_COPILOT_WORKSPACE=$(pwd)
 export GH_COPILOT_BACKUP_ROOT=/path/to/backups
+export API_SECRET_KEY=<generated_secret>
 python scripts/wlc_session_manager.py --steps 2 --db-path databases/production.db --verbose
 ```
 

--- a/scripts/archive_and_delete_manager.py
+++ b/scripts/archive_and_delete_manager.py
@@ -26,10 +26,10 @@ import py7zr
 from tqdm import tqdm
 
 # Enterprise logging setup
-ARCHIVE_ROOT = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "ARCHIVE(S)"
+ARCHIVE_ROOT = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app")) / "ARCHIVE(S)"
 MANUAL_DELETE_FOLDER = Path(os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups"))
 LOGS_DIR = (
-    Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "logs" / "archive_delete"
+    Path(os.getenv("GH_COPILOT_WORKSPACE", "/app")) / "logs" / "archive_delete"
 )
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"archive_delete_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
@@ -41,12 +41,12 @@ logging.basicConfig(
 )
 
 PRODUCTION_DB = (
-    Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "production.db"
+    Path(os.getenv("GH_COPILOT_WORKSPACE", "/app")) / "production.db"
 )
 
 
 def validate_no_recursive_folders() -> None:
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
     forbidden_patterns = ["*backup*", "*_backup_*", "backups", "*temp*"]
     for pattern in forbidden_patterns:
         for folder in workspace_root.rglob(pattern):
@@ -56,7 +56,7 @@ def validate_no_recursive_folders() -> None:
 
 
 def validate_environment_root() -> None:
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
     if not str(workspace_root).replace("\\", "/").endswith("gh_COPILOT"):
         logging.warning(f"Non-standard workspace root: {workspace_root}")
 
@@ -200,7 +200,7 @@ def main() -> None:
     manager = ArchiveAndDeleteManager()
     # Replace 'target_file_path' with actual file path to archive and delete
     target_file_path = (
-        Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "example.txt"
+        Path(os.getenv("GH_COPILOT_WORKSPACE", "/app")) / "example.txt"
     )
     if target_file_path.exists():
         archive_path = manager.archive(target_file_path)

--- a/scripts/correction_logger_and_rollback.py
+++ b/scripts/correction_logger_and_rollback.py
@@ -29,7 +29,7 @@ from scripts.continuous_operation_orchestrator import validate_enterprise_operat
 
 # Enterprise logging setup
 LOGS_DIR = (
-    Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
     / "logs"
     / "correction_logger"
 )
@@ -45,7 +45,7 @@ logging.basicConfig(
 )
 
 DASHBOARD_DIR = (
-    Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
     / "dashboard"
     / "compliance"
 )
@@ -237,9 +237,9 @@ def main(
     logging.info(f"Process ID: {process_id}")
 
     # Anti-recursion validation
-    validate_enterprise_operation(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    validate_enterprise_operation(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
 
-    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
     analytics_db = Path(analytics_db_path or workspace / "databases" / "analytics.db")
     dashboard = Path(dashboard_dir or workspace / "dashboard" / "compliance")
 

--- a/scripts/enterprise/enterprise_api_infrastructure_framework.py
+++ b/scripts/enterprise/enterprise_api_infrastructure_framework.py
@@ -132,14 +132,15 @@ class EnterpriseAuthentication:
             except json.JSONDecodeError:
                 self.secret_key = None
         if not self.secret_key:
-            self.secret_key = "enterprise_api_secret_2024"
+            log_message(__name__, "[ERROR] API_SECRET_KEY not set. Exiting.")
+            sys.exit(1)
         
         # Initialize default admin user
         self._create_default_users()
 
         # MANDATORY: Visual processing indicators
-        log_message("🔐 ENTERPRISE AUTHENTICATION INITIALIZED")
-        log_message(f"Default users created: {len(self.users)}")
+        log_message(__name__, f"🔐 ENTERPRISE AUTHENTICATION INITIALIZED PID:{os.getpid()} START:{datetime.now().isoformat()}")
+        log_message(__name__, f"Default users created: {len(self.users)}")
 
     def _create_default_users(self):
         """👤 Create default enterprise users"""
@@ -219,7 +220,7 @@ class APIDocumentationGenerator:
         self.endpoints = {}
 
         # MANDATORY: Visual processing indicators
-        log_message("📚 API DOCUMENTATION GENERATOR INITIALIZED")
+        log_message(__name__, "📚 API DOCUMENTATION GENERATOR INITIALIZED")
 
     def register_endpoint(self, endpoint: APIEndpoint):
         """📝 Register endpoint for documentation"""
@@ -369,9 +370,9 @@ class EnterpriseAPIServer:
             self.app = None
 
         # MANDATORY: Visual processing indicators
-        log_message("🌐 ENTERPRISE API SERVER INITIALIZED")
-        log_message(f"Flask Available: {FLASK_AVAILABLE}")
-        log_message(f"JWT Available: {JWT_AVAILABLE}")
+        log_message(__name__, "🌐 ENTERPRISE API SERVER INITIALIZED")
+        log_message(__name__, f"Flask Available: {FLASK_AVAILABLE}")
+        log_message(__name__, f"JWT Available: {JWT_AVAILABLE}")
 
     def _setup_flask_routes(self):
         """🔧 Setup Flask routes and middleware"""
@@ -611,10 +612,7 @@ class EnterpriseAPIServer:
             Dictionary describing server status and metadata.
         """
         if not FLASK_AVAILABLE:
-            log_message(
-                "Flask not available - starting simulation mode",
-                level=logging.WARNING,
-            )
+            log_message(__name__, "Flask not available - starting simulation mode", level=logging.WARNING)
             return self._start_simulation_mode()
 
         try:
@@ -625,9 +623,9 @@ class EnterpriseAPIServer:
             self.server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
             self.server_thread.start()
 
-            log_message(f"🚀 Enterprise API Server started on http://{self.host}:{self.port}")
-            log_message(f"📚 API Documentation: http://{self.host}:{self.port}/api/v1/docs")
-            log_message(f"🔧 OpenAPI Spec: http://{self.host}:{self.port}/api/v1/openapi.json")
+            log_message(__name__, f"🚀 Enterprise API Server started on http://{self.host}:{self.port}")
+            log_message(__name__, f"📚 API Documentation: http://{self.host}:{self.port}/api/v1/docs")
+            log_message(__name__, f"🔧 OpenAPI Spec: http://{self.host}:{self.port}/api/v1/openapi.json")
 
             return {
                 "server_status": "RUNNING",
@@ -649,7 +647,7 @@ class EnterpriseAPIServer:
 
     def _start_simulation_mode(self) -> Dict[str, Any]:
         """🎭 Start simulation mode when Flask unavailable"""
-        log_message("🎭 API Server running in simulation mode")
+        log_message(__name__, "🎭 API Server running in simulation mode")
 
         # Simulate API endpoints
         simulated_endpoints = [
@@ -674,7 +672,7 @@ class EnterpriseAPIServer:
             self.server.shutdown()
             if self.server_thread:
                 self.server_thread.join(timeout=5)
-            log_message("🛑 Enterprise API Server stopped")
+            log_message(__name__, "🛑 Enterprise API Server stopped")
 
     def get_server_metrics(self) -> Dict[str, Any]:
         """📊 Get comprehensive server metrics"""

--- a/scripts/github_copilot_instruction_alignment_confirmer.py
+++ b/scripts/github_copilot_instruction_alignment_confirmer.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -28,8 +29,9 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+    def __init__(self, workspace_path: str = None):
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.logger = logging.getLogger(__name__)
 
     def execute_utility(self) -> bool:

--- a/scripts/phase8_advanced_enterprise_intelligence.py
+++ b/scripts/phase8_advanced_enterprise_intelligence.py
@@ -152,7 +152,8 @@ class AdvancedEnterpriseIntelligenceSystem:
         self.validate_environment_compliance()
         
         # Initialize workspace
-        self.workspace_path = Path(workspace_path or os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.production_db = self.workspace_path / "production.db"
         
         # Advanced Intelligence Components

--- a/scripts/refined_production_builder.py
+++ b/scripts/refined_production_builder.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -28,8 +29,9 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+    def __init__(self, workspace_path: str = None):
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.logger = logging.getLogger(__name__)
 
     def execute_utility(self) -> bool:

--- a/scripts/regenerated/ENTERPRISE_QUALITY_ENHANCEMENT.py
+++ b/scripts/regenerated/ENTERPRISE_QUALITY_ENHANCEMENT.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -28,8 +29,9 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+    def __init__(self, workspace_path: str = None):
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.logger = logging.getLogger(__name__)
 
     def execute_utility(self) -> bool:

--- a/scripts/regenerated/enterprise_deployment/executive_alerts_test_suite.py
+++ b/scripts/regenerated/enterprise_deployment/executive_alerts_test_suite.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -28,8 +29,9 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+    def __init__(self, workspace_path: str = None):
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.logger = logging.getLogger(__name__)
 
     def execute_utility(self) -> bool:

--- a/scripts/regenerated/enterprise_deployment/quantum_enhanced_cache.py
+++ b/scripts/regenerated/enterprise_deployment/quantum_enhanced_cache.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -28,8 +29,9 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+    def __init__(self, workspace_path: str = None):
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.logger = logging.getLogger(__name__)
 
     def execute_utility(self) -> bool:

--- a/scripts/regenerated/integrated_deployment_orchestrator.py
+++ b/scripts/regenerated/integrated_deployment_orchestrator.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -28,8 +29,9 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+    def __init__(self, workspace_path: str = None):
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.logger = logging.getLogger(__name__)
 
     def execute_utility(self) -> bool:

--- a/scripts/regenerated/ml_models/recommendation_api.py
+++ b/scripts/regenerated/ml_models/recommendation_api.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -28,8 +29,9 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+    def __init__(self, workspace_path: str = None):
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.logger = logging.getLogger(__name__)
 
     def execute_utility(self) -> bool:

--- a/scripts/regenerated/monitoring/scripts/data_privacy_compliance_compliance.py
+++ b/scripts/regenerated/monitoring/scripts/data_privacy_compliance_compliance.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 """
 from datetime import datetime
 from pathlib import Path
+import os
 from tqdm import tqdm
 import sys
 
@@ -29,8 +30,9 @@ TEXT_INDICATORS = {
 class EnterpriseFlake8Corrector:
     """Enterprise-grade Flake8 correction system"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+    def __init__(self, workspace_path: str = None):
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.logger = logging.getLogger(__name__)
 
     def execute_correction(self) -> bool:

--- a/scripts/regenerated/scaling_innovation_framework.py
+++ b/scripts/regenerated/scaling_innovation_framework.py
@@ -11,6 +11,7 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -26,8 +27,9 @@ TEXT_INDICATORS = {
 class EnterpriseUtility:
     """Enterprise utility class"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
-        self.workspace_path = Path(workspace_path)
+    def __init__(self, workspace_path: str = None):
+        default_workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "/app"))
+        self.workspace_path = Path(workspace_path) if workspace_path else default_workspace
         self.logger = logging.getLogger(__name__)
 
     def execute_utility(self) -> bool:

--- a/tests/test_enterprise_api_auth.py
+++ b/tests/test_enterprise_api_auth.py
@@ -1,7 +1,14 @@
 import os
+import pytest
 from scripts.enterprise.enterprise_api_infrastructure_framework import EnterpriseAuthentication
 
 def test_secret_loaded_from_env(monkeypatch):
     monkeypatch.setenv("API_SECRET_KEY", "test_secret")
     auth = EnterpriseAuthentication(workspace_path=".")
     assert auth.secret_key == "test_secret"
+
+
+def test_missing_secret_exits(monkeypatch):
+    monkeypatch.delenv("API_SECRET_KEY", raising=False)
+    with pytest.raises(SystemExit):
+        EnterpriseAuthentication(workspace_path=".")


### PR DESCRIPTION
## Summary
- enforce API_SECRET_KEY via environment or config in enterprise_api_infrastructure_framework
- remove default secret and add pid/start log message
- update path defaults to use GH_COPILOT_WORKSPACE or `/app`
- document secret generation in README and environment examples
- add failing-secret tests

## Testing
- `ruff check scripts/enterprise/enterprise_api_infrastructure_framework.py tests/test_enterprise_api_auth.py`
- `ruff check scripts/refined_production_builder.py scripts/github_copilot_instruction_alignment_confirmer.py scripts/phase8_advanced_enterprise_intelligence.py scripts/archive_and_delete_manager.py scripts/correction_logger_and_rollback.py scripts/regenerated/scaling_innovation_framework.py scripts/regenerated/ml_models/recommendation_api.py scripts/regenerated/integrated_deployment_orchestrator.py scripts/regenerated/enterprise_deployment/quantum_enhanced_cache.py scripts/regenerated/enterprise_deployment/executive_alerts_test_suite.py scripts/regenerated/monitoring/scripts/data_privacy_compliance_compliance.py scripts/regenerated/ENTERPRISE_QUALITY_ENHANCEMENT.py`
- `pytest tests/test_enterprise_api_auth.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d10bb5b48331af6b5b59419c9637