### PR TITLE
Add tests for Windows optimizer

### DIFF
--- a/reports/test_coverage_report.md
+++ b/reports/test_coverage_report.md
@@ -2,14 +2,14 @@
 
 ## Missing Tests for Stubbed Modules
 
-- **WindowsCompatibleOptimizer** and its async version have stub definitions in `typings/windows_compatible_optimizer_async.pyi` but there are no dedicated tests covering `scripts/optimization/windows_compatible_optimizer.py` or `scripts/optimization/windows_compatible_optimizer_async.py`.
+Previously, the `WindowsCompatibleOptimizer` modules lacked tests. Unit tests have now been added under `tests/test_windows_compatible_optimizer.py`.
 
 ## Current Test Results
 
 The latest `pytest` execution resulted in multiple failures:
 
 ```
-43 failed, 200 passed, 2 skipped
+36 failed, 244 passed, 5 skipped
 ```
 
 Key failing suites include:

--- a/tests/test_windows_compatible_optimizer.py
+++ b/tests/test_windows_compatible_optimizer.py
@@ -1,0 +1,38 @@
+import sqlite3
+import asyncio
+from pathlib import Path
+
+from scripts.optimization.windows_compatible_optimizer import WindowsCompatibleOptimizer
+from scripts.optimization.windows_compatible_optimizer_async import WindowsCompatibleOptimizer as WindowsCompatibleOptimizerAsync
+
+
+def _create_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "sample.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)")
+        conn.executemany("INSERT INTO t(value) VALUES (?)", [("a",), ("b",)])
+    return db_path
+
+
+def test_analyze_database_health(tmp_path):
+    db_path = _create_db(tmp_path)
+    opt = WindowsCompatibleOptimizer()
+    opt.workspace_path = tmp_path
+    opt.results_dir = tmp_path / "results"
+    opt.results_dir.mkdir(parents=True, exist_ok=True)
+    health = opt.analyze_database_health("sample", str(db_path))
+    assert health.table_count == 1
+    assert health.record_count == 2
+    assert health.health_score > 0
+
+
+def test_async_analyze_database_health(tmp_path):
+    db_path = _create_db(tmp_path)
+    opt = WindowsCompatibleOptimizerAsync()
+    opt.workspace_path = tmp_path
+    health = asyncio.run(opt._analyze_database_health(db_path))
+    assert health is not None
+    assert health.table_count == 1
+    assert health.record_count == 2
+
+

--- a/validation/dual_copilot_database_check.py
+++ b/validation/dual_copilot_database_check.py
@@ -1,0 +1,31 @@
+"""Validation script demonstrating database-first operations and dual-copilot checks."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Tuple
+
+from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
+
+PRODUCTION_DB = Path("databases/production.db")
+
+
+def _database_has_tables() -> bool:
+    if not PRODUCTION_DB.exists():
+        return False
+    with sqlite3.connect(PRODUCTION_DB) as conn:
+        cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        return len(cur.fetchall()) > 0
+
+
+def run_validation(timeout_minutes: int = 5) -> Tuple[bool, bool]:
+    orchestrator = DualCopilotOrchestrator()
+    primary = _database_has_tables
+    return orchestrator.run(primary, [str(PRODUCTION_DB)], timeout_minutes)
+
+
+if __name__ == "__main__":
+    success, validated = run_validation()
+    print(f"Primary success: {success}")
+    print(f"Secondary success: {validated}")
+


### PR DESCRIPTION
## Summary
- add tests for `windows_compatible_optimizer` modules
- add `dual_copilot_database_check` validation script using database-first approach
- update test coverage report with new results

## Testing
- `ruff check tests/test_windows_compatible_optimizer.py validation/dual_copilot_database_check.py`
- `pytest tests/test_windows_compatible_optimizer.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5798a7488331b790318317a7011f