### PR TITLE
Add backup volume to compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ docker run -p 5000:5000 -e GH_COPILOT_BACKUP_ROOT=/path/to/backups gh_copilot
 
 Inside the image `GH_COPILOT_BACKUP_ROOT` defaults to `/backup`. Map this path to a host directory to persist logs and backups.
 
+When launching with Docker Compose, the provided `docker-compose.yml` mounts `${GH_COPILOT_BACKUP_ROOT:-/backup}` at `/backup`. Set `GH_COPILOT_BACKUP_ROOT` on the host before running `docker-compose up` so backups survive container restarts.
+
 ### Wrapping, Logging, and Compliance (WLC)
 Run the session manager after setting the workspace and backup paths:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - GH_COPILOT_WORKSPACE=/app
     volumes:
       - .:/app
+      - ${GH_COPILOT_BACKUP_ROOT:-/backup}:/backup
   web_gui:
     build: .
     command: python web_gui/app.py
@@ -14,6 +15,7 @@ services:
       - GH_COPILOT_WORKSPACE=/app
     volumes:
       - .:/app
+      - ${GH_COPILOT_BACKUP_ROOT:-/backup}:/backup
     ports:
       - "5000:5000"
       - "5001:5001"
@@ -27,5 +29,6 @@ services:
       - GH_COPILOT_WORKSPACE=/app
     volumes:
       - .:/app
+      - ${GH_COPILOT_BACKUP_ROOT:-/backup}:/backup
     depends_on:
       - app


### PR DESCRIPTION
## Summary
- expose `${GH_COPILOT_BACKUP_ROOT}` in `docker-compose.yml`
- document Docker Compose backup volume usage

## Testing
- `ruff check .`
- `pytest -q` *(fails: 22 failed, 149 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d78ad188331a421acc503ef05e9