### PR TITLE
feat: add ingestion validation

### DIFF
--- a/scripts/autonomous_setup_and_audit.py
+++ b/scripts/autonomous_setup_and_audit.py
@@ -146,6 +146,10 @@ def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
                 bar.update(1)
             conn.commit()
         log_sync_operation(db_path, "template_ingestion", start_time=start_tmpl)
+        from scripts.database.ingestion_validator import IngestionValidator
+        validator = IngestionValidator(doc_path.parent, db_path, analytics_db)
+        if not validator.validate():
+            raise RuntimeError("Asset ingestion validation failed")
     except Exception:
         conn.rollback()
         raise

--- a/scripts/database/ingestion_validator.py
+++ b/scripts/database/ingestion_validator.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+from template_engine.template_synchronizer import _compliance_score
+from utils.log_utils import _log_event
+
+
+class IngestionValidator:
+    """Validate ingested asset hashes and compliance scores."""
+
+    def __init__(self, workspace: Path, db_path: Path, analytics_db: Path) -> None:
+        self.workspace = workspace
+        self.db_path = db_path
+        self.analytics_db = analytics_db
+
+    def _fetch_logged_score(self, path: str) -> float | None:
+        try:
+            with sqlite3.connect(self.analytics_db) as conn:
+                conn.execute(
+                    "CREATE TABLE IF NOT EXISTS correction_logs (event TEXT, path TEXT, compliance_score REAL)"
+                )
+                row = conn.execute(
+                    "SELECT compliance_score FROM correction_logs WHERE path=? ORDER BY rowid DESC LIMIT 1",
+                    (path,),
+                ).fetchone()
+                return float(row[0]) if row else None
+        except sqlite3.Error:
+            return None
+
+    def _validate_row(self, path: str, stored_hash: str, asset_type: str) -> bool:
+        file_path = self.workspace / path
+        if not file_path.exists():
+            _log_event(
+                {
+                    "event": "ingestion_mismatch",
+                    "asset_type": asset_type,
+                    "path": path,
+                    "reason": "missing",
+                },
+                table="correction_logs",
+                db_path=self.analytics_db,
+                test_mode=False,
+            )
+            return False
+        content = file_path.read_text(encoding="utf-8")
+        digest = hashlib.sha256(content.encode()).hexdigest()
+        score = _compliance_score(content)
+        logged_score = self._fetch_logged_score(path)
+        ok = digest == stored_hash and (logged_score is None or logged_score == score)
+        if not ok:
+            _log_event(
+                {
+                    "event": "ingestion_mismatch",
+                    "asset_type": asset_type,
+                    "path": path,
+                    "stored_hash": stored_hash,
+                    "actual_hash": digest,
+                    "stored_score": logged_score,
+                    "actual_score": score,
+                },
+                table="correction_logs",
+                db_path=self.analytics_db,
+                test_mode=False,
+            )
+        return ok
+
+    def validate(self) -> bool:
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                docs = conn.execute("SELECT doc_path, content_hash FROM documentation_assets").fetchall()
+                tmpls = conn.execute("SELECT template_path, content_hash FROM template_assets").fetchall()
+        except sqlite3.Error:
+            return False
+
+        valid = True
+        for path, digest in docs:
+            if not self._validate_row(path, digest, "documentation"):
+                valid = False
+        for path, digest in tmpls:
+            if not self._validate_row(path, digest, "template"):
+                valid = False
+        return valid
+
+
+__all__ = ["IngestionValidator"]


### PR DESCRIPTION
## Summary
- add IngestionValidator module to confirm hashes and scores after ingestion
- call validator from ingest_assets workflow
- test detection of corrupted ingestion

## Testing
- `ruff check scripts tests`
- `pyright scripts/database/ingestion_validator.py tests/test_autonomous_setup_and_audit.py`
- `pytest -q` *(fails: 44 failed, 214 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68896e5d2cd483318adb750fc0e44660