### PR TITLE
docs: add catalog issue template

### DIFF
--- a/reports/generated_issue_templates.md
+++ b/reports/generated_issue_templates.md
@@ -34,3 +34,8 @@
 - **Labels**: bug, devops
 - **Assignee**: devops-team
 - **Description**: Ensure the Dockerfile uses an explicit entrypoint script that sets required environment variables before starting `dashboard/enterprise_dashboard.py`.
+
+## 8. Catalog missing and incomplete modules in gh_COPILOT
+- **Labels**: documentation, analysis, help wanted, triage
+- **Assignee**: maintainer
+- **Description**: Collect and document all `STUB-*` references listed in `docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md`. Summarize the missing modules and features so maintainers can prioritize implementation work.


### PR DESCRIPTION
Resolves the task derived from the YAML issue in prior conversation.

## Summary
- add new entry to `reports/generated_issue_templates.md` to catalog missing modules referenced by STUB markers

## Testing
- `ruff check .` *(fails: 35 errors)*
- `pyright` *(failed; log empty due to interruption)*
- `pytest -q` *(fails: 42 failed, 198 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688831f7799483319a84f6e8c9e186fd