### PR TITLE
feat: ingest additional asset types

### DIFF
--- a/scripts/autonomous_setup_and_audit.py
+++ b/scripts/autonomous_setup_and_audit.py
@@ -29,7 +29,11 @@ def init_database(db_path: Path) -> None:
 
 
 def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
-    """Load markdown documentation and template assets into ``db_path``.
+    """Load documentation and template assets into ``db_path``.
+
+    Files with ``.md``, ``.txt``, ``.json``, and ``.sql`` extensions are
+    collected. Line endings are normalized and trailing whitespace stripped
+    before hashing.
 
     This replicates the behavior of :mod:`documentation_ingestor` and
     :mod:`template_asset_ingestor` but targets ``production.db`` instead of
@@ -43,8 +47,17 @@ def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
     from scripts.database.cross_database_sync_logger import log_sync_operation
 
     # Gather files
-    doc_files = [p for p in doc_path.rglob("*.md") if p.is_file()] if doc_path.exists() else []
-    tmpl_files = [p for p in template_path.rglob("*.md") if p.is_file()] if template_path.exists() else []
+    extensions = [".md", ".txt", ".json", ".sql"]
+    doc_files = (
+        [p for p in doc_path.rglob("*") if p.is_file() and p.suffix in extensions]
+        if doc_path.exists()
+        else []
+    )
+    tmpl_files = (
+        [p for p in template_path.rglob("*") if p.is_file() and p.suffix in extensions]
+        if template_path.exists()
+        else []
+    )
 
     analytics_db = Path(os.getenv("GH_COPILOT_WORKSPACE", ".")) / "databases" / "analytics.db"
 
@@ -84,7 +97,8 @@ def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
                 if path.stat().st_size == 0:
                     bar.update(1)
                     continue
-                content = path.read_text(encoding="utf-8")
+                raw = path.read_text(encoding="utf-8")
+                content = "\n".join(line.rstrip() for line in raw.splitlines())
                 digest = hashlib.sha256(content.encode()).hexdigest()
                 modified_at = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
                 conn.execute(
@@ -117,7 +131,8 @@ def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
         with tqdm(total=len(tmpl_files), desc="Templates", unit="file") as bar:
             conn.execute("BEGIN")
             for path in tmpl_files:
-                content = path.read_text(encoding="utf-8")
+                raw = path.read_text(encoding="utf-8")
+                content = "\n".join(line.rstrip() for line in raw.splitlines())
                 digest = hashlib.sha256(content.encode()).hexdigest()
                 conn.execute(
                     "INSERT INTO template_assets (template_path, content_hash, created_at) VALUES (?, ?, ?)",


### PR DESCRIPTION
## Summary
- collect `.md`, `.txt`, `.json`, and `.sql` files in autonomous setup ingest
- normalize file content before hashing
- log ingestion events with compliance scores
- test ingestion of new file types

## Testing
- `pytest tests/test_autonomous_setup_and_audit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68896e5054e083319fee3d3fa95b8bc5