### PR TITLE
feat: embed flake8 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,8 @@ make test
 # Run linter
 ruff format .
 ruff check .
+# `.flake8` is the canonical lint configuration. Update it first and mirror any
+# changes in `pyproject.toml` to keep `ruff` and `flake8` consistent.
 
 # Enterprise validation
 python -m pytest tests/enterprise/ -v

--- a/docs/REPOSITORY_GUIDELINES.md
+++ b/docs/REPOSITORY_GUIDELINES.md
@@ -141,6 +141,11 @@ make test   # Preferred test aggregator, combines unit and integration tests
 pytest -v   # Alternative for verbose test output
 ```
 
+### Lint Configuration
+The `.flake8` file at the repository root is the single source of lint rules.
+`pyproject.toml` mirrors these settings for Ruff. When adjusting lint
+preferences, update `.flake8` first and sync `pyproject.toml` accordingly.
+
 ---
 
 ## ARCHIVAL POLICY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,19 @@ extend-exclude = [
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 extend-ignore = ["F541", "F841"]
-ignore = ["I001", "F401", "E402", "E501"]
+ignore = ["I001", "E402", "E501"]
+
+[tool.flake8]
+max-line-length = 120
+extend-ignore = ["E203", "W503"]
+exclude = [
+    ".git",
+    "__pycache__",
+    "build",
+    "builds",
+    "archive",
+    "archives",
+    "deployment_package_*",
+    "databases/*.db",
+    "*.log",
+]


### PR DESCRIPTION
## Summary
- sync ruff ignore list with CI rules
- mirror flake8 configuration inside `pyproject.toml`
- note canonical lint file in docs and README

## Testing
- `ruff check pyproject.toml`
- `ruff check .` *(fails: F401 unused imports)*
- `pytest -q` *(fails: 29 failed, 203 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688a3752cd788331b57a72749b4217d4