### PR TITLE
fix: resolve lint warnings in analysis scripts

### DIFF
--- a/quantum_database_search.py
+++ b/quantum_database_search.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Wrapper for :mod:`quantum.quantum_database_search` utilities."""
+
 from utils.cross_platform_paths import verify_environment_variables
 
 __all__ = [
@@ -13,31 +14,31 @@ __all__ = [
 def quantum_search_sql(*args, **kwargs):
     """Lazy import and execute ``quantum_search_sql``."""
     from quantum.quantum_database_search import quantum_search_sql as _func
+
     return _func(*args, **kwargs)
 
 
 def quantum_search_nosql(*args, **kwargs):
     """Lazy import and execute ``quantum_search_nosql``."""
     from quantum.quantum_database_search import quantum_search_nosql as _func
+
     return _func(*args, **kwargs)
 
 
 def quantum_search_hybrid(*args, **kwargs):
     """Lazy import and execute ``quantum_search_hybrid``."""
     from quantum.quantum_database_search import quantum_search_hybrid as _func
+
     return _func(*args, **kwargs)
 
 
 def cli() -> None:
     """Run :mod:`quantum.quantum_database_search` CLI after environment check."""
     verify_environment_variables()
-    from quantum.quantum_database_search import (
-        main,
-        quantum_search_hybrid,
-        quantum_search_nosql,
-        quantum_search_sql,
-    )
+    from quantum.quantum_database_search import main
+
     main()
+
 
 if __name__ == "__main__":  # pragma: no cover
     cli()

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -2,3 +2,7 @@
 
 from . import docs_metrics_validator, validate_docs_metrics
 
+__all__ = [
+    "docs_metrics_validator",
+    "validate_docs_metrics",
+]

--- a/scripts/advanced_visual_processing_engine.py
+++ b/scripts/advanced_visual_processing_engine.py
@@ -51,8 +51,11 @@ import psutil
 # Advanced visualization imports
 try:
     import matplotlib.pyplot as plt
-    import matplotlib.animation as animation
-    from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+    # Optional: advanced animations
+    import matplotlib.animation as animation  # noqa: F401
+    from matplotlib.backends.backend_agg import FigureCanvasAgg  # noqa: F401
+
     MATPLOTLIB_AVAILABLE = True
 except ImportError:
     MATPLOTLIB_AVAILABLE = False
@@ -61,8 +64,9 @@ except ImportError:
 try:
     import plotly.graph_objects as go
     import plotly.express as px
-    from plotly.subplots import make_subplots
+    from plotly.subplots import make_subplots  # noqa: F401
     import plotly.offline as pyo
+
     PLOTLY_AVAILABLE = True
 except ImportError:
     PLOTLY_AVAILABLE = False
@@ -70,6 +74,7 @@ except ImportError:
 
 try:
     import cv2
+
     OPENCV_AVAILABLE = True
 except ImportError:
     OPENCV_AVAILABLE = False
@@ -77,6 +82,7 @@ except ImportError:
 
 try:
     from PIL import Image, ImageDraw, ImageFont, ImageFilter, ImageEnhance
+
     PIL_AVAILABLE = True
 except ImportError:
     PIL_AVAILABLE = False
@@ -85,69 +91,81 @@ except ImportError:
 # Configure comprehensive logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
+    format="%(asctime)s - %(levelname)s - %(message)s",
     handlers=[
-        logging.FileHandler('logs/visual_processing/advanced_visual_processing_engine.log'),
-        logging.StreamHandler(sys.stdout)
-    ]
+        logging.FileHandler("logs/visual_processing/advanced_visual_processing_engine.log"),
+        logging.StreamHandler(sys.stdout),
+    ],
 )
 logger = logging.getLogger(__name__)
 
+
 class VisualProcessingState(Enum):
     """Visual processing states for comprehensive workflow management"""
-    INITIALIZING = "initializing"              # System startup and visual engine initialization
-    ACTIVE = "active"                          # Normal visual processing operations
-    RENDERING = "rendering"                    # Active visualization rendering
-    STREAMING = "streaming"                    # Real-time data streaming and live updates
-    ANALYZING = "analyzing"                    # Visual data analysis and pattern recognition
-    OPTIMIZING = "optimizing"                  # Performance optimization and GPU acceleration
-    DASHBOARD_ACTIVE = "dashboard_active"      # Interactive dashboard operations
+
+    INITIALIZING = "initializing"  # System startup and visual engine initialization
+    ACTIVE = "active"  # Normal visual processing operations
+    RENDERING = "rendering"  # Active visualization rendering
+    STREAMING = "streaming"  # Real-time data streaming and live updates
+    ANALYZING = "analyzing"  # Visual data analysis and pattern recognition
+    OPTIMIZING = "optimizing"  # Performance optimization and GPU acceleration
+    DASHBOARD_ACTIVE = "dashboard_active"  # Interactive dashboard operations
     QUANTUM_PROCESSING = "quantum_processing"  # Quantum-enhanced visual processing
-    AI_ANALYSIS = "ai_analysis"               # AI-powered visual analytics
-    EMERGENCY_HALT = "emergency_halt"          # Emergency shutdown due to critical issues
-    COMPLETED = "completed"                    # Normal processing completion
+    AI_ANALYSIS = "ai_analysis"  # AI-powered visual analytics
+    EMERGENCY_HALT = "emergency_halt"  # Emergency shutdown due to critical issues
+    COMPLETED = "completed"  # Normal processing completion
+
 
 class VisualizationType(Enum):
     """Visualization types for enterprise visual processing"""
-    REAL_TIME_DASHBOARD = "real_time_dashboard"        # Executive real-time dashboards
-    INTERACTIVE_CHARTS = "interactive_charts"          # Interactive data charts and graphs
-    DATA_ANALYTICS = "data_analytics"                  # Advanced data analytics visualization
-    PERFORMANCE_METRICS = "performance_metrics"        # System performance visualization
-    BUSINESS_INTELLIGENCE = "business_intelligence"    # Business intelligence dashboards
-    QUANTUM_VISUALIZATION = "quantum_visualization"    # Quantum data visualization
-    AI_PATTERN_DISPLAY = "ai_pattern_display"         # AI pattern recognition displays
-    EXECUTIVE_REPORTS = "executive_reports"            # Executive-level visual reports
-    MONITORING_DISPLAYS = "monitoring_displays"        # System monitoring visualizations
-    PREDICTIVE_ANALYTICS = "predictive_analytics"      # Predictive analytics visualization
+
+    REAL_TIME_DASHBOARD = "real_time_dashboard"  # Executive real-time dashboards
+    INTERACTIVE_CHARTS = "interactive_charts"  # Interactive data charts and graphs
+    DATA_ANALYTICS = "data_analytics"  # Advanced data analytics visualization
+    PERFORMANCE_METRICS = "performance_metrics"  # System performance visualization
+    BUSINESS_INTELLIGENCE = "business_intelligence"  # Business intelligence dashboards
+    QUANTUM_VISUALIZATION = "quantum_visualization"  # Quantum data visualization
+    AI_PATTERN_DISPLAY = "ai_pattern_display"  # AI pattern recognition displays
+    EXECUTIVE_REPORTS = "executive_reports"  # Executive-level visual reports
+    MONITORING_DISPLAYS = "monitoring_displays"  # System monitoring visualizations
+    PREDICTIVE_ANALYTICS = "predictive_analytics"  # Predictive analytics visualization
+
 
 class ProcessingPriority(Enum):
     """Processing priority levels for visual operations scheduling"""
-    CRITICAL = "critical"                      # Mission-critical visualizations requiring immediate processing
-    HIGH = "high"                             # High-priority visualizations with strict performance requirements
-    NORMAL = "normal"                         # Standard priority visualizations
-    LOW = "low"                               # Low-priority background visualizations
-    BATCH = "batch"                           # Batch processing operations
+
+    CRITICAL = "critical"  # Mission-critical visualizations requiring immediate processing
+    HIGH = "high"  # High-priority visualizations with strict performance requirements
+    NORMAL = "normal"  # Standard priority visualizations
+    LOW = "low"  # Low-priority background visualizations
+    BATCH = "batch"  # Batch processing operations
+
 
 class VisualQuality(Enum):
     """Visual quality levels for rendering optimization"""
-    ULTRA_HIGH = "ultra_high"                 # Maximum quality for executive presentations
-    HIGH = "high"                             # High quality for detailed analysis
-    STANDARD = "standard"                     # Standard quality for normal operations
-    OPTIMIZED = "optimized"                   # Optimized quality for real-time performance
-    LOW_BANDWIDTH = "low_bandwidth"           # Low bandwidth optimization for remote access
+
+    ULTRA_HIGH = "ultra_high"  # Maximum quality for executive presentations
+    HIGH = "high"  # High quality for detailed analysis
+    STANDARD = "standard"  # Standard quality for normal operations
+    OPTIMIZED = "optimized"  # Optimized quality for real-time performance
+    LOW_BANDWIDTH = "low_bandwidth"  # Low bandwidth optimization for remote access
+
 
 class AIAnalysisType(Enum):
     """AI analysis types for intelligent visual processing"""
-    PATTERN_RECOGNITION = "pattern_recognition"        # Visual pattern recognition and classification
-    ANOMALY_DETECTION = "anomaly_detection"           # Visual anomaly detection and alerting
-    PREDICTIVE_MODELING = "predictive_modeling"       # Predictive visual modeling and forecasting
-    TREND_ANALYSIS = "trend_analysis"                 # Visual trend analysis and identification
-    CORRELATION_ANALYSIS = "correlation_analysis"     # Multi-dimensional correlation visualization
-    OPTIMIZATION_ANALYSIS = "optimization_analysis"   # Visual optimization and recommendation analysis
+
+    PATTERN_RECOGNITION = "pattern_recognition"  # Visual pattern recognition and classification
+    ANOMALY_DETECTION = "anomaly_detection"  # Visual anomaly detection and alerting
+    PREDICTIVE_MODELING = "predictive_modeling"  # Predictive visual modeling and forecasting
+    TREND_ANALYSIS = "trend_analysis"  # Visual trend analysis and identification
+    CORRELATION_ANALYSIS = "correlation_analysis"  # Multi-dimensional correlation visualization
+    OPTIMIZATION_ANALYSIS = "optimization_analysis"  # Visual optimization and recommendation analysis
+
 
 @dataclass
 class VisualizationRequest:
     """Comprehensive visualization request definition for enterprise processing"""
+
     request_id: str
     request_name: str
     visualization_type: VisualizationType
@@ -167,9 +185,11 @@ class VisualizationRequest:
     status: str = "pending"
     progress: float = 0.0
 
+
 @dataclass
 class VisualProcessingResult:
     """Comprehensive visual processing result with analytics and metadata"""
+
     result_id: str
     request_id: str
     visualization_type: VisualizationType
@@ -185,9 +205,11 @@ class VisualProcessingResult:
     thumbnail_path: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
+
 @dataclass
 class DashboardConfiguration:
     """Dashboard configuration for enterprise visual displays"""
+
     dashboard_id: str
     dashboard_name: str
     dashboard_type: str
@@ -203,9 +225,11 @@ class DashboardConfiguration:
     export_capabilities: List[str]
     user_permissions: Dict[str, Any]
 
+
 @dataclass
 class VisualProcessingMetrics:
     """Comprehensive metrics for visual processing performance tracking"""
+
     processing_id: str
     total_requests: int
     completed_requests: int
@@ -225,30 +249,33 @@ class VisualProcessingMetrics:
     user_satisfaction: float
     performance_optimization_score: float
 
+
 @dataclass
 class VisualProcessingConfiguration:
     """Configuration settings for advanced visual processing engine"""
-    processing_threads: int = 8                       # Number of parallel processing threads
-    gpu_acceleration: bool = True                     # Enable GPU acceleration for rendering
-    real_time_refresh_rate: int = 1000               # Real-time refresh rate (milliseconds)
-    dashboard_update_interval: int = 5               # Dashboard update interval (seconds)
-    ai_analysis_enabled: bool = True                 # Enable AI-powered visual analysis
-    quantum_enhancement: bool = True                 # Enable quantum-enhanced processing
-    max_concurrent_renders: int = 20                 # Maximum concurrent rendering operations
-    cache_size_mb: int = 1024                       # Visual cache size in megabytes
+
+    processing_threads: int = 8  # Number of parallel processing threads
+    gpu_acceleration: bool = True  # Enable GPU acceleration for rendering
+    real_time_refresh_rate: int = 1000  # Real-time refresh rate (milliseconds)
+    dashboard_update_interval: int = 5  # Dashboard update interval (seconds)
+    ai_analysis_enabled: bool = True  # Enable AI-powered visual analysis
+    quantum_enhancement: bool = True  # Enable quantum-enhanced processing
+    max_concurrent_renders: int = 20  # Maximum concurrent rendering operations
+    cache_size_mb: int = 1024  # Visual cache size in megabytes
     export_quality: VisualQuality = VisualQuality.HIGH  # Default export quality
-    mobile_optimization: bool = True                 # Enable mobile optimization
-    interactive_features: bool = True                # Enable interactive visualization features
-    predictive_caching: bool = True                  # Enable predictive visualization caching
-    auto_optimization: bool = True                   # Enable automatic performance optimization
-    emergency_halt_enabled: bool = True             # Enable emergency halt capabilities
-    database_path: str = "visual_processing.db"     # Visual processing database file path
-    max_processing_duration: int = 3600             # Maximum processing duration (1 hour)
+    mobile_optimization: bool = True  # Enable mobile optimization
+    interactive_features: bool = True  # Enable interactive visualization features
+    predictive_caching: bool = True  # Enable predictive visualization caching
+    auto_optimization: bool = True  # Enable automatic performance optimization
+    emergency_halt_enabled: bool = True  # Enable emergency halt capabilities
+    database_path: str = "visual_processing.db"  # Visual processing database file path
+    max_processing_duration: int = 3600  # Maximum processing duration (1 hour)
+
 
 class AdvancedVisualProcessingEngine:
     """
     🎨 Advanced Visual Processing Engine with Quantum-Enhanced Capabilities
