### PR TITLE
Fix web_gui test import

### DIFF
--- a/tests/dashboard/test_live_metrics.py
+++ b/tests/dashboard/test_live_metrics.py
@@ -1,9 +1,12 @@
 import json
 import sqlite3
 from pathlib import Path
+import os
+import sys
 
 import pytest
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from web_gui.scripts.flask_apps import enterprise_dashboard as ed
 
 


### PR DESCRIPTION
## Summary
- add missing sys.path entry in test_live_metrics

## Testing
- `ruff check tests/dashboard/test_live_metrics.py`
- `pytest tests/dashboard/test_live_metrics.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_688a84b409408331af9347731e95925e