### PR TITLE
docs: add code quality report

### DIFF
--- a/reports/code_quality_report.md
+++ b/reports/code_quality_report.md
@@ -1,0 +1,16 @@
+# Code Quality Report
+
+## Flake8 Summary
+- Issues found: 11802
+
+## Ruff Summary
+- All checks passed!
+
+## Pytest Summary
+- 40 tests failed (estimated from summary)
+- ===== 40 failed, 224 passed, 5 skipped, 694 warnings in 106.73s (0:01:46) =====
+
+## Placeholder Counts
+- TODO markers: 19
+- FIXME markers: 5
+- 'pass' statements: 84


### PR DESCRIPTION
## Summary
- add code quality report with flake8, ruff, pytest, and placeholder info

## Testing
- `flake8 --exclude=.venv`
- `pytest -v` *(fails: 40 failed, 224 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6889d514f0b48331a9ad6621a3b2509b