### PR TITLE
Expose quantum scoring function with classical fallback

### DIFF
--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -28,14 +28,15 @@ from utils.log_utils import _log_event
 from .pattern_templates import get_pattern_templates
 from .placeholder_utils import DEFAULT_PRODUCTION_DB
 
-# Quantum demo import (placeholder for quantum-inspired scoring)
+# Quantum scoring helper
 try:
-    from quantum_algorithm_library_expansion import demo_quantum_fourier_transform
+    from quantum_algorithm_library_expansion import quantum_text_score
 except ImportError:
 
-    def demo_quantum_fourier_transform():
-        # Fallback: return a normalized vector
-        return np.ones(8) / np.sqrt(8)
+    def quantum_text_score(text: str) -> float:
+        # Fallback implementation mirrors classical path
+        arr = np.fromiter((ord(c) for c in text), dtype=float)
+        return float(np.linalg.norm(arr) / ((arr.size or 1) * 255))
 
 
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
@@ -163,10 +164,8 @@ class TemplateAutoGenerator:
         return templates
 
     def _quantum_score(self, text: str) -> float:
-        """Return a quantum-inspired score for ``text``."""
-        vec = np.array(demo_quantum_fourier_transform())
-        baseline = np.ones_like(vec) / np.sqrt(len(vec))
-        return float(abs(np.dot(vec, baseline.conj())))
+        """Return a quantum-inspired score for ``text`` using helper module."""
+        return quantum_text_score(text)
 
     def _load_production_patterns(self) -> list[str]:
         """Fetch template patterns from ``production.db`` if available."""

--- a/tests/test_quantum_scoring.py
+++ b/tests/test_quantum_scoring.py
@@ -1,0 +1,31 @@
+import sqlite3
+import quantum_algorithm_library_expansion as qal
+
+
+def test_quantum_text_score_qiskit(tmp_path):
+    db = tmp_path / "analytics.db"
+    qal.ANALYTICS_DB = db
+    db.touch()
+    qal.QISKIT_AVAILABLE = True
+    score = qal.quantum_text_score("hello")
+    assert 0 <= score <= 1
+    with sqlite3.connect(db) as conn:
+        detail = conn.execute(
+            "SELECT details FROM quantum_events ORDER BY ROWID DESC LIMIT 1"
+        ).fetchone()[0]
+    assert detail == "qiskit"
+
+
+def test_quantum_text_score_simulated(tmp_path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    qal.ANALYTICS_DB = db
+    db.touch()
+    monkeypatch.setattr(qal, "QISKIT_AVAILABLE", False)
+    score = qal.quantum_text_score("hello")
+    assert 0 <= score <= 1
+    with sqlite3.connect(db) as conn:
+        detail = conn.execute(
+            "SELECT details FROM quantum_events ORDER BY ROWID DESC LIMIT 1"
+        ).fetchone()[0]
+    assert detail == "simulated"
+


### PR DESCRIPTION
## Summary
- add `quantum_text_score` with qiskit-enabled and simulated paths
- use `quantum_text_score` in template auto generator
- test quantum scoring with and without qiskit

## Testing
- `ruff check quantum_algorithm_library_expansion.py template_engine/auto_generator.py tests/test_quantum_scoring.py --quiet`
- `pytest tests/test_quantum_scoring.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a44e490ec8331a3b88711828a113f