### PR TITLE
feat: log generated docs to production

### DIFF
--- a/scripts/documentation/enterprise_documentation_manager.py
+++ b/scripts/documentation/enterprise_documentation_manager.py
@@ -13,6 +13,7 @@ from template_engine.auto_generator import (
     DEFAULT_COMPLETION_DB,
     TemplateAutoGenerator,
 )
+from utils.database_utils import get_validated_production_db_connection
 
 TEXT_INDICATORS = {
     "start": "[START]",
@@ -33,10 +34,7 @@ class EnterpriseDocumentationManager:
         analytics_db: Path = DEFAULT_ANALYTICS_DB,
         completion_db: Path = DEFAULT_COMPLETION_DB,
     ) -> None:
-        self.workspace = Path(
-            workspace
-            or os.getenv("GH_COPILOT_WORKSPACE", Path(__file__).resolve().parents[2])
-        )
+        self.workspace = Path(workspace or os.getenv("GH_COPILOT_WORKSPACE", Path(__file__).resolve().parents[2]))
         self.db_path = Path(
             db_path
             or os.getenv(
@@ -44,9 +42,7 @@ class EnterpriseDocumentationManager:
                 self.workspace / "archives" / "documentation.db",
             )
         )
-        self.output_dir = (
-            self.workspace / "documentation" / "generated" / "enterprise_docs"
-        )
+        self.output_dir = self.workspace / "documentation" / "generated" / "enterprise_docs"
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.logger = logging.getLogger(__name__)
         self.generator = TemplateAutoGenerator(analytics_db, completion_db)
@@ -55,13 +51,9 @@ class EnterpriseDocumentationManager:
     def query_documentation(self, doc_type: str) -> list[tuple[str, str]]:
         """Return ``doc_id`` and ``content`` for the given ``doc_type``."""
         if not self.db_path.exists():
-            self.logger.error(
-                f"{TEXT_INDICATORS['error']} Missing database {self.db_path}"
-            )
+            self.logger.error(f"{TEXT_INDICATORS['error']} Missing database {self.db_path}")
             return []
-        query = (
-            "SELECT doc_id, content FROM enterprise_documentation WHERE doc_type=?"
-        )
+        query = "SELECT doc_id, content FROM enterprise_documentation WHERE doc_type=?"
         with sqlite3.connect(self.db_path) as conn:
             return conn.execute(query, (doc_type,)).fetchall()
 
@@ -70,9 +62,7 @@ class EnterpriseDocumentationManager:
         """Return best template for ``doc_type`` using ``TemplateAutoGenerator``."""
         template = self.generator.select_best_template(doc_type)
         if not template:
-            self.logger.info(
-                f"{TEXT_INDICATORS['info']} No template found for {doc_type}"
-            )
+            self.logger.info(f"{TEXT_INDICATORS['info']} No template found for {doc_type}")
         return template
 
     # ------------------------------------------------------------------
@@ -83,19 +73,38 @@ class EnterpriseDocumentationManager:
             return []
         template = self.select_template(doc_type)
         generated: List[Path] = []