-    
+
     Comprehensive enterprise visual processing system providing:
     - Real-time data visualization with interactive dashboards
     - AI-powered visual analytics and pattern recognition
@@ -257,22 +284,22 @@ class AdvancedVisualProcessingEngine:
     - Multi-platform visualization with mobile optimization
     - Advanced performance optimization with GPU acceleration
     """
-    
+
     def __init__(self, workspace_path: Optional[str] = None, config: Optional[VisualProcessingConfiguration] = None):
         """Initialize Advanced Visual Processing Engine with comprehensive capabilities"""
         # CRITICAL: Anti-recursion validation
         self.validate_workspace_integrity()
-        
+
         # Core configuration
         self.workspace_path = Path(workspace_path or os.getenv("GH_COPILOT_WORKSPACE", os.getcwd()))
         self.config = config or VisualProcessingConfiguration()
         self.processing_id = str(uuid.uuid4())
         self.start_time = datetime.now()
-        
+
         # Database connections
         self.production_db = self.workspace_path / "production.db"
         self.visual_processing_db = self.workspace_path / "databases" / self.config.database_path
-        
+
         # Processing state management
         self.processing_state = VisualProcessingState.INITIALIZING
         self.processing_active = False
@@ -280,27 +307,27 @@ class AdvancedVisualProcessingEngine:
         self.processing_results: Dict[str, VisualProcessingResult] = {}
         self.active_dashboards: Dict[str, DashboardConfiguration] = {}
         self.processing_metrics = None
-        
+
         # Threading and real-time processing
         self.processing_threads: List[threading.Thread] = []
         self.real_time_monitor_thread = None
         self.dashboard_server_thread = None
         self.monitoring_active = False
-        
+
         # Visual processing capabilities
         self.rendering_engine = None
         self.ai_analyzer = None
         self.quantum_processor = None
         self.dashboard_server = None
-        
+
         # Performance optimization
         self.gpu_available = self._check_gpu_availability()
         self.visual_cache = {}
         self.performance_optimizer = None
-        
+
         # Initialize comprehensive visual processing system
         self._initialize_visual_processing_system()
-        
+
         logger.info("🎨 Advanced Visual Processing Engine initialized successfully")
         logger.info(f"Processing ID: {self.processing_id}")
         logger.info(f"Workspace: {self.workspace_path}")
@@ -310,27 +337,27 @@ class AdvancedVisualProcessingEngine:
     def validate_workspace_integrity(self):
         """🚨 CRITICAL: Validate workspace integrity and prevent recursive violations"""
         workspace_root = Path(os.getcwd())
-        
+
         # MANDATORY: Check for recursive backup folders
-        forbidden_patterns = ['*backup*', '*_backup_*', 'backups', '*temp*']
+        forbidden_patterns = ["*backup*", "*_backup_*", "backups", "*temp*"]
         violations = []
-        
+
         for pattern in forbidden_patterns:
             for folder in workspace_root.rglob(pattern):
                 if folder.is_dir() and folder != workspace_root:
                     violations.append(str(folder))
-        
+
         if violations:
             logger.error(f"🚨 RECURSIVE FOLDER VIOLATIONS DETECTED:")
             for violation in violations:
                 logger.error(f"   - {violation}")
             raise RuntimeError("CRITICAL: Recursive folder violations prevent visual processing")
-        
+
         # MANDATORY: Validate proper environment root
         proper_root = "gh_COPILOT"
         if not str(workspace_root).endswith(proper_root):
             logger.warning(f"⚠️  Non-standard workspace root: {workspace_root}")
-        
+
         logger.info("✅ WORKSPACE INTEGRITY VALIDATED")
 
     def _check_gpu_availability(self) -> bool:
@@ -342,20 +369,21 @@ class AdvancedVisualProcessingEngine:
                 if gpu_count > 0:
                     logger.info(f"✅ GPU acceleration available: {gpu_count} CUDA devices")
                     return True
-            
+
             # Check system GPU information
             try:
                 import GPUtil
+
                 gpus = GPUtil.getGPUs()
                 if gpus:
                     logger.info(f"✅ GPU hardware detected: {len(gpus)} GPU(s)")
                     return True
             except ImportError:
                 pass
-            
+
             logger.info("ℹ️  GPU acceleration not available - using CPU processing")
             return False
-            
+
         except Exception as e:
             logger.warning(f"⚠️  GPU availability check failed: {e}")
             return False
@@ -363,47 +391,46 @@ class AdvancedVisualProcessingEngine:
     def _initialize_visual_processing_system(self):
         """Initialize comprehensive visual processing system with all components"""
         with tqdm(total=100, desc="🎨 Initializing Visual Processing", unit="%") as pbar:
-            
             # Phase 1: Database and storage initialization (15%)
             pbar.set_description("🗄️ Database initialization")
             self._initialize_databases()
             pbar.update(15)
-            
+
             # Phase 2: Rendering engine setup (20%)
             pbar.set_description("🖼️ Rendering engine setup")
             self._initialize_rendering_engine()
             pbar.update(20)
-            
+
             # Phase 3: AI analyzer initialization (20%)
             pbar.set_description("🧠 AI analyzer initialization")
             self._initialize_ai_analyzer()
             pbar.update(20)
-            
+
             # Phase 4: Quantum processor setup (15%)
             pbar.set_description("⚛️ Quantum processor setup")
             self._initialize_quantum_processor()
             pbar.update(15)
-            
+
             # Phase 5: Dashboard server setup (15%)
             pbar.set_description("📊 Dashboard server setup")
             self._initialize_dashboard_server()
             pbar.update(15)
-            
+
             # Phase 6: Performance optimization (15%)
             pbar.set_description("⚡ Performance optimization")
             self._initialize_performance_optimization()
             pbar.update(15)
-        
+
         logger.info("✅ Visual processing system initialization completed")
 
     def _initialize_databases(self):
         """Initialize visual processing databases with comprehensive schema"""
         # Ensure databases directory exists
         self.visual_processing_db.parent.mkdir(parents=True, exist_ok=True)
-        
+
         with sqlite3.connect(self.visual_processing_db) as conn:
             cursor = conn.cursor()
-            
+
             # Visualization requests table
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS visualization_requests (
@@ -430,7 +457,7 @@ class AdvancedVisualProcessingEngine:
                     timestamp TEXT NOT NULL
                 );
             """)
-            
+
             # Processing results table
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS processing_results (
@@ -453,7 +480,7 @@ class AdvancedVisualProcessingEngine:
                     timestamp TEXT NOT NULL
                 );
             """)
-            
+
             # Dashboard configurations table
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS dashboard_configurations (
@@ -476,7 +503,7 @@ class AdvancedVisualProcessingEngine:
                     timestamp TEXT NOT NULL
                 );
             """)
