### PR TITLE
feat: track resolved placeholders

### DIFF
--- a/scripts/dashboard_placeholder_sync.py
+++ b/scripts/dashboard_placeholder_sync.py
@@ -22,7 +22,9 @@ def sync(dashboard_dir: Path, analytics_db: Path) -> None:
     count = 0
     if analytics_db.exists():
         with sqlite3.connect(analytics_db) as conn:
-            cur = conn.execute("SELECT COUNT(*) FROM todo_fixme_tracking")
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=0"
+            )
             count = cur.fetchone()[0]
 
     compliance = max(0, 100 - count)

--- a/tests/test_code_placeholder_audit_logger.py
+++ b/tests/test_code_placeholder_audit_logger.py
@@ -47,7 +47,7 @@ def test_dashboard_placeholder_sync(tmp_path):
     with sqlite3.connect(analytics) as conn:
         conn.execute(
             (
-                "CREATE TABLE todo_fixme_tracking (file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, timestamp TEXT)"
+                "CREATE TABLE todo_fixme_tracking (file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, timestamp TEXT, resolved BOOLEAN DEFAULT 0, resolved_timestamp TEXT)"
             )
         )
         conn.execute(
@@ -55,7 +55,11 @@ def test_dashboard_placeholder_sync(tmp_path):
                 "CREATE TABLE code_audit_log (id INTEGER PRIMARY KEY, file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, timestamp TEXT)"
             )
         )
-        conn.execute(("INSERT INTO todo_fixme_tracking VALUES ('f', 1, 'TODO', 'ctx', 'ts')"))
+        conn.execute(
+            (
+                "INSERT INTO todo_fixme_tracking VALUES ('f', 1, 'TODO', 'ctx', 'ts', 0, NULL)"
+            )
+        )
         conn.execute(
             (
                 "INSERT INTO code_audit_log (file_path, line_number, placeholder_type, context, timestamp) VALUES ('f', 1, 'TODO', 'ctx', 'ts')"
@@ -75,7 +79,7 @@ def test_rollback_last_entry(tmp_path):
     with sqlite3.connect(analytics) as conn:
         conn.execute(
             (
-                "CREATE TABLE todo_fixme_tracking (file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, timestamp TEXT)"
+                "CREATE TABLE todo_fixme_tracking (file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, timestamp TEXT, resolved BOOLEAN DEFAULT 0, resolved_timestamp TEXT)"
             )
         )
         conn.execute(
@@ -85,7 +89,11 @@ def test_rollback_last_entry(tmp_path):
                 "context TEXT, timestamp TEXT)"
             )
         )
-        conn.execute(("INSERT INTO todo_fixme_tracking VALUES ('f', 1, 'TODO', 'ctx', 'ts')"))
+        conn.execute(
+            (
+                "INSERT INTO todo_fixme_tracking VALUES ('f', 1, 'TODO', 'ctx', 'ts', 0, NULL)"
+            )
+        )
         conn.execute(
             (
                 "INSERT INTO code_audit_log (file_path, line_number, placeholder_type, "

--- a/tests/test_placeholder_resolution.py
+++ b/tests/test_placeholder_resolution.py
@@ -1,0 +1,37 @@
+import os
+import sqlite3
+
+os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+
+from scripts.code_placeholder_audit import main
+
+
+def test_placeholder_resolution(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    target = workspace / "demo.py"
+    target.write_text("def demo():\n    pass  # TODO\n")
+
+    analytics = tmp_path / "analytics.db"
+
+    assert main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(tmp_path / "dashboard"),
+    )
+
+    target.write_text("def demo():\n    pass\n")
+    assert main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(tmp_path / "dashboard"),
+    )
+
+    with sqlite3.connect(analytics) as conn:
+        row = conn.execute(
+            "SELECT resolved FROM todo_fixme_tracking WHERE file_path=?",
+            (str(target),),
+        ).fetchone()
+    assert row and row[0] == 1


### PR DESCRIPTION
## Summary
- add `resolved` columns in placeholder audit DB table
- update placeholder audit script to mark resolved placeholders
- count unresolved placeholders in dashboard sync
- add unit test for placeholder resolution

## Testing
- `ruff check scripts/code_placeholder_audit.py scripts/dashboard_placeholder_sync.py dashboard/compliance_metrics_updater.py tests/test_code_placeholder_audit_logger.py tests/test_placeholder_resolution.py`
- `pytest tests/test_placeholder_audit.py::test_placeholder_logging tests/test_audit_codebase_placeholders.py::test_audit_places tests/test_code_placeholder_audit_logger.py::test_placeholder_audit_logger tests/test_code_placeholder_audit_logger.py::test_dashboard_placeholder_sync tests/test_code_placeholder_audit_logger.py::test_rollback_last_entry tests/test_placeholder_resolution.py::test_placeholder_resolution -q`


------
https://chatgpt.com/codex/tasks/task_e_688856bc172083318d41e617db9483f1