### PR TITLE
Fix audit workflow dependency install

### DIFF
--- a/.github/workflows/compliance-audit.yml
+++ b/.github/workflows/compliance-audit.yml
@@ -10,6 +10,14 @@ jobs:
       GH_COPILOT_WORKSPACE: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tqdm
+          pip install -r requirements.txt
       - name: Run placeholder audit
         env:
           GH_COPILOT_WORKSPACE: ${{ github.workspace }}

--- a/README.md
+++ b/README.md
@@ -816,6 +816,8 @@ python scripts/code_placeholder_audit.py \
 # The audit automatically populates `code_audit_log` in analytics.db for
 # compliance reporting.
 # Run `scripts/database/add_code_audit_log.py` if the table is missing.
+The `compliance-audit.yml` workflow now installs dependencies, including
+`tqdm`, using Python 3.11 before invoking this script.
 
 # Generate scored documentation templates
 python docs/quantum_template_generator.py

--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -23,7 +23,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ModuleNotFoundError:  # pragma: no cover - fallback for ad-hoc use
+    import subprocess
+    import sys
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "tqdm"])
+    from tqdm import tqdm
 
 from scripts.continuous_operation_orchestrator import (
     validate_enterprise_operation,


### PR DESCRIPTION
## Summary
- auto-install tqdm inside `code_placeholder_audit`
- ensure GitHub Actions installs requirements for compliance audit
- document the new workflow behavior in README

## Testing
- `ruff check scripts/code_placeholder_audit.py --exit-zero`
- `pytest -q` *(fails: 45 failed, 192 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887eed07ec083319160c9db47cf6023