### PR TITLE
feat: integrate audit test mode with dashboard metrics

### DIFF
--- a/tests/test_dashboard_placeholder_metrics.py
+++ b/tests/test_dashboard_placeholder_metrics.py
@@ -1,0 +1,45 @@
+from web_gui.scripts.flask_apps.enterprise_dashboard import app
+from scripts.code_placeholder_audit import main
+
+
+def test_dashboard_metrics_after_audit(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    target = workspace / "demo.py"
+    target.write_text("# TODO\n")
+    analytics = tmp_path / "analytics.db"
+    dashboard_dir = tmp_path / "dashboard" / "compliance"
+
+    main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(dashboard_dir),
+    )
+
+    # patch dashboard constants
+    import importlib
+
+    dash = importlib.import_module("web_gui.scripts.flask_apps.enterprise_dashboard")
+    monkeypatch.setattr(dash, "ANALYTICS_DB", analytics)
+    monkeypatch.setattr(dash, "COMPLIANCE_DIR", dashboard_dir)
+
+    client = app.test_client()
+    resp = client.get("/dashboard/compliance")
+    data = resp.get_json()
+    assert data["metrics"]["open_placeholders"] == 1
+
+    # remove placeholder and run in test mode
+    target.write_text("def demo():\n    pass\n")
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "1")
+    main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(dashboard_dir),
+    )
+    resp = client.get("/dashboard/compliance")
+    data = resp.get_json()
+    assert data["metrics"]["placeholder_removal"] >= 1
+    assert data["metrics"]["open_placeholders"] == 0

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -26,13 +26,15 @@ logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler(LOG_FILE),
 
 
 def _fetch_metrics() -> Dict[str, Any]:
-    metrics = {"placeholder_removal": 0, "compliance_score": 0.0}
+    metrics = {"placeholder_removal": 0, "open_placeholders": 0, "compliance_score": 0.0}
     if ANALYTICS_DB.exists():
         with sqlite3.connect(ANALYTICS_DB) as conn:
             cur = conn.cursor()
             try:
                 cur.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=1")
                 metrics["placeholder_removal"] = cur.fetchone()[0]
+                cur.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=0")
+                metrics["open_placeholders"] = cur.fetchone()[0]
                 cur.execute("SELECT AVG(compliance_score) FROM corrections")
                 val = cur.fetchone()[0]
                 metrics["compliance_score"] = float(val) if val is not None else 0.0


### PR DESCRIPTION
## Summary
- update `code_placeholder_audit` to respect `GH_COPILOT_TEST_MODE`
- compute dashboard metrics from analytics.db
- expose open placeholder count in the dashboard metrics
- add tests covering dashboard metrics and test mode

## Testing
- `pytest tests/test_dashboard_placeholder_metrics.py tests/test_placeholder_resolution.py tests/test_placeholder_audit.py tests/test_placeholder_excludes.py tests/test_audit_codebase_placeholders.py tests/test_code_placeholder_audit_logger.py tests/test_code_placeholder_audit_utils.py -q`
- `pyright scripts/code_placeholder_audit.py web_gui/scripts/flask_apps/enterprise_dashboard.py tests/test_dashboard_placeholder_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_688a44d34ed48331a77b8ee59f18f8c2