### PR TITLE
Add clustering option for template synchronizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,8 @@ compliance logging. The main modules are:
   computes compliance scores and writes dashboard-ready reports.
 * **TemplateSynchronizer** – keeps generated templates synchronized across
   environments. The analytics database is created only when running with the
-  `--real` flag.
+  `--real` flag. Templates may also be clustered via the `--cluster` flag to
+  synchronize only representative examples.
 * **Log Utilities** – unified `_log_event` helper under `utils.log_utils` logs
   events to `sync_events_log`, `sync_status`, or `doc_analysis` tables in
   `analytics.db` with visual indicators and DUAL COPILOT validation.
@@ -358,10 +359,11 @@ template = gen.generate_template({"action": "print"})
 sync_count = template_synchronizer.synchronize_templates([Path("databases/production.db")])
 ```
 
-Run in real mode to persist changes and log analytics:
+Run in real mode to persist changes and log analytics. Pass `--cluster` to
+enable KMeans grouping before synchronization:
 
 ```bash
-python template_engine/template_synchronizer.py --real
+python template_engine/template_synchronizer.py --real --cluster
 ```
 
 #### Unified Logging Helper

--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -39,9 +39,10 @@ export GH_COPILOT_WORKSPACE=/path/to/gh_COPILOT
 ## 4. Synchronization
 - Run `template_engine.template_synchronizer.synchronize_templates()` to preview
    synchronization across development, staging, and production databases. To
-   apply updates and record audit logs, use
-   `template_engine.template_synchronizer.synchronize_templates_real()` or run
-   the CLI with the `--real` flag.
+  apply updates and record audit logs, use
+  `template_engine.template_synchronizer.synchronize_templates_real()` or run
+  the CLI with the `--real` flag. Pass `--cluster` to enable KMeans-based
+  template grouping during synchronization.
 
 ## 5. Compliance & Correction
 - All generation actions must be logged for compliance review.


### PR DESCRIPTION
## Summary
- introduce KMeans-based clustering for template synchronization
- expose `--cluster` CLI flag
- update README and usage docs for clustering
- add clustering test for TemplateSynchronizer

## Testing
- `ruff check tests/test_template_synchronizer.py template_engine/template_synchronizer.py`
- `ruff check .` *(fails: E722 in integration_score_calculator.py and others)*
- `pytest tests/test_template_synchronizer.py::test_synchronize_with_clustering -q`

------
https://chatgpt.com/codex/tasks/task_e_68874b082d3c8331b1ef08db0c440ec3