### PR TITLE
Implement Dual Copilot validation for license assignment

### DIFF
--- a/docs/chatgpt_bot_integration_guide.md
+++ b/docs/chatgpt_bot_integration_guide.md
@@ -36,7 +36,9 @@ The server listens for GitHub events and triggers automation workflows.
 python scripts/bot/assign_copilot_license.py chatgpt-bot
 ```
 Use this script to grant GitHub Copilot licenses to new team members. The target
-organization is read from `GITHUB_ORG`.
+organization is read from `GITHUB_ORG`. The license operation runs through the
+`DualCopilotOrchestrator`, ensuring visual progress indicators and automatic
+flake8 validation after execution.
 
 Both scripts log activity under `$GH_COPILOT_BACKUP_ROOT/logs` and record events in `production.db`.
 


### PR DESCRIPTION
## Summary
- integrate `DualCopilotOrchestrator` into `assign_copilot_license.py`
- document Dual Copilot usage in ChatGPT bot guide
- ensure new orchestrator call is tested

## Testing
- `ruff check scripts/bot/assign_copilot_license.py tests/test_bot.py`
- `pytest tests/test_bot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68881ae8168c8331b45805e52a29fa15