### PR TITLE
Add negative webhook and license tests

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -20,6 +20,20 @@ def test_webhook_signature(monkeypatch, tmp_path):
     assert res.status_code == 200
 
 
+def test_webhook_invalid_signature(monkeypatch, tmp_path):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test")
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path))
+    app = create_app()
+    client = app.test_client()
+    payload = b"{}"
+    import hmac
+    import hashlib
+
+    sig = "sha256=" + hmac.new(b"wrong", payload, hashlib.sha256).hexdigest()
+    res = client.post("/webhook", data=payload, headers={"X-Hub-Signature-256": sig})
+    assert res.status_code == 400
+
+
 def test_assign_license(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "t")
     monkeypatch.setenv("GITHUB_ORG", "o")
@@ -29,3 +43,12 @@ def test_assign_license(monkeypatch):
         mock_post.return_value.text = "ok"
         assert assign_license("user")
 
+
+def test_assign_license_error(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_ORG", "o")
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", "/tmp")
+    with mock.patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 403
+        mock_post.return_value.text = "fail"
+        assert not assign_license("user")


### PR DESCRIPTION
## Summary
- extend `test_bot.py` with invalid webhook signature case
- add failure path for assigning license

## Testing
- `ruff check tests/test_bot.py`
- `pyright tests/test_bot.py`
- `pytest tests/test_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6887fbc3b2a08331bf887dad3d5f406c