### PR TITLE
Fix analytics tests and update backup docs

### DIFF
--- a/docs/enterprise_backup_guide.md
+++ b/docs/enterprise_backup_guide.md
@@ -3,7 +3,11 @@
 This guide describes how to use the data backup feature in the gh_COPILOT toolkit.
 
 ## Prerequisites
-- Ensure the `GH_COPILOT_BACKUP_ROOT` environment variable points to an external directory outside the repository workspace. When running the Docker container, this variable defaults to `/backup` and should be mapped to a host directory.
+- Ensure the `GH_COPILOT_BACKUP_ROOT` environment variable points to an external directory outside the repository workspace. When running the Docker container, map a host folder to `/backup` so the volume persists:
+  ```bash
+  docker compose up -d -v /host/backups:/backup
+  ```
+  Backups will then be available on the host under `/host/backups`.
 - Run `bash setup.sh` to create the `.venv` and install dependencies.
 
 ## Performing a Backup

--- a/monitoring/log_error_notifier.py
+++ b/monitoring/log_error_notifier.py
@@ -55,6 +55,7 @@ def monitor_logs(log_files: Iterable[Path], db_path: Optional[Path] = None) -> i
                             {"file": str(log_file), "error": line.strip()},
                             table="log_errors",
                             db_path=path,
+                            test_mode=False,
                         )
                         error_count += 1
         except FileNotFoundError:
@@ -70,7 +71,12 @@ def notify(error_count: int, db_path: Optional[Path] = None) -> None:
     """Record a notification event for ``error_count`` errors."""
 
     path = db_path or DB_PATH
