### PR TITLE
Add live metrics streaming and alerts to dashboard

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -82,6 +82,15 @@ Example screenshot:
 
 ![Dashboard Screenshot](static/dashboard_screenshot.png)
 
+### Live Metrics
+
+The dashboard templates consume `/metrics_stream` via Server-Sent Events (SSE).
+Metrics are retrieved from `analytics.db` and include placeholder removal totals,
+open placeholder counts, and the average compliance score. If SSE is
+unavailable, a JavaScript fallback polls `/metrics` and `/alerts` every five
+seconds. Alerts combine rollback and violation logs so operators can react to
+compliance issues immediately.
+
 ---
 
 ## ENDPOINTS

--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from web_gui.scripts.flask_apps.enterprise_dashboard import (
     app,
     _fetch_metrics,
+    _fetch_alerts,
+    metrics_stream,
 )
 
 ANALYTICS_DB = Path("databases/analytics.db")
@@ -45,7 +47,7 @@ def _fetch_correction_history(limit: int = 5) -> list[dict[str, str | float]]:
                 logging.error("History fetch error: %s", exc)
     return history
 
-__all__ = ["app", "main"]
+__all__ = ["app", "main", "metrics_stream"]
 
 
 def _validate_environment() -> None:
@@ -65,6 +67,7 @@ def main() -> None:
     logging.info("Dashboard starting at %s", datetime.utcnow().isoformat())
     _validate_environment()
     logging.info("Startup metrics: %s", _fetch_metrics())
+    logging.info("Startup alerts: %s", _fetch_alerts())
     logging.info("Recent corrections: %s", _fetch_correction_history())
     port = int(os.getenv("FLASK_RUN_PORT", "5000"))
     app.run(host="0.0.0.0", port=port, debug=bool(__name__ == "__main__"))

--- a/tests/dashboard/test_live_metrics.py
+++ b/tests/dashboard/test_live_metrics.py
@@ -1,0 +1,43 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from web_gui.scripts.flask_apps import enterprise_dashboard as ed
+
+
+@pytest.fixture()
+def test_app(tmp_path: Path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT)")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (1, 'ok')")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (0, 'open')")
+        conn.execute("CREATE TABLE correction_logs (compliance_score REAL, ts TEXT)")
+        conn.execute("INSERT INTO correction_logs VALUES (0.9, '2024-01-01T00:00:00Z')")
+        conn.execute("CREATE TABLE violation_logs (details TEXT, timestamp TEXT)")
+        conn.execute("INSERT INTO violation_logs VALUES ('violation', '2024-01-01T00:00:00Z')")
+        conn.execute("CREATE TABLE rollback_logs (target TEXT, backup TEXT, timestamp TEXT)")
+        conn.execute("INSERT INTO rollback_logs VALUES ('file.py', 'file.bak', '2024-01-01T00:00:00Z')")
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+    return ed.app
+
+
+def test_metrics_stream_once(test_app):
+    client = test_app.test_client()
+    resp = client.get("/metrics_stream?once=1")
+    assert resp.status_code == 200
+    line = resp.data.decode().split("\n")[0]
+    assert line.startswith("data:")
+    metrics = json.loads(line.split("data: ")[1])
+    assert metrics["placeholder_removal"] == 1
+
+
+def test_alerts_endpoint(test_app):
+    client = test_app.test_client()
+    resp = client.get("/alerts")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["violations"]) == 1
+    assert len(data["rollbacks"]) == 1

--- a/web_gui/templates/backup_restore.html
+++ b/web_gui/templates/backup_restore.html
@@ -3,4 +3,51 @@
 <h1>Backup and Restore</h1>
 <p>Manage backups here.</p>
 <div id="progress">Loading...</div>
+<div>
+    <strong>Placeholder Removals:</strong> <span id="placeholder_removal">0</span><br>
+    <strong>Open Placeholders:</strong> <span id="open_placeholders">0</span><br>
+    <strong>Compliance Score:</strong> <span id="compliance_score">0.000</span>
+</div>
+<h2>Violations</h2>
+<ul id="violations"></ul>
+<h2>Rollbacks</h2>
+<ul id="rollbacks"></ul>
 <p><a href="/dashboard/compliance">Compliance Metrics</a></p>
