### PR TITLE
Fix undefined names in tests and CLI

### DIFF
--- a/tests/test_continuous_operation_monitor.py
+++ b/tests/test_continuous_operation_monitor.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import subprocess
 import time
 from pathlib import Path

--- a/validation/cli/commands.py
+++ b/validation/cli/commands.py
@@ -7,12 +7,12 @@ import argparse
 import json
 import sys
 from datetime import datetime
+from typing import List
 from pathlib import Path
 
 from ..protocols.session import SessionProtocolValidator
 from ..protocols.deployment import DeploymentValidator
 from ..core.validators import (
-    CompositeValidator,
     ValidationResult,
     ValidationStatus,
 )


### PR DESCRIPTION
## Summary
- import missing `os` in test
- add typing import in CLI and remove unused validator

## Testing
- `pyright tests/test_continuous_operation_monitor.py validation/cli/commands.py`
- `pytest tests/test_continuous_operation_monitor.py::test_log_created -q`
- `ruff check tests/test_continuous_operation_monitor.py validation/cli/commands.py`

------
https://chatgpt.com/codex/tasks/task_e_688a579cd0448331a0ff6380b2724e1a