### PR TITLE
feat: add compliance dashboard metrics and alerts

### DIFF
--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -4,14 +4,16 @@ from web_gui.scripts.flask_apps.enterprise_dashboard import app
 
 def test_index_endpoint():
     client = app.test_client()
-    resp = client.get('/')
+    resp = client.get("/")
     assert resp.status_code == 200
-    assert b'Compliance Dashboard' in resp.data
+    data = resp.data.decode()
+    assert "<h1>Compliance Dashboard</h1>" in data
+    assert "metrics_stream" in data
 
 
 def test_metrics_endpoint():
     client = app.test_client()
-    resp = client.get('/metrics')
+    resp = client.get("/metrics")
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, dict)
@@ -19,55 +21,77 @@ def test_metrics_endpoint():
 
 def test_compliance_endpoint():
     client = app.test_client()
-    resp = client.get('/compliance')
+    resp = client.get("/compliance")
     assert resp.status_code == 200
     assert isinstance(resp.get_json(), dict)
 
 
 def test_dashboard_compliance_endpoint():
     client = app.test_client()
-    resp = client.get('/dashboard/compliance')
+    resp = client.get("/dashboard/compliance")
     assert resp.status_code == 200
     assert isinstance(resp.get_json(), dict)
 
 
 def test_rollback_alerts_endpoint():
     client = app.test_client()
-    resp = client.get('/rollback_alerts')
+    resp = client.get("/rollback_alerts")
     assert resp.status_code == 200
+
+
+def test_rollback_history_endpoint():
+    client = app.test_client()
+    resp = client.get("/rollback_history")
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json(), list)
 
 
 def test_dashboard_info_endpoint():
     client = app.test_client()
-    resp = client.get('/dashboard_info')
+    resp = client.get("/dashboard_info")
     assert resp.status_code == 200
     assert isinstance(resp.get_json(), dict)
 
 
 def test_health_endpoint():
     client = app.test_client()
-    resp = client.get('/health')
+    resp = client.get("/health")
     assert resp.status_code == 200
-    assert resp.get_json()['status'] == 'ok'
+    assert resp.get_json()["status"] == "ok"
+
+
+def test_error_endpoint():
+    client = app.test_client()
+    resp = client.get("/error")
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data["status"] == "error"
+
+
+def test_violations_endpoint():
+    client = app.test_client()
+    resp = client.get("/violations")
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json(), list)
 
 
 def test_reports_endpoint():
     client = app.test_client()
-    resp = client.get('/reports')
+    resp = client.get("/reports")
     assert resp.status_code == 200
 
 
 def test_realtime_metrics_endpoint():
     client = app.test_client()
-    resp = client.get('/realtime_metrics')
+    resp = client.get("/realtime_metrics")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert 'metrics' in data
-    assert 'corrections' in data
+    assert "metrics" in data
+    assert "corrections" in data
 
 
 def test_correction_history_endpoint():
     client = app.test_client()
-    resp = client.get('/correction_history')
+    resp = client.get("/correction_history")
     assert resp.status_code == 200
     assert isinstance(resp.get_json(), list)


### PR DESCRIPTION
## Summary
- render compliance dashboard using template on `/`
- expose `/violations` and `/rollback_history` for JSON summaries
- update `/error` to return structured JSON error
- serve templates from the project `web_gui/templates`
- expand endpoint tests for new routes and HTML rendering

## Testing
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py tests/test_dashboard_endpoints.py`
- `pyright web_gui/scripts/flask_apps/enterprise_dashboard.py tests/test_dashboard_endpoints.py`
- `pytest tests/test_dashboard_endpoints.py tests/dashboard/test_live_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_688a6c5749ec83319ce9b01478c37151