### PR TITLE
feat: add optimization analytics and CLI

### DIFF
--- a/scripts/optimization/automated_optimization_engine.py
+++ b/scripts/optimization/automated_optimization_engine.py
@@ -1,12 +1,15 @@
 """Automated optimization engine for continuous improvements."""
 from __future__ import annotations
 
+import argparse
 import logging
+import os
 from pathlib import Path
 
 from tqdm import tqdm
+from utils.log_utils import _log_event
 
-__all__ = ["AutomatedOptimizationEngine"]
+__all__ = ["AutomatedOptimizationEngine", "parse_args", "main"]
 
 
 class AutomatedOptimizationEngine:
@@ -18,8 +21,40 @@ class AutomatedOptimizationEngine:
     def optimize(self, workspace: Path) -> None:
         """Perform a simple optimization run over ``workspace``."""
         workspace = workspace.resolve()
+        analytics_db = workspace / "databases" / "analytics.db"
         files = list(workspace.rglob("*.py"))
         with tqdm(files, desc="Optimizing", unit="file") as bar:
             for f in bar:
                 bar.set_postfix(file=f.name)
+                try:
+                    size = f.stat().st_size
+                except OSError:
+                    size = 0
+                _log_event(
+                    {"event": "optimization_metric", "file": f.name, "size": size},
+                    table="optimization_metrics",
+                    db_path=analytics_db,
+                )
         self.logger.info("Optimization completed on %d files", len(files))
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run automated optimization")
+    parser.add_argument(
+        "workspace",
+        nargs="?",
+        type=Path,
+        default=Path(os.getenv("GH_COPILOT_WORKSPACE", ".")),
+        help="Workspace path",
+    )
+    return parser.parse_args(args)
+
+
+def main(args: list[str] | None = None) -> int:
+    ns = parse_args(args)
+    AutomatedOptimizationEngine().optimize(ns.workspace)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/optimization/intelligence_gathering_system.py
+++ b/scripts/optimization/intelligence_gathering_system.py
@@ -1,11 +1,16 @@
 """Gather unified analytics and predictive insights."""
 from __future__ import annotations
 
+import argparse
 import logging
+import os
 import sqlite3
 from pathlib import Path
 
-__all__ = ["IntelligenceGatheringSystem"]
+from tqdm import tqdm
+from utils.log_utils import _log_event
+
+__all__ = ["IntelligenceGatheringSystem", "parse_args", "main"]
 
 
 class IntelligenceGatheringSystem:
@@ -19,3 +24,41 @@ class IntelligenceGatheringSystem:
     def gather(self) -> None:
         """Gather analytics from ``production.db``."""
         self.logger.info("Gathering intelligence from %s", self.db_path)
+        analytics_db = Path(os.getenv("GH_COPILOT_WORKSPACE", ".")) / "databases" / "analytics.db"
+        cur = self.conn.cursor()
+        tables = [r[0] for r in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+        with tqdm(tables, desc="Collecting", unit="table") as bar:
+            for tbl in bar:
+                bar.set_postfix(table=tbl)
+                try:
+                    count = cur.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]
+                except sqlite3.Error:
+                    count = 0
+                _log_event(
+                    {"event": "table_summary", "table": tbl, "rows": count},
+                    table="intel_reports",
+                    db_path=analytics_db,
+                )
+        self.logger.info("Gathered metrics for %d tables", len(tables))
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gather analytics")
+    parser.add_argument(
+        "db_path",
+        nargs="?",
+        type=Path,
+        default=Path(os.getenv("GH_COPILOT_WORKSPACE", ".")) / "databases" / "production.db",
+        help="Path to production database",
+    )
+    return parser.parse_args(args)
+
+
+def main(args: list[str] | None = None) -> int:
+    ns = parse_args(args)
+    IntelligenceGatheringSystem(ns.db_path).gather()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_optimization_cli.py
+++ b/tests/test_optimization_cli.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import os
+import shutil
+
+from scripts.optimization.automated_optimization_engine import main as opt_main
+from scripts.optimization.intelligence_gathering_system import main as intel_main
+
+
+def _setup_workspace(tmp_path: Path) -> Path:
+    ws = tmp_path
+    (ws / "databases").mkdir()
+    shutil.copy(Path("databases/production.db"), ws / "databases" / "production.db")
+    (ws / "demo.py").write_text("print('hi')\n")
+    return ws
+
+
+def test_automated_optimizer_cli(tmp_path, monkeypatch):
+    ws = _setup_workspace(tmp_path)
+    events = []
+
+    def fake_log(event, **_):
+        events.append(event)
+        return True
+
+    monkeypatch.setattr(
+        "scripts.optimization.automated_optimization_engine._log_event", fake_log
+    )
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    assert opt_main([str(ws)]) == 0
+    assert any(e.get("event") == "optimization_metric" for e in events)
+
+
+def test_intelligence_gather_cli(tmp_path, monkeypatch):
+    ws = _setup_workspace(tmp_path)
+    events = []
+
+    def fake_log(event, **_):
+        events.append(event)
+        return True
+
+    monkeypatch.setattr(
+        "scripts.optimization.intelligence_gathering_system._log_event", fake_log
+    )
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    db = ws / "databases" / "production.db"
+    assert intel_main([str(db)]) == 0
+    assert any(e.get("event") == "table_summary" for e in events)


### PR DESCRIPTION
## Summary
- implement ML-based optimization placeholder that logs metrics
- implement intelligence gathering analytics logging
- add CLI entrypoints for both optimization modules
- test new CLIs with fake analytics logger

## Testing
- `ruff check scripts/optimization/automated_optimization_engine.py scripts/optimization/intelligence_gathering_system.py`
- `pytest tests/test_optimization_cli.py tests/test_new_placeholders.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68873fdacfb48331b0fc7e8ee96ce4b8