### PR TITLE
Fix docs path references

### DIFF
--- a/builds/final/production/builds/artifacts/documentation/FINAL_PROJECT_VALIDATION_SUMMARY.md
+++ b/builds/final/production/builds/artifacts/documentation/FINAL_PROJECT_VALIDATION_SUMMARY.md
@@ -110,7 +110,7 @@
 
 ### **Template Architecture**
 ```
-web_gui/templates/html/
+web_gui/templates/
 ├── base_enterprise.html (✅ Bootstrap 5 framework)
 ├── dashboard.html (✅ Real-time metrics)
 ├── analytics.html (✅ Data visualization)

--- a/builds/production/builds/artifacts/documentation/FINAL_PROJECT_VALIDATION_SUMMARY.md
+++ b/builds/production/builds/artifacts/documentation/FINAL_PROJECT_VALIDATION_SUMMARY.md
@@ -110,7 +110,7 @@
 
 ### **Template Architecture**
 ```
-web_gui/templates/html/
+web_gui/templates/
 ├── base_enterprise.html (✅ Bootstrap 5 framework)
 ├── dashboard.html (✅ Real-time metrics)
 ├── analytics.html (✅ Data visualization)

--- a/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
+++ b/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
@@ -162,7 +162,7 @@ implemented consistently.
 | `STUB-004` | Log all correction history with rollback design and compliance metrics | `documentation_db_analyzer.py`, `compliance_metrics_updater.py`, `databases/analytics.db` | Correction Logging |
 | `STUB-005` | Enhance documentation manager with DB-first templates and multi-format rendering | `archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py`, `README.md`, `DATABASE_FIRST_USAGE_GUIDE.md` | Documentation Framework |
 | `STUB-006` | Integrate quantum-inspired scoring and clustering hooks | `quantum/quantum_algorithm_library_expansion.py`, `template_engine/auto_generator.py` | Quantum Enhancements |
-| `STUB-007` | Extend dashboard to surface real-time metrics and rollback alerts | `enterprise_dashboard.py`, `web_gui/templates/html/` | Dashboard Integration |
+| `STUB-007` | Extend dashboard to surface real-time metrics and rollback alerts | `enterprise_dashboard.py`, `web_gui/templates/` | Dashboard Integration |
 | `STUB-008` | Add tests and validation scripts for new modules | `tests/`, `validation/` | Testing |
 | `STUB-009` | Remove hardcoded placeholders and enable analytics hooks | `workflow_enhancer.py`, `archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py` | Workflow Enhancements |
 | `STUB-010` | Update task suggestion file and logs with cross-references | `docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md`, `logs/`, `validation/` | Cross-Referencing |

--- a/documentation/FINAL_PROJECT_VALIDATION_SUMMARY.md
+++ b/documentation/FINAL_PROJECT_VALIDATION_SUMMARY.md
@@ -110,7 +110,7 @@
 
 ### **Template Architecture**
 ```
-web_gui/templates/html/
+web_gui/templates/
 ├── base_enterprise.html (✅ Bootstrap 5 framework)
 ├── dashboard.html (✅ Real-time metrics)
 ├── analytics.html (✅ Data visualization)


### PR DESCRIPTION
## Summary
- correct documentation paths referencing web_gui templates

## Testing
- `ruff check docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md documentation/FINAL_PROJECT_VALIDATION_SUMMARY.md builds/production/builds/artifacts/documentation/FINAL_PROJECT_VALIDATION_SUMMARY.md builds/final/production/builds/artifacts/documentation/FINAL_PROJECT_VALIDATION_SUMMARY.md`
- `pytest tests/test_auto_generator.py::test_pattern_templates_loaded`

------
https://chatgpt.com/codex/tasks/task_e_688863a408c083319c357958f45b655c