### PR TITLE
feat: add db-backed intelligent classifier

### DIFF
--- a/scripts/file_management/intelligent_file_classifier.py
+++ b/scripts/file_management/intelligent_file_classifier.py
@@ -3,37 +3,137 @@
 The classifier consults ``production.db`` to map file patterns to known
 categories. It logs classification confidence for auditing purposes.
 """
+
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
 import sqlite3
+from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict
 
 __all__ = ["IntelligentFileClassifier"]
 
 
 class IntelligentFileClassifier:
-    """Classify files using ML/database patterns."""
+    """Classify files using ML/database patterns with duplicate detection."""
 
-    def __init__(self, db_path: Path) -> None:
+    def __init__(self, db_path: Path, verbose: bool | None = None) -> None:
         self.db_path = db_path
         self.conn = sqlite3.connect(self.db_path)
         self.logger = logging.getLogger(__name__)
+        self.verbose = verbose or os.getenv("VERBOSE_LOGGING") == "1"
+        if self.verbose:
+            self.logger.setLevel(logging.DEBUG)
+        self._init_tables()
 
-    def classify(self, file_path: Path) -> str:
-        """Return the predicted category for ``file_path``.
-
-        This method checks the ``functional_components`` table for a matching
-        pattern and returns the associated classification. Confidence scores are
-        logged for auditing.
-        """
-        self.logger.debug("Classifying %s", file_path)
+    def _init_tables(self) -> None:
+        """Ensure required tables exist."""
         with self.conn:
-            cur = self.conn.execute(
-                "SELECT script_type FROM functional_components WHERE ? LIKE pattern",
-                (file_path.name,),
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS classification_results (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    file_path TEXT NOT NULL,
+                    file_hash TEXT NOT NULL,
+                    category TEXT NOT NULL,
+                    script_type TEXT NOT NULL,
+                    confidence REAL NOT NULL,
+                    version INTEGER NOT NULL,
+                    timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """
             )
-            row = cur.fetchone()
-            classification = row[0] if row else "unknown"
-        self.logger.info("Classified %s as %s", file_path, classification)
-        return classification
+            self.conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_classification_hash ON classification_results(file_hash)"
+            )
+
+    def _hash_file(self, path: Path) -> str:
+        with open(path, "rb") as f:
+            return hashlib.sha256(f.read()).hexdigest()
+
+    def _query_patterns(self, suffix: str) -> list[tuple[str, str, int]]:
+        cur = self.conn.execute(
+            """
+            SELECT functionality_category, script_type, COUNT(*) as frequency
+            FROM enhanced_script_tracking
+            WHERE script_path LIKE ?
+            GROUP BY functionality_category, script_type
+            ORDER BY frequency DESC
+            """,
+            (f"%{suffix}",),
+        )
+        return cur.fetchall()
+
+    @staticmethod
+    def calculate_classification_confidence(patterns: list[tuple[str, str, int]]) -> float:
+        if not patterns:
+            return 0.0
+        total = sum(p[2] for p in patterns)
+        return patterns[0][2] / total if total else 0.0
+
+    def _is_duplicate(self, file_hash: str) -> bool:
+        cur = self.conn.execute("SELECT 1 FROM script_tracking WHERE file_hash=?", (file_hash,))
+        return cur.fetchone() is not None
+
+    def _get_next_version(self, file_hash: str) -> int:
+        cur = self.conn.execute(
+            "SELECT version FROM classification_results WHERE file_hash=?",
+            (file_hash,),
+        )
+        row = cur.fetchone()
+        return (row[0] + 1) if row else 1
+
+    def classify_file_autonomously(self, file_path: Path) -> Dict[str, Any]:
+        """Classify files using database intelligence and ML patterns."""
+        self.logger.debug("Classifying %s", file_path)
+        file_hash = self._hash_file(file_path)
+        patterns = self._query_patterns(file_path.suffix)
+
+        category = patterns[0][0] if patterns else "general"
+        script_type = patterns[0][1] if patterns else "utility"
+        confidence = self.calculate_classification_confidence(patterns)
+
+        duplicate = self._is_duplicate(file_hash)
+        version = self._get_next_version(file_hash)
+
+        with self.conn:
+            if not duplicate:
+                self.conn.execute(
+                    "INSERT INTO script_tracking(file_path, file_hash, last_modified) VALUES (?, ?, ?)",
+                    (str(file_path), file_hash, datetime.now().isoformat()),
+                )
+            self.conn.execute(
+                "REPLACE INTO classification_results(file_path, file_hash, category,"
+                " script_type, confidence, version, timestamp)"
+                " VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                (
+                    str(file_path),
+                    file_hash,
+                    category,
+                    script_type,
+                    confidence,
+                    version,
+                ),
+            )
+
+        if self.verbose:
+            self.logger.info(
+                "[VERBOSE] %s -> %s/%s conf=%.2f dup=%s v%s",
+                file_path,
+                category,
+                script_type,
+                confidence,
+                duplicate,
+                version,
+            )
+
+        return {
+            "category": category,
+            "type": script_type,
+            "confidence": confidence,
+            "duplicate": duplicate,
+            "version": version,
+        }

--- a/tests/test_intelligent_file_classifier.py
+++ b/tests/test_intelligent_file_classifier.py
@@ -1,0 +1,43 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.file_management.intelligent_file_classifier import IntelligentFileClassifier
+
+
+def _setup_db(tmp_path: Path) -> Path:
+    db = tmp_path / "production.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE enhanced_script_tracking(\n                script_id INTEGER PRIMARY KEY AUTOINCREMENT,\n                script_path TEXT,\n                script_content TEXT,\n                script_hash TEXT,\n                script_type TEXT,\n                functionality_category TEXT\n            )"
+        )
+        conn.execute(
+            "CREATE TABLE script_tracking(id INTEGER PRIMARY KEY AUTOINCREMENT, file_path TEXT, file_hash TEXT, last_modified TEXT)"
+        )
+    return db
+
+
+def test_classification_and_version(tmp_path: Path) -> None:
+    db = _setup_db(tmp_path)
+    with sqlite3.connect(db) as conn:
+        conn.executemany(
+            "INSERT INTO enhanced_script_tracking(script_path, script_hash, script_type, functionality_category) VALUES (?, ?, ?, ?)",
+            [
+                ("util1.py", "a", "python", "scripts"),
+                ("util2.py", "b", "python", "scripts"),
+            ],
+        )
+
+    file_path = tmp_path / "test.py"
+    file_path.write_text("print('hi')")
+    clf = IntelligentFileClassifier(db)
+
+    result1 = clf.classify_file_autonomously(file_path)
+    assert result1["category"] == "scripts"
+    assert result1["type"] == "python"
+    assert result1["confidence"] > 0
+    assert result1["version"] == 1
+    assert not result1["duplicate"]
+
+    result2 = clf.classify_file_autonomously(file_path)
+    assert result2["duplicate"]
+    assert result2["version"] == 2


### PR DESCRIPTION
## Summary
- reference user prompt
- enhance intelligent classifier to use production.db for classification patterns
- detect duplicates using `script_tracking` table
- record results in new `classification_results` table
- add verbose logging support
- add tests for classification and duplicate detection

## Testing
- `ruff check scripts/file_management/intelligent_file_classifier.py tests/test_intelligent_file_classifier.py`
- `ruff format scripts/file_management/intelligent_file_classifier.py tests/test_intelligent_file_classifier.py`
- `pyright scripts/file_management/intelligent_file_classifier.py tests/test_intelligent_file_classifier.py`
- `pytest tests/test_intelligent_file_classifier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68873fd6c8b8833194bf67d67ca6a6c5