### PR TITLE
Add validation tools and tests for DB-first workflow

### DIFF
--- a/tests/test_dashboard_metrics_complete.py
+++ b/tests/test_dashboard_metrics_complete.py
@@ -1,0 +1,26 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from dashboard import compliance_metrics_updater as cmu
+
+
+def test_dashboard_metrics_complete(tmp_path: Path, monkeypatch) -> None:
+    analytics_db = tmp_path / "analytics.db"
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT)")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (1, 'resolved')")
+        conn.execute("CREATE TABLE correction_logs (compliance_score REAL)")
+        conn.execute("INSERT INTO correction_logs VALUES (1.0)")
+        conn.execute("CREATE TABLE violation_logs (id INTEGER)")
+    monkeypatch.setattr(cmu, "ANALYTICS_DB", analytics_db)
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    dash = tmp_path / "dashboard"
+    updater = cmu.ComplianceMetricsUpdater(dash)
+    updater.update()
+    data = json.loads((dash / "metrics.json").read_text())
+    assert data["status"] in {"issues_pending", "complete"}
+    assert "compliance_score" in data["metrics"]

--- a/tests/test_db_first_codegen_analytics.py
+++ b/tests/test_db_first_codegen_analytics.py
@@ -1,0 +1,30 @@
+import os
+import sqlite3
+from pathlib import Path
+
+from template_engine.db_first_code_generator import DBFirstCodeGenerator
+from template_engine import auto_generator
+import template_engine.db_first_code_generator as dbgen
+
+auto_generator.validate_no_recursive_folders = lambda: None
+dbgen.validate_enterprise_operation = lambda *a, **k: None
+
+
+def test_auto_generation_logs_event(tmp_path: Path) -> None:
+    prod_db = tmp_path / "production.db"
+    doc_db = tmp_path / "documentation.db"
+    tpl_db = tmp_path / "template.db"
+    analytics = tmp_path / "analytics.db"
+
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+    gen = DBFirstCodeGenerator(prod_db, doc_db, tpl_db, analytics)
+    result = gen.generate("TestObjective")
+    assert "Auto-generated template" in result
+
+    with sqlite3.connect(analytics) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM code_generation_events WHERE objective = ?",
+            ("TestObjective",),
+        ).fetchone()[0]
+    assert count == 1

--- a/tests/test_documentation_manager_validator.py
+++ b/tests/test_documentation_manager_validator.py
@@ -1,0 +1,45 @@
+import os
+import sqlite3
+from pathlib import Path
+
+from archive.consolidated_scripts.enterprise_database_driven_documentation_manager import (
+    DocumentationManager,
+    dual_validate,
+)
+from template_engine import auto_generator
+
+auto_generator.validate_no_recursive_folders = lambda: None
+
+
+def test_documentation_validator(tmp_path: Path) -> None:
+    prod_db = tmp_path / "production.db"
+    analytics = tmp_path / "databases" / "analytics.db"
+    analytics.parent.mkdir(parents=True)
+    completion_db = tmp_path / "template.db"
+
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute(
+            "CREATE TABLE documentation (title TEXT, content TEXT, compliance_score INTEGER)"
+        )
+        conn.execute("INSERT INTO documentation VALUES ('Doc1', 'body', 80)")
+
+    with sqlite3.connect(completion_db) as conn:
+        conn.execute("CREATE TABLE templates (template_content TEXT)")
+        conn.execute("INSERT INTO templates VALUES ('{content}')")
+
+    with sqlite3.connect(analytics) as conn:
+        conn.execute("CREATE TABLE ml_pattern_optimization (replacement_template TEXT)")
+        conn.execute("INSERT INTO ml_pattern_optimization VALUES ('{content}')")
+
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+    manager = DocumentationManager(
+        database=prod_db,
+        analytics_db=analytics,
+        completion_db=completion_db,
+    )
+    assert manager.render() == 1
+    import archive.consolidated_scripts.enterprise_database_driven_documentation_manager as mod
+    mod_obj = manager
+    setattr(mod, "DocumentationManager", lambda: mod_obj)
+    assert dual_validate()

