### PR TITLE
Initialize analytics DB on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ HEALTHCHECK --interval=30s --timeout=5s CMD ["python", "scripts/docker_healthche
 
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
-CMD ["/app/entrypoint.sh"]
+CMD ["bash", "/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Inside the image `GH_COPILOT_BACKUP_ROOT` defaults to `/backup`. Map this path t
 
 When launching with Docker Compose, the provided `docker-compose.yml` mounts `${GH_COPILOT_BACKUP_ROOT:-/backup}` at `/backup`. Set `GH_COPILOT_BACKUP_ROOT` on the host before running `docker-compose up` so backups survive container restarts.
 
+The container's `entrypoint.sh` now initializes `analytics.db` automatically before starting the dashboard service, so no manual step is required.
+
 ### Wrapping, Logging, and Compliance (WLC)
 Run the session manager after setting the workspace and backup paths:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 set -e
-python scripts/docker_entrypoint.py &
+
+# Ensure workspace and backup environment variables are exported
+export GH_COPILOT_WORKSPACE="${GH_COPILOT_WORKSPACE:-/app}"
+export GH_COPILOT_BACKUP_ROOT="${GH_COPILOT_BACKUP_ROOT:-/backup}"
+
+# Initialize analytics database before launching services
+python scripts/database/unified_database_initializer.py
+
+# Start background workers
 python dashboard/compliance_metrics_updater.py &
-wait -n
+
+# Launch the Flask dashboard in the foreground
+exec python scripts/docker_entrypoint.py

--- a/scripts/docker_healthcheck.py
+++ b/scripts/docker_healthcheck.py
@@ -1,11 +1,34 @@
 #!/usr/bin/env python3
-"""Simple health check for Docker container."""
+"""Simple health check for Docker container.
+
+This script validates the enterprise environment and ensures the Flask
+dashboard is responding on the configured port.
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.error import URLError
+from urllib.request import urlopen
 
 from utils.validation_utils import validate_enterprise_environment
 
-if __name__ == "__main__":
+
+def check_health() -> bool:
+    """Return ``True`` if the dashboard health endpoint responds successfully."""
+    validate_enterprise_environment()
+    port = int(os.getenv("FLASK_RUN_PORT", "5000"))
     try:
-        validate_enterprise_environment()
+        with urlopen(f"http://localhost:{port}/health", timeout=5) as resp:
+            return resp.status == 200
     except Exception:
-        raise SystemExit(1)
-    raise SystemExit(0)
+        return False
+
+
+def main() -> int:
+    """Run the health check and return an exit code."""
+    return 0 if check_health() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docker_healthcheck.py
+++ b/tests/test_docker_healthcheck.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import scripts.docker_healthcheck as dhc
+
+
+def test_healthcheck_success(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backup"))
+
+    class FakeResp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(dhc, "urlopen", lambda *a, **k: FakeResp())
+    assert dhc.main() == 0


### PR DESCRIPTION
## Summary
- initialize analytics DB before starting services
- keep dashboard server in the foreground and launch worker in background
- check `/health` endpoint for Docker healthcheck
- adjust container CMD to call the updated entrypoint
- document automatic DB initialization and add unit test for healthcheck

## Testing
- `ruff check scripts/docker_healthcheck.py tests/test_docker_healthcheck.py entrypoint.sh`
- `pytest tests/test_docker_healthcheck.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688a7df8f5648331875442d63f4d2927