### PR TITLE
feat: add rollback strategy weighting

### DIFF
--- a/scripts/database/add_rollback_strategy_history.py
+++ b/scripts/database/add_rollback_strategy_history.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Ensure the ``rollback_strategy_history`` table exists in ``analytics.db``."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from tqdm import tqdm
+
+from .size_compliance_checker import check_database_sizes
+from utils.log_utils import _log_event
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS rollback_strategy_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target TEXT NOT NULL,
+    strategy TEXT NOT NULL,
+    outcome TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rsh_target
+    ON rollback_strategy_history(target);
+"""
+
+
+def add_table(db_path: Path) -> None:
+    """Create ``rollback_strategy_history`` table in ``db_path``."""
+    start_time = datetime.now()
+    logger.info("[START] add_table for %s", db_path)
+    logger.info("Process ID: %s", os.getpid())
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path, timeout=5) as conn, tqdm(total=1, desc="create-table", unit="step") as bar:
+        conn.executescript(SCHEMA_SQL)
+        conn.commit()
+        bar.update(1)
+    logger.info("rollback_strategy_history ensured in %s", db_path)
+    check_database_sizes(db_path.parent)
+    _log_event({"event": "rollback_strategy_history_ready", "db": str(db_path)})
+
+    elapsed = datetime.now() - start_time
+    logger.info("[SUCCESS] Completed in %s", str(elapsed))
+
+
+def ensure_rollback_strategy_history(db_path: Path) -> None:
+    """Ensure ``rollback_strategy_history`` table exists."""
+    add_table(db_path)
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    db_path = root / "databases" / "analytics.db"
+    start = datetime.now()
+    add_table(db_path)
+    etc = start + timedelta(seconds=1)
+    logger.info(
+        "Migration completed at %s | ETC was %s",
+        datetime.utcnow().isoformat(),
+        etc.strftime("%Y-%m-%d %H:%M:%S"),
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()
+
+__all__ = ["add_table", "ensure_rollback_strategy_history"]
+

--- a/tests/test_strategy_adaptation.py
+++ b/tests/test_strategy_adaptation.py
@@ -1,0 +1,37 @@
+from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
+
+
+def test_strategy_adapts_with_history(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    events = []
+    monkeypatch.setattr(
+        "scripts.correction_logger_and_rollback._log_event",
+        lambda evt, **kw: events.append((kw.get("table"), evt)),
+    )
+
+    db = tmp_path / "analytics.db"
+    logger = CorrectionLoggerRollback(db)
+
+    target = tmp_path / "file.txt"
+    backup = tmp_path / "file.bak"
+    target.write_text("a")
+    backup.write_text("a")
+
+    # first rollback
+    assert logger.auto_rollback(target, backup)
+    assert logger.suggest_rollback_strategy(target) == "Standard rollback"
+
+    # second rollback
+    target.write_text("b")
+    assert logger.auto_rollback(target, backup)
+    assert logger.suggest_rollback_strategy(target) == "Automate regression tests for this file."
+
+    # induce failures
+    target.unlink()
+    logger.auto_rollback(target, None)
+    logger.auto_rollback(target, None)
+    msg = logger.suggest_rollback_strategy(target)
+    assert "audit" in msg.lower()
+
+    assert any(t == "rollback_strategy_history" for t, _ in events)

--- a/tests/test_violation_and_rollback_logging.py
+++ b/tests/test_violation_and_rollback_logging.py
@@ -1,5 +1,4 @@
 import sqlite3
-from pathlib import Path
 
 from dashboard import compliance_metrics_updater as cmu
 from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
@@ -7,7 +6,7 @@ from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
 
 def test_violation_and_rollback_logging(tmp_path, monkeypatch):
     events = []
-    monkeypatch.setattr(cmu, "_log_event", lambda evt, **kw: events.append((kw.get("table"), evt)))
+    monkeypatch.setattr(cmu, "insert_event", lambda evt, table, **kw: events.append((table, evt)))
     monkeypatch.setattr(
         "scripts.correction_logger_and_rollback._log_event",
         lambda evt, **kw: events.append((kw.get("table"), evt)),


### PR DESCRIPTION
## Summary
- track rollback strategies in `rollback_strategy_history`
- log corrections with `_log_event`
- use historical outcomes when suggesting rollback strategies
- add table migration helper for new history table
- extend tests to verify strategy adaptation

## Testing
- `ruff check scripts/correction_logger_and_rollback.py scripts/database/add_rollback_strategy_history.py`
- `ruff check tests/test_violation_and_rollback_logging.py tests/test_strategy_adaptation.py`
- `pytest tests/test_strategy_adaptation.py::test_strategy_adapts_with_history -q`
- `pytest tests/test_violation_and_rollback_logging.py tests/test_strategy_adaptation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688a6c749e548331a10274b9ecc377f4