### PR TITLE
Add logging events for compliance metrics

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -104,7 +104,7 @@ class ComplianceMetricsUpdater:
                     cur.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=1")
                 metrics["placeholder_removal"] = cur.fetchone()[0]
 
-                cur.execute("SELECT AVG(compliance_score) FROM correction_logs")
+                cur.execute("SELECT AVG(compliance_score) FROM corrections")
                 avg_score = cur.fetchone()[0]
                 metrics["compliance_score"] = float(avg_score) if avg_score is not None else 0.0
 
@@ -119,6 +119,18 @@ class ComplianceMetricsUpdater:
             metrics["progress_status"] = "issues_pending"
         else:
             metrics["progress_status"] = "complete"
+        if metrics["violation_count"]:
+            _log_event(
+                {"event": "violation_detected", "count": metrics["violation_count"]},
+                table="violation_logs",
+                db_path=ANALYTICS_DB,
+            )
+        if metrics["rollback_count"]:
+            _log_event(
+                {"event": "rollback_detected", "count": metrics["rollback_count"]},
+                table="rollback_logs",
+                db_path=ANALYTICS_DB,
+            )
         metrics["last_update"] = datetime.now().isoformat()
         return metrics
 

--- a/databases/migrations/README.md
+++ b/databases/migrations/README.md
@@ -6,6 +6,7 @@
 - `add_code_audit_history.sql`: Adds `code_audit_history` table for tracking audit events.
 - `add_violation_logs.sql`: Adds `violation_logs` table for compliance issues.
 - `add_rollback_logs.sql`: Adds `rollback_logs` table recording restorations.
+- `add_corrections.sql`: Adds `corrections` table used for compliance metrics.
 
 ## Applying Migrations
 Run each migration using:
@@ -15,6 +16,7 @@ sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
 sqlite3 databases/analytics.db < databases/migrations/add_code_audit_history.sql
 sqlite3 databases/analytics.db < databases/migrations/add_violation_logs.sql
 sqlite3 databases/analytics.db < databases/migrations/add_rollback_logs.sql
+sqlite3 databases/analytics.db < databases/migrations/add_corrections.sql
 ```
 
 ## Notes

--- a/databases/migrations/add_corrections.sql
+++ b/databases/migrations/add_corrections.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS corrections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path TEXT,
+    rationale TEXT,
+    compliance_score REAL,
+    rollback_reference TEXT,
+    ts TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_corrections_ts ON corrections(ts);

--- a/tests/test_compliance_metrics_updater.py
+++ b/tests/test_compliance_metrics_updater.py
@@ -14,12 +14,20 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch):
     with sqlite3.connect(analytics_db) as conn:
         conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER)")
         conn.execute("INSERT INTO todo_fixme_tracking VALUES (1)")
-        conn.execute("CREATE TABLE correction_logs (compliance_score REAL)")
-        conn.execute("INSERT INTO correction_logs VALUES (0.9)")
-        conn.execute("CREATE TABLE violation_logs (id INTEGER)")
-        conn.execute("INSERT INTO violation_logs VALUES (1)")
-        conn.execute("CREATE TABLE rollback_logs (id INTEGER)")
-        conn.execute("INSERT INTO rollback_logs VALUES (1)")
+        conn.execute("CREATE TABLE corrections (compliance_score REAL)")
+        conn.execute("INSERT INTO corrections VALUES (0.9)")
+        conn.execute(
+            "CREATE TABLE violation_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT, details TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO violation_logs (timestamp, details) VALUES ('ts', 'd')"
+        )
+        conn.execute(
+            "CREATE TABLE rollback_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, target TEXT, backup TEXT, timestamp TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO rollback_logs (target, backup, timestamp) VALUES ('t','b','ts')"
+        )
 
     dashboard_dir = tmp_path / "dashboard"
     updater = module.ComplianceMetricsUpdater(dashboard_dir)

--- a/tests/test_violation_and_rollback_logging.py
+++ b/tests/test_violation_and_rollback_logging.py
@@ -1,0 +1,48 @@
+import sqlite3
+from pathlib import Path
+
+from dashboard import compliance_metrics_updater as cmu
+from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
+
+
+def test_violation_and_rollback_logging(tmp_path, monkeypatch):
+    events = []
+    monkeypatch.setattr(cmu, "_log_event", lambda evt, **kw: events.append((kw.get("table"), evt)))
+    monkeypatch.setattr(
+        "scripts.correction_logger_and_rollback._log_event",
+        lambda evt, **kw: events.append((kw.get("table"), evt)),
+    )
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    analytics_db = db_dir / "analytics.db"
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER)")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (1)")
+        conn.execute(
+            "CREATE TABLE corrections (file_path TEXT, rationale TEXT, compliance_score REAL, rollback_reference TEXT, ts TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO corrections VALUES ('f','r',1.0,'b','ts')"
+        )
+        conn.execute("CREATE TABLE violation_logs (timestamp TEXT, details TEXT)")
+        conn.execute(
+            "CREATE TABLE rollback_logs (target TEXT, backup TEXT, timestamp TEXT)"
+        )
+        conn.commit()
+
+    logger = CorrectionLoggerRollback(analytics_db)
+    logger.log_violation("violation")
+
+    target = tmp_path / "f.txt"
+    target.write_text("x")
+    logger.auto_rollback(target, None)
+
+    dash = tmp_path / "dash"
+    updater = cmu.ComplianceMetricsUpdater(dash)
+    updater.update()
+
+    assert any(t == "violation_logs" for t, _ in events)
+    assert any(t == "rollback_logs" for t, _ in events)

--- a/tools/automation_setup.py
+++ b/tools/automation_setup.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 import sqlite3
-import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from tqdm import tqdm

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -32,7 +32,7 @@ def _fetch_metrics() -> Dict[str, Any]:
             try:
                 cur.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=1")
                 metrics["placeholder_removal"] = cur.fetchone()[0]
-                cur.execute("SELECT AVG(compliance_score) FROM correction_logs")
+                cur.execute("SELECT AVG(compliance_score) FROM corrections")
                 val = cur.fetchone()[0]
                 metrics["compliance_score"] = float(val) if val is not None else 0.0
             except sqlite3.Error as exc:


### PR DESCRIPTION
## Summary
- log violations and rollbacks via `_log_event`
- unify correction table naming
- create `add_corrections.sql` migration
- fix automation setup imports
- test new logging behavior

## Testing
- `ruff check .`
- `pytest tests/test_compliance_metrics_updater.py tests/test_violation_and_rollback_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889370f61808331aa2d9823bd53824a