### PR TITLE
fix: align quantum fallback indentation

### DIFF
--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -38,12 +38,13 @@ try:
         quantum_cluster_score,
     )
 except ImportError:  # pragma: no cover - optional dependency
-
     def quantum_text_score(text: str) -> float:
         """Gracefully degrade when quantum library is unavailable."""
         return 0.0
 
-    def quantum_similarity_score(a: Iterable[float], b: Iterable[float]) -> float:
+    def quantum_similarity_score(
+        a: Iterable[float], b: Iterable[float]
+    ) -> float:
         """Gracefully degrade when quantum library is unavailable."""
         return 0.0
 


### PR DESCRIPTION
Resolves user prompt to normalize indentation for quantum fallbacks in `auto_generator.py`.

- adjusted indentation in the `except ImportError` block to use consistent 4‑space style
- verified module compiles
- ensured database scoring tests pass


------
https://chatgpt.com/codex/tasks/task_e_688a7df2419483318c0618a320766ea4