-        self.logger.info(
-            f"{TEXT_INDICATORS['start']} Generating {doc_type} documentation"
-        )
-        with tqdm(total=len(docs), desc=f"{TEXT_INDICATORS['progress']} docs", unit="doc") as bar:
-            for doc_id, content in docs:
-                text = template.replace("{content}", content) if template else content
-                path = self.output_dir / f"{doc_id}.md"
-                path.write_text(text)
-                generated.append(path)
-                bar.update(1)
-        self.logger.info(
-            f"{TEXT_INDICATORS['success']} Generated {len(generated)} {doc_type} files"
-        )
+        self.logger.info(f"{TEXT_INDICATORS['start']} Generating {doc_type} documentation")
+        # record generation details in production.db
+        with get_validated_production_db_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS documentation_status (
+                    doc_id TEXT PRIMARY KEY,
+                    path TEXT,
+                    generated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            with tqdm(total=len(docs), desc=f"{TEXT_INDICATORS['progress']} docs", unit="doc") as bar:
+                for doc_id, content in docs:
+                    text = template.replace("{content}", content) if template else content
+                    path = self.output_dir / f"{doc_id}.md"
+                    path.write_text(text)
+                    generated.append(path)
+                    cur.execute(
+                        """
+                        INSERT INTO documentation_status (doc_id, path, generated_at)
+                        VALUES (?, ?, CURRENT_TIMESTAMP)
+                        ON CONFLICT(doc_id) DO UPDATE SET
+                            path=excluded.path,
+                            generated_at=excluded.generated_at
+                        """,
+                        (doc_id, str(path)),
+                    )
+                    bar.update(1)
+            conn.commit()
+        self.logger.info(f"{TEXT_INDICATORS['success']} Generated {len(generated)} {doc_type} files")
         return generated
 
 

--- a/tests/test_documentation_manager.py
+++ b/tests/test_documentation_manager.py
@@ -11,16 +11,10 @@ def create_template_dbs(tmp_path: Path):
     analytics_db = tmp_path / "analytics.db"
     completion_db = tmp_path / "template_completion.db"
     with sqlite3.connect(analytics_db) as conn:
-        conn.execute(
-            "CREATE TABLE ml_pattern_optimization (replacement_template TEXT)"
-        )
-        conn.execute(
-            "INSERT INTO ml_pattern_optimization VALUES ('{content}')"
-        )
+        conn.execute("CREATE TABLE ml_pattern_optimization (replacement_template TEXT)")
+        conn.execute("INSERT INTO ml_pattern_optimization VALUES ('{content}')")
     with sqlite3.connect(completion_db) as conn:
-        conn.execute(
-            "CREATE TABLE templates (template_content TEXT)"
-        )
+        conn.execute("CREATE TABLE templates (template_content TEXT)")
         conn.execute("INSERT INTO templates VALUES ('{content}')")
     return analytics_db, completion_db
 
@@ -33,9 +27,7 @@ def test_generate_files(tmp_path, monkeypatch):
     doc_dir.mkdir()
     db_path = db_dir / "documentation.db"
     with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            "CREATE TABLE enterprise_documentation (doc_id TEXT, doc_type TEXT, content TEXT)"
-        )
+        conn.execute("CREATE TABLE enterprise_documentation (doc_id TEXT, doc_type TEXT, content TEXT)")
         conn.executemany(
             "INSERT INTO enterprise_documentation VALUES (?,?,?)",
             [("1", "README", "alpha"), ("2", "README", "beta")],
@@ -54,3 +46,40 @@ def test_generate_files(tmp_path, monkeypatch):
     for f in files:
         assert f.exists()
         assert f.read_text() in {"alpha", "beta"}
+
+
+def test_generate_files_records_status(tmp_path, monkeypatch):
+    workspace = tmp_path
+    db_dir = workspace / "databases"
+    doc_dir = workspace / "documentation"
+    db_dir.mkdir()
+    doc_dir.mkdir()
+    doc_db = db_dir / "documentation.db"
+    prod_db = db_dir / "production.db"
+    prod_db.touch()
+    with sqlite3.connect(doc_db) as conn:
+        conn.execute("CREATE TABLE enterprise_documentation (doc_id TEXT, doc_type TEXT, content TEXT)")
+        conn.executemany(
+            "INSERT INTO enterprise_documentation VALUES (?,?,?)",
+            [("1", "README", "alpha"), ("2", "README", "beta")],
+        )
+
+    analytics_db, completion_db = create_template_dbs(tmp_path)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("DOCUMENTATION_DB_PATH", str(doc_db))
+    manager = EnterpriseDocumentationManager(
+        workspace=workspace,
+        db_path=doc_db,
+        analytics_db=analytics_db,
+        completion_db=completion_db,
+    )
+
+    manager.generate_files("README")
+
+    with sqlite3.connect(prod_db) as conn:
+        rows = conn.execute("SELECT doc_id, path FROM documentation_status ORDER BY doc_id").fetchall()
+
+    assert rows == [
+        ("1", str(workspace / "documentation" / "generated" / "enterprise_docs" / "1.md")),
+        ("2", str(workspace / "documentation" / "generated" / "enterprise_docs" / "2.md")),
+    ]


### PR DESCRIPTION
## Summary
- log generated documentation files to `production.db`
- test documentation manager updates new table

## Testing
- `pytest tests/test_documentation_manager.py::test_generate_files tests/test_documentation_manager.py::test_generate_files_records_status -q`


------
https://chatgpt.com/codex/tasks/task_e_6887cfbe07ac8331bcec6c8b6d01ff41