-            
+
             # Visual processing metrics table
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS visual_processing_metrics (
@@ -502,25 +529,25 @@ class AdvancedVisualProcessingEngine:
                     timestamp TEXT NOT NULL
                 );
             """)
-            
+
             conn.commit()
-            
+
         logger.info("✅ Visual processing databases initialized successfully")
 
     def _initialize_rendering_engine(self):
         """Initialize advanced rendering engine with multiple backend support"""
         rendering_backends = []
-        
+
         # Initialize Matplotlib backend
         if MATPLOTLIB_AVAILABLE:
             try:
                 if plt is not None:
-                    plt.style.use('seaborn-v0_8')  # Modern styling
+                    plt.style.use("seaborn-v0_8")  # Modern styling
                 rendering_backends.append("matplotlib")
                 logger.info("✅ Matplotlib rendering backend initialized")
             except Exception as e:
                 logger.warning(f"⚠️  Matplotlib initialization warning: {e}")
-        
+
         # Initialize Plotly backend
         if PLOTLY_AVAILABLE and pyo is not None:
             try:
@@ -533,7 +560,7 @@ class AdvancedVisualProcessingEngine:
         elif PLOTLY_AVAILABLE:
             rendering_backends.append("plotly")
             logger.info("✅ Plotly rendering backend initialized (offline mode)")
-        
+
         # Initialize OpenCV backend
         if OPENCV_AVAILABLE:
             try:
@@ -541,15 +568,15 @@ class AdvancedVisualProcessingEngine:
                 logger.info("✅ OpenCV rendering backend initialized")
             except Exception as e:
                 logger.warning(f"⚠️  OpenCV initialization warning: {e}")
-        
+
         self.rendering_engine = {
             "backends": rendering_backends,
             "active_backend": rendering_backends[0] if rendering_backends else "fallback",
             "gpu_acceleration": self.gpu_available,
             "cache_enabled": True,
-            "performance_mode": "optimized"
+            "performance_mode": "optimized",
         }
-        
+
         if not rendering_backends:
             logger.warning("⚠️  No advanced rendering backends available - using fallback")
             self.rendering_engine["active_backend"] = "fallback"
@@ -573,9 +600,9 @@ class AdvancedVisualProcessingEngine:
                         "anomaly_detection": "2.8.3",
                         "trend_analysis": "3.1.5",
                         "correlation_analysis": "2.9.2",
-                        "optimization": "3.0.8"
+                        "optimization": "3.0.8",
                     },
-                    "status": "active"
+                    "status": "active",
                 }
                 logger.info("✅ AI visual analyzer initialized")
                 logger.info(f"🧠 AI models loaded: {len(self.ai_analyzer['model_versions'])}")
@@ -596,7 +623,7 @@ class AdvancedVisualProcessingEngine:
                         "quantum_image_enhancement",
                         "quantum_pattern_matching",
                         "quantum_noise_reduction",
-                        "quantum_color_optimization"
+                        "quantum_color_optimization",
                     ],
                     "quantum_fidelity": 0.987,
                     "performance_boost": "3.2x",  # Aspirational quantum speedup
@@ -604,7 +631,7 @@ class AdvancedVisualProcessingEngine:
                     "optimization_level": "maximum",
                     "coherence_time": "100ms",
                     "error_correction": "surface_code",
-                    "status": "active"
+                    "status": "active",
                 }
                 logger.info("✅ Quantum visual processor initialized")
                 logger.info(f"⚛️ Quantum algorithms available: {len(self.quantum_processor['algorithms'])}")
@@ -630,12 +657,12 @@ class AdvancedVisualProcessingEngine:
                     "/api/dashboards",
                     "/api/real-time-data",
                     "/api/export",
-                    "/api/analytics"
+                    "/api/analytics",
                 ],
                 "supported_formats": ["html", "json", "svg", "png", "pdf"],
                 "max_concurrent_sessions": 100,
                 "session_timeout": 3600,
-                "status": "configured"
+                "status": "configured",
             }
             logger.info("✅ Dashboard server configured")
             logger.info(f"📊 Dashboard endpoints: {len(self.dashboard_server['api_endpoints'])}")
@@ -661,9 +688,9 @@ class AdvancedVisualProcessingEngine:
                     "rendering_speed": "maximum",
                     "quality": "high",
                     "memory_usage": "optimized",
-                    "bandwidth": "efficient"
+                    "bandwidth": "efficient",
                 },
-                "status": "active"
+                "status": "active",
             }
             logger.info("✅ Performance optimizer initialized")
         except Exception as e:
@@ -672,91 +699,87 @@ class AdvancedVisualProcessingEngine:
 
     def start_visual_processing_engine(self) -> Dict[str, Any]:
         """🚀 Start comprehensive visual processing engine with advanced capabilities"""
-        logger.info("="*80)
+        logger.info("=" * 80)
         logger.info("🎨 STARTING ADVANCED VISUAL PROCESSING ENGINE")
-        logger.info("="*80)
-        
+        logger.info("=" * 80)
+
         try:
             # MANDATORY: Timeout control
             start_time = datetime.now()
             timeout_seconds = self.config.max_processing_duration
-            
+
             # Phase 1: Pre-processing validation (20%)
             with tqdm(total=100, desc="🔍 Pre-processing validation", unit="%") as pbar:
-                
                 pbar.set_description("🏠 Workspace validation")
                 self.validate_workspace_integrity()
                 pbar.update(25)
-                
+
                 pbar.set_description("🗄️ Database connectivity")
                 self._validate_database_connectivity()
                 pbar.update(25)
-                
+
                 pbar.set_description("🎨 Rendering capabilities")
                 self._validate_rendering_capabilities()
                 pbar.update(25)
-                
+
                 pbar.set_description("⚛️ Advanced systems")
                 self._validate_advanced_systems()
                 pbar.update(25)
-            
+
             # Phase 2: Engine startup and initialization (25%)
             with tqdm(total=100, desc="🚀 Engine startup", unit="%") as pbar:
-                
                 pbar.set_description("🖼️ Rendering engine")
                 self._start_rendering_engine()
                 pbar.update(30)
-                
+
                 pbar.set_description("🧠 AI analyzer")
                 self._start_ai_analyzer()
                 pbar.update(25)
-                
+
                 pbar.set_description("⚛️ Quantum processor")
                 self._start_quantum_processor()
                 pbar.update(25)
-                
+
                 pbar.set_description("📊 Dashboard server")
                 self._start_dashboard_server()
                 pbar.update(20)
-            
+
             # Phase 3: Real-time processing activation (25%)
             with tqdm(total=100, desc="⚡ Real-time activation", unit="%") as pbar:
-                
                 pbar.set_description("📊 Real-time monitoring")
                 self._start_real_time_monitoring()
                 pbar.update(40)
-                
+
                 pbar.set_description("🔄 Background processing")
                 self._start_background_processing()
                 pbar.update(30)
-                
+
                 pbar.set_description("🎯 Performance optimization")
                 self._start_performance_optimization()
                 pbar.update(30)
-            
+
             # Phase 4: Enterprise features activation (30%)
             with tqdm(total=100, desc="🏢 Enterprise features", unit="%") as pbar:
-                
                 pbar.set_description("📈 Executive dashboards")
                 self._initialize_executive_dashboards()
                 pbar.update(35)
-                
+
                 pbar.set_description("📱 Mobile optimization")
                 self._initialize_mobile_optimization()
                 pbar.update(25)
-                
+
                 pbar.set_description("🔐 Security features")
                 self._initialize_security_features()
                 pbar.update(20)
-                
+
                 pbar.set_description("📊 Analytics integration")
                 self._initialize_analytics_integration()
                 pbar.update(20)
-            
+
             # Update processing state
             self.processing_state = VisualProcessingState.ACTIVE
             self.processing_active = True
-            
+
             # Initialize processing metrics
             self.processing_metrics = VisualProcessingMetrics(
                 processing_id=self.processing_id,
@@ -776,15 +799,15 @@ class AdvancedVisualProcessingEngine:
                 network_throughput=0.0,
                 quality_score=95.0,
                 user_satisfaction=92.0,
-                performance_optimization_score=94.0
+                performance_optimization_score=94.0,
             )
-            
+
             # Record processing start in database
             self._record_processing_metrics()
-            
+
             # MANDATORY: Completion logging
             duration = (datetime.now() - start_time).total_seconds()
-            logger.info("="*80)
+            logger.info("=" * 80)
             logger.info("✅ ADVANCED VISUAL PROCESSING ENGINE STARTED SUCCESSFULLY")
             logger.info(f"Processing ID: {self.processing_id}")
             logger.info(f"Rendering Backends: {self.rendering_engine['backends'] if self.rendering_engine else []}")
@@ -793,8 +816,8 @@ class AdvancedVisualProcessingEngine:
             logger.info(f"Dashboard Server: {bool(self.dashboard_server)}")
             logger.info(f"GPU Acceleration: {self.gpu_available}")
             logger.info(f"Startup Duration: {duration:.2f} seconds")
-            logger.info("="*80)
-            
+            logger.info("=" * 80)
+
             return {
                 "status": "success",
                 "processing_id": self.processing_id,
@@ -805,16 +828,12 @@ class AdvancedVisualProcessingEngine:
                 "gpu_acceleration": self.gpu_available,
                 "startup_duration": duration,
                 "monitoring_active": self.monitoring_active,
-                "initial_metrics": self.processing_metrics.__dict__
+                "initial_metrics": self.processing_metrics.__dict__,
             }
-            
+
         except Exception as e:
             logger.error(f"❌ Visual processing engine startup failed: {e}")
-            return {
-                "status": "failed",
-                "error": str(e),
-                "processing_id": self.processing_id
-            }
+            return {"status": "failed", "error": str(e), "processing_id": self.processing_id}
 
     def _validate_database_connectivity(self):
         """Validate database connectivity and performance"""
@@ -825,14 +844,14 @@ class AdvancedVisualProcessingEngine:
                 cursor.execute("SELECT COUNT(*) FROM sqlite_master WHERE type='table'")
                 table_count = cursor.fetchone()[0]
                 logger.info(f"✅ Production database: {table_count} tables")
-            
+
             # Test visual processing database
             with sqlite3.connect(self.visual_processing_db) as conn:
                 cursor = conn.cursor()
                 cursor.execute("SELECT COUNT(*) FROM sqlite_master WHERE type='table'")
                 table_count = cursor.fetchone()[0]
                 logger.info(f"✅ Visual processing database: {table_count} tables")
-                
+
         except Exception as e:
             raise RuntimeError(f"Database connectivity validation failed: {e}")
 
@@ -840,10 +859,10 @@ class AdvancedVisualProcessingEngine:
         """Validate rendering capabilities and backend availability"""
         if not self.rendering_engine or not self.rendering_engine["backends"]:
             raise RuntimeError("No rendering backends available")
-        
+
         available_backends = self.rendering_engine["backends"]
         logger.info(f"✅ Rendering validation: {len(available_backends)} backends available")
-        
+
         # Test basic rendering capability
         if "matplotlib" in available_backends and plt is not None:
             try:
@@ -863,7 +882,7 @@ class AdvancedVisualProcessingEngine:
             logger.info(f"✅ AI systems: {ai_models} models ready")
         else:
             logger.info("ℹ️  AI systems: Not configured")
-        
+
         if self.quantum_processor:
             quantum_algorithms = len(self.quantum_processor.get("algorithms", []))
             logger.info(f"✅ Quantum systems: {quantum_algorithms} algorithms ready")
@@ -875,14 +894,14 @@ class AdvancedVisualProcessingEngine:
         if self.rendering_engine:
             active_backend = self.rendering_engine["active_backend"]
             logger.info(f"🖼️ Rendering engine started with {active_backend} backend")
-            
+
             # Initialize rendering cache
             self.visual_cache = {
                 "static_cache": {},
                 "dynamic_cache": {},
                 "max_size_mb": self.config.cache_size_mb,
                 "hit_rate": 0.0,
-                "cache_enabled": True
+                "cache_enabled": True,
             }
         else:
             logger.warning("⚠️  Rendering engine not available")
@@ -923,14 +942,10 @@ class AdvancedVisualProcessingEngine:
         """Start background processing threads"""
         if self.config.processing_threads > 0:
             for i in range(min(self.config.processing_threads, 8)):
-                thread = threading.Thread(
-                    target=self._background_processing_loop,
-                    args=(f"worker_{i}",),
-                    daemon=True
-                )
+                thread = threading.Thread(target=self._background_processing_loop, args=(f"worker_{i}",), daemon=True)
                 self.processing_threads.append(thread)
                 thread.start()
-            
+
             logger.info(f"🔄 Background processing started with {len(self.processing_threads)} threads")
 
     def _start_performance_optimization(self):
@@ -948,22 +963,22 @@ class AdvancedVisualProcessingEngine:
                 "dashboard_id": "executive_overview",
                 "dashboard_name": "Executive Overview Dashboard",
                 "dashboard_type": "executive",
-                "widgets": ["kpi_summary", "trend_analysis", "performance_metrics"]
+                "widgets": ["kpi_summary", "trend_analysis", "performance_metrics"],
             },
             {
                 "dashboard_id": "operational_metrics",
                 "dashboard_name": "Operational Metrics Dashboard",
                 "dashboard_type": "operational",
-                "widgets": ["system_health", "resource_utilization", "service_status"]
+                "widgets": ["system_health", "resource_utilization", "service_status"],
             },
             {
                 "dashboard_id": "business_intelligence",
                 "dashboard_name": "Business Intelligence Dashboard",
                 "dashboard_type": "business",
-                "widgets": ["revenue_analytics", "customer_insights", "market_trends"]
-            }
+                "widgets": ["revenue_analytics", "customer_insights", "market_trends"],
+            },
         ]
-        
+
         for dashboard_config in executive_dashboards:
             dashboard = DashboardConfiguration(
                 dashboard_id=dashboard_config["dashboard_id"],
@@ -979,10 +994,10 @@ class AdvancedVisualProcessingEngine:
                 ai_enhancement=bool(self.ai_analyzer),
                 quantum_processing=bool(self.quantum_processor),
                 export_capabilities=["pdf", "png", "svg", "html"],
-                user_permissions={"admin": "full", "user": "read"}
+                user_permissions={"admin": "full", "user": "read"},
             )
             self.active_dashboards[dashboard.dashboard_id] = dashboard
-        
+
         logger.info(f"📈 Executive dashboards initialized: {len(self.active_dashboards)}")
 
     def _initialize_mobile_optimization(self):
@@ -993,7 +1008,7 @@ class AdvancedVisualProcessingEngine:
                 "touch_interactions",
                 "compressed_assets",
                 "offline_caching",
-                "progressive_loading"
+                "progressive_loading",
             ]
             logger.info(f"📱 Mobile optimization initialized with {len(mobile_features)} features")
         else:
@@ -1006,7 +1021,7 @@ class AdvancedVisualProcessingEngine:
             "session_management",
             "data_encryption",
             "access_control",
-            "audit_logging"
+            "audit_logging",
         ]
         logger.info(f"🔐 Security features initialized: {len(security_features)}")
 
@@ -1017,40 +1032,37 @@ class AdvancedVisualProcessingEngine:
             "performance_analytics",
             "usage_statistics",
             "quality_metrics",
-            "business_intelligence"
+            "business_intelligence",
         ]
         logger.info(f"📊 Analytics integration initialized: {len(analytics_capabilities)}")
 
     def _background_processing_loop(self, worker_id: str):
         """Background processing loop for continuous visual operations"""
         logger.info(f"🔄 Background worker {worker_id} started")
-        
+
         while self.processing_active:
             try:
                 # Check for pending visualization requests
-                pending_requests = [
-                    req for req in self.visualization_requests.values()
-                    if req.status == "pending"
-                ]
-                
+                pending_requests = [req for req in self.visualization_requests.values() if req.status == "pending"]
+
                 if pending_requests:
                     # Process highest priority request
                     request = min(pending_requests, key=lambda r: r.priority.value)
                     self._process_visualization_request(request, worker_id)
-                
+
                 # Performance monitoring
                 self._monitor_processing_performance()
-                
+
                 # Cache management
                 self._manage_visual_cache()
-                
+
                 # Sleep for processing interval
                 time.sleep(1.0)
-                
+
             except Exception as e:
                 logger.error(f"❌ Background processing error in {worker_id}: {e}")
                 time.sleep(5.0)
-        
+
         logger.info(f"🔄 Background worker {worker_id} stopped")
 
     def _process_visualization_request(self, request: VisualizationRequest, worker_id: str):
@@ -1058,37 +1070,36 @@ class AdvancedVisualProcessingEngine:
         try:
             request.status = "processing"
             start_time = datetime.now()
-            
+
             logger.info(f"🎨 Processing visualization: {request.request_name} (Worker: {worker_id})")
-            
+
             # Simulate visualization processing with progress updates
             with tqdm(total=100, desc=f"🎨 {request.request_name}", unit="%") as pbar:
-                
                 # Data preparation (25%)
                 pbar.set_description("📊 Data preparation")
                 time.sleep(0.1)
                 request.progress = 25.0
                 pbar.update(25)
-                
+
                 # Rendering (40%)
                 pbar.set_description("🖼️ Rendering")
                 self._render_visualization(request)
                 request.progress = 65.0
                 pbar.update(40)
-                
+
                 # AI analysis (20%)
                 if request.ai_analysis_types and self.ai_analyzer:
                     pbar.set_description("🧠 AI analysis")
                     self._perform_ai_analysis(request)
                     request.progress = 85.0
                     pbar.update(20)
-                
+
                 # Finalization (15%)
                 pbar.set_description("✅ Finalization")
                 self._finalize_visualization(request)
                 request.progress = 100.0
                 pbar.update(15)
-            
+
             # Create processing result
             processing_time = (datetime.now() - start_time).total_seconds()
             result = VisualProcessingResult(
@@ -1103,14 +1114,14 @@ class AdvancedVisualProcessingEngine:
                 visual_assets={"primary": f"{request.request_id}.png", "thumbnail": f"{request.request_id}_thumb.png"},
                 interactive_elements=[{"type": "zoom", "enabled": True}, {"type": "filter", "enabled": True}],
                 dashboard_components=[{"widget_id": f"widget_{request.request_id}", "type": "chart"}],
-                export_files=[f"{request.request_id}.{fmt}" for fmt in request.export_formats]
+                export_files=[f"{request.request_id}.{fmt}" for fmt in request.export_formats],
             )
-            
+
             self.processing_results[result.result_id] = result
             request.status = "completed"
-            
+
             logger.info(f"✅ Visualization completed: {request.request_name} ({processing_time:.2f}s)")
-            
+
         except Exception as e:
             logger.error(f"❌ Visualization processing failed: {request.request_name}: {e}")
             request.status = "failed"
@@ -1119,9 +1130,9 @@ class AdvancedVisualProcessingEngine:
         """Render visualization using appropriate backend"""
         if not self.rendering_engine:
             raise RuntimeError("Rendering engine not available")
-        
+
         backend = self.rendering_engine["active_backend"]
-        
+
         if backend == "matplotlib" and MATPLOTLIB_AVAILABLE and plt is not None:
             self._render_with_matplotlib(request)
         elif backend == "plotly" and PLOTLY_AVAILABLE and go is not None and px is not None:
@@ -1138,25 +1149,25 @@ class AdvancedVisualProcessingEngine:
             return
         try:
             fig, ax = plt.subplots(figsize=(12, 8))
-            
+
             # Sample data generation
             x = np.linspace(0, 10, 100)
             y = np.sin(x) + np.random.normal(0, 0.1, 100)
-            
+
             ax.plot(x, y, linewidth=2, alpha=0.8)
             ax.set_title(f"Matplotlib Visualization: {request.request_name}")
             ax.set_xlabel("X Axis")
             ax.set_ylabel("Y Axis")
             ax.grid(True, alpha=0.3)
-            
+
             # Save visualization
             output_path = self.workspace_path / "results" / f"{request.request_id}_matplotlib.png"
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            fig.savefig(str(output_path), dpi=300, bbox_inches='tight')
+            fig.savefig(str(output_path), dpi=300, bbox_inches="tight")
             plt.close(fig)
-            
+
             logger.info(f"📊 Matplotlib rendering completed: {output_path}")
-            
+
         except Exception as e:
             logger.error(f"❌ Matplotlib rendering failed: {e}")
 
@@ -1169,24 +1180,24 @@ class AdvancedVisualProcessingEngine:
             # Sample data generation
             x = np.linspace(0, 10, 100)
             y = np.sin(x) + np.random.normal(0, 0.1, 100)
-            
+
             fig = go.Figure()
-            fig.add_trace(go.Scatter(x=x, y=y, mode='lines+markers', name='Data'))
-            
+            fig.add_trace(go.Scatter(x=x, y=y, mode="lines+markers", name="Data"))
+
             fig.update_layout(
                 title=f"Plotly Visualization: {request.request_name}",
                 xaxis_title="X Axis",
                 yaxis_title="Y Axis",
-                showlegend=True
+                showlegend=True,
             )
-            
+
             # Save visualization
             output_path = self.workspace_path / "results" / f"{request.request_id}_plotly.html"
             output_path.parent.mkdir(parents=True, exist_ok=True)
             fig.write_html(str(output_path))
-            
+
             logger.info(f"📊 Plotly rendering completed: {output_path}")
-            
+
         except Exception as e:
             logger.error(f"❌ Plotly rendering failed: {e}")
 
@@ -1195,22 +1206,29 @@ class AdvancedVisualProcessingEngine:
         try:
             # Create sample image
             img = np.zeros((600, 800, 3), dtype=np.uint8)
-            
+
             # Add some visual elements
             if cv2 is not None:
                 cv2.rectangle(img, (50, 50), (750, 550), (255, 255, 255), 2)
-                cv2.putText(img, f"OpenCV: {request.request_name}", (100, 300), 
-                            getattr(cv2, "FONT_HERSHEY_SIMPLEX", 0), 1, (255, 255, 255), 2)
-            
+                cv2.putText(
+                    img,
+                    f"OpenCV: {request.request_name}",
+                    (100, 300),
+                    getattr(cv2, "FONT_HERSHEY_SIMPLEX", 0),
+                    1,
+                    (255, 255, 255),
+                    2,
+                )
+
                 # Save visualization
                 output_path = self.workspace_path / "results" / f"{request.request_id}_opencv.png"
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 cv2.imwrite(str(output_path), img)
-            
+
                 logger.info(f"📊 OpenCV rendering completed: {output_path}")
             else:
                 logger.warning("⚠️  OpenCV is not available for rendering.")
-            
+
         except Exception as e:
             logger.error(f"❌ OpenCV rendering failed: {e}")
 
@@ -1223,7 +1241,7 @@ class AdvancedVisualProcessingEngine:
         """Perform AI-powered analysis on visualization data"""
         if not self.ai_analyzer:
             return
-        
+
         for analysis_type in request.ai_analysis_types:
             if analysis_type == AIAnalysisType.PATTERN_RECOGNITION:
                 logger.info(f"🧠 Pattern recognition analysis for {request.request_name}")
@@ -1237,11 +1255,11 @@ class AdvancedVisualProcessingEngine:
         # Export in requested formats
         for export_format in request.export_formats:
             logger.info(f"📤 Exporting {request.request_name} as {export_format}")
-        
+
         # Generate thumbnail if needed
         if request.dashboard_integration:
             logger.info(f"🖼️ Generating thumbnail for {request.request_name}")
-        
+
         # Apply mobile optimization if needed
         if request.mobile_optimization:
             logger.info(f"📱 Applying mobile optimization for {request.request_name}")
@@ -1252,7 +1270,7 @@ class AdvancedVisualProcessingEngine:
             # Update system metrics
             self.processing_metrics.cpu_utilization = psutil.cpu_percent()
             self.processing_metrics.memory_usage = psutil.virtual_memory().percent
-            
+
             # Update processing metrics
             completed_requests = len([r for r in self.visualization_requests.values() if r.status == "completed"])
             self.processing_metrics.completed_requests = completed_requests
@@ -1273,7 +1291,8 @@ class AdvancedVisualProcessingEngine:
             try:
                 with sqlite3.connect(self.visual_processing_db) as conn:
                     cursor = conn.cursor()
-                    cursor.execute("""
+                    cursor.execute(
+                        """
                         INSERT INTO visual_processing_metrics (
                             processing_id, total_requests, completed_requests, failed_requests,
                             active_visualizations, real_time_streams, dashboard_sessions,
@@ -1282,27 +1301,29 @@ class AdvancedVisualProcessingEngine:
                             memory_usage, cpu_utilization, network_throughput, quality_score,
                             user_satisfaction, performance_optimization_score, timestamp
                         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """, (
-                        self.processing_metrics.processing_id,
-                        self.processing_metrics.total_requests,
-                        self.processing_metrics.completed_requests,
-                        self.processing_metrics.failed_requests,
-                        self.processing_metrics.active_visualizations,
-                        self.processing_metrics.real_time_streams,
-                        self.processing_metrics.dashboard_sessions,
-                        self.processing_metrics.ai_analysis_operations,
-                        self.processing_metrics.quantum_processing_operations,
-                        self.processing_metrics.average_processing_time,
-                        self.processing_metrics.average_rendering_time,
-                        self.processing_metrics.gpu_utilization,
-                        self.processing_metrics.memory_usage,
-                        self.processing_metrics.cpu_utilization,
-                        self.processing_metrics.network_throughput,
-                        self.processing_metrics.quality_score,
-                        self.processing_metrics.user_satisfaction,
-                        self.processing_metrics.performance_optimization_score,
-                        datetime.now().isoformat()
-                    ))
+                    """,
+                        (
+                            self.processing_metrics.processing_id,
+                            self.processing_metrics.total_requests,
+                            self.processing_metrics.completed_requests,
+                            self.processing_metrics.failed_requests,
+                            self.processing_metrics.active_visualizations,
+                            self.processing_metrics.real_time_streams,
+                            self.processing_metrics.dashboard_sessions,
+                            self.processing_metrics.ai_analysis_operations,
+                            self.processing_metrics.quantum_processing_operations,
+                            self.processing_metrics.average_processing_time,
+                            self.processing_metrics.average_rendering_time,
+                            self.processing_metrics.gpu_utilization,
+                            self.processing_metrics.memory_usage,
+                            self.processing_metrics.cpu_utilization,
+                            self.processing_metrics.network_throughput,
+                            self.processing_metrics.quality_score,
+                            self.processing_metrics.user_satisfaction,
+                            self.processing_metrics.performance_optimization_score,
+                            datetime.now().isoformat(),
+                        ),
+                    )
                     conn.commit()
             except Exception as e:
                 logger.error(f"❌ Failed to record processing metrics: {e}")
@@ -1324,18 +1345,18 @@ class AdvancedVisualProcessingEngine:
                 interactive_features=request_data.get("interactive_features", True),
                 export_formats=request_data.get("export_formats", ["png"]),
                 dashboard_integration=request_data.get("dashboard_integration", False),
-                mobile_optimization=request_data.get("mobile_optimization", True)
+                mobile_optimization=request_data.get("mobile_optimization", True),
             )
-            
+
             self.visualization_requests[request.request_id] = request
-            
+
             logger.info(f"🎨 Visualization request created: {request.request_name}")
             logger.info(f"   Request ID: {request.request_id}")
             logger.info(f"   Type: {request.visualization_type.value}")
             logger.info(f"   Priority: {request.priority.value}")
-            
+
             return request.request_id
-            
+
         except Exception as e:
             logger.error(f"❌ Failed to create visualization request: {e}")
             raise
@@ -1343,54 +1364,56 @@ class AdvancedVisualProcessingEngine:
     def stop_visual_processing_engine(self) -> Dict[str, Any]:
         """🛑 Stop visual processing engine with comprehensive cleanup"""
         logger.info("🛑 Stopping Advanced Visual Processing Engine...")
-        
+
         try:
             # Stop processing
             self.processing_active = False
             self.processing_state = VisualProcessingState.COMPLETED
-            
+
             # Wait for background threads to complete
             for thread in self.processing_threads:
                 if thread.is_alive():
                     thread.join(timeout=5.0)
-            
+
             # Final metrics recording
             self._record_processing_metrics()
-            
+
             # Cleanup
             if self.visual_cache:
                 self.visual_cache.clear()
-            
+
             duration = (datetime.now() - self.start_time).total_seconds()
-            
+
             logger.info("✅ Visual processing engine stopped successfully")
             logger.info(f"Total runtime: {duration:.2f} seconds")
-            
+
             return {
                 "status": "stopped",
                 "processing_id": self.processing_id,
                 "total_runtime": duration,
                 "requests_processed": len([r for r in self.visualization_requests.values() if r.status == "completed"]),
-                "final_metrics": self.processing_metrics.__dict__ if self.processing_metrics else {}
+                "final_metrics": self.processing_metrics.__dict__ if self.processing_metrics else {},
             }
-            
+
         except Exception as e:
             logger.error(f"❌ Error stopping visual processing engine: {e}")
             return {"status": "error", "error": str(e)}
 
+
 def main():
     """Main execution function for Advanced Visual Processing Engine"""
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Advanced Visual Processing Engine")
-    parser.add_argument("--action", choices=["start", "stop", "status", "create-request"], 
-                       default="start", help="Action to perform")
+    parser.add_argument(
+        "--action", choices=["start", "stop", "status", "create-request"], default="start", help="Action to perform"
+    )
     parser.add_argument("--config", type=str, help="Configuration file path")
     parser.add_argument("--workspace", type=str, help="Workspace directory path")
     parser.add_argument("--request-data", type=str, help="JSON visualization request data")
-    
+
     args = parser.parse_args()
-    
+
     try:
         # Initialize configuration
         config = VisualProcessingConfiguration()
@@ -1400,14 +1423,14 @@ def main():
                 for key, value in config_data.items():
                     if hasattr(config, key):
                         setattr(config, key, value)
-        
+
         # Initialize engine
         engine = AdvancedVisualProcessingEngine(workspace_path=args.workspace, config=config)
-        
+
         if args.action == "start":
             result = engine.start_visual_processing_engine()
             print(json.dumps(result, indent=2))
-            
+
         elif args.action == "create-request":
             if args.request_data:
                 request_data = json.loads(args.request_data)
@@ -1415,25 +1438,26 @@ def main():
                 print(f"Created visualization request: {request_id}")
             else:
                 print("Error: --request-data required for create-request action")
-                
+
         elif args.action == "stop":
             result = engine.stop_visual_processing_engine()
             print(json.dumps(result, indent=2))
-            
+
         elif args.action == "status":
             status = {
                 "processing_id": engine.processing_id,
                 "state": engine.processing_state.value,
                 "active": engine.processing_active,
                 "requests": len(engine.visualization_requests),
-                "results": len(engine.processing_results)
+                "results": len(engine.processing_results),
             }
             print(json.dumps(status, indent=2))
-            
+
     except Exception as e:
         logger.error(f"❌ Main execution failed: {e}")
         print(f"Error: {e}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/analysis/COMPREHENSIVE_MODULAR_BREAKDOWN_ANALYSIS.py
+++ b/scripts/analysis/COMPREHENSIVE_MODULAR_BREAKDOWN_ANALYSIS.py
@@ -17,25 +17,22 @@ Enterprise Compliance: ✅ VALIDATED
 Production Readiness: ✅ CERTIFIED
 """
 
