### PR TITLE
Add flake8 auto-fix utilities

### DIFF
--- a/scripts/utilities/critical_flake8_error_corrector.py
+++ b/scripts/utilities/critical_flake8_error_corrector.py
@@ -16,10 +16,12 @@ from datetime import datetime
 from pathlib import Path
 from tqdm import tqdm
 import os
+import subprocess
 from copilot.common.workspace_utils import (
     get_workspace_path,
     _within_workspace,
 )
+from .flake8_corrector_base import EnterpriseFlake8Corrector as BaseCorrector
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -31,69 +33,46 @@ TEXT_INDICATORS = {
 }
 
 
-class EnterpriseFlake8Corrector:
+class EnterpriseFlake8Corrector(BaseCorrector):
     """Enterprise-grade Flake8 correction system"""
 
     def __init__(self, workspace_path: str = os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")):
-        self.workspace_path = Path(workspace_path)
-        self.logger = logging.getLogger(__name__)
-
-    def execute_correction(self) -> bool:
-        """Execute Flake8 correction with visual indicators"""
-        start_time = datetime.now()
-        self.logger.info(f"{TEXT_INDICATORS['start']} Correction started: {start_time}")
-
-        try:
-            with tqdm(total=100, desc="[PROGRESS] Flake8 Correction", unit="%") as pbar:
-
-                pbar.set_description("[PROGRESS] Scanning files")
-                files_to_correct = self.scan_python_files()
-                pbar.update(25)
-
-                pbar.set_description("[PROGRESS] Applying corrections")
-                corrected_files = self.apply_corrections(files_to_correct)
-                pbar.update(50)
-
-                pbar.set_description("[PROGRESS] Validating results")
-                validation_passed = self.validate_corrections(corrected_files)
-                pbar.update(25)
-
-            duration = (datetime.now() - start_time).total_seconds()
-            self.logger.info(
-                f"{TEXT_INDICATORS['success']} Correction completed in {duration:.1f}s")
-            return validation_passed
-
-        except Exception as e:
-            self.logger.error(f"{TEXT_INDICATORS['error']} Correction failed: {e}")
-            return False
-
-    def scan_python_files(self) -> list:
-        """Scan for Python files requiring correction"""
-        python_files = []
-        for py_file in self.workspace_path.rglob("*.py"):
-            python_files.append(str(py_file))
-        return python_files
-
-    def apply_corrections(self, files: list) -> list:
-        """Apply corrections to files"""
-        corrected = []
-        for file_path in files:
-            if self.correct_file(file_path):
-                corrected.append(file_path)
-        return corrected
+        super().__init__(workspace_path)
 
     def correct_file(self, file_path: str) -> bool:
         """Correct a single file"""
         try:
-            # Implementation for file correction
-            return True
+            check = subprocess.run([
+                sys.executable,
+                "-m",
+                "flake8",
+                file_path,
+            ], capture_output=True, text=True)
+
+            if check.returncode == 0:
+                return False
+
+            original = Path(file_path).read_text(encoding="utf-8")
+
+            fix = subprocess.run([
+                sys.executable,
+                "-m",
+                "autopep8",
+                "--in-place",
+                file_path,
+            ], capture_output=True, text=True)
+
+            if fix.returncode != 0:
+                self.logger.error(
+                    f"{TEXT_INDICATORS['error']} File correction failed: {fix.stderr.strip()}"
+                )
+                return False
+
+            updated = Path(file_path).read_text(encoding="utf-8")
+            return original != updated
         except Exception as e:
             self.logger.error(f"{TEXT_INDICATORS['error']} File correction failed: {e}")
             return False
-
-    def validate_corrections(self, files: list) -> bool:
-        """Validate that corrections were successful"""
-        return len(files) > 0
 
 
 def main() -> bool:

--- a/scripts/utilities/flake8_corrector_base.py
+++ b/scripts/utilities/flake8_corrector_base.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Shared Flake8 correction utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from tqdm import tqdm
+
+
+class EnterpriseFlake8Corrector:
+    """Common functionality for simple flake8 based corrections."""
+
+    def __init__(self, workspace_path: str = os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) -> None:
+        self.workspace_path = Path(workspace_path)
+        self.logger = logging.getLogger(__name__)
+
+    def execute_correction(self) -> bool:
+        """Execute correction over all python files."""
+        start_time = datetime.now()
+        self.logger.info("[START] Correction started: %s", start_time)
+        try:
+            with tqdm(total=100, desc="[PROGRESS] Flake8 Correction", unit="%") as pbar:
+                pbar.set_description("[PROGRESS] Scanning files")
+                files = self.scan_python_files()
+                pbar.update(25)
+
+                pbar.set_description("[PROGRESS] Applying corrections")
+                corrected = self.apply_corrections(files)
+                pbar.update(50)
+
+                pbar.set_description("[PROGRESS] Validating results")
+                valid = self.validate_corrections(corrected)
+                pbar.update(25)
+
+            duration = (datetime.now() - start_time).total_seconds()
+            self.logger.info("[SUCCESS] Correction completed in %.1fs", duration)
+            return valid
+        except Exception as e:
+            self.logger.error("[ERROR] Correction failed: %s", e)
+            return False
+
+    def scan_python_files(self) -> list[str]:
+        """Return a list of python files under the workspace."""
+        return [str(p) for p in self.workspace_path.rglob("*.py")]
+
+    def apply_corrections(self, files: list[str]) -> list[str]:
+        """Apply corrections to provided files."""
+        corrected = []
+        for file_path in files:
+            if self.correct_file(file_path):
+                corrected.append(file_path)
+        return corrected
+
+    def correct_file(self, file_path: str) -> bool:  # pragma: no cover - overridden
+        """Correct a single file. Implemented in subclasses."""
+        raise NotImplementedError
+
+    def validate_corrections(self, files: list[str]) -> bool:
+        """Basic validation that something changed."""
+        return bool(files)

--- a/tests/test_flake8_fixers.py
+++ b/tests/test_flake8_fixers.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Tests for simple flake8 fixers."""
+
+from scripts.utilities.targeted_flake8_fixer import EnterpriseFlake8Corrector
+from scripts.utilities.critical_flake8_error_corrector import EnterpriseFlake8Corrector as CriticalCorrector
+
+
+def _write_bad_file(path):
+    path.write_text("print('hi')  \n", encoding="utf-8")
+
+
+def test_targeted_correct_file(tmp_path):
+    bad = tmp_path / "bad.py"
+    _write_bad_file(bad)
+    fixer = EnterpriseFlake8Corrector(workspace_path=str(tmp_path))
+    changed = fixer.correct_file(str(bad))
+    assert changed
+    assert bad.read_text(encoding="utf-8") == "print('hi')\n"
+
+
+def test_critical_correct_file(tmp_path):
+    bad = tmp_path / "bad.py"
+    _write_bad_file(bad)
+    fixer = CriticalCorrector(workspace_path=str(tmp_path))
+    changed = fixer.correct_file(str(bad))
+    assert changed
+    assert bad.read_text(encoding="utf-8") == "print('hi')\n"


### PR DESCRIPTION
## Summary
- implement `EnterpriseFlake8Corrector` base class for running flake8 and autopep8
- update `critical_flake8_error_corrector` and `targeted_flake8_fixer` to use the base class
- add tests verifying automatic correction of simple flake8 violations

## Testing
- `ruff check scripts/utilities/flake8_corrector_base.py scripts/utilities/critical_flake8_error_corrector.py scripts/utilities/targeted_flake8_fixer.py tests/test_flake8_fixers.py`
- `pytest -q tests/test_flake8_fixers.py`


------
https://chatgpt.com/codex/tasks/task_e_6887d0b826788331adfd405ee0e80ee0