### PR TITLE
Implement secret manager and use in Flask dashboard

### DIFF
--- a/config/secret_manager.py
+++ b/config/secret_manager.py
@@ -1,0 +1,15 @@
+"""Enterprise secret management utilities."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+
+def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Retrieve secret from environment variables securely."""
+    value = os.getenv(name, default)
+    return value
+
+
+

--- a/tests/test_secret_manager.py
+++ b/tests/test_secret_manager.py
@@ -1,0 +1,13 @@
+import os
+from config.secret_manager import get_secret
+
+
+def test_get_secret_found(monkeypatch):
+    monkeypatch.setenv("SECRET_TEST", "value")
+    assert get_secret("SECRET_TEST") == "value"
+
+
+def test_get_secret_default(monkeypatch):
+    monkeypatch.delenv("SECRET_TEST", raising=False)
+    assert get_secret("SECRET_TEST", "default") == "default"
+

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -13,10 +13,13 @@ from typing import Any, Dict, Iterable, List
 from flask import Flask, Response, jsonify, request
 from tqdm import tqdm
 
+from config.secret_manager import get_secret
+
 ANALYTICS_DB = Path("databases/analytics.db")
 COMPLIANCE_DIR = Path("dashboard/compliance")
 
 app = Flask(__name__)
+app.secret_key = get_secret("FLASK_SECRET_KEY", "dev_key")
 LOG_FILE = Path("logs/dashboard") / "dashboard.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler(LOG_FILE), logging.StreamHandler()])


### PR DESCRIPTION
## Summary
- add `config/secret_manager.py` to load secrets from env vars
- use the new secret manager for `FLASK_SECRET_KEY`
- add tests for secret manager

## Testing
- `ruff check config/secret_manager.py web_gui/scripts/flask_apps/enterprise_dashboard.py`
- `pyright config/secret_manager.py web_gui/scripts/flask_apps/enterprise_dashboard.py`
- `pytest -q tests/test_secret_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688a408f57808331964d0962ca9d317a