### PR TITLE
feat: table-level database size alerts

### DIFF
--- a/databases/migrations/add_size_violations.sql
+++ b/databases/migrations/add_size_violations.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS size_violations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     db TEXT,
+    table_name TEXT,
     size_mb REAL,
     threshold REAL,
     timestamp TEXT

--- a/scripts/database/size_compliance_checker.py
+++ b/scripts/database/size_compliance_checker.py
@@ -6,13 +6,14 @@ Fixed import-time logging configuration issue
 
 import os
 import sys
+import sqlite3
 from pathlib import Path
 from typing import Dict
 
 from tqdm import tqdm
 
 from utils.enterprise_logging import EnterpriseLoggingManager
-from utils.log_utils import log_event
+from utils.log_utils import log_event, stream_events
 
 ANALYTICS_DB = Path(os.getenv("ANALYTICS_DB", "databases/analytics.db"))
 
@@ -34,7 +35,7 @@ def setup_logging() -> None:
 
 
 def check_database_sizes(databases_dir: Path, threshold_mb: float = 99.9) -> Dict[str, float]:
-    """📏 Check database sizes with enterprise logging"""
+    """📏 Check database and table sizes with enterprise logging"""
     setup_logging()
 
     logger.info("=" * 60)
@@ -57,10 +58,47 @@ def check_database_sizes(databases_dir: Path, threshold_mb: float = 99.9) -> Dic
                 size_bytes = db_file.stat().st_size
                 size_mb = size_bytes / (1024 * 1024)
                 size_results[db_file.name] = size_mb
+                with sqlite3.connect(db_file) as conn:
+                    cur = conn.cursor()
+                    cur.execute("PRAGMA page_size")
+                    page_size = cur.fetchone()[0]
+                    tables = [row[0] for row in cur.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table'"
+                    ).fetchall()]
+                    for table in tables:
+                        try:
+                            cur.execute("SELECT sum(pgsize) FROM dbstat WHERE name=?", (table,))
+                            res = cur.fetchone()[0]
+                            if res is None:
+                                cur.execute(f"PRAGMA page_count('{table}')")
+                                pc = cur.fetchone()[0]
+                                res = pc * page_size
+                        except sqlite3.Error:
+                            cur.execute(f"PRAGMA page_count('{table}')")
+                            pc = cur.fetchone()[0]
+                            res = pc * page_size
+                        table_mb = (res or 0) / (1024 * 1024)
+                        if table_mb > threshold_mb:
+                            logger.warning(
+                                f"⚠️ {db_file.name}:{table}: {table_mb:.2f} MB > {threshold_mb} MB"
+                            )
+                            event = {
+                                "db": db_file.name,
+                                "table_name": table,
+                                "size_mb": table_mb,
+                                "threshold": threshold_mb,
+                            }
+                            log_event(event, table="size_violations", db_path=ANALYTICS_DB)
+                            for line in stream_events("size_violations", db_path=ANALYTICS_DB):
+                                if f'"db": "{db_file.name}"' in line and f'"table_name": "{table}"' in line:
+                                    print(line.strip())
+                                    break
                 if size_mb > threshold_mb:
-                    logger.warning(f"⚠️ {db_file.name}: {size_mb:.2f} MB > {threshold_mb} MB")
+                    logger.warning(
+                        f"⚠️ {db_file.name}: {size_mb:.2f} MB > {threshold_mb} MB"
+                    )
                     log_event(
-                        {"db": db_file.name, "size_mb": size_mb, "threshold": threshold_mb},
+                        {"db": db_file.name, "table_name": "__database__", "size_mb": size_mb, "threshold": threshold_mb},
                         table="size_violations",
                         db_path=ANALYTICS_DB,
                     )

--- a/tests/test_size_compliance_checker.py
+++ b/tests/test_size_compliance_checker.py
@@ -16,8 +16,33 @@ def test_check_database_sizes(tmp_path: Path) -> None:
     assert results["small.db"] <= 1
 
     db2 = tmp_path / "big.db"
-    db2.write_bytes(b"0" * (2 * 1024 * 1024))  # 2 MB
+    with sqlite3.connect(db2) as conn:
+        conn.execute("CREATE TABLE data(x TEXT)")
+        payload = "y" * 1024
+        for _ in range(1200):
+            conn.execute("INSERT INTO data(x) VALUES (?)", (payload,))
+        conn.commit()
     results = checker.check_database_sizes(tmp_path, threshold_mb=1)
     assert results["big.db"] > 1
     violations = list(stream_events("size_violations", db_path=db_file))
     assert violations
+
+
+def test_table_size_violation(tmp_path: Path, capsys) -> None:
+    db_file = tmp_path / "analytics.db"
+    os.environ["ANALYTICS_DB"] = str(db_file)
+    checker.ANALYTICS_DB = db_file
+
+    target = tmp_path / "oversize.db"
+    with sqlite3.connect(target) as conn:
+        conn.execute("CREATE TABLE big(data TEXT)")
+        payload = "x" * 1024
+        for _ in range(2000):
+            conn.execute("INSERT INTO big(data) VALUES (?)", (payload,))
+        conn.commit()
+
+    checker.check_database_sizes(tmp_path, threshold_mb=0.5)
+    output = capsys.readouterr().out
+    violations = list(stream_events("size_violations", db_path=db_file))
+    assert any("\"table_name\": \"big\"" in v for v in violations)
+    assert "data:" in output

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -103,6 +103,7 @@ TABLE_SCHEMAS: Dict[str, str] = {
         CREATE TABLE IF NOT EXISTS size_violations (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             db TEXT,
+            table_name TEXT,
             size_mb REAL,
             threshold REAL,
             timestamp TEXT


### PR DESCRIPTION
## Summary
- update size violations schema with `table_name`
- log table-level page_size and page_count in size compliance checker
- send SSE alerts on each violation
- test table size violations

## Testing
- `ruff check scripts/database/size_compliance_checker.py tests/test_size_compliance_checker.py utils/log_utils.py`
- `pytest tests/test_size_compliance_checker.py::test_check_database_sizes tests/test_size_compliance_checker.py::test_table_size_violation -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7d5f62608331971a55bcebae41ff