### PR TITLE
docs: clarify quantum simulation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. **Many features remain experimental or stubbed; quantum functionality is simulated only and several modules are still incomplete.**
 
 > **Note**
-> All quantum utilities operate in simulation unless `qiskit-ibm-provider` is installed and configured with `QISKIT_IBM_TOKEN`.
+> Quantum functions remain in **simulation mode** until hardware integration is complete. Install `qiskit-ibm-provider` and set `QISKIT_IBM_TOKEN` to enable real IBM Quantum backends when available.
 
 ### 🎯 **Recent Milestones**
 - **Lessons Learned Integration:** initial implementation in progress

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -18,6 +18,7 @@ The gh_COPILOT Toolkit v4.0 represents a revolutionary enterprise-grade automati
 - **Web Interface**: Flask dashboard with basic endpoints and templates
 - **Advanced AI Integration**: tooling supports further automation efforts
 - **Quantum-Enhanced Processing**: placeholder algorithms under exploration
+- *All quantum functions run in simulation mode until hardware integration is completed. Install `qiskit-ibm-provider` and configure `QISKIT_IBM_TOKEN` to enable real IBM Quantum backends when available.*
 - **Enterprise Security Framework**: Zero-tolerance anti-recursion and comprehensive session integrity
 - *Note: earlier drafts referenced a 32+ database ecosystem. The current repository ships with a handful of SQLite databases for testing.*
 


### PR DESCRIPTION
## Summary
- note that quantum features stay in simulation mode until hardware integration
- mention how to enable IBM Quantum backends using `qiskit-ibm-provider`

## Testing
- `ruff check README.md documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md`
- `pytest tests/test_documentation_consolidator.py::test_documentation_consolidator -q`

------
https://chatgpt.com/codex/tasks/task_e_688a57a35eec83319850196bf2204a2e