### PR TITLE
Fix logging recursion and update compliance metrics updater

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -221,14 +221,14 @@ class ComplianceMetricsUpdater:
                 {"event": "violation", "count": metrics["violation_count"]},
                 "violation_logs",
                 db_path=ANALYTICS_DB,
-                test_mode=False,
+                test_mode=True,
             )
         if metrics.get("rollback_count"):
             insert_event(
                 {"event": "rollback", "count": metrics["rollback_count"]},
                 "rollback_logs",
                 db_path=ANALYTICS_DB,
-                test_mode=False,
+                test_mode=True,
             )
 
     def update(self, simulate: bool = False) -> None:


### PR DESCRIPTION
## Summary
- avoid recursion in logging utility by skipping nested log_event calls
- add correction and violation log schemas
- log dashboard update events in test mode only

## Testing
- `ruff check utils/log_utils.py`
- `ruff check dashboard/compliance_metrics_updater.py`
- `pytest tests/test_autonomous_setup_and_audit.py::test_ingest_assets_collects_multiple_types -q`
- `pytest tests/test_compliance_metrics_updater.py::test_compliance_metrics_updater -q`


------
https://chatgpt.com/codex/tasks/task_e_688a579fdfb08331926286d030a2ca88