### PR TITLE
feat: integrate cleanup flags into audit

### DIFF
--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -97,7 +97,7 @@ The Flask dashboard exposes a `/dashboard/compliance` endpoint that reads these
 metrics and shows real-time placeholder removal progress. When a placeholder is corrected, record the update in `analytics.db:correction_logs`. This ensures future audits can cross-reference removed placeholders with generated fixes.
 
 ### Placeholder Correction Workflow
-1. Run `scripts/placeholder_cleanup.py` to audit and automatically remove flagged placeholders.
+1. Run `scripts/code_placeholder_audit.py --cleanup --force` to audit and automatically remove flagged placeholders.
 2. Review `dashboard/compliance` for updated metrics.
 3. If manual fixes were applied, re-run `scripts/code_placeholder_audit.py --update-resolutions`.
 4. Record finalized corrections with `scripts/correction_logger_and_rollback.py`.

--- a/docs/USER_PROMPTS.md
+++ b/docs/USER_PROMPTS.md
@@ -28,10 +28,13 @@ Audit summaries can be copied to new GitHub issues referencing affected modules.
 
 ## Automated Placeholder Cleanup
 ```bash
-python scripts/placeholder_cleanup.py $GH_COPILOT_WORKSPACE \
-    databases/analytics.db databases/production.db dashboard/compliance
+python scripts/code_placeholder_audit.py --workspace $GH_COPILOT_WORKSPACE \
+    --analytics-db databases/analytics.db \
+    --production-db databases/production.db \
+    --dashboard-dir dashboard/compliance --cleanup --force
 ```
-This command audits, cleans placeholders, logs corrections, and updates metrics.
+This command audits the workspace, removes placeholders, writes a summary JSON,
+and updates metrics.
 
 ## Mark Corrections and Verify
 ```bash

--- a/scripts/placeholder_cleanup.py
+++ b/scripts/placeholder_cleanup.py
@@ -1,16 +1,15 @@
-"""Placeholder Cleanup CLI.
+"""Deprecated placeholder cleanup wrapper.
 
-This script orchestrates placeholder auditing, removal, logging, and dashboard
-updates. It uses :mod:`scripts.code_placeholder_audit` for detection and
-:mod:`template_engine.template_placeholder_remover` for cleanup.
+This thin wrapper forwards arguments to :mod:`scripts.code_placeholder_audit`.
+Use ``scripts/code_placeholder_audit.py`` directly for all operations.
 """
+
 from __future__ import annotations
 
 import argparse
 from pathlib import Path
 
 import json
-from dashboard.compliance_metrics_updater import ComplianceMetricsUpdater
 from scripts import code_placeholder_audit as audit
 
 
@@ -24,19 +23,16 @@ def run(
     cleanup: bool = False,
     dry_run: bool = False,
 ) -> bool:
-    patterns = (
-        audit.DEFAULT_PATTERNS
-        + audit.fetch_db_placeholders(production_db)
-        + audit.load_best_practice_patterns()
+    """Proxy to :func:`scripts.code_placeholder_audit.main`."""
+    return audit.main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics_db),
+        production_db=str(production_db),
+        dashboard_dir=str(dashboard_dir),
+        timeout_minutes=timeout_minutes,
+        simulate=dry_run,
+        apply_fixes=cleanup,
     )
-    results = audit.scan_files(workspace, patterns, timeout_minutes * 60)
-    audit.log_findings(results, analytics_db, simulate=dry_run)
-    if cleanup and not dry_run:
-        audit.auto_remove_placeholders(results, production_db, analytics_db)
-        audit.log_findings([], analytics_db, update_resolutions=True)
-    if not dry_run:
-        ComplianceMetricsUpdater(dashboard_dir).update()
-    return audit.validate_results(0 if cleanup else len(results), analytics_db)
 
 
 if __name__ == "__main__":
@@ -48,13 +44,18 @@ if __name__ == "__main__":
     parser.add_argument("--timeout", type=int, default=30)
     parser.add_argument("--cleanup", action="store_true", help="Remove placeholders")
     parser.add_argument("--dry-run", action="store_true", help="Run without DB writes")
+    parser.add_argument("--force", action="store_true", help="Force cleanup when not in dry-run mode")
     parser.add_argument("--rollback-last", action="store_true", help="Rollback last audit")
     args = parser.parse_args()
     if args.rollback_last:
-        if audit.rollback_last_entry(args.analytics_db):
-            print("Rollback complete")
-            raise SystemExit(0)
+        result = audit.rollback_last_entry(args.analytics_db)
+        print(json.dumps({"rollback": result}))
+        raise SystemExit(0 if result else 1)
+
+    if args.cleanup and not (args.dry_run or args.force):
+        print(json.dumps({"error": "--cleanup requires --force when not in dry-run"}))
         raise SystemExit(1)
+
     success = run(
         args.workspace,
         args.analytics_db,
@@ -68,7 +69,7 @@ if __name__ == "__main__":
         "workspace": str(args.workspace),
         "cleanup": args.cleanup,
         "dry_run": args.dry_run,
-        "result": success,
+        "success": success,
     }
     print(json.dumps(summary))
     raise SystemExit(0 if success else 1)

--- a/tests/test_placeholder_cleanup.py
+++ b/tests/test_placeholder_cleanup.py
@@ -1,6 +1,7 @@
 import sqlite3
+import json
 
-import scripts.placeholder_cleanup as pc
+import scripts.code_placeholder_audit as audit
 
 
 def test_placeholder_cleanup_workflow(tmp_path, monkeypatch):
@@ -16,7 +17,13 @@ def test_placeholder_cleanup_workflow(tmp_path, monkeypatch):
     with sqlite3.connect(prod) as conn:
         conn.execute("CREATE TABLE template_placeholders (placeholder_name TEXT)")
         conn.execute("INSERT INTO template_placeholders VALUES ('VALID')")
-    pc.run(workspace, analytics, prod, dash, cleanup=True)
+    audit.main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=str(prod),
+        dashboard_dir=str(dash),
+        apply_fixes=True,
+    )
 
     cleaned = target.read_text()
     assert "TODO" not in cleaned
@@ -24,5 +31,5 @@ def test_placeholder_cleanup_workflow(tmp_path, monkeypatch):
     with sqlite3.connect(analytics) as conn:
         count = conn.execute("SELECT COUNT(*) FROM corrections").fetchone()[0]
     assert count >= 1
-    metrics = (dash / "metrics.json").read_text()
-    assert metrics
+    summary = json.loads((dash / "placeholder_summary.json").read_text())
+    assert summary["resolved_count"] >= 1


### PR DESCRIPTION
## Summary
- merge placeholder cleanup CLI into main audit script
- support `--cleanup`, `--dry-run`, and `--force` with JSON summaries
- deprecate old cleanup wrapper
- document new single entrypoint
- test cleanup and rollback through unified interface

## Testing
- `ruff check scripts/code_placeholder_audit.py scripts/placeholder_cleanup.py tests/test_placeholder_cleanup.py tests/test_code_placeholder_audit_logger.py`
- `ruff format scripts/code_placeholder_audit.py scripts/placeholder_cleanup.py tests/test_placeholder_cleanup.py tests/test_code_placeholder_audit_logger.py`
- `pytest tests/test_placeholder_cleanup.py tests/test_code_placeholder_audit_logger.py tests/placeholder_audit/test_full_scan.py tests/test_placeholder_audit.py tests/test_placeholder_apply_fixes.py tests/test_placeholder_excludes.py tests/test_placeholder_resolution.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a64c49da0833181548b9dbefbf559