### PR TITLE
feat: add compliance logging and ingestion tests

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -83,6 +83,8 @@ class ComplianceMetricsUpdater:
         """Fetch compliance metrics from analytics.db."""
         metrics = {
             "placeholder_removal": 0,
+            "open_placeholders": 0,
+            "resolved_placeholders": 0,
             "compliance_score": 0.0,
             "violation_count": 0,
             "rollback_count": 0,
@@ -100,9 +102,14 @@ class ComplianceMetricsUpdater:
                     "SELECT name FROM sqlite_master WHERE type='table' AND name='correction_history'"
                 ).fetchone():
                     cur.execute("SELECT COUNT(*) FROM correction_history WHERE fix_applied='REMOVED_PLACEHOLDER'")
+                    metrics["resolved_placeholders"] = cur.fetchone()[0]
+                    metrics["open_placeholders"] = 0
                 else:
                     cur.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=1")
-                metrics["placeholder_removal"] = cur.fetchone()[0]
+                    metrics["resolved_placeholders"] = cur.fetchone()[0]
+                    cur.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=0")
+                    metrics["open_placeholders"] = cur.fetchone()[0]
+                metrics["placeholder_removal"] = metrics["resolved_placeholders"]
 
                 cur.execute("SELECT AVG(compliance_score) FROM corrections")
                 avg_score = cur.fetchone()[0]

--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -48,7 +48,17 @@ export GH_COPILOT_WORKSPACE=/path/to/gh_COPILOT
 - All generation actions must be logged for compliance review.
 - When corrections occur, update `analytics.db:correction_patterns` for future reference.
 - Placeholder detection results are written to `analytics.db:placeholder_audit`  and mirrored in `code_audit_log` for dashboard reporting.
-- Resolution tracking is enabled via `todo_fixme_tracking.resolved` and `resolved_timestamp` fields.
+- Resolution tracking is enabled via `todo_fixme_tracking.resolved` and `resolved_timestamp` fields. The table structure is:
+
+| column | type |
+| ------ | ---- |
+| file_path | TEXT |
+| line_number | INTEGER |
+| placeholder_type | TEXT |
+| context | TEXT |
+| timestamp | DATETIME |
+| resolved | BOOLEAN |
+| resolved_timestamp | DATETIME |
 - Run `python scripts/database/add_code_audit_log.py` or apply
   `databases/migrations/add_code_audit_log.sql` to ensure this table exists on
   older analytics databases.

--- a/docs/STUB_MODULE_STATUS.md
+++ b/docs/STUB_MODULE_STATUS.md
@@ -22,7 +22,7 @@ The file `DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md` lists pending tasks marked
 | STUB-008 | Add tests and validation scripts for new modules | tests/<br>validation/ | workflow enhancer logging tests added |
 | STUB-009 | Remove placeholders and enable analytics hooks | workflow_enhancer.py<br>archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py | both modules present |
 | STUB-010 | Update task suggestion files with cross-references | docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md<br>logs/<br>validation/ | file and directories exist |
-| STUB-011 | Record outputs to analytics.db across modules | various modules | workflow enhancer now logs events |
+| STUB-011 | Record outputs to analytics.db across modules | various modules | ingestion, template sync and documentation manager all log to `correction_logs`, `violation_logs`, and `rollback_logs` |
 | STUB-012 | Display placeholder removal progress on dashboard | dashboard/compliance_metrics_updater.py | exists |
 
 Implementation note: the `ingest_assets` workflow is fully implemented in

--- a/reports/MISSING_INCOMPLETE_COMPONENTS_AUDIT.md
+++ b/reports/MISSING_INCOMPLETE_COMPONENTS_AUDIT.md
@@ -11,6 +11,7 @@ See `docs/STUB_MODULE_STATUS.md` for a checklist of stub modules and whether the
 | **Flake8 Corrector Base Class** | `EnterpriseFlake8Corrector.correct_file` raises `NotImplementedError` – subclasses must implement logic. | 2025-07-10 |
 | **Placeholder Resolution Tracking** | The `todo_fixme_tracking` table now records resolution via `resolved` (boolean) and `resolved_timestamp` columns. Placeholder entries update to `resolved=1` when fixed. | 2025-07-30 |
 | **Compliance Dashboard Gaps** | Logging for `violation_logs`, `rollback_logs` and consistent use of `correction_logs` is missing. | N/A |
+| **Open vs. Resolved Metrics** | Dashboard now shows counts of open and resolved placeholders from `todo_fixme_tracking`. | 2025-07-31 |
 | **Template Sync Cluster Option** | Implemented in commit `99ba7f9` – real synchronizer now honors `--cluster`. | 2025-07-29 |
 | **Dual Copilot Full Integration** | Some flows implement the dual-copilot pattern while others rely on basic logging only. | 2025-07-17 |
 | **Documentation vs. Code Parity** | Documentation lists features not fully reflected in code. | 2025-07-03 |

