### PR TITLE
feat: dashboard metrics and compliance enhancements

### DIFF
--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -9,10 +9,41 @@ from __future__ import annotations
 
 import logging
 import os
+import sqlite3
 from datetime import datetime
+from pathlib import Path
 
-from web_gui.scripts.flask_apps.enterprise_dashboard import app
+from web_gui.scripts.flask_apps.enterprise_dashboard import (
+    app,
+    _fetch_metrics,
+)
+
+ANALYTICS_DB = Path("databases/analytics.db")
 from utils.validation_utils import validate_enterprise_environment
+
+
+def _fetch_correction_history(limit: int = 5) -> list[dict[str, str | float]]:
+    """Return recent correction log entries."""
+    history: list[dict[str, str | float]] = []
+    if ANALYTICS_DB.exists():
+        with sqlite3.connect(ANALYTICS_DB) as conn:
+            try:
+                cur = conn.execute(
+                    "SELECT file_path, compliance_score, ts FROM correction_logs "
+                    "ORDER BY ts DESC LIMIT ?",
+                    (limit,),
+                )
+                history = [
+                    {
+                        "file_path": row[0],
+                        "compliance_score": row[1],
+                        "timestamp": row[2],
+                    }
+                    for row in cur.fetchall()
+                ]
+            except sqlite3.Error as exc:
+                logging.error("History fetch error: %s", exc)
+    return history
 
 __all__ = ["app", "main"]
 
@@ -33,6 +64,8 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     logging.info("Dashboard starting at %s", datetime.utcnow().isoformat())
     _validate_environment()
+    logging.info("Startup metrics: %s", _fetch_metrics())
+    logging.info("Recent corrections: %s", _fetch_correction_history())
     port = int(os.getenv("FLASK_RUN_PORT", "5000"))
     app.run(host="0.0.0.0", port=port, debug=bool(__name__ == "__main__"))
 

--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -55,3 +55,19 @@ def test_reports_endpoint():
     client = app.test_client()
     resp = client.get('/reports')
     assert resp.status_code == 200
+
+
+def test_realtime_metrics_endpoint():
+    client = app.test_client()
+    resp = client.get('/realtime_metrics')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'metrics' in data
+    assert 'corrections' in data
+
+
+def test_correction_history_endpoint():
+    client = app.test_client()
+    resp = client.get('/correction_history')
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json(), list)

--- a/tests/test_web_gui_templates.py
+++ b/tests/test_web_gui_templates.py
@@ -1,0 +1,18 @@
+import pytest
+from flask import render_template
+from web_gui.scripts.flask_apps.enterprise_dashboard import app
+
+TEMPLATES = [
+    "dashboard.html",
+    "backup_restore.html",
+    "database.html",
+    "deployment.html",
+    "migration.html",
+]
+
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_templates_include_progress_and_compliance(template):
+    with app.app_context():
+        html = render_template(template, metrics={}, compliance={})
+    assert "id=\"progress\"" in html
+    assert "/dashboard/compliance" in html

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -53,6 +53,29 @@ def _fetch_rollbacks() -> List[Dict[str, Any]]:
     return records
 
 
+def _fetch_correction_history(limit: int = 5) -> List[Dict[str, Any]]:
+    history: List[Dict[str, Any]] = []
+    if ANALYTICS_DB.exists():
+        with sqlite3.connect(ANALYTICS_DB) as conn:
+            try:
+                cur = conn.execute(
+                    "SELECT file_path, compliance_score, ts FROM correction_logs "
+                    "ORDER BY ts DESC LIMIT ?",
+                    (limit,),
+                )
+                history = [
+                    {
+                        "file_path": row[0],
+                        "compliance_score": row[1],
+                        "timestamp": row[2],
+                    }
+                    for row in cur.fetchall()
+                ]
+            except sqlite3.Error as exc:
+                logging.error("History fetch error: %s", exc)
+    return history
+
+
 @app.get("/compliance")
 def compliance() -> Any:
     with tqdm(total=1, desc="compliance", unit="step") as pbar:
@@ -145,6 +168,20 @@ def reports() -> Any:
     etc = f"ETC: {calculate_etc(start, 1, 1)}"
     logging.info("Reports served | %s", etc)
     return jsonify(data)
+
+
+@app.get("/realtime_metrics")
+def realtime_metrics() -> Any:
+    data = {
+        "metrics": _fetch_metrics(),
+        "corrections": _fetch_correction_history(),
+    }
+    return jsonify(data)
+
+
+@app.get("/correction_history")
+def correction_history() -> Any:
+    return jsonify(_fetch_correction_history())
 
 
 def calculate_etc(start_time: float, current_progress: int, total_work: int) -> str:

--- a/web_gui/templates/backup_restore.html
+++ b/web_gui/templates/backup_restore.html
@@ -2,3 +2,5 @@
 <title>Backup & Restore</title>
 <h1>Backup and Restore</h1>
 <p>Manage backups here.</p>
+<div id="progress">Loading...</div>
+<p><a href="/dashboard/compliance">Compliance Metrics</a></p>

--- a/web_gui/templates/dashboard.html
+++ b/web_gui/templates/dashboard.html
@@ -1,12 +1,14 @@
 <!doctype html>
 <title>Compliance Dashboard</title>
 <h1>Compliance Dashboard</h1>
+<div id="progress">Loading...</div>
 <h2>Metrics</h2>
 <ul>
 {% for entry in metrics %}
 <li>{{ entry }}</li>
 {% endfor %}
 </ul>
+<p><a href="/dashboard/compliance">Compliance Metrics</a></p>
 <h2>Compliance</h2>
 <ul>
 {% for key, value in compliance.items() %}

--- a/web_gui/templates/database.html
+++ b/web_gui/templates/database.html
@@ -2,3 +2,5 @@
 <title>Database Info</title>
 <h1>Database Status</h1>
 <div id="status">Loading...</div>
+<div id="progress">Loading...</div>
+<p><a href="/dashboard/compliance">Compliance Metrics</a></p>

--- a/web_gui/templates/deployment.html
+++ b/web_gui/templates/deployment.html
@@ -2,3 +2,5 @@
 <title>Deployment</title>
 <h1>Deployment Overview</h1>
 <p>Deployment status information.</p>
+<div id="progress">Loading...</div>
+<p><a href="/dashboard/compliance">Compliance Metrics</a></p>

--- a/web_gui/templates/migration.html
+++ b/web_gui/templates/migration.html
@@ -2,3 +2,5 @@
 <title>Migration</title>
 <h1>Migration Process</h1>
 <p>Details about database migrations.</p>
+<div id="progress">Loading...</div>
+<p><a href="/dashboard/compliance">Compliance Metrics</a></p>


### PR DESCRIPTION
## Summary
- fetch metrics and recent corrections on startup
- add realtime_metrics and correction_history endpoints
- show progress and compliance links in templates
- test new endpoints and templates

## Testing
- `ruff check dashboard/enterprise_dashboard.py web_gui/scripts/flask_apps/enterprise_dashboard.py tests/test_dashboard_endpoints.py tests/test_web_gui_templates.py web_gui/templates/backup_restore.html web_gui/templates/dashboard.html web_gui/templates/database.html web_gui/templates/deployment.html web_gui/templates/migration.html`
- `pytest -q` *(fails: 24 failed, 210 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a44e9d68c8331b77a2419f439de40