### PR TITLE
Use OpenAIClient in connector

### DIFF
--- a/github_integration/openai_connector.py
+++ b/github_integration/openai_connector.py
@@ -1,9 +1,7 @@
 import os
 from typing import Any, Dict
 
-import requests
-
-OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+from third_party.openai_client import OpenAIClient
 
 
 def get_api_key() -> str:
@@ -14,17 +12,10 @@ def get_api_key() -> str:
     return api_key
 
 
+client = OpenAIClient(api_key=get_api_key())
+
+
 def send_prompt(prompt: str, model: str = "gpt-3.5-turbo", **kwargs: Any) -> Dict[str, Any]:
     """Send a prompt to the OpenAI API and return the JSON response."""
-    headers = {
-        "Authorization": f"Bearer {get_api_key()}",
-        "Content-Type": "application/json",
-    }
-    payload = {
-        "model": model,
-        "messages": [{"role": "user", "content": prompt}],
-        **kwargs,
-    }
-    response = requests.post(OPENAI_API_URL, json=payload, headers=headers, timeout=30)
-    response.raise_for_status()
-    return response.json()
+    messages = [{"role": "user", "content": prompt}]
+    return client.chat_completion(messages, model=model, **kwargs)

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from third_party.openai_client import OpenAIClient
+import third_party.openai_client as oc
 
 
 def test_chat_completion_success(monkeypatch):
@@ -13,3 +14,45 @@ def test_chat_completion_success(monkeypatch):
         resp = client.chat_completion([{"role": "user", "content": "hi"}])
     assert resp == result
     assert req.called
+
+
+def test_chat_completion_retry(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    client = OpenAIClient(base_url="http://api", max_retries=2)
+    first = mock.Mock(status_code=500)
+    second = mock.Mock(status_code=200)
+    second.json.return_value = {"ok": True}
+    with mock.patch("requests.Session.request", side_effect=[first, second]) as req:
+        resp = client.chat_completion([{"role": "user", "content": "hi"}])
+    assert req.call_count == 2
+    assert resp == {"ok": True}
+
+
+def test_rate_limiting(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    client = OpenAIClient(base_url="http://api", rate_limit=1.0)
+
+    current = {"t": 0.0}
+
+    def fake_time() -> float:
+        return current["t"]
+
+    sleeps: list[float] = []
+
+    def fake_sleep(d: float) -> None:
+        sleeps.append(d)
+        current["t"] += d
+
+    monkeypatch.setattr(oc.time, "time", fake_time)
+    monkeypatch.setattr(oc.time, "sleep", fake_sleep)
+
+    with mock.patch("requests.Session.request") as req:
+        req.return_value.status_code = 200
+        req.return_value.json.return_value = {}
+        client.chat_completion([{"role": "user", "content": "a"}])
+        t1 = current["t"]
+        client.chat_completion([{"role": "user", "content": "b"}])
+        t2 = current["t"]
+
+    assert t2 - t1 >= 1.0
+    assert sleeps == [1.0, 1.0]


### PR DESCRIPTION
## Summary
- delegate OpenAI API requests to `OpenAIClient`
- add retry and rate limit unit tests for the client

## Testing
- `ruff check github_integration/openai_connector.py tests/test_openai_client.py`
- `pytest tests/test_openai_client.py tests/test_env_paths.py::test_openai_api_key -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7d64b7288331ad5afbe360d0f0f5