### PR TITLE
Add basic flake8 correction subclasses

### DIFF
--- a/tests/test_flake8_corrector_base.py
+++ b/tests/test_flake8_corrector_base.py
@@ -1,5 +1,11 @@
 from pathlib import Path
-from scripts.utilities.flake8_corrector_base import WhitespaceCorrector, ImportOrderCorrector
+from scripts.utilities.flake8_corrector_base import (
+    WhitespaceCorrector,
+    ImportOrderCorrector,
+    LineLengthCorrector,
+    IndentationCorrector,
+    ComplexityCorrector,
+)
 
 
 def test_whitespace_corrector(tmp_path: Path) -> None:
@@ -17,3 +23,30 @@ def test_import_order_corrector(tmp_path: Path) -> None:
     assert c.execute_correction()
     text = f.read_text()
     assert "import os" in text and "import sys" in text
+
+
+def test_line_length_corrector(tmp_path: Path) -> None:
+    long_line = "print('" + "a" * 90 + "')\n"
+    f = tmp_path / "bad.py"
+    f.write_text(long_line)
+    c = LineLengthCorrector(workspace_path=str(tmp_path))
+    assert c.execute_correction()
+    assert len(f.read_text().splitlines()) > 1
+
+
+def test_indentation_corrector(tmp_path: Path) -> None:
+    bad_code = "def x():\nprint('hi')\n"
+    f = tmp_path / "bad.py"
+    f.write_text(bad_code)
+    c = IndentationCorrector(workspace_path=str(tmp_path))
+    assert c.execute_correction()
+    assert f.read_text() == "def x():\n    print('hi')\n"
+
+
+def test_complexity_corrector(tmp_path: Path) -> None:
+    lines = ["    if x == {}:\n        pass\n".format(i) for i in range(11)]
+    f = tmp_path / "bad.py"
+    f.write_text("def f(x):\n" + "".join(lines))
+    c = ComplexityCorrector(workspace_path=str(tmp_path))
+    assert c.execute_correction()
+    assert f.read_text().startswith("# TODO: reduce complexity")


### PR DESCRIPTION
## Summary
- expand `flake8_corrector_base` with line length, indentation, and complexity fixers
- log each fix attempt
- cover new classes with unit tests

## Testing
- `ruff check scripts/utilities/flake8_corrector_base.py tests/test_flake8_corrector_base.py`
- `pytest tests/test_flake8_corrector_base.py::test_line_length_corrector tests/test_flake8_corrector_base.py::test_indentation_corrector tests/test_flake8_corrector_base.py::test_complexity_corrector -q`
- `pytest -q` *(fails: test_dashboard_placeholder_metrics.py, test_database_list.py, test_db_helper_usage.py, test_disallowed_paths.py, test_documentation_consolidator.py, test_documentation_db_analyzer.py, test_documentation_manager.py, test_documentation_manager_validator.py, test_enterprise_database_driven_documentation_manager.py, test_enterprise_template_compliance_enhancer.py, test_init_and_audit.py)*

------
https://chatgpt.com/codex/tasks/task_e_688a7cf2f1d48331b3489fcb600c714f