### PR TITLE
Expand automation_setup ingestion

### DIFF
--- a/tests/test_tools_automation_setup.py
+++ b/tests/test_tools_automation_setup.py
@@ -1,0 +1,38 @@
+import sqlite3
+from pathlib import Path
+
+from tools import automation_setup
+
+
+def test_ingest_assets(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path.parent / "backups"))
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+
+    docs_dir = tmp_path / "documentation"
+    docs_dir.mkdir()
+    (docs_dir / "doc.md").write_text("# doc")
+
+    templates_dir = tmp_path / "prompts"
+    templates_dir.mkdir()
+    (templates_dir / "temp.md").write_text("template")
+
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+
+    monkeypatch.setattr(automation_setup, "DB_PATH", db_dir / "production.db")
+    monkeypatch.setattr(automation_setup, "ANALYTICS_DB", db_dir / "analytics.db")
+    monkeypatch.setattr(automation_setup, "DOC_DIRS", [docs_dir])
+    monkeypatch.setattr(automation_setup, "TEMPLATE_DIRS", [templates_dir])
+
+    automation_setup.init_databases()
+    automation_setup.ingest_assets()
+
+    with sqlite3.connect(db_dir / "production.db") as conn:
+        doc_count = conn.execute("SELECT COUNT(*) FROM documentation_assets").fetchone()[0]
+        template_count = conn.execute("SELECT COUNT(*) FROM template_assets").fetchone()[0]
+        pattern_count = conn.execute("SELECT COUNT(*) FROM pattern_assets").fetchone()[0]
+
+    assert doc_count == 1
+    assert template_count == 1
+    assert pattern_count == 1

--- a/tools/automation_setup.py
+++ b/tools/automation_setup.py
@@ -1,20 +1,49 @@
 from __future__ import annotations
 
+import hashlib
+import os
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from tqdm import tqdm
 
-DB_PATH = Path('databases/production.db')
-DOCS_DIR = Path('docs')
-TEMPLATE_DIR = Path('template_engine/templates')
+from utils.log_utils import _log_event, DEFAULT_ANALYTICS_DB
+
+DB_PATH = Path("databases/production.db")
+ANALYTICS_DB = DEFAULT_ANALYTICS_DB
+DOC_DIRS = [Path("documentation"), Path("docs")]
+TEMPLATE_DIRS = [Path("prompts"), Path("template_engine/templates")]
 
 
 def init_databases() -> None:
     if not DB_PATH.exists():
         conn = sqlite3.connect(DB_PATH)
-        conn.execute('CREATE TABLE IF NOT EXISTS logs(id INTEGER PRIMARY KEY, message TEXT)')
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS documentation_assets ("
+            "id INTEGER PRIMARY KEY,"
+            "doc_path TEXT NOT NULL,"
+            "content_hash TEXT NOT NULL,"
+            "created_at TEXT NOT NULL,"
+            "modified_at TEXT NOT NULL"
+            ")"
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS template_assets ("
+            "id INTEGER PRIMARY KEY,"
+            "template_path TEXT NOT NULL,"
+            "content_hash TEXT NOT NULL,"
+            "created_at TEXT NOT NULL"
+            ")"
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS pattern_assets ("
+            "id INTEGER PRIMARY KEY,"
+            "pattern TEXT NOT NULL,"
+            "usage_count INTEGER DEFAULT 0,"
+            "created_at TEXT NOT NULL"
+            ")"
+        )
         conn.commit()
         conn.close()
 
@@ -22,10 +51,63 @@ def init_databases() -> None:
 def ingest_assets() -> None:
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
-    for path in tqdm(list(DOCS_DIR.rglob('*.md')) + list(TEMPLATE_DIR.rglob('*.tpl'))):
-        cur.execute('INSERT INTO logs(message) VALUES (?)', (f"ingested {path}",))
+
+    doc_files = []
+    for d in DOC_DIRS:
+        if d.exists():
+            doc_files.extend(sorted(p for p in d.rglob("*.md") if p.is_file()))
+
+    tmpl_files = []
+    for d in TEMPLATE_DIRS:
+        if d.exists():
+            tmpl_files.extend(sorted(p for p in d.rglob("*.md") if p.is_file()))
+
+    start_docs = datetime.now(timezone.utc)
+    with tqdm(total=len(doc_files), desc="Docs", unit="file") as bar:
+        for path in doc_files:
+            if path.stat().st_size == 0:
+                bar.update(1)
+                continue
+            content = path.read_text(encoding="utf-8")
+            digest = hashlib.sha256(content.encode()).hexdigest()
+            modified = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
+            cur.execute(
+                "INSERT INTO documentation_assets (doc_path, content_hash, created_at, modified_at)"
+                " VALUES (?, ?, ?, ?)",
+                (
+                    str(path),
+                    digest,
+                    datetime.now(timezone.utc).isoformat(),
+                    modified,
+                ),
+            )
+            bar.update(1)
+    conn.commit()
+    _log_event({"event": "docs_ingested", "count": len(doc_files)}, db_path=ANALYTICS_DB)
+
+    start_tpl = datetime.now(timezone.utc)
+    with tqdm(total=len(tmpl_files), desc="Templates", unit="file") as bar:
+        for path in tmpl_files:
+            content = path.read_text(encoding="utf-8")
+            digest = hashlib.sha256(content.encode()).hexdigest()
+            cur.execute(
+                "INSERT INTO template_assets (template_path, content_hash, created_at)"
+                " VALUES (?, ?, ?)",
+                (
+                    str(path),
+                    digest,
+                    datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+            cur.execute(
+                "INSERT INTO pattern_assets (pattern, usage_count, created_at)"
+                " VALUES (?, 0, ?)",
+                (content[:1000], datetime.now(timezone.utc).isoformat()),
+            )
+            bar.update(1)
     conn.commit()
     conn.close()
+    _log_event({"event": "templates_ingested", "count": len(tmpl_files)}, db_path=ANALYTICS_DB)
 
 
 def run_audit() -> None:


### PR DESCRIPTION
## Summary
- extend `automation_setup` to load documentation and template assets
- log ingestion progress and record events in analytics database
- add regression test for the new ingestion behavior

## Testing
- `ruff check tools/automation_setup.py tests/test_tools_automation_setup.py`
- `pytest tests/test_tools_automation_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_688863b12640833198162f24f8090dc9