### PR TITLE
Fix docs metrics validator path

### DIFF
--- a/docs/DOCS_METRICS_VALIDATION_ROOT_CAUSE.md
+++ b/docs/DOCS_METRICS_VALIDATION_ROOT_CAUSE.md
@@ -1,0 +1,21 @@
+# Documentation Metrics Validation Failure
+
+The continuous integration job `docs-validation.yml` failed because it attempted
+to execute `scripts/docs_metrics_validator.py`, which did not exist in the
+repository. The correct validation script was named
+`scripts/validate_docs_metrics.py`. The workflow therefore raised a
+`FileNotFoundError` and halted documentation metrics validation.
+
+## Remediation
+
+An alias script named `scripts/docs_metrics_validator.py` has been added. It
+wraps `validate_docs_metrics.validate()` and preserves the existing command line
+interface. The CI workflow now invokes this wrapper to ensure compatibility.
+Documentation has been updated to reference the new script path.
+
+## Preventive Steps
+
+* Maintain consistency between workflow configuration and script names.
+* Validate CI changes locally with `pytest` and `ruff` before merging.
+* Include wrapper scripts when renaming utilities to avoid breaking existing
+  automation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ database entries from `documentation/DATABASE_LIST.md`. Use the
 ## Validation
 
 After updating documentation, execute
-`python scripts/validate_docs_metrics.py`. The validator compares the numbers in
+`python scripts/docs_metrics_validator.py`. The validator compares the numbers in
 `README.md`, `documentation/generated/README.md`, and the technical whitepaper
 against the real database values. Pass `--db-path` to override the database
 location. The command exits with an error if any values are inconsistent.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,4 @@
 """scripts package"""
+
+from . import docs_metrics_validator, validate_docs_metrics
+

--- a/scripts/docs_metrics_validator.py
+++ b/scripts/docs_metrics_validator.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper for documentation metrics validation.
+
+This script delegates to :mod:`validate_docs_metrics` to ensure
+backwards compatibility with existing CI workflows expecting
+``docs_metrics_validator.py``.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import validate_docs_metrics
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for docs metrics validation.
+
+    Parameters
+    ----------
+    argv: list[str] | None
+        Optional command line arguments. If ``None``, ``sys.argv[1:]`` is used.
+    """
+    parser = argparse.ArgumentParser(description="Validate documentation metrics")
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=validate_docs_metrics.DB_PATH,
+        help="Path to the production database",
+    )
+    args = parser.parse_args(argv)
+    success = validate_docs_metrics.validate(args.db_path)
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_docs_metrics.py
+++ b/tests/test_docs_metrics.py
@@ -36,3 +36,13 @@ def test_validate_get_db_metrics(tmp_path, monkeypatch):
     monkeypatch.setattr(validate_docs_metrics, "DATABASE_LIST", db_list)
     metrics = validate_docs_metrics.get_db_metrics(db_path)
     assert metrics == {"scripts": 2, "templates": 3, "databases": 1}
+
+def test_docs_metrics_validator_wrapper(tmp_path, monkeypatch):
+    db_path = _setup_db(tmp_path)
+    monkeypatch.setattr(
+        validate_docs_metrics, "validate", lambda path: path == db_path
+    )
+    from scripts import docs_metrics_validator
+
+    result = docs_metrics_validator.main(["--db-path", str(db_path)])
+    assert result == 0


### PR DESCRIPTION
## Summary
- add `docs_metrics_validator.py` wrapper under scripts
- adjust docs and expose in package
- document root cause and preventive steps
- test wrapper functionality

## Testing
- `ruff check scripts/docs_metrics_validator.py tests/test_docs_metrics.py scripts/__init__.py`
- `pytest tests/test_docs_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886f1959ab08331a8e3916ef1c4d11f