### PR TITLE
Add similarity-based template ranking

### DIFF
--- a/tests/test_auto_generator.py
+++ b/tests/test_auto_generator.py
@@ -3,6 +3,7 @@ import sqlite3
 from pathlib import Path
 
 from template_engine.auto_generator import TemplateAutoGenerator
+import template_engine.auto_generator as auto_generator
 
 
 def create_test_dbs(tmp_path: Path):
@@ -50,3 +51,27 @@ def test_cluster_rep_no_dimension_error(tmp_path: Path, monkeypatch) -> None:
     gen = TemplateAutoGenerator(analytics_db, completion_db, production_db=prod_db)
     reps = gen.get_cluster_representatives()
     assert len(reps) == gen.cluster_model.n_clusters
+
+
+def test_rank_templates_uses_similarity(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    analytics_db, completion_db = create_test_dbs(tmp_path)
+    prod_db = tmp_path / "production.db"
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
+        conn.executemany(
+            "INSERT INTO code_templates (template_code) VALUES (?)",
+            [("foo",), ("bar",)],
+        )
+    gen = TemplateAutoGenerator(analytics_db, completion_db, production_db=prod_db)
+
+    called = {"used": False}
+
+    def fake_scores(*args, **kwargs):
+        called["used"] = True
+        return [(1, 0.1), (2, 0.9)]
+
+    monkeypatch.setattr(auto_generator, "compute_similarity_scores", fake_scores)
+    ranked = gen.rank_templates("bar")
+    assert called["used"]
+    assert ranked[0] == "bar"


### PR DESCRIPTION
## Summary
- integrate compute_similarity_scores and pattern_mining_engine in TemplateAutoGenerator
- prioritize production.db in template retrieval
- update DBFirstCodeGenerator to rank templates with similarity and patterns
- add unit tests for new ranking logic

## Testing
- `ruff check template_engine/auto_generator.py template_engine/db_first_code_generator.py`
- `ruff check tests/test_auto_generator.py tests/test_db_first_code_generator.py`
- `pytest tests/test_auto_generator.py::test_rank_templates_uses_similarity tests/test_db_first_code_generator.py::test_similarity_ranking_selects_best -q`
- `pytest tests/test_auto_generator.py tests/test_db_first_code_generator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a44da5f488331887c8e4c919dea12