### PR TITLE
Add env-controlled logging and streaming utilities

### DIFF
--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -1,9 +1,11 @@
+import os
 import sqlite3
 
 from utils.log_utils import _log_event
 
 
-def test_log_event_multiple_tables(tmp_path):
+def test_log_event_multiple_tables(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "1")
     db_dir = tmp_path / "databases"
     db_dir.mkdir()
     db = db_dir / "analytics.db"

--- a/tests/test_log_utils_extended.py
+++ b/tests/test_log_utils_extended.py
@@ -1,0 +1,33 @@
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from itertools import islice
+
+from utils.log_utils import ensure_tables, log_event, log_stream
+
+
+def test_high_frequency_logging(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "0")
+    db = tmp_path / "hf.db"
+    ensure_tables(db, ["violation_logs"], test_mode=False)
+    for i in range(100):
+        log_event({"details": str(i)}, table="violation_logs", db_path=db)
+    with sqlite3.connect(db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM violation_logs").fetchone()[0]
+    assert count == 100
+
+
+def test_log_recovery_after_interruption(tmp_path: Path) -> None:
+    db = tmp_path / "recover.db"
+    ensure_tables(db, ["violation_logs"], test_mode=False)
+    conn = sqlite3.connect(db)
+    for i in range(5):
+        conn.execute(
+            "INSERT INTO violation_logs (details, timestamp) VALUES (?, ?)",
+            (str(i), datetime.utcnow().isoformat()),
+        )
+    conn.commit()
+    conn.close()
+    events = list(islice(log_stream("violation_logs", db_path=db, poll_interval=0.1), 5))
+    assert len(events) == 5


### PR DESCRIPTION
## Summary
- log_utils._log_event now relies on `GH_COPILOT_TEST_MODE` to decide if writes are simulated
- include timestamp/module/level context in `_log_event`
- add `log_stream` for continuous SSE streaming
- update existing log util test and add new coverage for high frequency and recovery

## Testing
- `ruff check utils/log_utils.py tests/test_log_utils.py tests/test_log_utils_stream.py tests/test_log_utils_extended.py`
- `pytest tests/test_log_utils.py tests/test_log_utils_stream.py tests/test_log_utils_extended.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7d6253888331af3e65b881bd2b2e