-import os
 import ast
 import json
-import sqlite3
 import logging
 import hashlib
-import re
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Tuple, Set
+from typing import Dict, List, Any, Optional
 from tqdm import tqdm
 from dataclasses import dataclass, asdict
-from collections import defaultdict, Counter
-import difflib
+from collections import defaultdict
 
 
 @dataclass
 class FunctionSignature:
     """Function signature analysis for modular extraction"""
+
     name: str
     parameters: List[str]
     return_type: Optional[str]
@@ -48,6 +45,7 @@ class FunctionSignature:
 @dataclass
 class ModularOpportunity:
     """Modular extraction opportunity identification"""
+
     pattern_name: str
     common_functions: List[str]
     affected_scripts: List[str]
@@ -61,14 +59,14 @@ class ModularOpportunity:
 class ComprehensiveModularBreakdownAnalyzer:
     """
     Advanced modular breakdown analyzer for enterprise script optimization
-    
+
     Post-Strategic Implementation Analysis:
     - All 4 strategic options completed with 100% success
     - Enterprise compliance validated
     - Production readiness certified
     - Ready for modular architecture implementation
     """
-    
+
     def __init__(self, workspace_path: str):
         """Initialize modular breakdown analyzer"""
         self.workspace_path = Path(workspace_path)
@@ -78,118 +76,119 @@ class ComprehensiveModularBreakdownAnalyzer:
         self.script_functions = {}
         self.common_imports = defaultdict(int)
         self.logger = self._setup_logging()
-        
+
         # Strategic Implementation Status Validation
         self.validate_strategic_completion()
-        
+
     def _setup_logging(self) -> logging.Logger:
         """Setup enterprise logging configuration"""
         logging.basicConfig(
             level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            handlers=[
-                logging.FileHandler('modular_breakdown_analysis.log'),
-                logging.StreamHandler()
-            ]
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            handlers=[logging.FileHandler("modular_breakdown_analysis.log"), logging.StreamHandler()],
         )
         return logging.getLogger(__name__)
-    
+
     def validate_strategic_completion(self):
         """Validate that strategic implementation is 100% complete"""
         try:
             report_path = self.workspace_path / "strategic_implementation_report_799a754f_20250716_205911.json"
             if report_path.exists():
-                with open(report_path, 'r', encoding='utf-8') as f:
+                with open(report_path, "r", encoding="utf-8") as f:
                     report = json.load(f)
-                    
-                success_rate = report.get("strategic_implementation_report", {}).get(
-                    "comprehensive_metrics", {}
-                ).get("success_rate", "0%")
-                
+
+                success_rate = (
+                    report.get("strategic_implementation_report", {})
+                    .get("comprehensive_metrics", {})
+                    .get("success_rate", "0%")
+                )
+
                 if success_rate == "100.0%":
                     self.logger.info("✅ Strategic Implementation: 100% COMPLETE - Proceeding with modular analysis")
                     return True
                 else:
                     self.logger.warning(f"⚠️ Strategic Implementation: {success_rate} - Analysis may be incomplete")
-                    
+
         except Exception as e:
             self.logger.error(f"❌ Cannot validate strategic completion: {e}")
-            
+
         return False
-    
+
     def analyze_script_functions(self, script_path: Path) -> Dict[str, Any]:
         """Analyze functions in a single script for modular patterns"""
         try:
-            with open(script_path, 'r', encoding='utf-8', errors='ignore') as f:
+            with open(script_path, "r", encoding="utf-8", errors="ignore") as f:
                 content = f.read()
-                
+
             # Parse AST for function analysis
             tree = ast.parse(content)
             functions = []
             imports = []
             classes = []
-            
+
             for node in ast.walk(tree):
                 if isinstance(node, ast.FunctionDef):
                     func_signature = self._extract_function_signature(node, content)
                     functions.append(func_signature)
-                    
+
                 elif isinstance(node, ast.Import):
                     for alias in node.names:
                         imports.append(alias.name)
                         self.common_imports[alias.name] += 1
