### PR TITLE
chore: pin Flask for tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ psutil
 tqdm
 numpy
 scikit-learn
-Flask
+Flask==3.1.1
 qiskit>=1.4,<2.0
 qiskit-aer==0.17.1
 qiskit-machine-learning>=0.6.0


### PR DESCRIPTION
## Summary
- pin Flask to 3.1.1 in requirements-test.txt

## Testing
- `ruff check .`
- `ruff format --check .`
- `pyright` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failures expected)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d7589e48331a7e20d3070568503