--- a/template_engine/template_synchronizer.py
+++ b/template_engine/template_synchronizer.py
@@ -402,10 +402,20 @@ def synchronize_templates_real(
             if conn is not None:
                 try:
                     conn.rollback()
+                    log_event_simulation(
+                        {"event": "rollback", "db": str(db)},
+                        table="rollback_logs",
+                        db_path=ANALYTICS_DB,
+                    )
                 except sqlite3.Error:  # pragma: no cover - rollback best effort
                     pass
                 conn.close()
             _log_audit_real(str(db), str(exc))
+            log_event_simulation(
+                {"event": "sync_violation", "db": str(db), "error": str(exc)},
+                table="violation_logs",
+                db_path=ANALYTICS_DB,
+            )
         finally:
             if conn is not None:
                 conn.close()

--- a/tests/test_enterprise_template_compliance_enhancer.py
+++ b/tests/test_enterprise_template_compliance_enhancer.py
@@ -1,4 +1,6 @@
 import logging
+import sqlite3
+from pathlib import Path
 from scripts.optimization.enterprise_template_compliance_enhancer import EnterpriseFlake8Corrector
 
 
@@ -13,3 +15,29 @@ def test_correct_file_logs_and_fixes(tmp_path, caplog):
     assert changed
     assert bad.read_text(encoding="utf-8") == "import os\nimport sys\n\nprint('hi')\n"
     assert any("SUCCESS" in record.message for record in caplog.records)
+
+
+def test_correct_file_updates_tracking(tmp_path, monkeypatch):
+    bad = tmp_path / "bad.py"
+    bad.write_text("print('hi')  \n", encoding="utf-8")
+    analytics = tmp_path / "databases" / "analytics.db"
+    analytics.parent.mkdir(parents=True)
+    with sqlite3.connect(analytics) as conn:
+        conn.execute("CREATE TABLE todo_fixme_tracking (file_path TEXT, resolved INTEGER, resolved_timestamp TEXT)")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (?,0,NULL)", (str(bad),))
+
+    events = []
+    monkeypatch.setattr(
+        "scripts.optimization.enterprise_template_compliance_enhancer._log_event",
+        lambda evt, **kw: events.append((kw.get("table"), evt)),
+    )
+    fixer = EnterpriseFlake8Corrector(workspace_path=str(tmp_path))
+    fixer.analytics_db = analytics
+    assert fixer.correct_file(str(bad))
+    with sqlite3.connect(analytics) as conn:
+        resolved = conn.execute(
+            "SELECT resolved FROM todo_fixme_tracking WHERE file_path=?",
+            (str(bad),),
+        ).fetchone()[0]
+    assert resolved == 1
+    assert any(t == "correction_logs" for t, _ in events)

--- a/tests/test_sync_logging.py
+++ b/tests/test_sync_logging.py
@@ -1,0 +1,25 @@
+import sqlite3
+from pathlib import Path
+import pytest
+from template_engine import template_synchronizer
+
+
+def create_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE templates (name TEXT PRIMARY KEY, template_content TEXT)")
+        conn.execute("INSERT INTO templates VALUES ('t', 'x')")
+
+
+def test_sync_logs_violation_and_rollback(tmp_path, monkeypatch):
+    db = tmp_path / "a.db"
+    create_db(db)
+    analytics = tmp_path / "analytics.db"
+    monkeypatch.setattr(template_synchronizer, "ANALYTICS_DB", analytics)
+    events = []
+    monkeypatch.setattr(
+        template_synchronizer, "log_event_simulation", lambda evt, **kw: events.append((kw.get("table"), evt))
+    )
+    monkeypatch.setattr(template_synchronizer, "_compliance_check", lambda *_: False)
+    template_synchronizer.synchronize_templates_real([db])
+    assert any(t == "violation_logs" for t, _ in events)
+    assert any(t == "rollback_logs" for t, _ in events)


### PR DESCRIPTION
## Summary
- wrap asset ingestion in transactions and log events with compliance scores
- ensure placeholder remover updates `todo_fixme_tracking`
- track open/resolved metrics in dashboard updater
- log violations and rollbacks during template sync
- extend flake8 corrector with analytics logging
- document new tracking fields and update stub status
- add tests for ingestion, flake8 corrections, and sync logging

## Testing
- `ruff check scripts/autonomous_setup_and_audit.py template_engine/template_placeholder_remover.py scripts/optimization/enterprise_template_compliance_enhancer.py dashboard/compliance_metrics_updater.py tests/test_autonomous_setup_and_audit.py tests/test_enterprise_template_compliance_enhancer.py tests/test_sync_logging.py`
- `pytest tests/test_autonomous_setup_and_audit.py tests/test_enterprise_template_compliance_enhancer.py tests/test_sync_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68894761a7708331903473b0ccde3c57