-                        
+
                 elif isinstance(node, ast.ImportFrom):
                     module = node.module or ""
                     for alias in node.names:
                         import_name = f"{module}.{alias.name}" if module else alias.name
                         imports.append(import_name)
                         self.common_imports[import_name] += 1
-                        
+
                 elif isinstance(node, ast.ClassDef):
                     classes.append(node.name)
-            
+
             return {
-                'script_path': str(script_path),
-                'functions': functions,
-                'imports': imports,
-                'classes': classes,
-                'total_lines': len(content.splitlines()),
-                'function_count': len(functions)
+                "script_path": str(script_path),
+                "functions": functions,
+                "imports": imports,
+                "classes": classes,
+                "total_lines": len(content.splitlines()),
+                "function_count": len(functions),
             }
-            
+
         except Exception as e:
             self.logger.error(f"Error analyzing {script_path}: {e}")
             return {}
-    
+
     def _extract_function_signature(self, func_node: ast.FunctionDef, content: str) -> FunctionSignature:
         """Extract detailed function signature for similarity analysis"""
         # Extract parameters
         parameters = []
         for arg in func_node.args.args:
             parameters.append(arg.arg)
-            
+
         # Extract docstring
         docstring = None
-        if (func_node.body and 
-            isinstance(func_node.body[0], ast.Expr) and 
-            isinstance(func_node.body[0].value, ast.Constant) and 
-            isinstance(func_node.body[0].value.value, str)):
+        if (
+            func_node.body
+            and isinstance(func_node.body[0], ast.Expr)
+            and isinstance(func_node.body[0].value, ast.Constant)
+            and isinstance(func_node.body[0].value.value, str)
+        ):
             docstring = func_node.body[0].value.value
-            
+
         # Calculate function body hash for similarity
-        body_lines = content.splitlines()[func_node.lineno-1:func_node.end_lineno]
-        body_content = '\n'.join(body_lines)
+        body_lines = content.splitlines()[func_node.lineno - 1 : func_node.end_lineno]
+        body_content = "\n".join(body_lines)
         body_hash = hashlib.md5(body_content.encode()).hexdigest()
-        
+
         # Calculate complexity score (simple metric)
         complexity_score = len(func_node.body) + len(parameters)
-        
+
         # Calculate line count safely
         start_line = func_node.lineno if func_node.lineno else 1
         end_line = func_node.end_lineno if func_node.end_lineno else start_line
         line_count = max(1, end_line - start_line + 1)
-        
+
         return FunctionSignature(
             name=func_node.name,
             parameters=parameters,
@@ -197,82 +196,102 @@ class ComprehensiveModularBreakdownAnalyzer:
             docstring=docstring,
             body_hash=body_hash,
             line_count=line_count,
-            complexity_score=complexity_score
+            complexity_score=complexity_score,
         )
-    
+
     def identify_similar_functions(self) -> Dict[str, List[str]]:
         """Identify functions with similar signatures across scripts"""
         function_groups = defaultdict(list)
-        
+
         # Group functions by name and parameter patterns
         for script_path, analysis in self.script_functions.items():
-            for func in analysis.get('functions', []):
+            for func in analysis.get("functions", []):
                 # Create signature key for grouping
                 param_signature = f"{func.name}({len(func.parameters)})"
-                function_groups[param_signature].append({
-                    'script': script_path,
-                    'function': func,
-                    'signature': param_signature
-                })
-        
+                function_groups[param_signature].append(
+                    {"script": script_path, "function": func, "signature": param_signature}
+                )
+
         # Filter groups with multiple scripts (potential modular opportunities)
         similar_functions = {}
         for signature, func_list in function_groups.items():
             if len(func_list) >= 2:  # At least 2 scripts have this function
-                scripts_with_function = [item['script'] for item in func_list]
+                scripts_with_function = [item["script"] for item in func_list]
                 similar_functions[signature] = scripts_with_function
-                
+
         return similar_functions
-    
+
     def analyze_common_patterns(self):
         """Analyze common patterns for modular extraction opportunities"""
         similar_functions = self.identify_similar_functions()
-        
+
         # Common database operations
         db_patterns = [
-            'get_database_connection', 'execute_query', 'create_table',
-            'insert_record', 'update_record', 'delete_record', 'close_connection'
+            "get_database_connection",
+            "execute_query",
+            "create_table",
+            "insert_record",
+            "update_record",
+            "delete_record",
+            "close_connection",
         ]
-        
+
         # Common file operations
         file_patterns = [
-            'read_file', 'write_file', 'create_directory', 'delete_file',
-            'copy_file', 'move_file', 'list_files', 'check_file_exists'
+            "read_file",
+            "write_file",
+            "create_directory",
+            "delete_file",
+            "copy_file",
+            "move_file",
+            "list_files",
+            "check_file_exists",
         ]
-        
+
         # Common validation operations
         validation_patterns = [
-            'validate_input', 'check_requirements', 'verify_environment',
-            'validate_configuration', 'check_permissions'
+            "validate_input",
+            "check_requirements",
+            "verify_environment",
+            "validate_configuration",
+            "check_permissions",
         ]
-        
+
         # Common utility operations
         utility_patterns = [
-            'setup_logging', 'parse_arguments', 'load_configuration',
-            'save_configuration', 'format_output', 'handle_error'
+            "setup_logging",
+            "parse_arguments",
+            "load_configuration",
+            "save_configuration",
+            "format_output",
+            "handle_error",
         ]
-        
+
         # Common reporting operations
         reporting_patterns = [
-            'generate_report', 'create_summary', 'format_results',
-            'save_report', 'display_progress', 'log_metrics'
+            "generate_report",
+            "create_summary",
+            "format_results",
+            "save_report",
+            "display_progress",
+            "log_metrics",
         ]
-        
+
         pattern_groups = {
-            'database_utils': db_patterns,
-            'file_utils': file_patterns,
-            'validation_utils': validation_patterns,
-            'utility_utils': utility_patterns,
-            'reporting_utils': reporting_patterns
+            "database_utils": db_patterns,
+            "file_utils": file_patterns,
+            "validation_utils": validation_patterns,
+            "utility_utils": utility_patterns,
+            "reporting_utils": reporting_patterns,
         }
-        
+
         modular_opportunities = []
-        
+
         for module_name, patterns in pattern_groups.items():
             affected_scripts = set()
             common_functions = []
             estimated_savings = 0
-            
+
             for pattern in patterns:
                 for signature, scripts in similar_functions.items():
                     if pattern in signature.lower():
@@ -280,106 +299,106 @@ class ComprehensiveModularBreakdownAnalyzer:
                         common_functions.append(signature)
                         # Estimate 10-20 lines per function instance
                         estimated_savings += len(scripts) * 15
-            
+
             if len(affected_scripts) >= 3:  # Minimum 3 scripts for modular extraction
                 opportunity = ModularOpportunity(
-                    pattern_name=module_name.replace('_', ' ').title(),
+                    pattern_name=module_name.replace("_", " ").title(),
                     common_functions=common_functions,
                     affected_scripts=list(affected_scripts),
                     estimated_lines_saved=estimated_savings,
                     suggested_module_name=module_name,
                     similarity_score=len(common_functions) / len(patterns),
                     complexity_reduction=len(affected_scripts) * 0.15,  # 15% complexity reduction per script
-                    implementation_priority='HIGH' if estimated_savings > 200 else 'MEDIUM'
+                    implementation_priority="HIGH" if estimated_savings > 200 else "MEDIUM",
                 )
                 modular_opportunities.append(opportunity)
-        
+
         return modular_opportunities
-    
+
     def analyze_import_patterns(self) -> Dict[str, Any]:
         """Analyze common import patterns for standardization"""
         # Get most common imports
-        sorted_imports = sorted(
-            self.common_imports.items(),
-            key=lambda x: x[1],
-            reverse=True
-        )
-        
+        sorted_imports = sorted(self.common_imports.items(), key=lambda x: x[1], reverse=True)
+
         # Identify standardization opportunities
         standardization_opportunities = []
         for import_name, count in sorted_imports[:20]:  # Top 20 imports
             if count >= 5:  # Used in at least 5 scripts
-                standardization_opportunities.append({
-                    'import': import_name,
-                    'usage_count': count,
-                    'consolidation_potential': 'HIGH' if count >= 10 else 'MEDIUM'
-                })
-        
+                standardization_opportunities.append(
+                    {
+                        "import": import_name,
+                        "usage_count": count,
+                        "consolidation_potential": "HIGH" if count >= 10 else "MEDIUM",
+                    }
+                )
+
         return {
-            'total_unique_imports': len(self.common_imports),
-            'most_common_imports': sorted_imports[:20],
-            'standardization_opportunities': standardization_opportunities
+            "total_unique_imports": len(self.common_imports),
+            "most_common_imports": sorted_imports[:20],
+            "standardization_opportunities": standardization_opportunities,
         }
-    
+
     def generate_implementation_plan(self, opportunities: List[ModularOpportunity]) -> Dict[str, Any]:
         """Generate implementation plan for modular architecture"""
-        high_priority = [op for op in opportunities if op.implementation_priority == 'HIGH']
-        medium_priority = [op for op in opportunities if op.implementation_priority == 'MEDIUM']
-        
+        high_priority = [op for op in opportunities if op.implementation_priority == "HIGH"]
+        medium_priority = [op for op in opportunities if op.implementation_priority == "MEDIUM"]
+
         # Calculate total impact
         total_lines_saved = sum(op.estimated_lines_saved for op in opportunities)
-        total_scripts_affected = len(set(
-            script for op in opportunities for script in op.affected_scripts
-        ))
-        
+        total_scripts_affected = len(set(script for op in opportunities for script in op.affected_scripts))
+
         implementation_phases = [
             {
-                'phase': 'Phase 1: Core Utilities',
-                'modules': ['database_utils.py', 'file_utils.py'],
-                'estimated_impact': sum(op.estimated_lines_saved for op in high_priority[:2]) if len(high_priority) >= 2 else 0,
-                'duration': '1-2 weeks',
-                'risk': 'LOW'
+                "phase": "Phase 1: Core Utilities",
+                "modules": ["database_utils.py", "file_utils.py"],
+                "estimated_impact": sum(op.estimated_lines_saved for op in high_priority[:2])
+                if len(high_priority) >= 2
+                else 0,
+                "duration": "1-2 weeks",
+                "risk": "LOW",
             },
             {
-                'phase': 'Phase 2: Advanced Operations',
-                'modules': ['validation_utils.py', 'reporting_utils.py'],
-                'estimated_impact': sum(op.estimated_lines_saved for op in high_priority[2:]) if len(high_priority) > 2 else 0,
-                'duration': '2-3 weeks',
-                'risk': 'MEDIUM'
+                "phase": "Phase 2: Advanced Operations",
+                "modules": ["validation_utils.py", "reporting_utils.py"],
+                "estimated_impact": sum(op.estimated_lines_saved for op in high_priority[2:])
+                if len(high_priority) > 2
+                else 0,
+                "duration": "2-3 weeks",
+                "risk": "MEDIUM",
             },
             {
-                'phase': 'Phase 3: Specialized Modules',
-                'modules': ['utility_utils.py', 'enterprise_utils.py'],
-                'estimated_impact': sum(op.estimated_lines_saved for op in medium_priority),
-                'duration': '1-2 weeks',
-                'risk': 'LOW'
-            }
+                "phase": "Phase 3: Specialized Modules",
+                "modules": ["utility_utils.py", "enterprise_utils.py"],
+                "estimated_impact": sum(op.estimated_lines_saved for op in medium_priority),
+                "duration": "1-2 weeks",
+                "risk": "LOW",
+            },
         ]
-        
+
         return {
-            'total_opportunities': len(opportunities),
-            'high_priority_count': len(high_priority),
-            'medium_priority_count': len(medium_priority),
-            'total_lines_saved': total_lines_saved,
-            'total_scripts_affected': total_scripts_affected,
-            'implementation_phases': implementation_phases,
-            'success_metrics': {
-                'code_reduction_target': f"{total_lines_saved:,} lines",
-                'maintenance_improvement': f"{total_scripts_affected * 15}% easier maintenance",
-                'reusability_improvement': "80% function reusability",
-                'complexity_reduction': "60% lower script complexity"
-            }
+            "total_opportunities": len(opportunities),
+            "high_priority_count": len(high_priority),
+            "medium_priority_count": len(medium_priority),
+            "total_lines_saved": total_lines_saved,
+            "total_scripts_affected": total_scripts_affected,
+            "implementation_phases": implementation_phases,
+            "success_metrics": {
+                "code_reduction_target": f"{total_lines_saved:,} lines",
+                "maintenance_improvement": f"{total_scripts_affected * 15}% easier maintenance",
+                "reusability_improvement": "80% function reusability",
+                "complexity_reduction": "60% lower script complexity",
+            },
         }
-    
+
     def execute_comprehensive_analysis(self) -> Dict[str, Any]:
         """Execute comprehensive modular breakdown analysis"""
         self.logger.info("🚀 Starting Comprehensive Modular Breakdown Analysis")
         self.logger.info("✅ Strategic Implementation Status: 100% COMPLETE")
-        
+
         # Get all Python scripts in workspace root
-        python_scripts = list(self.workspace_path.glob('*.py'))
+        python_scripts = list(self.workspace_path.glob("*.py"))
         self.logger.info(f"📊 Analyzing {len(python_scripts)} Python scripts in workspace root")
-        
+
         # Analyze each script
         with tqdm(python_scripts, desc="Analyzing script functions") as pbar:
             for script_path in pbar:
@@ -387,51 +406,61 @@ class ComprehensiveModularBreakdownAnalyzer:
                 analysis = self.analyze_script_functions(script_path)
                 if analysis:
                     self.script_functions[str(script_path)] = analysis
-        
+
         # Identify modular opportunities
         self.logger.info("🔍 Identifying modular extraction opportunities...")
         modular_opportunities = self.analyze_common_patterns()
-        
+
         # Analyze import patterns
         import_analysis = self.analyze_import_patterns()
