### PR TITLE
Add unified wrapup migration and audit enhancements

### DIFF
--- a/databases/migrations/README.md
+++ b/databases/migrations/README.md
@@ -9,6 +9,8 @@
 - `add_violation_logs.sql`: Adds `violation_logs` table for compliance issues.
 - `add_rollback_logs.sql`: Adds `rollback_logs` table recording restorations.
 - `add_corrections.sql`: Adds `corrections` table used for compliance metrics.
+- `add_unified_wrapup_sessions.sql`: Adds `unified_wrapup_sessions` table used
+  by wrap-up orchestrators.
 - `extend_todo_fixme_tracking.sql`: Adds `status` and `removal_id` columns linking to `placeholder_removals`.
 
 ## Applying Migrations
@@ -20,6 +22,7 @@ sqlite3 databases/analytics.db < databases/migrations/add_code_audit_history.sql
 sqlite3 databases/analytics.db < databases/migrations/add_violation_logs.sql
 sqlite3 databases/analytics.db < databases/migrations/add_rollback_logs.sql
 sqlite3 databases/analytics.db < databases/migrations/add_corrections.sql
+sqlite3 databases/analytics.db < databases/migrations/add_unified_wrapup_sessions.sql
 sqlite3 databases/analytics.db < databases/migrations/create_todo_fixme_tracking.sql
 sqlite3 databases/analytics.db < databases/migrations/extend_todo_fixme_tracking.sql
 ```

--- a/databases/migrations/add_unified_wrapup_sessions.sql
+++ b/databases/migrations/add_unified_wrapup_sessions.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS unified_wrapup_sessions (
+    session_id TEXT PRIMARY KEY,
+    start_time TEXT,
+    end_time TEXT,
+    status TEXT,
+    files_organized INTEGER,
+    configs_validated INTEGER,
+    scripts_modularized INTEGER,
+    root_files_remaining INTEGER,
+    compliance_score REAL,
+    validation_results TEXT,
+    error_details TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_unified_wrapup_status ON unified_wrapup_sessions(status);

--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -1,24 +1,65 @@
 from __future__ import annotations
 
-"""Enterprise compliance helpers."""
+"""Enterprise compliance helpers and enforcement routines."""
 
 import os
 import shutil
+import sqlite3
+from datetime import datetime
 from pathlib import Path
+
+from scripts.database.add_violation_logs import ensure_violation_logs
+
+
+def _log_violation(details: str) -> None:
+    """Log a compliance violation to analytics.db."""
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    analytics_db = workspace / "databases" / "analytics.db"
+    analytics_db.parent.mkdir(parents=True, exist_ok=True)
+    ensure_violation_logs(analytics_db)
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            "INSERT INTO violation_logs (timestamp, details) VALUES (?, ?)",
+            (datetime.now().isoformat(), details),
+        )
+        conn.commit()
 
 
 def validate_enterprise_operation(target_path: str | None = None) -> bool:
     """Ensure operations comply with backup and path policies."""
     workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    backup_root = Path(os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups"))
     path = Path(target_path or workspace)
 
-    # Disallow workspace backups
-    forbidden = [p for p in workspace.rglob("*backup*") if p.is_dir()]
-    for item in forbidden:
-        shutil.rmtree(item, ignore_errors=True)
-        return False
+    violations = []
+
+    # Disallow backup directories inside the workspace
+    if backup_root.resolve().as_posix().startswith(workspace.resolve().as_posix()):
+        violations.append("backup_root_inside_workspace")
+
+    if path.resolve().as_posix().startswith(backup_root.resolve().as_posix()):
+        violations.append("operation_within_backup_root")
 
     # Disallow operations in C:/temp
     if str(path).lower().startswith("c:/temp"):
-        return False
-    return True
+        violations.append("forbidden_system_temp")
+
+    for parent in path.parents:
+        if parent == workspace:
+            break
+        if parent.name.lower().startswith("backup"):
+            violations.append(f"forbidden_subpath:{parent}")
+
+    # Cleanup forbidden backup folders within workspace
+    for item in workspace.rglob("*backup*"):
+        if item.is_dir() and item != backup_root and workspace in item.parents:
+            shutil.rmtree(item, ignore_errors=True)
+            violations.append(f"removed_forbidden:{item}")
+
+    for violation in violations:
+        _log_violation(violation)
+
+    return not violations
+
+
+__all__ = ["validate_enterprise_operation"]

--- a/scripts/placeholder_cleanup.py
+++ b/scripts/placeholder_cleanup.py
@@ -9,24 +9,34 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import json
 from dashboard.compliance_metrics_updater import ComplianceMetricsUpdater
 from scripts import code_placeholder_audit as audit
 
 
-def main(
+def run(
     workspace: Path,
     analytics_db: Path,
     production_db: Path,
     dashboard_dir: Path,
+    *,
     timeout_minutes: int = 30,
+    cleanup: bool = False,
+    dry_run: bool = False,
 ) -> bool:
-    patterns = audit.DEFAULT_PATTERNS + audit.fetch_db_placeholders(production_db)
+    patterns = (
+        audit.DEFAULT_PATTERNS
+        + audit.fetch_db_placeholders(production_db)
+        + audit.load_best_practice_patterns()
+    )
     results = audit.scan_files(workspace, patterns, timeout_minutes * 60)
-    audit.log_findings(results, analytics_db)
-    audit.auto_remove_placeholders(results, production_db, analytics_db)
-    audit.log_findings([], analytics_db, update_resolutions=True)
-    ComplianceMetricsUpdater(dashboard_dir).update()
-    return audit.validate_results(0, analytics_db)
+    audit.log_findings(results, analytics_db, simulate=dry_run)
+    if cleanup and not dry_run:
+        audit.auto_remove_placeholders(results, production_db, analytics_db)
+        audit.log_findings([], analytics_db, update_resolutions=True)
+    if not dry_run:
+        ComplianceMetricsUpdater(dashboard_dir).update()
+    return audit.validate_results(0 if cleanup else len(results), analytics_db)
 
 
 if __name__ == "__main__":
@@ -36,12 +46,29 @@ if __name__ == "__main__":
     parser.add_argument("production_db", type=Path)
     parser.add_argument("dashboard_dir", type=Path)
     parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--cleanup", action="store_true", help="Remove placeholders")
+    parser.add_argument("--dry-run", action="store_true", help="Run without DB writes")
+    parser.add_argument("--rollback-last", action="store_true", help="Rollback last audit")
     args = parser.parse_args()
-    success = main(
+    if args.rollback_last:
+        if audit.rollback_last_entry(args.analytics_db):
+            print("Rollback complete")
+            raise SystemExit(0)
+        raise SystemExit(1)
+    success = run(
         args.workspace,
         args.analytics_db,
         args.production_db,
         args.dashboard_dir,
-        args.timeout,
+        timeout_minutes=args.timeout,
+        cleanup=args.cleanup,
+        dry_run=args.dry_run,
     )
+    summary = {
+        "workspace": str(args.workspace),
+        "cleanup": args.cleanup,
+        "dry_run": args.dry_run,
+        "result": success,
+    }
+    print(json.dumps(summary))
     raise SystemExit(0 if success else 1)

--- a/tests/test_analytics_db_creation.py
+++ b/tests/test_analytics_db_creation.py
@@ -10,6 +10,7 @@ MIGRATIONS = [
     Path("databases/migrations/add_code_audit_history.sql"),
     Path("databases/migrations/add_violation_logs.sql"),
     Path("databases/migrations/add_rollback_logs.sql"),
+    Path("databases/migrations/add_unified_wrapup_sessions.sql"),
 ]
 
 

--- a/tests/test_placeholder_cleanup.py
+++ b/tests/test_placeholder_cleanup.py
@@ -1,6 +1,4 @@
-import os
 import sqlite3
-from pathlib import Path
 
 import scripts.placeholder_cleanup as pc
 
@@ -18,7 +16,7 @@ def test_placeholder_cleanup_workflow(tmp_path, monkeypatch):
     with sqlite3.connect(prod) as conn:
         conn.execute("CREATE TABLE template_placeholders (placeholder_name TEXT)")
         conn.execute("INSERT INTO template_placeholders VALUES ('VALID')")
-    pc.main(workspace, analytics, prod, dash)
+    pc.run(workspace, analytics, prod, dash, cleanup=True)
 
     cleaned = target.read_text()
     assert "TODO" not in cleaned


### PR DESCRIPTION
## Summary
- add `add_unified_wrapup_sessions.sql` migration
- document new migration usage in README
- expand compliance enforcement and logging
- extend placeholder auditing with best-practice patterns and rollback CLI
- unify placeholder cleanup entry point with new options
- enhance setup orchestrator with event logging and validation tracking
- update tests for new migration and cleanup API

## Testing
- `ruff check scripts/autonomous_setup_and_audit.py scripts/code_placeholder_audit.py scripts/placeholder_cleanup.py enterprise_modules/compliance.py tests/test_placeholder_cleanup.py tests/test_analytics_db_creation.py`
- `pytest -q` *(fails: 19 failed, 253 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a4dafed408331ad60a160ed9d7e35