### PR TITLE
feat: update bot docs and lint config

### DIFF
--- a/docs/chatgpt_bot_integration_guide.md
+++ b/docs/chatgpt_bot_integration_guide.md
@@ -19,21 +19,27 @@ Set the following variables before starting the services:
 - `GH_COPILOT_WORKSPACE` – absolute path to the repository root.
 - `GH_COPILOT_BACKUP_ROOT` – directory outside the workspace for logs and backups.
 - `GITHUB_TOKEN` – token with access to your organization.
-- `WEBHOOK_SECRET` – shared secret for validating incoming GitHub webhooks.
+- `GITHUB_WEBHOOK_SECRET` – shared secret for validating incoming GitHub webhooks.
 
 Export them manually or place them in a `.env` file and `source` it.
 
 ## Example Commands
 ### Start the Webhook Server
 ```bash
-python github_integration/webhook_server.py --host 0.0.0.0 --port 9000
+python scripts/bot/webhook_server.py
 ```
 The server listens for GitHub events and triggers automation workflows.
 
 ### Assign Copilot Licenses
 ```bash
-python github_integration/assign_copilot_license.py --org my-org --user alice
+python scripts/bot/assign_copilot_license.py my-org chatgpt-bot
 ```
 Use this script to grant GitHub Copilot licenses to new team members.
 
 Both scripts log activity under `$GH_COPILOT_BACKUP_ROOT/logs` and record events in `production.db`.
+
+## Testing & Validation
+Run the integration checks after configuration to ensure both components work:
+```bash
+python scripts/bot/test_integration.py
+```

--- a/scripts/bot/assign_copilot_license.py
+++ b/scripts/bot/assign_copilot_license.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Manage GitHub Copilot seat assignments via REST API."""
+# pyright: reportMissingImports=false
 
 from __future__ import annotations
 

--- a/scripts/bot/test_integration.py
+++ b/scripts/bot/test_integration.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Integration test utilities for the bot scripts."""
+# pyright: reportMissingImports=false
 
 from __future__ import annotations
 

--- a/scripts/bot/webhook_server.py
+++ b/scripts/bot/webhook_server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Minimal GitHub webhook server with HMAC validation."""
+# pyright: reportMissingImports=false
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- fix docs to point to `scripts/bot` utilities
- silence Pyright import warnings for bot scripts

## Testing
- `ruff check scripts/bot tests/test_bot.py`
- `pyright scripts/bot tests/test_bot.py`
- `pytest -q tests/test_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6887e67916908331bed9027fa59c19ea