### PR TITLE
Fix duplicate imports in tests

### DIFF
--- a/tests/test_complete_consolidation_orchestrator.py
+++ b/tests/test_complete_consolidation_orchestrator.py
@@ -1,7 +1,6 @@
 import os
 import sqlite3
 from pathlib import Path
-import os
 
 import py7zr  # pyright: ignore[reportMissingImports]
 import pytest

--- a/tests/test_qubo_solver.py
+++ b/tests/test_qubo_solver.py
@@ -7,7 +7,7 @@ from scripts.optimization.advanced_qubo_optimization import (
 )
 
 
-class DummyTqdm:
+class SimpleDummyTqdm:
     """Minimal tqdm replacement for progress validation."""
 
     def __init__(self, iterable, *args, **kwargs):
@@ -33,7 +33,7 @@ def test_solve_qubo_bruteforce(monkeypatch):
     bars = []
 
     def dummy_tqdm(iterable, *args, **kwargs):
-        bar = DummyTqdm(iterable)
+        bar = RecordingDummyTqdm(iterable)
         bars.append(bar)
         return bar
 
@@ -47,7 +47,7 @@ def test_solve_qubo_bruteforce(monkeypatch):
     assert energy == -2.0
 
 
-class DummyTqdm:
+class RecordingDummyTqdm:
     """Minimal tqdm replacement for progress validation."""
 
     def __init__(self, iterable, *args, **kwargs):
@@ -80,7 +80,7 @@ def test_execute_utility_progress_and_db(tmp_path, monkeypatch, caplog):
     bars = []
 
     def dummy_tqdm(iterable, *args, **kwargs):
-        bar = DummyTqdm(iterable, *args, **kwargs)
+        bar = RecordingDummyTqdm(iterable, *args, **kwargs)
         bars.append(bar)
         return bar
 


### PR DESCRIPTION
## Summary
- fix duplicate `os` import in `test_complete_consolidation_orchestrator`
- avoid DummyTqdm redefinition in `test_qubo_solver`

## Testing
- `ruff check tests`
- `pytest tests/test_complete_consolidation_orchestrator.py tests/test_qubo_solver.py -q` *(fails: SevenZipFile.__init__() got an unexpected keyword argument 'compression_level')*

------
https://chatgpt.com/codex/tasks/task_e_6887fbd5e3cc83319d6d84bfede2f647