### PR TITLE
Fix stub status docs and clarify CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           import template_engine.template_synchronizer
           PY
 
-      - name: Run tests
+      - name: Run full test suite
         run: make test
 
       - name: Upload test reports
@@ -117,8 +117,8 @@ jobs:
 
       - name: Lint
         run: ruff check .
-      - name: Test
-        run: pytest -q
+      - name: Test (full suite)
+        run: pytest -q tests
 
       - name: Upload coverage
         if: always()

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Status:** Active development with incremental improvements
 
-> **Limitations:** The project is under heavy development. Some tests fail and several modules are only partially implemented.
+> **Limitations:** The project is under heavy development. Some modules remain incomplete (see `docs/STUB_MODULE_STATUS.md`), including `DBFirstCodeGenerator`, `documentation_db_analyzer`, and `workflow_enhancer`. These gaps cause a portion of the test suite to fail.
 
 ---
 
@@ -785,7 +785,7 @@ source .venv/bin/activate
 pip install -r requirements-test.txt
 
 # Run comprehensive test suite
-make test
+make test  # runs `pytest tests`
 
 # Run linter
 ruff format .

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.1.10] - 2025-08-01
+- Updated `STUB_MODULE_STATUS.md` to mark `DBFirstCodeGenerator`,
+  `documentation_db_analyzer`, and `workflow_enhancer` as incomplete.
+- Clarified failing tests in README with explicit module references.
+- Documented full test suite execution in CI configuration.
+
 ## [4.1.8] - 2025-07-30
 - Added documentation update workflow instructions
 - Clarified that quantum modules operate in simulation mode only

--- a/docs/STUB_MODULE_STATUS.md
+++ b/docs/STUB_MODULE_STATUS.md
@@ -13,14 +13,14 @@ The file `DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md` lists pending tasks marked
 | ID | Description (short) | Module/Path | Exists? |
 |----|--------------------|-------------|---------|
 | STUB-001 | Maintain full traversal scanning using `scripts/code_placeholder_audit.py` | scripts/code_placeholder_audit.py | yes |
-| STUB-002 | Expand DB-first code generation with similarity scoring | template_engine/auto_generator.py<br>template_engine/db_first_code_generator.py<br>pattern_mining_engine.py<br>objective_similarity_scorer.py | **complete** |
+| STUB-002 | Expand DB-first code generation with similarity scoring | template_engine/auto_generator.py<br>template_engine/db_first_code_generator.py<br>template_engine/pattern_mining_engine.py<br>template_engine/objective_similarity_scorer.py | **in progress** |
 | STUB-003 | Implement KMeans clustering for template selection | template_engine/template_synchronizer.py<br>copilot/copilot-instructions.md | **complete** |
-| STUB-004 | Log correction history with rollback metrics | documentation_db_analyzer.py<br>compliance_metrics_updater.py<br>databases/analytics.db | **complete** |
+| STUB-004 | Log correction history with rollback metrics | documentation_db_analyzer.py (missing)<br>dashboard/compliance_metrics_updater.py<br>databases/analytics.db | **incomplete** |
 | STUB-005 | Enhance documentation manager with DB-first templates | archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py<br>README.md<br>DATABASE_FIRST_USAGE_GUIDE.md | **complete** |
 | STUB-006 | Integrate quantum-inspired scoring hooks | quantum/quantum_algorithm_library_expansion.py<br>template_engine/auto_generator.py | **complete** |
-| STUB-007 | Extend dashboard for real-time metrics and alerts | enterprise_dashboard.py<br>web_gui/templates/html/ | **complete** |
+| STUB-007 | Extend dashboard for real-time metrics and alerts | dashboard/enterprise_dashboard.py<br>web_gui/templates/ | **complete** |
 | STUB-008 | Add tests and validation scripts for new modules | tests/<br>validation/ | **complete** |
-| STUB-009 | Remove placeholders and enable analytics hooks | workflow_enhancer.py<br>archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py | **complete** |
+| STUB-009 | Remove placeholders and enable analytics hooks | workflow_enhancer.py (missing)<br>archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py | **partial** |
 | STUB-010 | Update task suggestion files with cross-references | docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md<br>logs/<br>validation/ | **complete** |
 | STUB-011 | Record outputs to analytics.db across modules | various modules | **complete** |
 | STUB-012 | Display placeholder removal progress on dashboard | dashboard/compliance_metrics_updater.py | **complete** |
@@ -35,7 +35,7 @@ Implementation note: the `ingest_assets` workflow is fully implemented in
 
 ## Test Coverage
 
-Running `pytest` currently results in multiple failures. Only a subset of tests executes successfully.
+Running `pytest` currently results in multiple failures. The majority of failures stem from incomplete modules such as `DBFirstCodeGenerator`, `documentation_db_analyzer`, and `workflow_enhancer`.
 
 Most quantum-oriented modules operate purely in simulation mode. Hardware execution is not supported and several helper scripts remain stubs.
 


### PR DESCRIPTION
## Summary
- mark missing modules in STUB_MODULE_STATUS
- update README limitations section
- document new release in CHANGELOG
- run full test suite in CI workflow

## Testing
- `ruff check docs/STUB_MODULE_STATUS.md README.md .github/workflows/ci.yml docs/CHANGELOG.md`
- `pyright template_engine/db_first_code_generator.py`
- `pytest tests/test_db_first_code_generator.py::test_existing_pattern_loaded -q`


------
https://chatgpt.com/codex/tasks/task_e_688a7e012b688331a82482ae580f27f1