### PR TITLE
docs: summarize verified module metrics

### DIFF
--- a/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
+++ b/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
@@ -168,3 +168,13 @@ implemented consistently.
 | `STUB-010` | Update task suggestion file and logs with cross-references | `docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md`, `logs/`, `validation/` | Cross-Referencing |
 | `STUB-011` | Ensure all modules record outputs to `analytics.db` and link to compliance reports | various modules | Final Validation |
 | `STUB-012` | Display placeholder removal progress status on dashboard metrics | `dashboard/compliance_metrics_updater.py` | Compliance Dashboard |
+
+## 19. Verified Module Status and Quality Metrics
+
+Recent reports confirm several modules have reached production-ready status. Key metrics include:
+
+- **Python Compliance**: [databases_python_compliance_action_statement.md](../reports/databases_python_compliance_action_statement.md) lists 100% compatibility for Python 3.10/3.11, zero flake8 violations and full database reproduction.
+- **Test Coverage**: [`comprehensive_test_results.json`](../comprehensive_test_results.json) records four executed tests with all passing.
+- **Deployment Verification**: [`ENTERPRISE_DEPLOYMENT_COMPLETION_REPORT.json`](../reports/ENTERPRISE_DEPLOYMENT_COMPLETION_REPORT.json) marks deployment modules as *100% VERIFIED* and *ENTERPRISE READY*.
+
+For modules still labeled `STUB-*`, refer to Issue **8. Catalog missing and incomplete modules** in [`reports/generated_issue_templates.md`](../reports/generated_issue_templates.md). Use these verified metrics to prioritize the unresolved items.


### PR DESCRIPTION
## Summary
- document the quality metrics confirming database-first modules are ready
- cross-reference the generated issue templates for missing module tracking

## Testing
- `ruff check docs`
- `pyright docs`
- `pytest -q tests/test_archive_scripts.py` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68886376f25083319071b5aa3f44e56b