### PR TITLE
docs: correct synchronized database count

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 
 ### 🏆 **Enterprise Achievements**
  - ✅ **Script Validation**: 1679 scripts synchronized
- - **30 Synchronized Databases**: Enterprise data management
+ - **24 Synchronized Databases**: Enterprise data management
 
 ---
 
@@ -681,7 +681,7 @@ gh_COPILOT/
 │   ├── validation/          # Enterprise validation framework
 │   ├── database/            # Database management
 │   └── automation/          # Autonomous operations
-├── databases/               # 30 synchronized databases
+├── databases/               # 24 synchronized databases
 ├── web_gui/                 # Flask enterprise dashboard
 ├── documentation/           # Comprehensive documentation
 ├── .github/instructions/    # GitHub Copilot instruction modules

--- a/docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md
+++ b/docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md
@@ -142,7 +142,7 @@ TEXT_INDICATORS = {
 - **Instruction Integration:** 100% (16 instruction files updated)
 
 ### **Key Performance Indicators**
-- **Database Integration:** 32 synchronized databases operational
+ - **Database Integration:** 24 synchronized databases operational
 - **Visual Processing:** 100% compliance across all scripts
 - **Autonomous Operations:** 24/7 continuous operation mode achieved
 - **Enterprise Standards:** 100% DUAL COPILOT pattern compliance


### PR DESCRIPTION
## Summary
- update README to reflect 24 synchronized databases
- update validation report with accurate database count

## Testing
- `ruff check README.md docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md`
- `pyright --version`
- `pytest -q` *(fails: 15 failed, 98 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d74825c83318e7da63ca6221cd3