### PR TITLE
Add ingest_assets and metrics updater tests

### DIFF
--- a/tests/test_compliance_metrics_updater.py
+++ b/tests/test_compliance_metrics_updater.py
@@ -30,4 +30,7 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch):
     assert metrics_file.exists()
     data = json.loads(metrics_file.read_text())
     assert data["metrics"]["placeholder_removal"] == 1
+    assert data["metrics"]["compliance_score"] == 0.9
+    assert data["metrics"]["violation_count"] == 1
+    assert data["metrics"]["rollback_count"] == 1
     assert data["metrics"]["progress_status"] == "issues_pending"

--- a/tests/test_setup_ingest_audit.py
+++ b/tests/test_setup_ingest_audit.py
@@ -1,0 +1,39 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.unified_database_initializer import initialize_database
+from scripts.automation.setup_ingest_audit import ingest_assets
+
+
+def test_ingest_assets(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path.parent / "backups"))
+
+    docs_dir = tmp_path / "documentation"
+    docs_dir.mkdir()
+    (docs_dir / "doc.md").write_text("# doc")
+
+    templates_dir = tmp_path / "prompts"
+    templates_dir.mkdir()
+    (templates_dir / "temp.md").write_text("template")
+
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    db_path = db_dir / "enterprise_assets.db"
+    initialize_database(db_path)
+
+    ingest_assets(tmp_path)
+
+    with sqlite3.connect(db_path) as conn:
+        doc_count = conn.execute("SELECT COUNT(*) FROM documentation_assets").fetchone()[0]
+        template_count = conn.execute("SELECT COUNT(*) FROM template_assets").fetchone()[0]
+        pattern_count = conn.execute("SELECT COUNT(*) FROM pattern_assets").fetchone()[0]
+        ops_count = conn.execute(
+            "SELECT COUNT(*) FROM cross_database_sync_operations"
+        ).fetchone()[0]
+
+    assert doc_count == 1
+    assert template_count == 1
+    assert pattern_count == 1
+    # two records from database initialization and one each from docs/templates
+    assert ops_count == 4


### PR DESCRIPTION
## Summary
- ensure ingest_assets populates documentation/templates
- verify ComplianceMetricsUpdater handles new log tables

## Testing
- `ruff check tests/test_setup_ingest_audit.py tests/test_compliance_metrics_updater.py`
- `pytest tests/test_setup_ingest_audit.py tests/test_compliance_metrics_updater.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688856c769b88331bd9c926234276194