### PR TITLE
feat: include resolved placeholders in dashboard metrics

### DIFF
--- a/scripts/dashboard_placeholder_sync.py
+++ b/scripts/dashboard_placeholder_sync.py
@@ -20,18 +20,20 @@ def sync(dashboard_dir: Path, analytics_db: Path) -> None:
     dashboard_dir.mkdir(parents=True, exist_ok=True)
 
     count = 0
+    resolved = 0
     if analytics_db.exists():
         with sqlite3.connect(analytics_db) as conn:
-            cur = conn.execute(
-                "SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=0"
-            )
+            cur = conn.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=0")
             count = cur.fetchone()[0]
+            cur = conn.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=1")
+            resolved = cur.fetchone()[0]
 
     compliance = max(0, 100 - count)
     status = "complete" if count == 0 else "issues_pending"
     data = {
         "timestamp": datetime.now().isoformat(),
         "findings": count,
+        "resolved_count": resolved,
         "compliance_score": compliance,
         "progress_status": status,
     }

--- a/tests/test_audit_codebase_placeholders.py
+++ b/tests/test_audit_codebase_placeholders.py
@@ -39,3 +39,4 @@ def test_audit_places(tmp_path):
     assert summary_file.exists()
     data = json.loads(summary_file.read_text())
     assert data["progress_status"] == "issues_pending"
+    assert data["resolved_count"] == 0

--- a/tests/test_code_placeholder_audit_logger.py
+++ b/tests/test_code_placeholder_audit_logger.py
@@ -38,6 +38,7 @@ def test_placeholder_audit_logger(tmp_path):
     assert summary_file.exists()
     data = json.loads(summary_file.read_text())
     assert data["progress_status"] == "issues_pending"
+    assert data["resolved_count"] == 0
 
 
 def test_dashboard_placeholder_sync(tmp_path):
@@ -55,11 +56,7 @@ def test_dashboard_placeholder_sync(tmp_path):
                 "CREATE TABLE code_audit_log (id INTEGER PRIMARY KEY, file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, timestamp TEXT)"
             )
         )
-        conn.execute(
-            (
-                "INSERT INTO todo_fixme_tracking VALUES ('f', 1, 'TODO', 'ctx', 'ts', 0, NULL)"
-            )
-        )
+        conn.execute(("INSERT INTO todo_fixme_tracking VALUES ('f', 1, 'TODO', 'ctx', 'ts', 0, NULL)"))
         conn.execute(
             (
                 "INSERT INTO code_audit_log (file_path, line_number, placeholder_type, context, timestamp) VALUES ('f', 1, 'TODO', 'ctx', 'ts')"
@@ -71,6 +68,7 @@ def test_dashboard_placeholder_sync(tmp_path):
     data = json.loads(dash.joinpath("placeholder_summary.json").read_text())
     assert data["findings"] == 1
     assert data["progress_status"] == "issues_pending"
+    assert data["resolved_count"] == 0
 
 
 def test_rollback_last_entry(tmp_path):
@@ -89,11 +87,7 @@ def test_rollback_last_entry(tmp_path):
                 "context TEXT, timestamp TEXT)"
             )
         )
-        conn.execute(
-            (
-                "INSERT INTO todo_fixme_tracking VALUES ('f', 1, 'TODO', 'ctx', 'ts', 0, NULL)"
-            )
-        )
+        conn.execute(("INSERT INTO todo_fixme_tracking VALUES ('f', 1, 'TODO', 'ctx', 'ts', 0, NULL)"))
         conn.execute(
             (
                 "INSERT INTO code_audit_log (file_path, line_number, placeholder_type, "

--- a/tests/test_placeholder_resolution.py
+++ b/tests/test_placeholder_resolution.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import json
 
 os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
 
@@ -29,9 +30,12 @@ def test_placeholder_resolution(tmp_path):
         dashboard_dir=str(tmp_path / "dashboard"),
     )
 
+    dash_file = tmp_path / "dashboard" / "placeholder_summary.json"
     with sqlite3.connect(analytics) as conn:
         row = conn.execute(
-            "SELECT resolved FROM todo_fixme_tracking WHERE file_path=?",
+            "SELECT resolved, resolved_timestamp FROM todo_fixme_tracking WHERE file_path=?",
             (str(target),),
         ).fetchone()
-    assert row and row[0] == 1
+    assert row and row[0] == 1 and row[1] is not None
+    data = json.loads(dash_file.read_text())
+    assert data["resolved_count"] >= 1


### PR DESCRIPTION
## Summary
- extend placeholder audit to write resolved counts to the dashboard
- sync script reports resolved counts as well
- cover new behaviour in placeholder resolution tests

## Testing
- `ruff check scripts/code_placeholder_audit.py scripts/dashboard_placeholder_sync.py tests/test_placeholder_resolution.py tests/test_code_placeholder_audit_logger.py tests/test_audit_codebase_placeholders.py`
- `pytest tests/test_placeholder_audit.py tests/test_placeholder_resolution.py tests/test_code_placeholder_audit_logger.py tests/test_audit_codebase_placeholders.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688863ad38f4833196c97aae87ed15a1