### PR TITLE
Implement init_and_audit utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ gh_COPILOT/
 - **`scripts/utilities/self_healing_self_learning_system.py`** - Autonomous operations
 - **`scripts/validation/enterprise_dual_copilot_validator.py`** - DUAL COPILOT validation
 - **`scripts/utilities/unified_script_generation_system.py`** - Database-first generation
+- **`scripts/utilities/init_and_audit.py`** - Initialize databases and run placeholder audit
  - **`dashboard/enterprise_dashboard.py`** - Wrapper for Flask dashboard app
 - **`validation/compliance_report_generator.py`** - Summarize lint and test results
 - **`web_gui/dashboard_actionable_gui.py`** - Actionable compliance dashboard

--- a/scripts/utilities/init_and_audit.py
+++ b/scripts/utilities/init_and_audit.py
@@ -1,0 +1,63 @@
+"""Initialize databases and run code placeholder audit.
+
+This utility sets up required SQLite databases if they do not
+exist and then invokes :mod:`scripts.code_placeholder_audit`.
+It logs operations for compliance tracking.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from pathlib import Path
+from typing import List
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import code_placeholder_audit
+
+LOGGER = logging.getLogger(__name__)
+
+
+
+def ensure_database(db_path: Path, ddl: List[str]) -> None:
+    """Create ``db_path`` with the provided DDL statements if missing."""
+    if db_path.exists():
+        return
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        for stmt in ddl:
+            conn.execute(stmt)
+    LOGGER.info("Created database %s", db_path)
+
+
+def run() -> None:
+    """Run initialization and audit."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "."))
+    production_db = workspace / "databases" / "production.db"
+    analytics_db = workspace / "databases" / "analytics.db"
+
+    ensure_database(
+        production_db,
+        [
+            "CREATE TABLE IF NOT EXISTS template_placeholders (placeholder_name TEXT)",
+        ],
+    )
+    ensure_database(
+        analytics_db,
+        [
+            "CREATE TABLE IF NOT EXISTS code_audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, file_path TEXT, line_number INTEGER, context TEXT, timestamp TEXT)"
+        ],
+    )
+
+    code_placeholder_audit.main(simulate=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/tests/test_init_and_audit.py
+++ b/tests/test_init_and_audit.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import sqlite3
+
+
+def test_init_and_audit(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "ext_backups"))
+    from scripts.utilities import init_and_audit
+    production_db = tmp_path / "databases" / "production.db"
+    analytics_db = tmp_path / "databases" / "analytics.db"
+
+    init_and_audit.run()
+
+    assert production_db.exists()
+    assert analytics_db.exists()
+    with sqlite3.connect(production_db) as conn:
+        cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='template_placeholders'")
+        assert cur.fetchone() is not None


### PR DESCRIPTION
## Summary
- add `init_and_audit.py` to bootstrap databases and run placeholder audit
- document new utility in README
- test initialization via new pytest case

## Testing
- `ruff check scripts/utilities/init_and_audit.py tests/test_init_and_audit.py`
- `pytest tests/test_init_and_audit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e6f309d88331a2bbc8c5c8b6e29b