### PR TITLE
feat: optimize workspace via db stats

### DIFF
--- a/scripts/file_management/workspace_optimizer.py
+++ b/scripts/file_management/workspace_optimizer.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+import sqlite3
+import gzip
+import shutil
+from datetime import datetime, timedelta
+
+from utils.cross_platform_paths import CrossPlatformPathManager
+from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
 
 from tqdm import tqdm
 
@@ -14,15 +21,88 @@ __all__ = ["WorkspaceOptimizer"]
 class WorkspaceOptimizer:
     """Optimize workspace storage and access patterns."""
 
-    def __init__(self) -> None:
+    DAYS_UNUSED = 365
+
+    def __init__(self, db_path: Path | None = None) -> None:
         self.logger = logging.getLogger(__name__)
+        self.db_path = db_path or CrossPlatformPathManager.get_workspace_path() / "databases" / "production.db"
+        self.conn = sqlite3.connect(self.db_path)
+        self._init_metrics_table()
+
+    def _init_metrics_table(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS workspace_optimization_metrics (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    file_path TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    original_size INTEGER,
+                    new_size INTEGER,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+
+    def _get_old_files(self, workspace: Path) -> list[Path]:
+        cutoff = datetime.now() - timedelta(days=self.DAYS_UNUSED)
+        with self.conn:
+            cur = self.conn.execute(
+                "SELECT script_path FROM tracked_scripts WHERE last_modified < ?",
+                (cutoff.strftime("%Y-%m-%d %H:%M:%S"),),
+            )
+            candidates = [workspace / row[0].lstrip("/") for row in cur.fetchall()]
+        return [p for p in candidates if p.exists()]
+
+    def _archive_file(self, file_path: Path, archive_dir: Path) -> tuple[int, int]:
+        original_size = file_path.stat().st_size
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        dest = archive_dir / f"{file_path.name}.gz"
+        with open(file_path, "rb") as f_in, gzip.open(dest, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+        new_size = dest.stat().st_size
+        file_path.unlink()
+        return original_size, new_size
+
+    def _log_metric(self, file_path: Path, original_size: int, new_size: int) -> None:
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO workspace_optimization_metrics (file_path, action, original_size, new_size) VALUES (?, 'archive', ?, ?)",
+                (str(file_path), original_size, new_size),
+            )
 
     def optimize(self, workspace: Path) -> None:
-        """Run a basic optimization routine on ``workspace``."""
+        """Archive rarely used files under ``workspace`` and log metrics."""
         validate_enterprise_environment()
         workspace = workspace.resolve()
-        files = list(workspace.rglob("*.py"))
+        archive_root = CrossPlatformPathManager.get_backup_root() / "workspace_archive"
+        files = self._get_old_files(workspace)
         with tqdm(files, desc="Optimizing", unit="file") as bar:
             for f in bar:
                 bar.set_postfix(file=f.name)
+                orig, new = self._archive_file(f, archive_root)
+                self._log_metric(f, orig, new)
         self.logger.info("Optimization run complete on %d files", len(files))
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Workspace optimization tool")
+    parser.add_argument(
+        "workspace",
+        nargs="?",
+        type=Path,
+        default=CrossPlatformPathManager.get_workspace_path(),
+        help="Workspace directory",
+    )
+    args = parser.parse_args(argv)
+
+    optimizer = WorkspaceOptimizer()
+    orchestrator = DualCopilotOrchestrator()
+    orchestrator.run(lambda: (optimizer.optimize(args.workspace) or True), [])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workspace_optimizer.py
+++ b/tests/test_workspace_optimizer.py
@@ -1,0 +1,74 @@
+import os
+import sqlite3
+import shutil
+from pathlib import Path
+
+from scripts.file_management.workspace_optimizer import WorkspaceOptimizer, main
+
+
+def setup_db(db_path: Path, file_rel: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO tracked_scripts (script_name, script_path, last_modified) VALUES (?, ?, ?)",
+            (Path(file_rel).name, file_rel, "2000-01-01 00:00:00"),
+        )
+
+
+def test_optimizer_archives_and_logs(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    db_dir = workspace / "databases"
+    archive_root = tmp_path / "backups"
+    workspace.mkdir()
+    db_dir.mkdir()
+    shutil.copy(Path("databases/production.db"), db_dir / "production.db")
+    test_file = workspace / "old.py"
+    test_file.write_text("print('x')\n")
+    setup_db(db_dir / "production.db", "/old.py")
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(archive_root))
+
+    optimizer = WorkspaceOptimizer(db_dir / "production.db")
+    optimizer.optimize(workspace)
+
+    assert not test_file.exists()
+    archive = archive_root / "workspace_archive" / "old.py.gz"
+    assert archive.exists()
+
+    with sqlite3.connect(db_dir / "production.db") as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM workspace_optimization_metrics"
+        ).fetchone()[0]
+        assert count == 1
+
+
+def test_cli_invokes_dual(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    db_dir = workspace / "databases"
+    workspace.mkdir()
+    db_dir.mkdir()
+    shutil.copy(Path("databases/production.db"), db_dir / "production.db")
+    setup_db(db_dir / "production.db", "/dummy.py")
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
+
+    called = {"run": False}
+
+    class DummyOrchestrator:
+        def __init__(self, logger=None):
+            pass
+
+        def run(self, primary, targets):
+            called["run"] = True
+            primary()
+            return True
+
+    monkeypatch.setattr(
+        "scripts.file_management.workspace_optimizer.DualCopilotOrchestrator",
+        DummyOrchestrator,
+    )
+
+    monkeypatch.chdir(workspace)
+    assert main([]) == 0
+    assert called["run"]


### PR DESCRIPTION
## Summary
- archive old workspace files using `WorkspaceOptimizer`
- log optimization metrics in `production.db`
- add CLI entry point with dual copilot validation
- test workspace optimizer metrics and dual orchestrator integration

## Testing
- `ruff check scripts/file_management/workspace_optimizer.py tests/test_workspace_optimizer.py`
- `pytest -q tests/test_workspace_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_68873fd8a0bc8331a2d83db525a7150f