### PR TITLE
Add DB-first documentation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ python -m scripts.docs_metrics_validator
 python scripts/wlc_session_manager.py --db-path databases/production.db
 ```
 The session manager logs the documentation update to `production.db` and writes a log file under `$GH_COPILOT_BACKUP_ROOT/logs`.
+To regenerate enterprise documentation directly from the production database use:
+
+```bash
+python archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py
+```
+This script pulls templates from `production.db` and outputs Markdown, HTML and JSON files under `logs/template_rendering/`.
 Both ``session_protocol_validator.py`` and ``session_management_consolidation_executor.py``
 are thin CLI wrappers. They delegate to the core implementations under
 ``validation.protocols.session`` and ``session_management_consolidation_executor``.

--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -35,6 +35,11 @@ export GH_COPILOT_WORKSPACE=/path/to/gh_COPILOT
 - Documentation patterns are stored in `documentation.db`.
 - Use `scripts/documentation/enterprise_documentation_manager.py` to render Markdown files from these entries and record the generation event.
 - Rendered output is also saved to `logs/template_rendering/` with timestamped filenames for auditing.
+- For production systems use
+  `archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py`.
+  This manager pulls templates directly from `production.db` and writes Markdown,
+  HTML and JSON files for each compliant entry. All renders are logged to
+  `analytics.db:render_events` for compliance.
 
 ## 4. Synchronization
 - Run `template_engine.template_synchronizer.synchronize_templates()` to preview


### PR DESCRIPTION
## Summary
- pull templates directly from production.db in enterprise doc manager
- log documentation consolidation events and produce multi-format outputs
- document database-first docs workflow in README and usage guide
- test consolidator for csv/md/json output and analytics logging

## Testing
- `ruff check archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py scripts/documentation_consolidator.py tests/test_documentation_consolidator.py`
- `pytest tests/test_documentation_consolidator.py::test_documentation_consolidator -q`
- `pytest -q` *(fails: 24 failed, 240 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a44dfac7483318e068e7b41e34ba1