--- a/tests/test_placeholder_apply_fixes.py
+++ b/tests/test_placeholder_apply_fixes.py
@@ -1,0 +1,36 @@
+import os
+import sqlite3
+from pathlib import Path
+
+os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+
+from scripts.code_placeholder_audit import main
+
+
+def test_apply_fixes_removes_placeholders(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    target = workspace / "demo.py"
+    target.write_text("def demo():\n    pass  # TODO\n")
+
+    analytics = tmp_path / "analytics.db"
+    prod_db = tmp_path / "production.db"
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute(
+            "CREATE TABLE template_placeholders (placeholder_name TEXT)"
+        )
+        conn.execute("INSERT INTO template_placeholders VALUES ('PLACE')")
+
+    os.environ["GH_COPILOT_WORKSPACE"] = str(workspace)
+    assert main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=str(prod_db),
+        dashboard_dir=str(tmp_path / "dashboard"),
+        apply_fixes=True,
+    )
+
+    assert "TODO" not in target.read_text()
+    with sqlite3.connect(analytics) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM corrections").fetchone()[0]
+    assert count >= 1

--- a/validation/protocols/__init__.py
+++ b/validation/protocols/__init__.py
@@ -1,6 +1,17 @@
-"""Validation protocol modules"""
+"""Validation protocol modules."""
 
 from .session import SessionProtocolValidator
 from .deployment import DeploymentValidator
+from .code_audit import PlaceholderAuditValidator
+from .code_generation import DBFirstGenerationValidator
+from .documentation_manager import DocumentationManagerValidator
+from .dashboard import DashboardMetricsValidator
 
-__all__ = ['SessionProtocolValidator', 'DeploymentValidator']
+__all__ = [
+    "SessionProtocolValidator",
+    "DeploymentValidator",
+    "PlaceholderAuditValidator",
+    "DBFirstGenerationValidator",
+    "DocumentationManagerValidator",
+    "DashboardMetricsValidator",
+]

--- a/validation/protocols/code_audit.py
+++ b/validation/protocols/code_audit.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from ..core.validators import BaseValidator, ValidationResult, ValidationStatus
+
+
+class PlaceholderAuditValidator(BaseValidator):
+    """Validate placeholder audit results exist."""
+
+    def __init__(self, analytics_db: Path) -> None:
+        super().__init__("Placeholder Audit Validator")
+        self.analytics_db = Path(analytics_db)
+
+    def validate(self, target: object = None) -> ValidationResult:
+        if not self.analytics_db.exists():
+            return ValidationResult(
+                status=ValidationStatus.FAILED,
+                message=f"analytics db not found: {self.analytics_db}",
+            )
+        try:
+            with sqlite3.connect(self.analytics_db) as conn:
+                cur = conn.execute("SELECT COUNT(*) FROM code_audit_log")
+                count = cur.fetchone()[0]
+            status = ValidationStatus.PASSED if count > 0 else ValidationStatus.FAILED
+            msg = "audit log entries found" if count > 0 else "no audit log entries"
+            return ValidationResult(status=status, message=msg, details={"entries": count})
+        except Exception as exc:  # pragma: no cover - error path
+            return ValidationResult(
+                status=ValidationStatus.ERROR,
+                message=f"validation error: {exc}",
+                errors=[str(exc)],
+            )

--- a/validation/protocols/code_generation.py
+++ b/validation/protocols/code_generation.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from ..core.validators import BaseValidator, ValidationResult, ValidationStatus
+
+
+class DBFirstGenerationValidator(BaseValidator):
+    """Validate DB-first generation events are logged."""
+
+    def __init__(self, analytics_db: Path, objective: str) -> None:
+        super().__init__("DB-First Generation Validator")
+        self.analytics_db = Path(analytics_db)
+        self.objective = objective
+
+    def validate(self, target: object = None) -> ValidationResult:
+        if not self.analytics_db.exists():
+            return ValidationResult(
+                status=ValidationStatus.FAILED,
+                message=f"analytics db not found: {self.analytics_db}",
+            )
+        try:
+            with sqlite3.connect(self.analytics_db) as conn:
+                cur = conn.execute(
+                    "SELECT COUNT(*) FROM code_generation_events WHERE objective = ?",
+                    (self.objective,),
+                )
+                count = cur.fetchone()[0]
+            status = ValidationStatus.PASSED if count > 0 else ValidationStatus.FAILED
+            msg = "generation event logged" if count > 0 else "missing generation event"
+            return ValidationResult(status=status, message=msg, details={"count": count})
+        except Exception as exc:  # pragma: no cover - error path
+            return ValidationResult(
+                status=ValidationStatus.ERROR,
+                message=f"validation error: {exc}",
+                errors=[str(exc)],
+            )

