### PR TITLE
Update compliance metrics to use correction logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ python dashboard/enterprise_dashboard.py  # wrapper for web_gui Flask app
 
 Compliance metrics are generated with `dashboard/compliance_metrics_updater.py`.
 This script reads from `analytics.db` and writes `dashboard/compliance/metrics.json`.
+The compliance score is averaged from records in the `correction_logs` table.
 Correction history is summarized via `scripts/correction_logger_and_rollback.py`,
 producing `dashboard/compliance/correction_summary.json`.
 Set `GH_COPILOT_WORKSPACE` before running these utilities:

--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -111,8 +111,14 @@ class ComplianceMetricsUpdater:
                     metrics["open_placeholders"] = cur.fetchone()[0]
                 metrics["placeholder_removal"] = metrics["resolved_placeholders"]
 
-                cur.execute("SELECT AVG(compliance_score) FROM corrections")
-                avg_score = cur.fetchone()[0]
+                # compliance score is derived from correction_logs
+                if cur.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='correction_logs'"
+                ).fetchone():
+                    cur.execute("SELECT AVG(compliance_score) FROM correction_logs")
+                    avg_score = cur.fetchone()[0]
+                else:
+                    avg_score = None
                 metrics["compliance_score"] = float(avg_score) if avg_score is not None else 0.0
 
                 cur.execute("SELECT COUNT(*) FROM violation_logs")

--- a/docs/STUB_MODULE_STATUS.md
+++ b/docs/STUB_MODULE_STATUS.md
@@ -4,7 +4,7 @@ This document catalogs unfinished modules and missing components referenced in t
 Generated: 2025-07-29
 
 The `ingest_assets` function referenced in early drafts is now fully
-implemented (see `scripts/autonomous_setup_and_audit.py` lines 26-119).
+implemented (see `scripts/autonomous_setup_and_audit.py` lines 30-150).
 
 ## STUB Overview
 
@@ -26,7 +26,7 @@ The file `DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md` lists pending tasks marked
 | STUB-012 | Display placeholder removal progress on dashboard | dashboard/compliance_metrics_updater.py | exists |
 
 Implementation note: the `ingest_assets` workflow is fully implemented in
-`scripts/autonomous_setup_and_audit.py` lines 26-119.
+`scripts/autonomous_setup_and_audit.py` lines 30-150.
 
 ## Lint and Type Check Summary
 

--- a/tests/test_compliance_metrics_updater.py
+++ b/tests/test_compliance_metrics_updater.py
@@ -14,8 +14,10 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch):
     with sqlite3.connect(analytics_db) as conn:
         conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER)")
         conn.execute("INSERT INTO todo_fixme_tracking VALUES (1)")
-        conn.execute("CREATE TABLE corrections (compliance_score REAL)")
-        conn.execute("INSERT INTO corrections VALUES (0.9)")
+        conn.execute(
+            "CREATE TABLE correction_logs (file_path TEXT, compliance_score REAL, ts TEXT)"
+        )
+        conn.execute("INSERT INTO correction_logs VALUES ('test.py', 0.9, 'ts')")
         conn.execute(
             "CREATE TABLE violation_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT, details TEXT)"
         )

--- a/tests/test_enterprise_template_compliance_enhancer.py
+++ b/tests/test_enterprise_template_compliance_enhancer.py
@@ -41,3 +41,10 @@ def test_correct_file_updates_tracking(tmp_path, monkeypatch):
         ).fetchone()[0]
     assert resolved == 1
     assert any(t == "correction_logs" for t, _ in events)
+    with sqlite3.connect(analytics) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM correction_logs WHERE file_path=?",
+            (str(bad),),
+        ).fetchone()[0]
+    assert count == 1
+    analytics.unlink()


### PR DESCRIPTION
## Summary
- compute compliance score from `correction_logs`
- document new table usage in README
- adjust stub documentation line references
- verify correction log entries in enterprise template enhancer test
- update compliance metrics updater test for new table

## Testing
- `ruff check .`
- `pytest tests/test_compliance_metrics_updater.py tests/test_enterprise_template_compliance_enhancer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68895ef87e50833184909353b472f81e