-    _log_event({"errors_found": error_count}, table="log_notifications", db_path=path)
+    _log_event(
+        {"errors_found": error_count},
+        table="log_notifications",
+        db_path=path,
+        test_mode=False,
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/tests/test_analytics_db_creation.py
+++ b/tests/test_analytics_db_creation.py
@@ -4,12 +4,12 @@ import sqlite3
 from pathlib import Path
 
 MIGRATIONS = [
+    Path("databases/migrations/create_todo_fixme_tracking.sql"),
     Path("databases/migrations/add_code_audit_log.sql"),
     Path("databases/migrations/add_correction_history.sql"),
     Path("databases/migrations/add_code_audit_history.sql"),
     Path("databases/migrations/add_violation_logs.sql"),
     Path("databases/migrations/add_rollback_logs.sql"),
-    Path("databases/migrations/extend_todo_fixme_tracking.sql"),
 ]
 
 

--- a/tests/test_final_validation_logging.py
+++ b/tests/test_final_validation_logging.py
@@ -16,12 +16,16 @@ MODULES = [
 @pytest.mark.parametrize("module_name", MODULES)
 def test_final_validation_logs(tmp_path: Path, module_name: str) -> None:
     module = importlib.import_module(module_name)
-    prod_db = tmp_path / "production.db"
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    prod_db = db_dir / "production.db"
     an_db = tmp_path / "analytics.db"
     with sqlite3.connect(prod_db) as conn:
-        conn.execute("CREATE TABLE t(id INTEGER)")
+        conn.execute("CREATE TABLE script_repository (script_path TEXT)")
+        conn.execute("INSERT INTO script_repository (script_path) VALUES ('dummy.py')")
+    (tmp_path / 'dummy.py').write_text('print("hi")')
     util = module.EnterpriseUtility(workspace_path=str(tmp_path))
     assert util.perform_utility_function() is True
     with sqlite3.connect(an_db) as conn:
-        count = conn.execute("SELECT COUNT(*) FROM validation_results").fetchone()[0]
+        count = conn.execute("SELECT COUNT(*) FROM validation_log").fetchone()[0]
     assert count == 1

--- a/tests/test_log_error_notifier.py
+++ b/tests/test_log_error_notifier.py
@@ -8,13 +8,15 @@ import monitoring.log_error_notifier as notifier
 
 
 def _prepare_db(tmp_path: Path) -> Path:
-    db = tmp_path / "analytics.db"
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    db = db_dir / "analytics.db"
     with sqlite3.connect(db) as conn:
         conn.execute(
-            "CREATE TABLE IF NOT EXISTS log_errors (timestamp TEXT, data TEXT)"
+            "CREATE TABLE IF NOT EXISTS log_errors (file TEXT, error TEXT, timestamp TEXT)"
         )
         conn.execute(
-            "CREATE TABLE IF NOT EXISTS log_notifications (timestamp TEXT, data TEXT)"
+            "CREATE TABLE IF NOT EXISTS log_notifications (errors_found INTEGER, timestamp TEXT)"
         )
     return db
 

--- a/tests/test_maintenance_scheduler.py
+++ b/tests/test_maintenance_scheduler.py
@@ -26,11 +26,15 @@ class DummyTqdm:
     def update(self, n: int = 1) -> None:
         self.updates += n
 
+    @property
+    def format_dict(self) -> dict:
+        return {"elapsed": 0, "remaining": 0}
+
     def set_postfix_str(self, *args: str, **kwargs: str) -> None:
         pass
 
 
-def test_run_cycle(tmp_path: Path) -> None:
+def test_run_cycle(tmp_path: Path, monkeypatch) -> None:
     db_dir = tmp_path / "databases"
     docs_dir = tmp_path / "documentation"
     db_dir.mkdir()
@@ -39,6 +43,7 @@ def test_run_cycle(tmp_path: Path) -> None:
     master = db_dir / "enterprise_assets.db"
     replica = db_dir / "replica.db"
     log_db = master
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     initialize_database(log_db)
 
     with sqlite3.connect(master) as conn:
@@ -65,6 +70,7 @@ def test_run_cycle_logging_and_progress(tmp_path: Path, monkeypatch) -> None:
 
     master = db_dir / "enterprise_assets.db"
     log_db = master
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     initialize_database(log_db)
 
     with sqlite3.connect(master) as conn:

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -190,11 +190,15 @@ def _log_event(
     start_ts = time.time()
     with tqdm(total=1, desc="log (TEST ONLY)", unit="evt", leave=False) as bar:
         if test_result:
-            # Visual processing indicator: show simulated DB and table
-            tqdm.write(f"[TEST] analytics.db WOULD BE created at: {db_path}")
-            tqdm.write(f"[TEST] Table WOULD BE: {table}")
-            tqdm.write(f"[TEST] Payload: {json.dumps(payload)}")
-            bar.set_postfix_str("ETC: 0s")
+            if test_mode:
+                # Visual processing indicator: show simulated DB and table
+                tqdm.write(f"[TEST] analytics.db WOULD BE created at: {db_path}")
+                tqdm.write(f"[TEST] Table WOULD BE: {table}")
+                tqdm.write(f"[TEST] Payload: {json.dumps(payload)}")
+                bar.set_postfix_str("ETC: 0s")
+            else:
+                insert_event(payload, table, db_path=db_path, test_mode=False)
+                bar.set_postfix_str("written")
         else:
             tqdm.write(f"[FAIL] analytics.db could NOT be created at: {db_path}")
             bar.set_postfix_str("ERROR")


### PR DESCRIPTION
## Summary
- fix migration order in analytics db test
- patch validation logging tests to build temp databases
- allow log error notifier to write to analytics.db
- adjust maintenance scheduler tests for workspace path
- refine `_log_event` to write when test mode disabled
- document backup volume mapping for Docker

## Testing
- `ruff check .`
- `pytest tests/test_analytics_db_creation.py tests/test_final_validation_logging.py tests/test_log_error_notifier.py tests/test_maintenance_scheduler.py::test_run_cycle_logging_and_progress -q`


------
https://chatgpt.com/codex/tasks/task_e_6889d514f0b48331a9ad6621a3b2509b