### PR TITLE
feat: flesh out equivalence stubs

### DIFF
--- a/copilot_qiskit_stubs/_accelerate/equivalence.py
+++ b/copilot_qiskit_stubs/_accelerate/equivalence.py
@@ -14,10 +14,17 @@ class BaseEquivalenceLibrary:
         return self.data.keys()
 
 class SessionEquivalenceLibrary(BaseEquivalenceLibrary):
-    pass
+    """Session-scoped equivalence library used in tests."""
+
+    def __init__(self, base=None, session_id=None):
+        super().__init__(base)
+        self.session_id = session_id
 
 class EquivalenceLibrary(BaseEquivalenceLibrary):
-    pass
+    """Simple equivalence library placeholder."""
+
+    def __init__(self, base=None):
+        super().__init__(base)
 
 class Key:
     def __init__(self, name=None, num_qubits=0):
@@ -30,7 +37,13 @@ class Equivalence:
         self.circuit = circuit
 
 class NodeData(dict):
-    pass
+    """Dictionary wrapper for node attributes."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 class EdgeData(dict):
-    pass
+    """Dictionary wrapper for edge attributes."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add simple implementations for `SessionEquivalenceLibrary` and `EquivalenceLibrary`
- provide lightweight `NodeData` and `EdgeData` wrappers

## Testing
- `ruff check .`
- `pytest -q` *(fails: 29 failed, 235 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d7820cc8331b7706736201195b6