### PR TITLE
docs: add documentation audit report

### DIFF
--- a/reports/documentation_audit_2025-07-30.md
+++ b/reports/documentation_audit_2025-07-30.md
@@ -1,0 +1,20 @@
+# Documentation vs. System Audit (2025-07-30)
+
+| Claim | Status | Action | Timestamp |
+|-------|--------|--------|-----------|
+| "30 Synchronized Databases" (README line 35) | Not fully implemented (repo has ~28 db files) | Update docs to reflect actual number | 2025-07-30 |
+| Multiple SQLite databases (production.db, analytics.db, monitoring.db) | Implemented (databases directory contains these files) | None | 2025-07-30 |
+| Flask Dashboard with 7 endpoints | Implemented (enterprise_dashboard.py defines multiple endpoints) but count differs (8) | Update docs to match code | 2025-07-30 |
+| Template Intelligence Platform tracking scripts | Implemented in template_engine modules | None | 2025-07-30 |
+| Self-Healing systems (experimental) | Implemented (`self_healing_self_learning_system.py`) | None | 2025-07-30 |
+| Placeholder auditing logs to analytics.db | Implemented (`scripts/code_placeholder_audit.py`) | None | 2025-07-30 |
+| Correction history table in analytics.db | Implemented (`scripts/database/add_correction_history.sql`) | None | 2025-07-30 |
+| Quantum utilities with simulation fallback | Implemented (`quantum_optimizer.py`) | None | 2025-07-30 |
+| Data backup feature via GH_COPILOT_BACKUP_ROOT | Implemented and documented | None | 2025-07-30 |
+| DUAL COPILOT pattern enforcement | Implemented (`secondary_copilot_validator.py`) | None | 2025-07-30 |
+| Visual processing indicators (progress bars) | Implemented (tqdm usage across scripts) | None | 2025-07-30 |
+| Real-time dashboard UI metrics | Implemented (`enterprise_dashboard.py`) | None | 2025-07-30 |
+| 32+ database ecosystem (whitepaper) | Aspirational, not present in repo | Update docs or implement more databases | 2025-07-30 |
+| Compliance scoring for sessions | Implemented (`wlc_session_manager.py`) | None | 2025-07-30 |
+| Backup prevention (anti-recursion) | Implemented (`validate_enterprise_operation` in `scripts/continuous_operation_orchestrator.py`) | None | 2025-07-30 |
+


### PR DESCRIPTION
## Summary
- provide documentation audit table covering claims vs. implementation

## Testing
- `ruff check .`
- `pytest -q` *(fails: 8 failed, 67 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6889d63f375083319406b61b9bff1e1d