### PR TITLE
Update script generation and clustering

### DIFF
--- a/scripts/autonomous_setup_and_audit.py
+++ b/scripts/autonomous_setup_and_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
+import hashlib
 from pathlib import Path
 from typing import Optional
 
@@ -41,7 +42,6 @@ def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
     """
     LOGGER.info("Ingesting assets from %s and %s", doc_path, template_path)
 
-    import hashlib
     from datetime import datetime, timezone
 
     from scripts.database.cross_database_sync_logger import log_sync_operation

--- a/scripts/check_zero_logs.sh
+++ b/scripts/check_zero_logs.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TARGET="${1:-.}"
+TARGET="${1:-logs}"
 
 if [ ! -d "$TARGET" ]; then
-    echo "Directory '$TARGET' does not exist. Nothing to check."
+    echo "Directory '$TARGET' does not exist."
     exit 0
 fi
 

--- a/template_engine/template_placeholder_remover.py
+++ b/template_engine/template_placeholder_remover.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import List
 
 from tqdm import tqdm
-from utils.log_utils import ensure_tables, insert_event
+from utils.log_utils import ensure_tables
 
 DEFAULT_PRODUCTION_DB = Path("databases/production.db")
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
@@ -115,11 +115,9 @@ def remove_unused_placeholders(
                 if ph not in valid:
                     pattern = r"{{\s*%s\s*}}" % re.escape(ph)
                     result = re.sub(pattern, "", result)
-                    insert_event(
-                        {"placeholder": ph, "ts": datetime.utcnow().isoformat()},
-                        "placeholder_removals",
-                        db_path=analytics_db,
-                        test_mode=False,
+                    cur = conn.execute(
+                        "INSERT INTO placeholder_removals (placeholder, ts) VALUES (?, ?)",
+                        (ph, datetime.utcnow().isoformat()),
                     )
                     removal_id = cur.lastrowid
                     conn.execute(

--- a/tests/test_auto_generator.py
+++ b/tests/test_auto_generator.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 from pathlib import Path
 
@@ -27,11 +28,25 @@ def test_auto_generator_cluster_representatives(tmp_path: Path, monkeypatch) -> 
     analytics_db, completion_db = create_test_dbs(tmp_path)
     generator = TemplateAutoGenerator(analytics_db, completion_db)
     reps = generator.get_cluster_representatives()
+    allowed = set(generator.templates + generator.patterns + generator._load_production_patterns())
     assert len(reps) == generator.cluster_model.n_clusters
-    assert all(r in generator.templates or r in generator.patterns for r in reps)
+    assert all(r in allowed for r in reps)
 
 
 def test_pattern_templates_loaded(tmp_path: Path) -> None:
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     analytics_db, completion_db = create_test_dbs(tmp_path)
     generator = TemplateAutoGenerator(analytics_db, completion_db)
     assert any("DatabaseFirstOperator" in t for t in generator.templates)
+
+
+def test_cluster_rep_no_dimension_error(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    analytics_db, completion_db = create_test_dbs(tmp_path)
+    prod_db = tmp_path / "production.db"
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute("CREATE TABLE script_template_patterns (template_content TEXT)")
+        conn.execute("INSERT INTO script_template_patterns VALUES ('extra pattern')")
+    gen = TemplateAutoGenerator(analytics_db, completion_db, production_db=prod_db)
+    reps = gen.get_cluster_representatives()
+    assert len(reps) == gen.cluster_model.n_clusters

--- a/tests/test_check_zero_logs.py
+++ b/tests/test_check_zero_logs.py
@@ -6,7 +6,7 @@ SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_zero_logs.sh"
 
 def run_script(workdir: Path) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ["bash", str(SCRIPT)], cwd=workdir, capture_output=True, text=True
+        ["bash", str(SCRIPT), "logs"], cwd=workdir, capture_output=True, text=True
     )
 
 

--- a/tests/test_production_template_utils.py
+++ b/tests/test_production_template_utils.py
@@ -9,8 +9,10 @@ def test_generate_script_from_repository(tmp_path: Path) -> None:
     db_dir.mkdir()
     db_path = db_dir / "production.db"
     with sqlite3.connect(db_path) as conn:
-        conn.execute("CREATE TABLE script_repository (script_content TEXT)")
-        conn.execute("INSERT INTO script_repository VALUES ('print(\"hi\")')")
+        conn.execute("CREATE TABLE script_repository (script_path TEXT)")
+        conn.execute("INSERT INTO script_repository VALUES ('demo.py')")
+
+    (tmp_path / "demo.py").write_text("print('hi')")
 
     result = generate_script_from_repository(tmp_path, "out.py")
     assert result is True

--- a/tests/test_template_placeholder_remover.py
+++ b/tests/test_template_placeholder_remover.py
@@ -33,6 +33,10 @@ def test_remove_unused_placeholders(tmp_path: Path) -> None:
         conn.execute(
             "INSERT INTO template_placeholders (placeholder_name) VALUES ('VALID_PLACEHOLDER')"
         )
+    with sqlite3.connect(analytics) as conn:
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking (file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, timestamp TEXT, resolved INTEGER, resolved_timestamp TEXT, status TEXT, removal_id INTEGER)"
+        )
 
     # Remove unused placeholders from template string
     with sqlite3.connect(prod) as conn:
@@ -58,6 +62,10 @@ def test_no_placeholders_returns_same(tmp_path: Path) -> None:
         conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
         conn.execute("INSERT INTO code_templates VALUES (1, 'def foo(): pass')")
         conn.execute("CREATE TABLE template_placeholders (placeholder_name TEXT)")
+    with sqlite3.connect(analytics) as conn:
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking (file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, timestamp TEXT, resolved INTEGER, resolved_timestamp TEXT, status TEXT, removal_id INTEGER)"
+        )
     code = "def foo(): pass"
     result = remove_unused_placeholders(code, prod, analytics, timeout_minutes=1)
     assert result == code


### PR DESCRIPTION
## Summary
- read scripts from disk via `script_path`
- store TF-IDF vectorizer for clustering and reuse for representatives
- copy placeholder removal IDs into tracking table
- move hashlib import for easier testing
- default zero-log checks to `logs/`
- adjust tests for new logic

## Testing
- `ruff check .`
- `pytest tests/test_production_template_utils.py tests/test_auto_generator.py tests/test_autonomous_setup_and_audit.py tests/test_template_placeholder_remover.py tests/test_check_zero_logs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889958944608331a14c3792816fe3ee