### PR TITLE
Fix docs metrics import path

### DIFF
--- a/scripts/generate_docs_metrics.py
+++ b/scripts/generate_docs_metrics.py
@@ -8,10 +8,15 @@ import re
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+# Extend sys.path so the script can import project utilities when executed
+# directly as ``python scripts/generate_docs_metrics.py``.
+sys.path.append(str(ROOT))
 
 from utils.log_utils import DEFAULT_ANALYTICS_DB, _log_event
 
-ROOT = Path(__file__).resolve().parents[1]
 DB_PATH = ROOT / "production.db"
 README_PATHS = [
     ROOT / "README.md",


### PR DESCRIPTION
## Summary
- extend `sys.path` in `generate_docs_metrics.py` so it can import `utils`
- add explanatory comments

## Testing
- `ruff format scripts/generate_docs_metrics.py`
- `ruff check scripts/generate_docs_metrics.py`
- `pyright scripts/generate_docs_metrics.py`
- `pytest tests/test_docs_metrics.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qiskit.circuit.library.templates')*

------
https://chatgpt.com/codex/tasks/task_e_6886e1dc578c83319c274e9de167452d