### PR TITLE
Add quantum algorithm stubs and metrics

### DIFF
--- a/scripts/quantum/quantum_algorithm_suite.py
+++ b/scripts/quantum/quantum_algorithm_suite.py
@@ -1,4 +1,5 @@
 """Simulated quantum algorithm suite with common stubs."""
+
 from __future__ import annotations
 
 import logging
@@ -14,20 +15,25 @@ class QuantumAlgorithmSuite:
 
     def grover(self) -> str:
         self.logger.info("Running Grover placeholder")
+        print("Quantum Fidelity: 98.7%; Performance: simulated")
         return "grover"
 
     def shor(self) -> str:
         self.logger.info("Running Shor placeholder")
+        print("Quantum Fidelity: 98.7%; Performance: simulated")
         return "shor"
 
     def qft(self) -> str:
         self.logger.info("Running QFT placeholder")
+        print("Quantum Fidelity: 98.7%; Performance: simulated")
         return "qft"
 
     def clustering(self) -> str:
         self.logger.info("Running Quantum Clustering placeholder")
+        print("Quantum Fidelity: 98.7%; Performance: simulated")
         return "clustering"
 
     def quantum_neural_network(self) -> str:
         self.logger.info("Running QNN placeholder")
+        print("Quantum Fidelity: 98.7%; Performance: simulated")
         return "qnn"

--- a/scripts/quantum/quantum_database_processor.py
+++ b/scripts/quantum/quantum_database_processor.py
@@ -1,4 +1,5 @@
 """Quantum database processor with simulation placeholders."""
+
 from __future__ import annotations
 
 import logging
@@ -12,7 +13,18 @@ class QuantumDatabaseProcessor:
     def __init__(self) -> None:
         self.logger = logging.getLogger(__name__)
 
-    def quantum_enhanced_query(self, query: str) -> str:
-        """Run a simulated quantum-enhanced query."""
-        self.logger.info("Simulated quantum query: %s", query)
-        return "simulated_result"
+    def quantum_enhanced_query(self, query: str) -> dict[str, str]:
+        """Run a simulated Grover-based query.
+
+        References `QUANTUM_OPTIMIZATION.instructions.md` for guidance.
+        """
+        self.logger.info("Simulated quantum query using Grover: %s", query)
+        fidelity = "98.7%"
+        performance = "simulated"
+        print(f"Quantum Fidelity: {fidelity}; Performance: {performance}")
+        return {
+            "result": "simulated_result",
+            "algorithm": "grover",
+            "quantum_fidelity": fidelity,
+            "performance": performance,
+        }

--- a/tests/test_new_placeholders.py
+++ b/tests/test_new_placeholders.py
@@ -19,6 +19,7 @@ from scripts.orchestration.UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED import (
 )
 
 
+# See QUANTUM_OPTIMIZATION.instructions.md for algorithm expectations
 def test_placeholders_importable(tmp_path):
     workspace = tmp_path
     db = workspace / "databases"
@@ -40,8 +41,13 @@ def test_placeholders_importable(tmp_path):
     ContinuousMonitoringEngine().run_cycle([])
     AutomatedOptimizationEngine().optimize(workspace)
     IntelligenceGatheringSystem(db / "production.db").gather()
-    QuantumDatabaseProcessor().quantum_enhanced_query("SELECT 1")
+    result = QuantumDatabaseProcessor().quantum_enhanced_query("SELECT 1")
+    assert result["algorithm"] == "grover"
     QuantumAlgorithmSuite().grover()
+    QuantumAlgorithmSuite().shor()
+    QuantumAlgorithmSuite().qft()
+    QuantumAlgorithmSuite().clustering()
+    QuantumAlgorithmSuite().quantum_neural_network()
     WebGUIIntegrator(db / "production.db").initialize()
     DocumentationValidator().validate(tmp_path)
     UnifiedDeploymentOrchestrator(workspace).run()


### PR DESCRIPTION
## Summary
- extend quantum database processor with Grover-based stub
- expose Fourier transform, clustering, and neural network in algorithm suite
- log simulated fidelity and performance metrics
- update placeholder test to exercise new stubs

## Testing
- `ruff check scripts/quantum/quantum_database_processor.py scripts/quantum/quantum_algorithm_suite.py tests/test_new_placeholders.py`
- `pytest tests/test_new_placeholders.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68873fdbab28833197614b91cec341da