### PR TITLE
Fix placeholder test imports and monitoring cycle

### DIFF
--- a/tests/test_new_placeholders.py
+++ b/tests/test_new_placeholders.py
@@ -1,4 +1,7 @@
 import importlib
+import os
+import shutil
+import sqlite3
 from pathlib import Path
 from unittest.mock import patch
 import pytest
@@ -6,7 +9,6 @@ import pytest
 from scripts.session.COMPREHENSIVE_WORKSPACE_MANAGER import ComprehensiveWorkspaceManager
 from scripts.file_management.autonomous_file_manager import AutonomousFileManager
 from scripts.file_management.intelligent_file_classifier import IntelligentFileClassifier
-import pytest
 try:
     from scripts.file_management.autonomous_backup_manager import AutonomousBackupManager
 except Exception:  # pragma: no cover - module may have syntax errors
@@ -62,7 +64,7 @@ def test_placeholders_importable(tmp_path, caplog):
     backup_dest = AutonomousBackupManager().create_backup(workspace)
     assert workspace.resolve() not in Path(backup_dest).resolve().parents
     WorkspaceOptimizer().optimize(workspace)
-    ContinuousMonitoringEngine().run_cycle([])
+    ContinuousMonitoringEngine(cycle_seconds=0).run_cycle([])
     AutomatedOptimizationEngine().optimize(workspace)
     IntelligenceGatheringSystem(db / "production.db").gather()
     result = QuantumDatabaseProcessor().quantum_enhanced_query("SELECT 1")


### PR DESCRIPTION
## Summary
- fix imports in `test_new_placeholders`
- avoid long sleep by setting `cycle_seconds=0`

## Testing
- `ruff check tests/test_new_placeholders.py`
- `pyright tests/test_new_placeholders.py`
- `pytest tests/test_new_placeholders.py::test_placeholders_importable -q`
- `ruff check`
- `pyright` *(fails: Import "flask" could not be resolved)*
- `pytest -q` *(fails: 43 failed, 154 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6887c24527188331b27e5c7a58782025