### PR TITLE
docs: add stub module status

### DIFF
--- a/docs/STUB_MODULE_STATUS.md
+++ b/docs/STUB_MODULE_STATUS.md
@@ -1,0 +1,21 @@
+# Stub Modules Status
+
+This document catalogs incomplete or missing modules referenced across the repository documentation. It is derived from `docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md` and a quick audit of the filesystem.
+
+## Status Table
+| ID | Module/Path(s) | Exists? | Notes |
+|----|---------------|---------|-------|
+| STUB-001 | scripts/code_placeholder_audit.py | Yes | - |
+| STUB-002 | template_engine/auto_generator.py,<br>template_engine/db_first_code_generator.py,<br>pattern_mining_engine.py,<br>objective_similarity_scorer.py | Yes | - |
+| STUB-003 | template_engine/template_synchronizer.py,<br>copilot/copilot-instructions.md | Yes | - |
+| STUB-004 | scripts/database/documentation_db_analyzer.py,<br>dashboard/compliance_metrics_updater.py,<br>databases/analytics.db | Yes | - |
+| STUB-005 | archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py,<br>README.md,<br>docs/DATABASE_FIRST_USAGE_GUIDE.md | Partial | Missing `archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py` |
+| STUB-006 | quantum_algorithm_library_expansion.py,<br>template_engine/auto_generator.py | Yes | - |
+| STUB-007 | dashboard/enterprise_dashboard.py,<br>web_gui/scripts/flask_apps/enterprise_dashboard.py,<br>web_gui/templates/html/ | Partial | `web_gui/templates/html/` not found |
+| STUB-008 | tests/, validation/ | Yes | - |
+| STUB-009 | template_engine/workflow_enhancer.py,<br>archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py | Partial | Same missing archive script |
+| STUB-010 | docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md,<br>logs/, validation/ | Yes | - |
+| STUB-011 | various modules | N/A | Requires manual review |
+| STUB-012 | dashboard/compliance_metrics_updater.py | Yes | - |
+
+

--- a/reports/MISSING_INCOMPLETE_COMPONENTS_AUDIT.md
+++ b/reports/MISSING_INCOMPLETE_COMPONENTS_AUDIT.md
@@ -2,6 +2,8 @@
 
 This report identifies placeholder implementations and incomplete features in the `gh_COPILOT` codebase (pre-release **Aries-Serpent**) and proposes next steps.
 
+See `docs/STUB_MODULE_STATUS.md` for a checklist of stub modules and whether the referenced paths currently exist.
+
 ## Analysis / Discovery Report
 | Item/Name | Details/Notes | Last Updated |
 |-----------|---------------|--------------|


### PR DESCRIPTION
## Summary
- add STUB_MODULE_STATUS.md cataloging stub modules and whether paths exist
- reference the new table from MISSING_INCOMPLETE_COMPONENTS_AUDIT.md

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688861a59bcc8331953c6582e64e6f0e