### PR TITLE
Fix flake8 issues and clean imports

### DIFF
--- a/copilot/__init__.py
+++ b/copilot/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 # Copilot Package Initialization
 """
 gh_COPILOT Toolkit v4.0 Enterprise Architecture

--- a/copilot/common/__init__.py
+++ b/copilot/common/__init__.py
@@ -1,2 +1,1 @@
 #!/usr/bin/env python3
-import logging

--- a/copilot/common/workspace_utils.py
+++ b/copilot/common/workspace_utils.py
@@ -4,7 +4,6 @@
 import os
 from pathlib import Path
 from typing import Optional
-import logging
 
 DEFAULT_ENV_VAR = "GH_COPILOT_WORKSPACE"
 

--- a/copilot/core/__init__.py
+++ b/copilot/core/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 # Core Module Initialization
 """
 Core components for gh_COPILOT Toolkit

--- a/copilot/orchestrators/__init__.py
+++ b/copilot/orchestrators/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 # Orchestrators Module Initialization
 """
 Enterprise orchestration components

--- a/copilot_qiskit_stubs/__init__.py
+++ b/copilot_qiskit_stubs/__init__.py
@@ -4,4 +4,3 @@ from pkgutil import extend_path
 
 # Ensure all submodules under this package are discoverable.
 __path__ = extend_path(__path__, __name__)
-

--- a/copilot_qiskit_stubs/_accelerate/circuit.py
+++ b/copilot_qiskit_stubs/_accelerate/circuit.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from collections import namedtuple
 
+
 class CircuitData(list):
     """Simplified list-based storage for circuit instructions."""
+
 
 class _StandardGateMeta(type):
     def __getattr__(cls, name: str):
         return name
+
 
 class StandardGate(metaclass=_StandardGateMeta):
     HGate = "h"
@@ -20,5 +23,6 @@ class StandardGate(metaclass=_StandardGateMeta):
     ZGate = "z"
     CZGate = "cz"
     SwapGate = "swap"
+
 
 CircuitInstruction = namedtuple("CircuitInstruction", ["operation", "qubits", "clbits"])

--- a/copilot_qiskit_stubs/_accelerate/circuit_duration.py
+++ b/copilot_qiskit_stubs/_accelerate/circuit_duration.py
@@ -1,5 +1,6 @@
 """Fallback duration estimation utilities."""
 
+
 def compute_estimated_duration(_dag, _target):
     """Return zero duration in fallback mode."""
     return 0

--- a/copilot_qiskit_stubs/_accelerate/equivalence.py
+++ b/copilot_qiskit_stubs/_accelerate/equivalence.py
@@ -1,5 +1,6 @@
 """Fallback equivalence utilities for testing."""
 
+
 class BaseEquivalenceLibrary:
     """Minimal placeholder class used during tests."""
 
@@ -13,24 +14,30 @@ class BaseEquivalenceLibrary:
     def keys(self):
         return self.data.keys()
 
+
 class SessionEquivalenceLibrary(BaseEquivalenceLibrary):
     pass
 
+
 class EquivalenceLibrary(BaseEquivalenceLibrary):
     pass
+
 
 class Key:
     def __init__(self, name=None, num_qubits=0):
         self.name = name
         self.num_qubits = num_qubits
 
+
 class Equivalence:
     def __init__(self, params, circuit):
         self.params = params
         self.circuit = circuit
 
+
 class NodeData(dict):
     pass
+
 
 class EdgeData(dict):
     pass

--- a/copilot_qiskit_stubs/algorithms/__init__.py
+++ b/copilot_qiskit_stubs/algorithms/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Minimal Shor implementation for tests."""
+
 from __future__ import annotations
 
 import numpy as np
-import logging
 
 
 class Shor:

--- a/validation/reporting/formatters.py
+++ b/validation/reporting/formatters.py
@@ -12,10 +12,10 @@ from ..core.validators import ValidationResult, ValidationStatus
 
 class ValidationReportFormatter:
     """Formats validation results into various output formats"""
-    
+
     def __init__(self):
         self.timestamp = datetime.now()
-    
+
     def format_text_report(self, results: List[ValidationResult], title: str = "Validation Report") -> str:
         """Format validation results as text report"""
         lines = []
