### PR TITLE
Implement ruff-based file correction

### DIFF
--- a/tests/test_enterprise_template_compliance_enhancer.py
+++ b/tests/test_enterprise_template_compliance_enhancer.py
@@ -1,0 +1,15 @@
+import logging
+from scripts.optimization.enterprise_template_compliance_enhancer import EnterpriseFlake8Corrector
+
+
+def test_correct_file_logs_and_fixes(tmp_path, caplog):
+    bad = tmp_path / "bad.py"
+    bad.write_text("import os, sys\nprint('hi')  \n", encoding="utf-8")
+
+    fixer = EnterpriseFlake8Corrector(workspace_path=str(tmp_path))
+    caplog.set_level(logging.INFO)
+    changed = fixer.correct_file(str(bad))
+
+    assert changed
+    assert bad.read_text(encoding="utf-8") == "import os\nimport sys\n\nprint('hi')\n"
+    assert any("SUCCESS" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- implement ruff-based correction in `enterprise_template_compliance_enhancer`
- add default implementation to `flake8_corrector_base`
- test correction and logging behaviour

## Testing
- `pytest -q tests/test_enterprise_template_compliance_enhancer.py`
- `pytest -q tests/test_flake8_fixers.py`

------
https://chatgpt.com/codex/tasks/task_e_688934e9f5f88331a8c52e1137d9138c