+<script>
+function updateMetrics(data){
+    document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
+    document.getElementById('open_placeholders').textContent = data.open_placeholders;
+    document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
+}
+function updateAlerts(data){
+    const v = document.getElementById('violations');
+    v.innerHTML = '';
+    data.violations.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.details;
+        v.appendChild(li);
+    });
+    const r = document.getElementById('rollbacks');
+    r.innerHTML = '';
+    data.rollbacks.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.target + (a.backup ? '(' + a.backup + ')' : '');
+        r.appendChild(li);
+    });
+}
+window.onload = function(){
+    if(window.EventSource){
+        const es = new EventSource('/metrics_stream');
+        es.onmessage = function(evt){
+            const metrics = JSON.parse(evt.data);
+            updateMetrics(metrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        };
+    } else {
+        setInterval(function(){
+            fetch('/metrics').then(r => r.json()).then(updateMetrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        }, 5000);
+    }
+};
+</script>

--- a/web_gui/templates/dashboard.html
+++ b/web_gui/templates/dashboard.html
@@ -2,16 +2,51 @@
 <title>Compliance Dashboard</title>
 <h1>Compliance Dashboard</h1>
 <div id="progress">Loading...</div>
-<h2>Metrics</h2>
-<ul>
-{% for entry in metrics %}
-<li>{{ entry }}</li>
-{% endfor %}
-</ul>
+<div>
+    <strong>Placeholder Removals:</strong> <span id="placeholder_removal">0</span><br>
+    <strong>Open Placeholders:</strong> <span id="open_placeholders">0</span><br>
+    <strong>Compliance Score:</strong> <span id="compliance_score">0.000</span>
+</div>
+<h2>Violations</h2>
+<ul id="violations"></ul>
+<h2>Rollbacks</h2>
+<ul id="rollbacks"></ul>
 <p><a href="/dashboard/compliance">Compliance Metrics</a></p>
-<h2>Compliance</h2>
-<ul>
-{% for key, value in compliance.items() %}
-<li>{{ key }}: {{ value }}</li>
-{% endfor %}
-</ul>
+<script>
+function updateMetrics(data){
+    document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
+    document.getElementById('open_placeholders').textContent = data.open_placeholders;
+    document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
+}
+function updateAlerts(data){
+    const v = document.getElementById('violations');
+    v.innerHTML = '';
+    data.violations.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.details;
+        v.appendChild(li);
+    });
+    const r = document.getElementById('rollbacks');
+    r.innerHTML = '';
+    data.rollbacks.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.target + (a.backup ? '(' + a.backup + ')' : '');
+        r.appendChild(li);
+    });
+}
+window.onload = function(){
+    if(window.EventSource){
+        const es = new EventSource('/metrics_stream');
+        es.onmessage = function(evt){
+            const metrics = JSON.parse(evt.data);
+            updateMetrics(metrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        };
+    } else {
+        setInterval(function(){
+            fetch('/metrics').then(r => r.json()).then(updateMetrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        }, 5000);
+    }
+};
+</script>

--- a/web_gui/templates/database.html
+++ b/web_gui/templates/database.html
@@ -3,4 +3,51 @@
 <h1>Database Status</h1>
 <div id="status">Loading...</div>
 <div id="progress">Loading...</div>
+<div>
+    <strong>Placeholder Removals:</strong> <span id="placeholder_removal">0</span><br>
+    <strong>Open Placeholders:</strong> <span id="open_placeholders">0</span><br>
+    <strong>Compliance Score:</strong> <span id="compliance_score">0.000</span>
+</div>
+<h2>Violations</h2>
+<ul id="violations"></ul>
+<h2>Rollbacks</h2>
+<ul id="rollbacks"></ul>
 <p><a href="/dashboard/compliance">Compliance Metrics</a></p>
+<script>
+function updateMetrics(data){
+    document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
+    document.getElementById('open_placeholders').textContent = data.open_placeholders;
+    document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
+}
+function updateAlerts(data){
+    const v = document.getElementById('violations');
+    v.innerHTML = '';
+    data.violations.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.details;
+        v.appendChild(li);
+    });
+    const r = document.getElementById('rollbacks');
+    r.innerHTML = '';
+    data.rollbacks.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.target + (a.backup ? '(' + a.backup + ')' : '');
+        r.appendChild(li);
+    });
+}
+window.onload = function(){
+    if(window.EventSource){
+        const es = new EventSource('/metrics_stream');
+        es.onmessage = function(evt){
+            const metrics = JSON.parse(evt.data);
+            updateMetrics(metrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        };
+    } else {
+        setInterval(function(){
+            fetch('/metrics').then(r => r.json()).then(updateMetrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        }, 5000);
+    }
+};
+</script>

--- a/web_gui/templates/deployment.html
+++ b/web_gui/templates/deployment.html
@@ -3,4 +3,51 @@
 <h1>Deployment Overview</h1>
 <p>Deployment status information.</p>
 <div id="progress">Loading...</div>
+<div>
+    <strong>Placeholder Removals:</strong> <span id="placeholder_removal">0</span><br>
+    <strong>Open Placeholders:</strong> <span id="open_placeholders">0</span><br>
+    <strong>Compliance Score:</strong> <span id="compliance_score">0.000</span>
+</div>
+<h2>Violations</h2>
+<ul id="violations"></ul>
+<h2>Rollbacks</h2>
+<ul id="rollbacks"></ul>
 <p><a href="/dashboard/compliance">Compliance Metrics</a></p>
+<script>
+function updateMetrics(data){
+    document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
+    document.getElementById('open_placeholders').textContent = data.open_placeholders;
+    document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
+}
+function updateAlerts(data){
+    const v = document.getElementById('violations');
+    v.innerHTML = '';
+    data.violations.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.details;
+        v.appendChild(li);
+    });
+    const r = document.getElementById('rollbacks');
+    r.innerHTML = '';
+    data.rollbacks.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.target + (a.backup ? '(' + a.backup + ')' : '');
+        r.appendChild(li);
+    });
+}
+window.onload = function(){
+    if(window.EventSource){
+        const es = new EventSource('/metrics_stream');
+        es.onmessage = function(evt){
+            const metrics = JSON.parse(evt.data);
+            updateMetrics(metrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        };
+    } else {
+        setInterval(function(){
+            fetch('/metrics').then(r => r.json()).then(updateMetrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        }, 5000);
+    }
+};
+</script>

--- a/web_gui/templates/migration.html
+++ b/web_gui/templates/migration.html
@@ -3,4 +3,51 @@
 <h1>Migration Process</h1>
 <p>Details about database migrations.</p>
 <div id="progress">Loading...</div>
+<div>
+    <strong>Placeholder Removals:</strong> <span id="placeholder_removal">0</span><br>
+    <strong>Open Placeholders:</strong> <span id="open_placeholders">0</span><br>
+    <strong>Compliance Score:</strong> <span id="compliance_score">0.000</span>
+</div>
+<h2>Violations</h2>
+<ul id="violations"></ul>
+<h2>Rollbacks</h2>
+<ul id="rollbacks"></ul>
 <p><a href="/dashboard/compliance">Compliance Metrics</a></p>
+<script>
+function updateMetrics(data){
+    document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
+    document.getElementById('open_placeholders').textContent = data.open_placeholders;
+    document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
+}
+function updateAlerts(data){
+    const v = document.getElementById('violations');
+    v.innerHTML = '';
+    data.violations.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.details;
+        v.appendChild(li);
+    });
+    const r = document.getElementById('rollbacks');
+    r.innerHTML = '';
+    data.rollbacks.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a.timestamp + ' - ' + a.target + (a.backup ? '(' + a.backup + ')' : '');
+        r.appendChild(li);
+    });
+}
+window.onload = function(){
+    if(window.EventSource){
+        const es = new EventSource('/metrics_stream');
+        es.onmessage = function(evt){
+            const metrics = JSON.parse(evt.data);
+            updateMetrics(metrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        };
+    } else {
+        setInterval(function(){
+            fetch('/metrics').then(r => r.json()).then(updateMetrics);
+            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        }, 5000);
+    }
+};
+</script>


### PR DESCRIPTION
## Summary
- stream live metrics from `analytics.db` via `/metrics_stream`
- show rollback and compliance alerts in dashboard templates
- document live metrics stream in the dashboard README
- add integration tests for metrics stream and alerts

## Testing
- `ruff check dashboard/enterprise_dashboard.py tests/dashboard/test_live_metrics.py`
- `PYTHONPATH=. pytest -q tests/dashboard/test_live_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_688a57961bc08331afb7bf4977af0b31