-        
+
         # Generate implementation plan
         implementation_plan = self.generate_implementation_plan(modular_opportunities)
-        
+
         # Compile comprehensive results
         results = {
-            'analysis_metadata': {
-                'timestamp': datetime.now().isoformat(),
-                'workspace_path': str(self.workspace_path),
-                'scripts_analyzed': len(self.script_functions),
-                'strategic_implementation_status': '100% COMPLETE',
-                'enterprise_compliance': 'VALIDATED',
-                'production_readiness': 'CERTIFIED'
+            "analysis_metadata": {
+                "timestamp": datetime.now().isoformat(),
+                "workspace_path": str(self.workspace_path),
+                "scripts_analyzed": len(self.script_functions),
+                "strategic_implementation_status": "100% COMPLETE",
+                "enterprise_compliance": "VALIDATED",
+                "production_readiness": "CERTIFIED",
             },
-            'script_analysis_summary': {
-                'total_scripts': len(self.script_functions),
-                'total_functions': sum(len(analysis.get('functions', [])) for analysis in self.script_functions.values()),
-                'average_functions_per_script': sum(len(analysis.get('functions', [])) for analysis in self.script_functions.values()) / len(self.script_functions) if self.script_functions else 0,
-                'total_lines_analyzed': sum(analysis.get('total_lines', 0) for analysis in self.script_functions.values())
+            "script_analysis_summary": {
+                "total_scripts": len(self.script_functions),
+                "total_functions": sum(
+                    len(analysis.get("functions", [])) for analysis in self.script_functions.values()
+                ),
+                "average_functions_per_script": sum(
+                    len(analysis.get("functions", [])) for analysis in self.script_functions.values()
+                )
+                / len(self.script_functions)
+                if self.script_functions
+                else 0,
+                "total_lines_analyzed": sum(
+                    analysis.get("total_lines", 0) for analysis in self.script_functions.values()
+                ),
             },
-            'modular_opportunities': [asdict(op) for op in modular_opportunities],
-            'import_analysis': import_analysis,
-            'implementation_plan': implementation_plan,
-            'top_modular_candidates': sorted(
-                [asdict(op) for op in modular_opportunities],
-                key=lambda x: x['estimated_lines_saved'],
-                reverse=True
-            )[:10]
+            "modular_opportunities": [asdict(op) for op in modular_opportunities],
+            "import_analysis": import_analysis,
+            "implementation_plan": implementation_plan,
+            "top_modular_candidates": sorted(
+                [asdict(op) for op in modular_opportunities], key=lambda x: x["estimated_lines_saved"], reverse=True
+            )[:10],
         }
-        
+
         # Save results
-        output_file = self.workspace_path / f"comprehensive_modular_breakdown_analysis_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
-        with open(output_file, 'w', encoding='utf-8') as f:
+        output_file = (
+            self.workspace_path
+            / f"comprehensive_modular_breakdown_analysis_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        )
+        with open(output_file, "w", encoding="utf-8") as f:
             json.dump(results, f, indent=2, ensure_ascii=False)
-        
+
         self.logger.info(f"📄 Analysis complete! Results saved to: {output_file}")
         return results
-    
+
     def generate_executive_summary(self, results: Dict[str, Any]):
         """Generate executive summary of modular breakdown analysis"""
         summary = f"""
@@ -442,36 +471,36 @@ class ComprehensiveModularBreakdownAnalyzer:
 - **Strategic Implementation Status**: ✅ 100% COMPLETE
 - **Enterprise Compliance**: ✅ VALIDATED  
 - **Production Readiness**: ✅ CERTIFIED
-- **Scripts Analyzed**: {results['script_analysis_summary']['total_scripts']}
-- **Functions Analyzed**: {results['script_analysis_summary']['total_functions']}
-- **Total Lines Analyzed**: {results['script_analysis_summary']['total_lines_analyzed']:,}
+- **Scripts Analyzed**: {results["script_analysis_summary"]["total_scripts"]}
+- **Functions Analyzed**: {results["script_analysis_summary"]["total_functions"]}
+- **Total Lines Analyzed**: {results["script_analysis_summary"]["total_lines_analyzed"]:,}
 
 ### 🎯 MODULAR OPPORTUNITIES IDENTIFIED
-- **Total Opportunities**: {results['implementation_plan']['total_opportunities']}
-- **High Priority**: {results['implementation_plan']['high_priority_count']}
-- **Medium Priority**: {results['implementation_plan']['medium_priority_count']}
-- **Estimated Lines Saved**: {results['implementation_plan']['total_lines_saved']:,}
-- **Scripts to be Optimized**: {results['implementation_plan']['total_scripts_affected']}
+- **Total Opportunities**: {results["implementation_plan"]["total_opportunities"]}
+- **High Priority**: {results["implementation_plan"]["high_priority_count"]}
+- **Medium Priority**: {results["implementation_plan"]["medium_priority_count"]}
+- **Estimated Lines Saved**: {results["implementation_plan"]["total_lines_saved"]:,}
+- **Scripts to be Optimized**: {results["implementation_plan"]["total_scripts_affected"]}
 
 ### 🚀 TOP MODULAR EXTRACTION CANDIDATES
 """
-        
-        for i, opportunity in enumerate(results['top_modular_candidates'][:5], 1):
+
+        for i, opportunity in enumerate(results["top_modular_candidates"][:5], 1):
             summary += f"""
-#### {i}. {opportunity['pattern_name']}
-- **Module**: `{opportunity['suggested_module_name']}.py`
-- **Affected Scripts**: {len(opportunity['affected_scripts'])}
-- **Lines Saved**: {opportunity['estimated_lines_saved']}
-- **Priority**: {opportunity['implementation_priority']}
-- **Similarity Score**: {opportunity['similarity_score']:.2f}
+#### {i}. {opportunity["pattern_name"]}
+- **Module**: `{opportunity["suggested_module_name"]}.py`
+- **Affected Scripts**: {len(opportunity["affected_scripts"])}
+- **Lines Saved**: {opportunity["estimated_lines_saved"]}
+- **Priority**: {opportunity["implementation_priority"]}
+- **Similarity Score**: {opportunity["similarity_score"]:.2f}
 """
 
         summary += f"""
 ### 📈 IMPLEMENTATION IMPACT
-- **Code Reduction**: {results['implementation_plan']['success_metrics']['code_reduction_target']}
-- **Maintenance Improvement**: {results['implementation_plan']['success_metrics']['maintenance_improvement']}
-- **Reusability**: {results['implementation_plan']['success_metrics']['reusability_improvement']}
-- **Complexity Reduction**: {results['implementation_plan']['success_metrics']['complexity_reduction']}
+- **Code Reduction**: {results["implementation_plan"]["success_metrics"]["code_reduction_target"]}
+- **Maintenance Improvement**: {results["implementation_plan"]["success_metrics"]["maintenance_improvement"]}
+- **Reusability**: {results["implementation_plan"]["success_metrics"]["reusability_improvement"]}
+- **Complexity Reduction**: {results["implementation_plan"]["success_metrics"]["complexity_reduction"]}
 
 ### 🛡️ ENTERPRISE COMPLIANCE STATUS
 - ✅ **Strategic Implementation**: All 4 options completed successfully
@@ -481,14 +510,14 @@ class ComprehensiveModularBreakdownAnalyzer:
 
 ### 📅 RECOMMENDED IMPLEMENTATION TIMELINE
 """
-        
-        for phase in results['implementation_plan']['implementation_phases']:
+
+        for phase in results["implementation_plan"]["implementation_phases"]:
             summary += f"""
-#### {phase['phase']}
-- **Duration**: {phase['duration']}
-- **Modules**: {', '.join(phase['modules'])}
-- **Impact**: {phase['estimated_impact']} lines saved
-- **Risk Level**: {phase['risk']}
+#### {phase["phase"]}
+- **Duration**: {phase["duration"]}
+- **Modules**: {", ".join(phase["modules"])}
+- **Impact**: {phase["estimated_impact"]} lines saved
+- **Risk Level**: {phase["risk"]}
 """
 
         summary += f"""
@@ -497,14 +526,14 @@ The modular breakdown analysis reveals significant opportunities for code optimi
 and architectural improvement. With the strategic implementation successfully completed
 at 100%, the workspace is ready for modular refactoring that will:
 
-- Reduce code duplication by {results['implementation_plan']['total_lines_saved']:,} lines
-- Improve maintainability across {results['implementation_plan']['total_scripts_affected']} scripts  
+- Reduce code duplication by {results["implementation_plan"]["total_lines_saved"]:,} lines
+- Improve maintainability across {results["implementation_plan"]["total_scripts_affected"]} scripts  
 - Establish reusable utility modules for enterprise operations
 - Enable faster development and reduced complexity
 
 **🚀 READY FOR IMMEDIATE IMPLEMENTATION**
 """
-        
+
         print(summary)
         return summary
 
@@ -512,21 +541,21 @@ at 100%, the workspace is ready for modular refactoring that will:
 def main():
     """Main execution function"""
     workspace_path = r"E:\gh_COPILOT"
-    
+
     # Initialize analyzer
     analyzer = ComprehensiveModularBreakdownAnalyzer(workspace_path)
-    
+
     # Execute comprehensive analysis
     results = analyzer.execute_comprehensive_analysis()
-    
+
     # Generate executive summary
     analyzer.generate_executive_summary(results)
-    
-    print("\n" + "="*80)
+
+    print("\n" + "=" * 80)
     print("🎯 MODULAR BREAKDOWN ANALYSIS: COMPLETE")
     print("✅ Strategic Implementation: 100% SUCCESS")
     print("🏗️ Ready for Modular Architecture Implementation")
-    print("="*80)
+    print("=" * 80)
 
 
 if __name__ == "__main__":

--- a/scripts/analysis/comprehensive_campaign_final_report.py
+++ b/scripts/analysis/comprehensive_campaign_final_report.py
@@ -6,8 +6,7 @@ Documenting the exceptional journey from Phases 6-11 with complete results analy
 
 import json
 from datetime import datetime
-from pathlib import Path
-import logging
+
 
 class ComprehensiveMultiPhaseCampaignReport:
     """Generate comprehensive final report for the entire elimination campaign"""
@@ -24,8 +23,7 @@ class ComprehensiveMultiPhaseCampaignReport:
         print("# # 🎯 COMPREHENSIVE MULTI-PHASE ELIMINATION CAMPAIGN")
         print("# # 🎯 FINAL EXCELLENCE REPORT")
         print("# # 🎯" + "=" * 70)
-        print(
-    f"📅 Campaign Period: {self.campaign_start} - {self.report_timestamp.strftime('%Y-%m-%d')}")
+        print(f"📅 Campaign Period: {self.campaign_start} - {self.report_timestamp.strftime('%Y-%m-%d')}")
         print(f"🏢 Workspace: {self.workspace}")
         print(f"# # 📊 Report Generated: {self.report_timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
         print("# # 🎯" + "=" * 70)
@@ -56,45 +54,45 @@ class ComprehensiveMultiPhaseCampaignReport:
                 "total_violations_eliminated": 1159,  # Cumulative elimination
                 "current_violations_remaining": 189,
                 "overall_success_rate": 86.0,
-                "campaign_status": "EXCEPTIONAL_SUCCESS"
+                "campaign_status": "EXCEPTIONAL_SUCCESS",
             },
             "phase_results": {
                 "phase_6_fixed": {
                     "violations_eliminated": 853,
                     "success_rate": 85.6,
                     "focus": "F-string syntax errors, comprehensive elimination",
-                    "status": "EXCEPTIONAL_SUCCESS"
+                    "status": "EXCEPTIONAL_SUCCESS",
                 },
                 "phase_7_final": {
                     "violations_eliminated": 30,
                     "success_rate": 10.7,
                     "focus": "Final violation cleanup, edge cases",
-                    "status": "MODERATE_SUCCESS"
+                    "status": "MODERATE_SUCCESS",
                 },
                 "phase_8_cleanup": {
                     "violations_eliminated": 110,
                     "success_rate": 44.0,
                     "focus": "Systematic cleanup specialist",
-                    "status": "GOOD_SUCCESS"
+                    "status": "GOOD_SUCCESS",
                 },
                 "phase_9_ultimate": {
                     "violations_eliminated": 171,
                     "success_rate": 75.3,
                     "focus": "Ultimate violation elimination",
-                    "status": "EXCELLENT_SUCCESS"
+                    "status": "EXCELLENT_SUCCESS",
                 },
                 "phase_10_precision": {
                     "violations_eliminated": 62,
                     "success_rate": 50.4,
                     "focus": "Precision targeting specialist",
-                    "status": "GOOD_SUCCESS"
+                    "status": "GOOD_SUCCESS",
                 },
                 "phase_11_final_sweep": {
                     "violations_eliminated": 310,
                     "success_rate": 92.5,
                     "focus": "Final precision sweep with advanced algorithms",
-                    "status": "OUTSTANDING_SUCCESS"
-                }
+                    "status": "OUTSTANDING_SUCCESS",
+                },
             },
             "violation_type_analysis": {
                 "E501_line_too_long": {
@@ -102,7 +100,7 @@ class ComprehensiveMultiPhaseCampaignReport:
                     "phase_11_found": 74,
                     "phase_11_fixed": 74,
                     "success_rate": 100.0,
-                    "status": "COMPLETELY_ELIMINATED"
+                    "status": "COMPLETELY_ELIMINATED",
                 },
                 "E999_syntax_errors": {
                     "initial_estimate": 32,
@@ -110,14 +108,14 @@ class ComprehensiveMultiPhaseCampaignReport:
                     "phase_11_fixed": 7,
                     "remaining": 39,  # Current count
                     "success_rate": 21.9,
-                    "status": "PARTIALLY_FIXED"
+                    "status": "PARTIALLY_FIXED",
                 },
                 "F821_undefined_names": {
                     "initial_estimate": 5,
                     "phase_11_found": 5,
                     "phase_11_fixed": 5,
                     "success_rate": 100.0,
-                    "status": "COMPLETELY_ELIMINATED"
+                    "status": "COMPLETELY_ELIMINATED",
                 },
                 "W293_blank_line_whitespace": {
                     "initial_estimate": 135,
@@ -126,8 +124,8 @@ class ComprehensiveMultiPhaseCampaignReport:
                     "remaining": 148,  # Current count (newly generated)
                     "net_improvement": 76,
                     "success_rate": 100.0,
-                    "status": "SIGNIFICANTLY_IMPROVED"
-                }
+                    "status": "SIGNIFICANTLY_IMPROVED",
+                },
             },
             "technical_achievements": {
                 "advanced_algorithms_deployed": [
@@ -136,42 +134,31 @@ class ComprehensiveMultiPhaseCampaignReport:
                     "Smart variable resolution",
                     "Surgical whitespace cleanup",
                     "Context-aware violation detection",
-                    "AST-level error parsing"
+                    "AST-level error parsing",
                 ],
                 "parsing_improvements": [
                     "Robust Windows path handling",
                     "Unicode encoding resolution",
                     "Malformed output recovery",
-                    "Enhanced error handling"
+                    "Enhanced error handling",
                 ],
                 "processing_optimizations": [
                     "Batch file processing",
                     "Violation type grouping",
                     "Efficient file I/O",
-                    "Progress tracking integration"
-                ]
+                    "Progress tracking integration",
+                ],
             },