@@ -24,14 +24,14 @@ class ValidationReportFormatter:
         lines.append(f"Generated: {self.timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
         lines.append("=" * 80)
         lines.append("")
-        
+
         # Summary
         passed = sum(1 for r in results if r.status == ValidationStatus.PASSED)
         failed = sum(1 for r in results if r.status == ValidationStatus.FAILED)
         warnings = sum(1 for r in results if r.status == ValidationStatus.WARNING)
         errors = sum(1 for r in results if r.status == ValidationStatus.ERROR)
         skipped = sum(1 for r in results if r.status == ValidationStatus.SKIPPED)
-        
+
         lines.append("SUMMARY:")
         lines.append(f"  Total Validations: {len(results)}")
         lines.append(f"  Passed: {passed}")
@@ -40,7 +40,7 @@ class ValidationReportFormatter:
         lines.append(f"  Errors: {errors}")
         lines.append(f"  Skipped: {skipped}")
         lines.append("")
-        
+
         # Overall status
         if failed > 0 or errors > 0:
             overall_status = "FAILED"
@@ -48,33 +48,33 @@ class ValidationReportFormatter:
             overall_status = "PASSED WITH WARNINGS"
         else:
             overall_status = "PASSED"
-        
+
         lines.append(f"OVERALL STATUS: {overall_status}")
         lines.append("")
-        
+
         # Detailed results
         lines.append("DETAILED RESULTS:")
         lines.append("-" * 40)
-        
+
         for i, result in enumerate(results, 1):
             status_symbol = self._get_status_symbol(result.status)
             lines.append(f"{i}. {status_symbol} {result.message}")
-            
+
             if result.errors:
                 for error in result.errors:
                     lines.append(f"     Error: {error}")
-            
+
             if result.warnings:
                 for warning in result.warnings:
                     lines.append(f"     Warning: {warning}")
-            
+
             if result.details:
                 lines.append(f"     Details: {self._format_details(result.details)}")
-            
+
             lines.append("")
-        
+
         return "\n".join(lines)
-    
+
     def format_json_report(self, results: List[ValidationResult], title: str = "Validation Report") -> str:
         """Format validation results as JSON report"""
         report_data = {
@@ -82,9 +82,9 @@ class ValidationReportFormatter:
             "timestamp": self.timestamp.isoformat(),
             "summary": self._get_summary(results),
             "overall_status": self._get_overall_status(results),
-            "results": []
+            "results": [],
         }
-        
+
         for result in results:
             result_data = {
                 "status": result.status.value,
@@ -92,12 +92,12 @@ class ValidationReportFormatter:
                 "timestamp": result.timestamp.isoformat(),
                 "details": result.details,
                 "errors": result.errors,
-                "warnings": result.warnings
+                "warnings": result.warnings,
             }
             report_data["results"].append(result_data)
-        
+
         return json.dumps(report_data, indent=2, ensure_ascii=False)
-    
+
     def format_markdown_report(self, results: List[ValidationResult], title: str = "Validation Report") -> str:
         """Format validation results as Markdown report"""
         lines = []
@@ -105,7 +105,7 @@ class ValidationReportFormatter:
         lines.append("")
         lines.append(f"**Generated:** {self.timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
         lines.append("")
-        
+
         # Summary
         summary = self._get_summary(results)
         lines.append("## Summary")
@@ -117,69 +117,74 @@ class ValidationReportFormatter:
         lines.append(f"- **Errors:** {summary['errors']}")
         lines.append(f"- **Skipped:** {summary['skipped']}")
         lines.append("")
-        
+
         # Overall status
         overall_status = self._get_overall_status(results)
         status_emoji = "✅" if overall_status == "PASSED" else "⚠️" if "WARNING" in overall_status else "❌"
         lines.append(f"## Overall Status: {status_emoji} {overall_status}")
         lines.append("")
-        
+
         # Detailed results
         lines.append("## Detailed Results")
         lines.append("")
-        
+
         for i, result in enumerate(results, 1):
             status_emoji = self._get_status_emoji(result.status)
             lines.append(f"### {i}. {status_emoji} {result.message}")
             lines.append("")
-            
+
             if result.errors:
                 lines.append("**Errors:**")
                 for error in result.errors:
                     lines.append(f"- {error}")
                 lines.append("")
-            
+
             if result.warnings:
                 lines.append("**Warnings:**")
                 for warning in result.warnings:
                     lines.append(f"- {warning}")
                 lines.append("")
-            
+
             if result.details:
                 lines.append("**Details:**")
                 lines.append("```json")
                 lines.append(json.dumps(result.details, indent=2))
                 lines.append("```")
                 lines.append("")
-        
+
         return "\n".join(lines)
-    
-    def save_report(self, results: List[ValidationResult], output_path: Path, 
-                   format_type: str = "json", title: str = "Validation Report") -> bool:
+
+    def save_report(
+        self,
+        results: List[ValidationResult],
+        output_path: Path,
+        format_type: str = "json",
+        title: str = "Validation Report",
+    ) -> bool:
         """Save validation report to file"""
         try:
             if format_type.lower() == "json":
                 content = self.format_json_report(results, title)
-                output_path = output_path.with_suffix('.json')
+                output_path = output_path.with_suffix(".json")
             elif format_type.lower() == "markdown" or format_type.lower() == "md":
                 content = self.format_markdown_report(results, title)
-                output_path = output_path.with_suffix('.md')
+                output_path = output_path.with_suffix(".md")
             elif format_type.lower() == "text" or format_type.lower() == "txt":
                 content = self.format_text_report(results, title)
-                output_path = output_path.with_suffix('.txt')
+                output_path = output_path.with_suffix(".txt")
             else:
                 raise ValueError(f"Unsupported format type: {format_type}")
-            
+
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(output_path, 'w', encoding='utf-8') as f:
+            with open(output_path, "w", encoding="utf-8") as f:
                 f.write(content)
-            
+
             return True
-            
+
         except Exception as e:
             print(f"Error saving report: {e}")
             return False
-    
+
     def _get_summary(self, results: List[ValidationResult]) -> Dict[str, int]:
         """Get summary statistics"""
         return {
@@ -188,20 +193,20 @@ class ValidationReportFormatter:
             "failed": sum(1 for r in results if r.status == ValidationStatus.FAILED),
             "warnings": sum(1 for r in results if r.status == ValidationStatus.WARNING),
             "errors": sum(1 for r in results if r.status == ValidationStatus.ERROR),
-            "skipped": sum(1 for r in results if r.status == ValidationStatus.SKIPPED)
+            "skipped": sum(1 for r in results if r.status == ValidationStatus.SKIPPED),
         }
-    
+
     def _get_overall_status(self, results: List[ValidationResult]) -> str:
         """Get overall validation status"""
         summary = self._get_summary(results)
-        
+
         if summary["failed"] > 0 or summary["errors"] > 0:
             return "FAILED"
         elif summary["warnings"] > 0:
             return "PASSED WITH WARNINGS"
         else:
             return "PASSED"
-    
+
     def _get_status_symbol(self, status: ValidationStatus) -> str:
         """Get text symbol for status"""
         symbols = {
@@ -209,10 +214,10 @@ class ValidationReportFormatter:
             ValidationStatus.FAILED: "✗",
             ValidationStatus.WARNING: "⚠",
             ValidationStatus.ERROR: "💥",
-            ValidationStatus.SKIPPED: "⏭"
+            ValidationStatus.SKIPPED: "⏭",
         }
         return symbols.get(status, "?")
-    
+
     def _get_status_emoji(self, status: ValidationStatus) -> str:
         """Get emoji for status"""
         emojis = {
@@ -220,15 +225,15 @@ class ValidationReportFormatter:
             ValidationStatus.FAILED: "❌",
             ValidationStatus.WARNING: "⚠️",
             ValidationStatus.ERROR: "💥",
-            ValidationStatus.SKIPPED: "⏭️"
+            ValidationStatus.SKIPPED: "⏭️",
         }
         return emojis.get(status, "❓")
-    
+
     def _format_details(self, details: Dict[str, Any]) -> str:
         """Format details for text output"""
         if not details:
             return ""
-        
+
         # Simplified formatting for text output
         formatted_items = []
         for key, value in details.items():
@@ -236,5 +241,5 @@ class ValidationReportFormatter:
                 formatted_items.append(f"{key}={json.dumps(value)}")
             else:
                 formatted_items.append(f"{key}={value}")
-        
+
         return ", ".join(formatted_items)

--- a/web_gui/scripts/flask_apps/__init__.py
+++ b/web_gui/scripts/flask_apps/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3
 # Flask Apps Module
 """Flask applications for gh_COPILOT enterprise dashboard."""
-

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Enterprise compliance dashboard with real-time metrics."""
+
 from __future__ import annotations
 
 import json
@@ -18,10 +19,7 @@ COMPLIANCE_DIR = Path("dashboard/compliance")
 app = Flask(__name__)
 LOG_FILE = Path("logs/dashboard") / "dashboard.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-logging.basicConfig(
-    level=logging.INFO,
-    handlers=[logging.FileHandler(LOG_FILE), logging.StreamHandler()]
-)
+logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler(LOG_FILE), logging.StreamHandler()])
 
 
 def _fetch_metrics() -> Dict[str, Any]:
@@ -50,6 +48,7 @@ def _fetch_rollbacks() -> List[Dict[str, Any]]:
         except json.JSONDecodeError:
             logging.warning("Invalid correction summary JSON")
     return records
+
 
 @app.get("/compliance")
 def compliance() -> Any:
@@ -102,8 +101,6 @@ def metrics_stream() -> Response:
             yield f"data: {json.dumps(metrics)}\n\n"
 
     return Response(generate(), mimetype="text/event-stream")
-
-
 
 
 @app.get("/rollback_alerts")


### PR DESCRIPTION
## Summary
- remove unused `logging` imports in various modules
- adjust spacing in `copilot_qiskit_stubs/_accelerate` stubs
- trim whitespace in validation formatter and dashboard
- ensure flake8 passes on updated files

## Testing
- `ruff check .`
- `pyright copilot/__init__.py copilot/core/__init__.py copilot/common/__init__.py copilot/common/workspace_utils.py copilot/orchestrators/__init__.py copilot_qiskit_stubs/__init__.py copilot_qiskit_stubs/algorithms/__init__.py copilot_qiskit_stubs/_accelerate/circuit.py copilot_qiskit_stubs/_accelerate/circuit_duration.py copilot_qiskit_stubs/_accelerate/equivalence.py`
- `flake8 copilot copilot_qiskit_stubs --exclude=.venv`
- `flake8 --exclude=.venv` *(fails: many unrelated errors)*
- `pytest -q` *(fails: 20 failed, 149 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d747fc88331acddb9f6e2ab55a0