### PR TITLE
docs: clarify quantum simulation requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 
 The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. **Many features remain experimental or stubbed; quantum functionality is simulated only and several modules are still incomplete.**
 
+> **Note**
+> All quantum utilities operate in simulation unless `qiskit-ibm-provider` is installed and configured with `QISKIT_IBM_TOKEN`.
+
 ### 🎯 **Recent Milestones**
 - **Lessons Learned Integration:** initial implementation in progress
 - **Database-First Architecture:** `databases/production.db` used as primary reference
@@ -219,8 +222,7 @@ print(f"[SUCCESS] Generated with {result.confidence_score}% confidence")
 python simplified_quantum_integration_orchestrator.py
 ```
 
-To execute algorithms on IBM Quantum hardware install `qiskit-ibm-provider` and
-run:
+By default the orchestrator uses the simulator. To execute algorithms on IBM Quantum hardware install `qiskit-ibm-provider` and run:
 
 ```bash
 python quantum_integration_orchestrator.py --hardware --backend ibm_oslo

--- a/docs/quantum/ADVANCED_QUANTUM_OPTIMIZATION_GUIDE.md
+++ b/docs/quantum/ADVANCED_QUANTUM_OPTIMIZATION_GUIDE.md
@@ -2,6 +2,9 @@
 
 This guide outlines how to extend the existing quantum module with an advanced optimization algorithm. It assumes familiarity with the repository's quantum package and the base `QuantumAlgorithmBase` class.
 
+> **Note**
+> All quantum functionality runs in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+
 ## 1. Create the Module
 1. Navigate to `quantum/algorithms/`.
 2. Create a new file named `advanced_optimization.py` that defines `AdvancedQuantumOptimizer` inheriting from `QuantumAlgorithmBase`.

--- a/docs/quantum/INDEX.md
+++ b/docs/quantum/INDEX.md
@@ -4,6 +4,9 @@
 ### Document Overview
 This documentation suite provides comprehensive information about the quantum optimization features integrated into the PIS (Plan Issued Statement) Framework.
 
+> **Note**
+> All quantum functionality operates in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+
 ### Available Documents
 1. **[Quantum Optimization Overview](QUANTUM_OPTIMIZATION_OVERVIEW.md)**
    - Executive summary and business benefits

--- a/docs/quantum/QUANTUM_ALGORITHMS_SPECIFICATION.md
+++ b/docs/quantum/QUANTUM_ALGORITHMS_SPECIFICATION.md
@@ -1,6 +1,9 @@
 # QUANTUM ALGORITHMS SPECIFICATION
 ## Technical Implementation Details
 
+> **Note**
+> All quantum algorithms are executed in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+
 ### Algorithm Architecture
 
 #### 1. Quantum Annealing Optimization

--- a/docs/quantum/QUANTUM_ENTERPRISE_COMPLIANCE.md
+++ b/docs/quantum/QUANTUM_ENTERPRISE_COMPLIANCE.md
@@ -1,6 +1,9 @@
 # QUANTUM ENTERPRISE COMPLIANCE
 ## Regulatory and Security Compliance
 
+> **Note**
+> All quantum capabilities operate in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+
 ### Compliance Framework
 The quantum-enhanced PIS Framework meets all enterprise compliance requirements:
 

--- a/docs/quantum/QUANTUM_INTEGRATION_GUIDE.md
+++ b/docs/quantum/QUANTUM_INTEGRATION_GUIDE.md
@@ -1,6 +1,9 @@
 # QUANTUM INTEGRATION GUIDE
 ## Implementation and Deployment
 
+> **Note**
+> All quantum features run in simulation unless `qiskit-ibm-provider` is installed and configured with `QISKIT_IBM_TOKEN`.
+
 ### Integration Architecture
 ```
 PIS Framework

--- a/docs/quantum/QUANTUM_OPTIMIZATION_OVERVIEW.md
+++ b/docs/quantum/QUANTUM_OPTIMIZATION_OVERVIEW.md
@@ -1,6 +1,9 @@
 # QUANTUM OPTIMIZATION OVERVIEW
 ## Enterprise-Grade PIS Framework Quantum Integration
 
+> **Note**
+> All quantum features operate in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+
 ### Executive Summary
 The PIS (Plan Issued Statement) Framework integrates quantum optimization algorithms to achieve unprecedented performance improvements in code analysis, error detection, and compliance validation. The latest update introduces the **Quantum Database Search** module for Grover-based queries.
 

--- a/docs/quantum/QUANTUM_PERFORMANCE_METRICS.md
+++ b/docs/quantum/QUANTUM_PERFORMANCE_METRICS.md
@@ -1,6 +1,9 @@
 # QUANTUM PERFORMANCE METRICS
 ## Comprehensive Performance Analysis
 
+> **Note**
+> All benchmarks are generated using the simulator unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+
 ### Baseline Performance Comparison
 
 | Metric | Classical | Quantum | Improvement |

--- a/quantum/README.md
+++ b/quantum/README.md
@@ -3,6 +3,9 @@
 This package provides experimental quantum-inspired utilities used across the
 gh_COPILOT toolkit.
 
+> **Note**
+> All quantum modules run in simulation unless `qiskit-ibm-provider` is installed and configured with `QISKIT_IBM_TOKEN`.
+
 ## Optimizers
 - `optimizers.quantum_optimizer.QuantumOptimizer` – classical/quantum hybrid
   optimizer with progress logging. Events are recorded using

--- a/quantum_optimizer.py
+++ b/quantum_optimizer.py
@@ -60,6 +60,9 @@ class QuantumOptimizer:
     - Provides QAOA and VQE stubs if Qiskit is available
     - Unified run interface with progress reporting
     - Logs optimization metrics for compliance and reproducibility
+    
+    Note:
+        All quantum routines execute in simulation unless `qiskit-ibm-provider` is installed and configured with `QISKIT_IBM_TOKEN`.
     """
 
     def __init__(self, objective_function: Callable, variable_bounds: List[Tuple[float, float]], method: str = "simulated_annealing", options: Optional[Dict[str, Any]] = None, backend: Any = None, use_hardware: bool = False):


### PR DESCRIPTION
## Summary
- state that quantum features run in simulation unless `qiskit-ibm-provider` is configured
- document this disclaimer across the quantum docs and READMEs
- note the limitation in `QuantumOptimizer` docstring

## Testing
- `ruff check .`
- `pytest -q` *(fails: 25 failed, 153 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d7749108331a9df0317a801f3fe