### PR TITLE
Add DBFirstCodeGenerator with analytics logging

### DIFF
--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -39,7 +39,7 @@ try:
 except ImportError:  # pragma: no cover - optional dependency
 
     def quantum_text_score(text: str) -> float:
-       """Fallback quantum text scoring implementation."""
+        """Fallback quantum text scoring implementation."""
         arr = np.fromiter((ord(c) for c in text), dtype=float)
         return float(np.linalg.norm(arr) / ((arr.size or 1) * 255))
 
@@ -51,7 +51,6 @@ except ImportError:  # pragma: no cover - optional dependency
             return 0.0
         denom = (np.linalg.norm(arr_a) * np.linalg.norm(arr_b)) or 1.0
         return float(np.dot(arr_a, arr_b) / denom)
-
 
     def quantum_cluster_score(matrix: np.ndarray) -> float:
         n_clusters = min(len(matrix), 2)


### PR DESCRIPTION
## Summary
- implement `DBFirstCodeGenerator` in `db_first_code_generator.py`
- log generation events to `code_generation_events` table
- add integration-ready code generation method
- fix indentation in `auto_generator`
- add tests for new generator and analytics logging

## Testing
- `ruff check template_engine/db_first_code_generator.py tests/test_db_first_code_generator.py tests/test_db_first_codegen_analytics.py`
- `pytest tests/test_db_first_code_generator.py tests/test_db_first_codegen_analytics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688a7250327483318ddfb0d7693e8e25