--- a/validation/protocols/dashboard.py
+++ b/validation/protocols/dashboard.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..core.validators import BaseValidator, ValidationResult, ValidationStatus
+
+
+class DashboardMetricsValidator(BaseValidator):
+    """Validate dashboard metrics status."""
+
+    def __init__(self, dashboard_dir: Path) -> None:
+        super().__init__("Dashboard Metrics Validator")
+        self.dashboard_file = Path(dashboard_dir) / "metrics.json"
+
+    def validate(self, target: object = None) -> ValidationResult:
+        if not self.dashboard_file.exists():
+            return ValidationResult(
+                status=ValidationStatus.FAILED,
+                message=f"metrics file missing: {self.dashboard_file}",
+            )
+        try:
+            data = json.loads(self.dashboard_file.read_text(encoding="utf-8"))
+            status_str = data.get("status")
+            result_status = (
+                ValidationStatus.PASSED if status_str == "complete" else ValidationStatus.WARNING
+            )
+            return ValidationResult(
+                status=result_status,
+                message=f"dashboard status: {status_str}",
+                details={"status": status_str},
+            )
+        except Exception as exc:  # pragma: no cover - error path
+            return ValidationResult(
+                status=ValidationStatus.ERROR,
+                message=f"validation error: {exc}",
+                errors=[str(exc)],
+            )

--- a/validation/protocols/documentation_manager.py
+++ b/validation/protocols/documentation_manager.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from ..core.validators import BaseValidator, ValidationResult, ValidationStatus
+
+
+class DocumentationManagerValidator(BaseValidator):
+    """Validate documentation render events are logged."""
+
+    def __init__(self, analytics_db: Path) -> None:
+        super().__init__("Documentation Manager Validator")
+        self.analytics_db = Path(analytics_db)
+
+    def validate(self, target: object = None) -> ValidationResult:
+        if not self.analytics_db.exists():
+            return ValidationResult(
+                status=ValidationStatus.FAILED,
+                message=f"analytics db not found: {self.analytics_db}",
+            )
+        try:
+            with sqlite3.connect(self.analytics_db) as conn:
+                cur = conn.execute("SELECT COUNT(*) FROM render_events")
+                count = cur.fetchone()[0]
+            status = ValidationStatus.PASSED if count > 0 else ValidationStatus.FAILED
+            msg = "render events logged" if count > 0 else "no render events"
+            return ValidationResult(status=status, message=msg, details={"count": count})
+        except Exception as exc:  # pragma: no cover - error path
+            return ValidationResult(
+                status=ValidationStatus.ERROR,
+                message=f"validation error: {exc}",
+                errors=[str(exc)],
+            )


### PR DESCRIPTION
## Summary
- add validators for placeholder audit, DB-first generation, documentation manager and dashboard metrics
- implement new tests covering code generation, documentation rendering, placeholder cleanup, and metrics

## Testing
- `ruff check validation/protocols/__init__.py validation/protocols/code_audit.py validation/protocols/code_generation.py validation/protocols/documentation_manager.py validation/protocols/dashboard.py tests/test_dashboard_metrics_complete.py tests/test_db_first_codegen_analytics.py tests/test_documentation_manager_validator.py tests/test_placeholder_apply_fixes.py`
- `pytest -q tests/test_placeholder_apply_fixes.py tests/test_db_first_codegen_analytics.py tests/test_documentation_manager_validator.py tests/test_dashboard_metrics_complete.py`
- `pytest -q` *(fails: OperationalError, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a44eeb2388331814bb08c21cc3e12