### PR TITLE
docs: clarify bot license setup

### DIFF
--- a/docs/chatgpt_bot_integration_guide.md
+++ b/docs/chatgpt_bot_integration_guide.md
@@ -18,6 +18,7 @@ This guide explains how to run the optional GitHub bot components used in enterp
 Set the following variables before starting the services:
 - `GH_COPILOT_WORKSPACE` – absolute path to the repository root.
 - `GH_COPILOT_BACKUP_ROOT` – directory outside the workspace for logs and backups.
+- `GITHUB_ORG` – name of your GitHub organization used for license management.
 - `GITHUB_TOKEN` – token with access to your organization.
 - `GITHUB_WEBHOOK_SECRET` – shared secret for validating incoming GitHub webhooks.
 
@@ -32,9 +33,10 @@ The server listens for GitHub events and triggers automation workflows.
 
 ### Assign Copilot Licenses
 ```bash
-python scripts/bot/assign_copilot_license.py my-org chatgpt-bot
+python scripts/bot/assign_copilot_license.py chatgpt-bot
 ```
-Use this script to grant GitHub Copilot licenses to new team members.
+Use this script to grant GitHub Copilot licenses to new team members. The target
+organization is read from `GITHUB_ORG`.
 
 Both scripts log activity under `$GH_COPILOT_BACKUP_ROOT/logs` and record events in `production.db`.
 


### PR DESCRIPTION
## Summary
- document GITHUB_ORG usage for license scripts
- fix example for `assign_copilot_license.py`

## Testing
- `ruff check scripts/bot`
- `pytest -q` *(fails: 46 failed, 193 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6888034cc8d083318ff216b843b78b8c