### PR TITLE
test: verify ingest_assets populates production db

### DIFF
--- a/docs/STUB_MODULE_STATUS.md
+++ b/docs/STUB_MODULE_STATUS.md
@@ -3,6 +3,9 @@
 This document catalogs unfinished modules and missing components referenced in the repository.
 Generated: 2025-07-24
 
+The `ingest_assets` function referenced in early drafts is now fully
+implemented (see `scripts/autonomous_setup_and_audit.py` lines 26-119).
+
 ## STUB Overview
 
 The file `DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md` lists pending tasks marked with `STUB-*` identifiers. The following table consolidates those references and notes whether each module currently exists.

--- a/tests/test_autonomous_setup_and_audit.py
+++ b/tests/test_autonomous_setup_and_audit.py
@@ -1,0 +1,40 @@
+"""Tests for :mod:`scripts.autonomous_setup_and_audit`."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from scripts.autonomous_setup_and_audit import ingest_assets
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def test_ingest_assets_populates_db(tmp_path: Path, monkeypatch) -> None:
+    """``ingest_assets`` should load sample files into the database."""
+
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
+    monkeypatch.chdir(tmp_path)
+
+    docs_dir = tmp_path / "documentation"
+    docs_dir.mkdir()
+    (docs_dir / "doc.md").write_text("# doc")
+
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "template.md").write_text("template body")
+
+    db_path = tmp_path / "production.db"
+    initialize_database(db_path)
+
+    ingest_assets(docs_dir, templates_dir, db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        doc_count = conn.execute("SELECT COUNT(*) FROM documentation_assets").fetchone()[0]
+        template_count = conn.execute("SELECT COUNT(*) FROM template_assets").fetchone()[0]
+        pattern_count = conn.execute("SELECT COUNT(*) FROM pattern_assets").fetchone()[0]
+
+    assert doc_count == 1
+    assert template_count == 1
+    assert pattern_count == 1


### PR DESCRIPTION
## Summary
- add autonomous setup audit tests for ingest_assets
- clarify ingest_assets implemented in stub status doc

## Testing
- `ruff check tests/test_autonomous_setup_and_audit.py`
- `pyright tests/test_autonomous_setup_and_audit.py`
- `pytest tests/test_autonomous_setup_and_audit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688933aed55c833191a6218a2bde0bac