### PR TITLE
feat: docker entrypoint validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN chown -R appuser:appgroup /app
 
 # Set default workspace environment variable
 ENV GH_COPILOT_WORKSPACE=/app
+ENV GH_COPILOT_BACKUP_ROOT=/backup
 
 # Switch to the non-root user
 USER appuser
@@ -29,4 +30,6 @@ USER appuser
 # Port 8080: Web interface
 EXPOSE 5000 5001 5002 5003 5004 5005 5006 8080
 
-CMD ["python", "dashboard/enterprise_dashboard.py"]
+HEALTHCHECK --interval=30s --timeout=5s CMD ["python", "scripts/docker_healthcheck.py"]
+
+CMD ["python", "scripts/docker_entrypoint.py"]

--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ to create and manage backups. This variable ensures backups never reside in the
 workspace, maintaining anti-recursion compliance.
 The `validate_enterprise_environment` helper enforces these settings at script startup.
 
+### Docker Usage
+Build and run the container with Docker:
+
+```bash
+docker build -t gh_copilot .
+docker run -p 5000:5000 -e GH_COPILOT_BACKUP_ROOT=/path/to/backups gh_copilot
+```
+
+Inside the image `GH_COPILOT_BACKUP_ROOT` defaults to `/backup`. Map this path to a host directory to persist logs and backups.
+
 ### Wrapping, Logging, and Compliance (WLC)
 Run the session manager after setting the workspace and backup paths:
 

--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -12,19 +12,20 @@ import os
 from datetime import datetime
 
 from web_gui.scripts.flask_apps.enterprise_dashboard import app
+from utils.validation_utils import validate_enterprise_environment
 
 __all__ = ["app", "main"]
 
 
 def _validate_environment() -> None:
-    """Validate required environment variables and log them."""
-    required = ["GH_COPILOT_WORKSPACE"]
-    for var in required:
-        value = os.getenv(var)
-        if not value:
-            logging.warning("%s not set", var)
-        else:
-            logging.info("%s=%s", var, value)
+    """Validate required environment variables."""
+    try:
+        validate_enterprise_environment()
+    except EnvironmentError as exc:
+        logging.error("Environment validation failed: %s", exc)
+        raise
+    for var in ["GH_COPILOT_WORKSPACE", "GH_COPILOT_BACKUP_ROOT"]:
+        logging.info("%s=%s", var, os.getenv(var))
 
 
 def main() -> None:

--- a/docs/enterprise_backup_guide.md
+++ b/docs/enterprise_backup_guide.md
@@ -3,7 +3,7 @@
 This guide describes how to use the data backup feature in the gh_COPILOT toolkit.
 
 ## Prerequisites
-- Ensure the `GH_COPILOT_BACKUP_ROOT` environment variable points to an external directory outside the repository workspace.
+- Ensure the `GH_COPILOT_BACKUP_ROOT` environment variable points to an external directory outside the repository workspace. When running the Docker container, this variable defaults to `/backup` and should be mapped to a host directory.
 - Run `bash setup.sh` to create the `.venv` and install dependencies.
 
 ## Performing a Backup

--- a/scripts/docker_entrypoint.py
+++ b/scripts/docker_entrypoint.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Docker entrypoint for the enterprise dashboard."""
+
+from utils.validation_utils import validate_enterprise_environment
+from dashboard.enterprise_dashboard import main
+
+if __name__ == "__main__":
+    validate_enterprise_environment()
+    main()

--- a/scripts/docker_healthcheck.py
+++ b/scripts/docker_healthcheck.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Simple health check for Docker container."""
+
+from utils.validation_utils import validate_enterprise_environment
+
+if __name__ == "__main__":
+    try:
+        validate_enterprise_environment()
+    except Exception:
+        raise SystemExit(1)
+    raise SystemExit(0)


### PR DESCRIPTION
Fixes: update Dockerfile to set GH_COPILOT_BACKUP_ROOT and include health check.
Adds docker_entrypoint wrapper calling validate_enterprise_environment and a
simple healthcheck script. README and enterprise backup docs describe the new
Docker usage and default backup location.

Tests: ruff, pyright run. pytest fails due to missing qiskit modules.

------
https://chatgpt.com/codex/tasks/task_e_6886ed1fc82883318985d4f0a66537dc