### PR TITLE
feat: orchestrate monitoring cycles via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --s
 python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --status
 python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --stop
 ```
+Set `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT` before invoking to ensure logs and databases are found.
+
+### Workspace Optimizer CLI
+Archive rarely used files and log metrics:
+
+```bash
+export GH_COPILOT_WORKSPACE=$(pwd)
+export GH_COPILOT_BACKUP_ROOT=/path/to/backups
+python scripts/file_management/workspace_optimizer.py
+```
 
 ### Docker Usage
 Build and run the container with Docker:


### PR DESCRIPTION
## Summary
- add CLI with DualCopilotOrchestrator to `continuous_monitoring_engine`
- log health check and remediation failures with stack traces
- test orchestrated monitoring cycles and error handling
- document workspace optimizer and deployment orchestrator CLI usage

## Testing
- `ruff check scripts/monitoring/continuous_monitoring_engine.py tests/test_continuous_monitoring_engine.py README.md`
- `pytest -q tests/test_continuous_monitoring_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6887cf172218833195ece95c7ac4ede4