### PR TITLE
feat: persist pattern clusters and provide retrieval API

### DIFF
--- a/tests/test_pattern_mining_engine.py
+++ b/tests/test_pattern_mining_engine.py
@@ -2,15 +2,19 @@ import os
 import sqlite3
 from pathlib import Path
 
+import template_engine.pattern_mining_engine as pme
 from template_engine.pattern_mining_engine import (
     extract_patterns,
     mine_patterns,
+    get_clusters,
     validate_mining,
 )
+
 
 def test_extract_patterns():
     # Start time logging for visual processing indicator
     from datetime import datetime
+
     start_time = datetime.now()
     print(f"PROCESS STARTED: test_extract_patterns")
     print(f"Start Time: {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
@@ -25,9 +29,13 @@ def test_extract_patterns():
     duration = (end_time - start_time).total_seconds()
     print(f"TEST COMPLETED: test_extract_patterns in {duration:.2f}s")
 
-def test_mine_patterns(tmp_path: Path):
+
+def test_mine_patterns(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(pme, "_log_audit_real", lambda *a, **k: None)
     # Start time logging for visual processing indicator
     from datetime import datetime
+
     start_time = datetime.now()
     print(f"PROCESS STARTED: test_mine_patterns")
     print(f"Start Time: {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
@@ -35,12 +43,8 @@ def test_mine_patterns(tmp_path: Path):
 
     prod = tmp_path / "production.db"
     with sqlite3.connect(prod) as conn:
-        conn.execute(
-            "CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)"
-        )
-        conn.execute(
-            "INSERT INTO code_templates (template_code) VALUES ('def x(): pass')"
-        )
+        conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
+        conn.execute("INSERT INTO code_templates (template_code) VALUES ('def x(): pass')")
     analytics = tmp_path / "analytics.db"
     patterns = mine_patterns(prod, analytics)
     assert patterns, "No patterns mined from templates"
@@ -50,8 +54,11 @@ def test_mine_patterns(tmp_path: Path):
     assert validate_mining(len(patterns), analytics), "DUAL COPILOT validation failed"
 
 
-def test_mine_patterns_clusters(tmp_path: Path) -> None:
+def test_mine_patterns_clusters(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(pme, "_log_audit_real", lambda *a, **k: None)
     from datetime import datetime
+
     start_time = datetime.now()
     prod = tmp_path / "production.db"
     analytics = tmp_path / "analytics.db"
@@ -68,3 +75,32 @@ def test_mine_patterns_clusters(tmp_path: Path) -> None:
     end_time = datetime.now()
     duration = (end_time - start_time).total_seconds()
     print(f"TEST COMPLETED: test_mine_patterns in {duration:.2f}s")
+
+
+def test_get_clusters_and_audit_logging(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    prod = tmp_path / "production.db"
+    analytics = tmp_path / "analytics.db"
+    with sqlite3.connect(prod) as conn:
+        conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
+        conn.execute("INSERT INTO code_templates (template_code) VALUES ('def x(): pass')")
+        conn.execute("INSERT INTO code_templates (template_code) VALUES ('def y(): pass')")
+
+    def audit_log(db_name: str, details: str) -> None:
+        with sqlite3.connect(analytics) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, db_name TEXT, details TEXT, ts TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO audit_log (db_name, details, ts) VALUES (?, ?, ?)",
+                (db_name, details, "test"),
+            )
+            conn.commit()
+
+    monkeypatch.setattr(pme, "_log_audit_real", audit_log)
+    mine_patterns(prod, analytics)
+    clusters = get_clusters(analytics)
+    assert clusters
+    with sqlite3.connect(analytics) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM audit_log").fetchone()[0]
+    assert count > 0


### PR DESCRIPTION
## Summary
- log pattern clusters count via `_log_audit_real`
- add `get_clusters` helper to load saved cluster data
- ensure tests patch audit logger and validate cluster persistence

## Testing
- `ruff check . --exit-zero`
- `ruff format template_engine/pattern_mining_engine.py tests/test_pattern_mining_engine.py`
- `pyright --project pyproject.toml` *(interrupted manually)*
- `pytest -q tests/test_pattern_mining_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_688a7cef48088331a97d95f986d69811