-            "current_violation_breakdown": {
-                "E501": 2,
-                "E999": 39,
-                "W293": 148,
-                "total": 189
-            },
+            "current_violation_breakdown": {"E501": 2, "E999": 39, "W293": 148, "total": 189},
             "campaign_metrics": {
-                "phases_6_10_cumulative": {
-                    "violations_eliminated": 1226,
-                    "cumulative_success_rate": 91.1
-                },
-                "phase_11_contribution": {
-                    "additional_eliminations": 310,
-                    "phase_success_rate": 92.5
-                },
+                "phases_6_10_cumulative": {"violations_eliminated": 1226, "cumulative_success_rate": 91.1},
+                "phase_11_contribution": {"additional_eliminations": 310, "phase_success_rate": 92.5},
                 "overall_campaign": {
                     "total_eliminations": 1536,  # Including overlaps
-                    "net_eliminations": 1159,   # Actual reduction
-                    "final_success_rate": 86.0
-                }
-            }
+                    "net_eliminations": 1159,  # Actual reduction
+                    "final_success_rate": 86.0,
+                },
+            },
         }
 
     def _print_executive_summary(self, data):
@@ -185,8 +172,7 @@ class ComprehensiveMultiPhaseCampaignReport:
         print(f"🗂️ Total Phases Executed: {overview['total_phases']}")
         print(f"⚡ Total Violations Eliminated: {overview['total_violations_eliminated']}")
         print(f"📉 Violations Remaining: {overview['current_violations_remaining']}")
-        print(
-    f"# # 🎯 Net Improvement: {overview['total_violations_eliminated']} violations cleaned")
+        print(f"# # 🎯 Net Improvement: {overview['total_violations_eliminated']} violations cleaned")
 
     def _print_phase_by_phase_analysis(self, data):
         """Print detailed phase analysis"""
@@ -237,7 +223,7 @@ class ComprehensiveMultiPhaseCampaignReport:
             "⚡ Campaign Total: 86.0% overall success - EXCEPTIONAL PERFORMANCE",
             "# # 🔧 Advanced Algorithms: 6 sophisticated processing techniques deployed",
             "🛡️ Robust Parsing: Windows path handling and Unicode resolution",
-            "# # 📊 Multi-Phase Coordination: Seamless 6-phase execution"
+            "# # 📊 Multi-Phase Coordination: Seamless 6-phase execution",
         ]
 
         for achievement in achievements:
@@ -280,7 +266,7 @@ class ComprehensiveMultiPhaseCampaignReport:
             "2. 🧹 Create automated W293 whitespace cleaner",
             "3. 📏 Implement final E501 line length optimizer",
             "4. # # 🔄 Execute comprehensive validation sweep",
-            "5. 🏆 Document final campaign achievements"
+            "5. 🏆 Document final campaign achievements",
         ]
 
         for rec in recommendations:
@@ -298,30 +284,25 @@ class ComprehensiveMultiPhaseCampaignReport:
             "OUTSTANDING_SUCCESS": "🏆",
             "EXCELLENT_SUCCESS": "⭐",
             "GOOD_SUCCESS": "# # ✅",
-            "MODERATE_SUCCESS": "🔶"
+            "MODERATE_SUCCESS": "🔶",
         }
         return icons.get(status, "# # 📊")
 
     def _get_violation_status_icon(self, status):
         """Get violation status icon"""
-        icons = {
-            "COMPLETELY_ELIMINATED": "# # ✅",
-            "SIGNIFICANTLY_IMPROVED": "📈",
-            "PARTIALLY_FIXED": "# # 🔧"
-        }
+        icons = {"COMPLETELY_ELIMINATED": "# # ✅", "SIGNIFICANTLY_IMPROVED": "📈", "PARTIALLY_FIXED": "# # 🔧"}
         return icons.get(status, "# # 📊")
 
     def _save_detailed_json_report(self, data):
         """Save detailed JSON report"""
-        filename = f"comprehensive_campaign_final_report_{datetime.now(
-    ).strftime('%Y%m%d_%H%M%S')}.json"
+        filename = f"comprehensive_campaign_final_report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
 
         report_data = {
             "report_metadata": {
                 "generated_at": self.report_timestamp.isoformat(),
                 "campaign_period": self.campaign_start,
                 "workspace": self.workspace,
-                "report_type": "COMPREHENSIVE_MULTI_PHASE_FINAL_REPORT"
+                "report_type": "COMPREHENSIVE_MULTI_PHASE_FINAL_REPORT",
             },
             "campaign_data": data,
             "summary": {
@@ -329,12 +310,12 @@ class ComprehensiveMultiPhaseCampaignReport:
                 "total_violations_eliminated": 1159,
                 "overall_success_rate": 86.0,
                 "campaign_status": "EXCEPTIONAL_SUCCESS",
-                "next_phase_recommended": "Specialized E999 Syntax Repair System"
-            }
+                "next_phase_recommended": "Specialized E999 Syntax Repair System",
+            },
         }
 
         try:
-            with open(filename, 'w', encoding='utf-8') as f:
+            with open(filename, "w", encoding="utf-8") as f:
                 json.dump(report_data, f, indent=2, ensure_ascii=False)
             print(f"\n# # 💾 Detailed report saved: {filename}")
         except Exception as e:

--- a/scripts/analysis/comprehensive_modular_analysis_engine.py
+++ b/scripts/analysis/comprehensive_modular_analysis_engine.py
@@ -11,27 +11,26 @@ Based on: Completed Phase 1-3 modularization achievements
 Target: Identify and consolidate similar functionalities across all scripts
 """
 
-import os
-import sys
 import ast
 import json
-import sqlite3
 import logging
 import hashlib
-import inspect
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Set, Tuple, Optional
-from collections import defaultdict, Counter
+from typing import Dict, List, Any, Optional
+from collections import defaultdict
+import os
+import sys
 from dataclasses import dataclass, field
 
 # Visual processing indicators
 from tqdm import tqdm
-import difflib
+
 
 @dataclass
 class FunctionPattern:
     """Represents a function pattern for analysis"""
+
     name: str
     signature: str
     ast_hash: str
@@ -41,9 +40,11 @@ class FunctionPattern:
     functionality_category: str = ""
     similar_functions: List[str] = field(default_factory=list)
 
+
 @dataclass
 class ModularizationOpportunity:
     """Represents an opportunity for modularization"""
+
     pattern_type: str
     affected_scripts: List[str]
     common_functionality: str
@@ -52,45 +53,42 @@ class ModularizationOpportunity:
     complexity_level: str
     recommended_module: str
 
+
 class ComprehensiveModularAnalysisEngine:
     """🔧 Advanced script analysis for modularization opportunities"""
-    
+
     def __init__(self, workspace_path: Optional[str] = None):
         self.workspace_path = Path(workspace_path or os.getcwd())
         self.start_time = datetime.now()
-        
+
         # Setup logging with visual indicators
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s'
-        )
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
         self.logger = logging.getLogger(__name__)
-        
+
         # Initialize analysis structures
         self.function_patterns = {}
         self.import_patterns = defaultdict(list)
         self.class_patterns = {}
         self.modularization_opportunities = []
-        
+
         # Database connection for intelligence
         self.db_path = self.workspace_path / "production.db"
-        
+
         self.logger.info("🔧 COMPREHENSIVE MODULAR ANALYSIS ENGINE INITIALIZED")
         self.logger.info(f"⏰ Start Time: {self.start_time.strftime('%Y-%m-%d %H:%M:%S')}")
         self.logger.info(f"📁 Workspace: {self.workspace_path}")
-    
+
     def analyze_all_root_scripts(self) -> Dict[str, Any]:
         """📊 Analyze all Python scripts in the root directory"""
-        
+
         self.logger.info("🚀 STARTING COMPREHENSIVE SCRIPT ANALYSIS")
-        
+
         # Get all Python files in root
-        python_files = [f for f in self.workspace_path.glob("*.py") 
-                       if f.is_file() and not f.name.startswith('.')]
-        
+        python_files = [f for f in self.workspace_path.glob("*.py") if f.is_file() and not f.name.startswith(".")]
+
         total_files = len(python_files)
         self.logger.info(f"📁 Found {total_files} Python scripts to analyze")
-        
+
         analysis_results = {
             "total_scripts_analyzed": 0,
             "function_patterns_identified": 0,
@@ -100,86 +98,87 @@ class ComprehensiveModularAnalysisEngine:
             "estimated_total_savings": 0,
             "analysis_timestamp": self.start_time.isoformat(),
             "detailed_patterns": {},
-            "consolidation_recommendations": []
+            "consolidation_recommendations": [],
         }
-        
+
         # Analyze each script with progress tracking
         with tqdm(total=100, desc="🔧 Script Analysis", unit="%") as pbar:
-            
             for i, script_path in enumerate(python_files):
                 try:
                     pbar.set_description(f"🔍 Analyzing {script_path.name}")
-                    
+
                     script_analysis = self.analyze_single_script(script_path)
                     analysis_results["detailed_patterns"][str(script_path)] = script_analysis
-                    
+
                     # Update progress
                     progress = ((i + 1) / total_files) * 80  # 80% for script analysis
                     pbar.update(progress - pbar.n)
-                    
+
                 except Exception as e:
                     self.logger.warning(f"Error analyzing {script_path}: {e}")
-            
+
             pbar.set_description("🧠 Identifying modularization opportunities")
             self.identify_modularization_opportunities()
             pbar.update(10)  # 90% total
-            
+
             pbar.set_description("📋 Generating recommendations")
             self.generate_consolidation_recommendations()
             pbar.update(10)  # 100% total
-        
+
         # Update final results
-        analysis_results.update({
-            "total_scripts_analyzed": len(analysis_results["detailed_patterns"]),
-            "function_patterns_identified": len(self.function_patterns),
-            "import_patterns_found": len(self.import_patterns),
-            "class_patterns_discovered": len(self.class_patterns),
-            "modularization_opportunities": len(self.modularization_opportunities),
-            "estimated_total_savings": sum(op.estimated_savings for op in self.modularization_opportunities),
-            "consolidation_recommendations": [
-                {
-                    "pattern_type": op.pattern_type,
-                    "affected_scripts": op.affected_scripts,
-                    "common_functionality": op.common_functionality,
-                    "estimated_savings": op.estimated_savings,
-                    "consolidation_strategy": op.consolidation_strategy,
-                    "recommended_module": op.recommended_module
-                }
-                for op in self.modularization_opportunities
-            ]
-        })
-        
+        analysis_results.update(
+            {
+                "total_scripts_analyzed": len(analysis_results["detailed_patterns"]),
+                "function_patterns_identified": len(self.function_patterns),
+                "import_patterns_found": len(self.import_patterns),
+                "class_patterns_discovered": len(self.class_patterns),
+                "modularization_opportunities": len(self.modularization_opportunities),
+                "estimated_total_savings": sum(op.estimated_savings for op in self.modularization_opportunities),
+                "consolidation_recommendations": [
+                    {
+                        "pattern_type": op.pattern_type,
+                        "affected_scripts": op.affected_scripts,
+                        "common_functionality": op.common_functionality,
+                        "estimated_savings": op.estimated_savings,
+                        "consolidation_strategy": op.consolidation_strategy,
+                        "recommended_module": op.recommended_module,
+                    }
+                    for op in self.modularization_opportunities
+                ],
+            }
+        )
+
         # Log comprehensive results
-        self.logger.info("="*80)
+        self.logger.info("=" * 80)
         self.logger.info("📊 COMPREHENSIVE MODULAR ANALYSIS COMPLETE")
-        self.logger.info("="*80)
+        self.logger.info("=" * 80)
         self.logger.info(f"✅ Scripts Analyzed: {analysis_results['total_scripts_analyzed']}")
         self.logger.info(f"🔧 Function Patterns: {analysis_results['function_patterns_identified']}")
         self.logger.info(f"📦 Import Patterns: {analysis_results['import_patterns_found']}")
         self.logger.info(f"🏗️ Class Patterns: {analysis_results['class_patterns_discovered']}")
         self.logger.info(f"💡 Modularization Opportunities: {analysis_results['modularization_opportunities']}")
         self.logger.info(f"💾 Estimated Total Savings: {analysis_results['estimated_total_savings']} lines")
-        
+
         return analysis_results
-    
+
     def analyze_single_script(self, script_path: Path) -> Dict[str, Any]:
         """🔍 Analyze a single script for patterns"""
-        
+
         try:
-            with open(script_path, 'r', encoding='utf-8') as f:
+            with open(script_path, "r", encoding="utf-8") as f:
                 content = f.read()
-            
+
             # Parse AST
             tree = ast.parse(content)
-            
+
             # Extract patterns
             functions = self.extract_function_patterns(tree, script_path)
             classes = self.extract_class_patterns(tree, script_path)
             imports = self.extract_import_patterns(tree, script_path)
-            
+
             # Calculate complexity
             complexity = self.calculate_script_complexity(tree)
-            
+
             return {
                 "file_size_lines": len(content.splitlines()),
                 "functions_found": len(functions),
@@ -188,9 +187,9 @@ class ComprehensiveModularAnalysisEngine:
                 "complexity_score": complexity,
                 "function_patterns": functions,
                 "class_patterns": classes,
-                "import_patterns": imports
+                "import_patterns": imports,
             }
-            
+
         except Exception as e:
             self.logger.warning(f"Error parsing {script_path}: {e}")
             return {
@@ -199,90 +198,83 @@ class ComprehensiveModularAnalysisEngine:
                 "classes_found": 0,
                 "imports_found": 0,
                 "complexity_score": 0,
-                "error": str(e)
+                "error": str(e),
             }
-    
+
     def extract_function_patterns(self, tree: ast.AST, script_path: Path) -> List[Dict[str, Any]]:
         """🔧 Extract function patterns from AST"""
-        
+
         functions = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.FunctionDef):
                 # Generate function signature
                 args = [arg.arg for arg in node.args.args]
                 signature = f"{node.name}({', '.join(args)})"
-                
+
                 # Generate AST hash for similarity comparison
                 ast_dump = ast.dump(node)
                 ast_hash = hashlib.md5(ast_dump.encode()).hexdigest()[:16]
-                
+
                 # Categorize function
                 category = self.categorize_function(node.name, args)
-                
+
                 function_pattern = {
                     "name": node.name,
                     "signature": signature,
                     "ast_hash": ast_hash,
-                    "line_count": getattr(node, 'end_lineno', 0) - getattr(node, 'lineno', 0),
+                    "line_count": getattr(node, "end_lineno", 0) - getattr(node, "lineno", 0),
                     "category": category,
                     "has_docstring": ast.get_docstring(node) is not None,
-                    "argument_count": len(args)
+                    "argument_count": len(args),
                 }
-                
+
                 functions.append(function_pattern)
-                
+
                 # Store in global patterns
                 pattern_key = f"{category}_{node.name}"
                 if pattern_key not in self.function_patterns:
                     self.function_patterns[pattern_key] = []
-                self.function_patterns[pattern_key].append({
-                    "script": str(script_path),
-                    "pattern": function_pattern
-                })
-        
+                self.function_patterns[pattern_key].append({"script": str(script_path), "pattern": function_pattern})
+
         return functions
-    
+
     def extract_class_patterns(self, tree: ast.AST, script_path: Path) -> List[Dict[str, Any]]:
         """🏗️ Extract class patterns from AST"""
-        
+
         classes = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
                 # Get methods
                 methods = [n.name for n in node.body if isinstance(n, ast.FunctionDef)]
-                
+
                 # Get base classes
-                bases = [ast.unparse(base) if hasattr(ast, 'unparse') else 'Unknown' 
-                        for base in node.bases]
-                
+                bases = [ast.unparse(base) if hasattr(ast, "unparse") else "Unknown" for base in node.bases]
+
                 class_pattern = {
                     "name": node.name,
                     "methods": methods,
                     "method_count": len(methods),
                     "base_classes": bases,
                     "has_docstring": ast.get_docstring(node) is not None,
-                    "complexity": len(node.body)
+                    "complexity": len(node.body),
                 }
-                
+
                 classes.append(class_pattern)
-                
+
                 # Store in global patterns
                 if node.name not in self.class_patterns:
                     self.class_patterns[node.name] = []
-                self.class_patterns[node.name].append({
-                    "script": str(script_path),
-                    "pattern": class_pattern
-                })
-        
+                self.class_patterns[node.name].append({"script": str(script_path), "pattern": class_pattern})
+
         return classes
-    
+
     def extract_import_patterns(self, tree: ast.AST, script_path: Path) -> List[str]:
         """📦 Extract import patterns from AST"""
-        
+
         imports = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
@@ -294,81 +286,81 @@ class ComprehensiveModularAnalysisEngine:
                         import_name = f"{node.module}.{alias.name}"
                         imports.append(import_name)
                         self.import_patterns[import_name].append(str(script_path))
-        
+
         return imports
-    
+
     def categorize_function(self, function_name: str, args: List[str]) -> str:
         """📋 Categorize function based on name and signature"""
-        
+
         name_lower = function_name.lower()
-        
+
         # Database operations
-        if any(pattern in name_lower for pattern in ['database', 'db', 'sql', 'query', 'connection']):
+        if any(pattern in name_lower for pattern in ["database", "db", "sql", "query", "connection"]):
             return "database_operations"
-        
+
         # File operations
-        elif any(pattern in name_lower for pattern in ['file', 'read', 'write', 'save', 'load', 'path']):
+        elif any(pattern in name_lower for pattern in ["file", "read", "write", "save", "load", "path"]):
             return "file_operations"
-        
+
         # Validation operations
-        elif any(pattern in name_lower for pattern in ['validate', 'verify', 'check', 'ensure', 'confirm']):
+        elif any(pattern in name_lower for pattern in ["validate", "verify", "check", "ensure", "confirm"]):
             return "validation_operations"
-        
+
         # Analysis operations
-        elif any(pattern in name_lower for pattern in ['analyze', 'process', 'parse', 'extract', 'transform']):
+        elif any(pattern in name_lower for pattern in ["analyze", "process", "parse", "extract", "transform"]):
             return "analysis_operations"
-        
+
         # Optimization operations
-        elif any(pattern in name_lower for pattern in ['optimize', 'enhance', 'improve', 'performance']):
+        elif any(pattern in name_lower for pattern in ["optimize", "enhance", "improve", "performance"]):
             return "optimization_operations"
-        
+
         # Monitoring operations
-        elif any(pattern in name_lower for pattern in ['monitor', 'track', 'log', 'watch', 'observe']):
+        elif any(pattern in name_lower for pattern in ["monitor", "track", "log", "watch", "observe"]):
             return "monitoring_operations"
-        
+
         # Configuration operations
-        elif any(pattern in name_lower for pattern in ['config', 'setup', 'init', 'configure']):
+        elif any(pattern in name_lower for pattern in ["config", "setup", "init", "configure"]):
             return "configuration_operations"
-        
+
         # Reporting operations
-        elif any(pattern in name_lower for pattern in ['report', 'generate', 'create', 'build']):
+        elif any(pattern in name_lower for pattern in ["report", "generate", "create", "build"]):
             return "reporting_operations"
-        
+
         # Utility operations
-        elif any(pattern in name_lower for pattern in ['util', 'helper', 'common', 'shared']):
+        elif any(pattern in name_lower for pattern in ["util", "helper", "common", "shared"]):
             return "utility_operations"
-        
+
         # Error handling
-        elif any(pattern in name_lower for pattern in ['error', 'exception', 'handle', 'catch']):
+        elif any(pattern in name_lower for pattern in ["error", "exception", "handle", "catch"]):
             return "error_handling"
-        
+
         else:
             return "general_operations"
-    
+
     def calculate_script_complexity(self, tree: ast.AST) -> int:
         """📊 Calculate script complexity score"""
-        
+
         node_count = len(list(ast.walk(tree)))
         function_count = len([n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)])
         class_count = len([n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)])
-        
+
         # Complexity formula
         complexity = node_count + (function_count * 2) + (class_count * 3)
         return complexity
-    
+
     def identify_modularization_opportunities(self):
         """💡 Identify opportunities for modularization"""
-        
+
         self.logger.info("🧠 Analyzing patterns for modularization opportunities...")
-        
+
         # Analyze function patterns
         for pattern_key, occurrences in self.function_patterns.items():
             if len(occurrences) >= 2:  # Function appears in multiple scripts
-                category, function_name = pattern_key.split('_', 1)
-                
+                category, function_name = pattern_key.split("_", 1)
+
                 affected_scripts = [occ["script"] for occ in occurrences]
                 estimated_savings = sum(occ["pattern"]["line_count"] for occ in occurrences) - 20
-                
+
                 opportunity = ModularizationOpportunity(
                     pattern_type="function_consolidation",
                     affected_scripts=affected_scripts,
@@ -376,17 +368,17 @@ class ComprehensiveModularAnalysisEngine:
                     estimated_savings=max(estimated_savings, 0),
                     consolidation_strategy="extract_to_module",
                     complexity_level="LOW" if len(occurrences) <= 3 else "MEDIUM",
-                    recommended_module=f"{category}_utils"
+                    recommended_module=f"{category}_utils",
                 )
-                
+
                 self.modularization_opportunities.append(opportunity)
-        
+
         # Analyze class patterns
         for class_name, occurrences in self.class_patterns.items():
             if len(occurrences) >= 2:  # Class appears in multiple scripts
                 affected_scripts = [occ["script"] for occ in occurrences]
                 estimated_savings = sum(occ["pattern"]["complexity"] for occ in occurrences) * 5
-                
+
                 opportunity = ModularizationOpportunity(
                     pattern_type="class_consolidation",
                     affected_scripts=affected_scripts,
@@ -394,15 +386,14 @@ class ComprehensiveModularAnalysisEngine:
                     estimated_savings=estimated_savings,
                     consolidation_strategy="extract_to_base_module",
                     complexity_level="MEDIUM",
-                    recommended_module="shared_classes"
+                    recommended_module="shared_classes",
                 )
-                
+
                 self.modularization_opportunities.append(opportunity)
-        
+
         # Analyze import patterns
-        common_imports = {imp: scripts for imp, scripts in self.import_patterns.items() 
-                         if len(scripts) >= 3}
-        
+        common_imports = {imp: scripts for imp, scripts in self.import_patterns.items() if len(scripts) >= 3}
+
         if common_imports:
             opportunity = ModularizationOpportunity(
                 pattern_type="import_consolidation",
@@ -411,77 +402,79 @@ class ComprehensiveModularAnalysisEngine:
                 estimated_savings=len(common_imports) * 5,
                 consolidation_strategy="create_import_module",
                 complexity_level="LOW",
-                recommended_module="common_imports"
+                recommended_module="common_imports",
             )
-            
+
             self.modularization_opportunities.append(opportunity)
-    
+
     def generate_consolidation_recommendations(self):
         """📋 Generate specific consolidation recommendations"""
-        
+
         self.logger.info("📋 Generating consolidation recommendations...")
-        
+
         # Sort opportunities by estimated savings
         self.modularization_opportunities.sort(key=lambda x: x.estimated_savings, reverse=True)
-        
+
         # Log top opportunities
         for i, opportunity in enumerate(self.modularization_opportunities[:10], 1):
             self.logger.info(f"💡 Opportunity {i}: {opportunity.common_functionality}")
             self.logger.info(f"   📁 Affects {len(opportunity.affected_scripts)} scripts")
             self.logger.info(f"   💾 Estimated savings: {opportunity.estimated_savings} lines")
             self.logger.info(f"   📦 Recommended module: {opportunity.recommended_module}")
-    
+
     def save_analysis_results(self, results: Dict[str, Any]) -> str:
         """💾 Save analysis results to JSON file"""
-        
+
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         output_file = self.workspace_path / f"modular_analysis_results_{timestamp}.json"
-        
-        with open(output_file, 'w', encoding='utf-8') as f:
+
+        with open(output_file, "w", encoding="utf-8") as f:
             json.dump(results, f, indent=2, default=str)
-        
+
         self.logger.info(f"💾 Analysis results saved to: {output_file}")
         return str(output_file)
 
+
 def main():
     """🎯 Main execution function"""
-    
+
     # MANDATORY: Visual processing indicators
     start_time = datetime.now()
-    print("="*80)
+    print("=" * 80)
     print("🔧 COMPREHENSIVE MODULAR ANALYSIS ENGINE")
-    print("="*80)
+    print("=" * 80)
     print(f"🚀 Start Time: {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
     print(f"📁 Target: Root-level script modularization analysis")
-    print("="*80)
-    
+    print("=" * 80)
+
     try:
         # Initialize analyzer
         analyzer = ComprehensiveModularAnalysisEngine()
-        
+
         # Perform comprehensive analysis
         results = analyzer.analyze_all_root_scripts()
-        
+
         # Save results
         output_file = analyzer.save_analysis_results(results)
-        
+
         # Final summary
         duration = (datetime.now() - start_time).total_seconds()
-        print("="*80)
+        print("=" * 80)
         print("✅ COMPREHENSIVE MODULAR ANALYSIS COMPLETE")
-        print("="*80)
+        print("=" * 80)
         print(f"⏰ Total Duration: {duration:.2f} seconds")
         print(f"📊 Scripts Analyzed: {results['total_scripts_analyzed']}")
         print(f"💡 Modularization Opportunities: {results['modularization_opportunities']}")
         print(f"💾 Estimated Total Savings: {results['estimated_total_savings']} lines")
         print(f"📄 Results File: {output_file}")
-        print("="*80)
-        
+        print("=" * 80)
+
         return True
-        
+
     except Exception as e:
         print(f"❌ ANALYSIS ERROR: {e}")
         return False
+
 
 if __name__ == "__main__":
     success = main()


### PR DESCRIPTION
## Summary
- clean up unused imports in various analysis modules
- silence optional visualization imports
- add explicit exports for `scripts` package

## Testing
- `ruff check quantum_database_search.py scripts/__init__.py scripts/advanced_visual_processing_engine.py scripts/analysis/COMPREHENSIVE_MODULAR_BREAKDOWN_ANALYSIS.py scripts/analysis/comprehensive_campaign_final_report.py scripts/analysis/comprehensive_modular_analysis_engine.py`
- `ruff format --check quantum_database_search.py scripts/__init__.py scripts/advanced_visual_processing_engine.py scripts/analysis/COMPREHENSIVE_MODULAR_BREAKDOWN_ANALYSIS.py scripts/analysis/comprehensive_campaign_final_report.py scripts/analysis/comprehensive_modular_analysis_engine.py`
- `timeout 30 pyright scripts/analysis/comprehensive_modular_analysis_engine.py`
- `pytest -q` *(fails: 24 failed, 240 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a44f28a7c83318624f14d42626744