### PR TITLE
Fix backup manager duplication and tests

### DIFF
--- a/scripts/file_management/autonomous_backup_manager.py
+++ b/scripts/file_management/autonomous_backup_manager.py
@@ -1,4 +1,5 @@
 """Autonomous backup manager with anti-recursion safeguards."""
+
 from __future__ import annotations
 
 import logging
@@ -40,21 +41,6 @@ class AutonomousBackupManager:
                 return False
         workspace = CrossPlatformPathManager.get_workspace_path().resolve()
         return workspace not in self.backup_root.parents and workspace != self.backup_root
-
-    def create_backup(self, target: Path) -> Path:
-        """Backup ``target`` to the backup root with validation."""
-        target = Path(target).resolve()
-
-        if self.backup_root in target.parents:
-    def _validate_target(self, target: Path) -> None:
-        workspace = CrossPlatformPathManager.get_workspace_path().resolve()
-        backup_root = CrossPlatformPathManager.get_backup_root().resolve()
-        if backup_root in target.parents:
-            raise RuntimeError("Refusing to back up inside backup root")
-        if workspace in target.parents:
-            self.logger.debug("Backup of workspace subdir %s", target)
-        if str(target).startswith("C:/temp"):
-            raise RuntimeError("Forbidden backup location")
 
     def _validate_target(self, target: Path) -> None:
         workspace = CrossPlatformPathManager.get_workspace_path().resolve()

--- a/scripts/file_management/intelligent_file_classifier.py
+++ b/scripts/file_management/intelligent_file_classifier.py
@@ -3,6 +3,7 @@
 The classifier consults ``production.db`` to map file patterns to known
 categories. It logs classification confidence for auditing purposes.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -136,3 +137,8 @@ class IntelligentFileClassifier:
             "duplicate": duplicate,
             "version": version,
         }
+
+    def classify(self, file_path: Path) -> str:
+        """Return the classification category for the given file."""
+        result = self.classify_file_autonomously(file_path)
+        return result["category"]

--- a/scripts/quantum/quantum_database_processor.py
+++ b/scripts/quantum/quantum_database_processor.py
@@ -1,4 +1,5 @@
 """Quantum database processor with simulation placeholders."""
+
 from __future__ import annotations
 
 import logging
@@ -12,7 +13,7 @@ class QuantumDatabaseProcessor:
     def __init__(self) -> None:
         self.logger = logging.getLogger(__name__)
 
-    def quantum_enhanced_query(self, query: str) -> str:
+    def quantum_enhanced_query(self, query: str) -> dict[str, str]:
         """Run a simulated quantum-enhanced query."""
         self.logger.info("Simulated quantum query: %s", query)
-        return "simulated_result"
+        return {"algorithm": "grover", "result": "simulated_result"}

--- a/tests/test_autonomous_backup_manager.py
+++ b/tests/test_autonomous_backup_manager.py
@@ -46,3 +46,33 @@ def test_backup_rejects_recursive_path(tmp_path: Path, monkeypatch: pytest.Monke
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(workspace / "backups"))
     with pytest.raises(EnvironmentError):
         AutonomousBackupManager()
+
+
+def test_create_backup_rejects_target_inside_backup_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    backup_root = tmp_path / "backups"
+    backup_root.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    manager = AutonomousBackupManager()
+    target = backup_root / "nested"
+    target.mkdir()
+
+    with pytest.raises(RuntimeError):
+        manager.create_backup(target)
+
+
+def test_validate_target_disallows_c_temp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    backup_root = tmp_path / "backups"
+    backup_root.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    manager = AutonomousBackupManager()
+
+    with pytest.raises(RuntimeError):
+        manager._validate_target(Path("C:/temp/data"))

--- a/tests/test_new_placeholders.py
+++ b/tests/test_new_placeholders.py
@@ -42,7 +42,7 @@ def test_placeholders_importable(tmp_path):
     with sqlite3.connect(db / "production.db") as conn:
         conn.execute(
             "INSERT INTO enhanced_script_tracking (script_path, script_content, script_hash, script_type) VALUES (?, ?, 'x', 'test')",
-            (str(sample), 'print(\'hi\')'),
+            (str(sample), "print('hi')"),
         )
     file_manager.organize_files(workspace)
     dest = workspace / "organized" / "test" / "sample.py"
@@ -51,7 +51,7 @@ def test_placeholders_importable(tmp_path):
     backup_dest = AutonomousBackupManager().create_backup(workspace)
     assert workspace.resolve() not in Path(backup_dest).resolve().parents
     WorkspaceOptimizer().optimize(workspace)
-    ContinuousMonitoringEngine().run_cycle([])
+    ContinuousMonitoringEngine(cycle_seconds=0).run_cycle([])
     AutomatedOptimizationEngine().optimize(workspace)
     IntelligenceGatheringSystem(db / "production.db").gather()
     result = QuantumDatabaseProcessor().quantum_enhanced_query("SELECT 1")


### PR DESCRIPTION
## Summary
- clean up duplicate logic in `AutonomousBackupManager`
- add coverage for invalid backup targets
- expose simple `classify` helper on the file classifier
- return structured data in `QuantumDatabaseProcessor`
- adjust placeholder test to use short monitoring cycles

## Testing
- `ruff check scripts/file_management/autonomous_backup_manager.py scripts/file_management/intelligent_file_classifier.py scripts/quantum/quantum_database_processor.py tests/test_autonomous_backup_manager.py tests/test_new_placeholders.py | head -n 20`
- `pytest tests/test_new_placeholders.py::test_placeholders_importable -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688748819b148331b3dae6b3f34f0197