### PR TITLE
fix: return row id from analytics logging

### DIFF
--- a/template_engine/template_placeholder_remover.py
+++ b/template_engine/template_placeholder_remover.py
@@ -115,13 +115,12 @@ def remove_unused_placeholders(
                 if ph not in valid:
                     pattern = r"{{\s*%s\s*}}" % re.escape(ph)
                     result = re.sub(pattern, "", result)
-                    insert_event(
+                    removal_id = insert_event(
                         {"placeholder": ph, "ts": datetime.utcnow().isoformat()},
                         "placeholder_removals",
                         db_path=analytics_db,
                         test_mode=False,
                     )
-                    removal_id = cur.lastrowid
                     conn.execute(
                         "UPDATE todo_fixme_tracking SET resolved=1, resolved_timestamp=?, status='resolved', removal_id=?"
                         " WHERE placeholder_type=? AND resolved=0",


### PR DESCRIPTION
## Summary
- extend `todo_fixme_tracking` table schema with status and removal link
- return inserted row ID from `utils.log_utils.insert_event`
- use the row ID in placeholder remover updates

## Testing
- `ruff check .`
- `pytest tests/test_template_placeholder_remover.py`

------
https://chatgpt.com/codex/tasks/task_e_688995c8ffa88331abc4fe478d913d4a