### PR TITLE
docs: document docker deployment

### DIFF
--- a/docs/DEPLOYMENT_ORCHESTRATOR.md
+++ b/docs/DEPLOYMENT_ORCHESTRATOR.md
@@ -10,3 +10,32 @@ python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --s
 ```
 This command starts a managed session with `ComprehensiveWorkspaceManager` and
 executes the deployment workflow.
+
+## Docker Deployment
+
+The orchestrator can run inside the provided Docker image. Build and tag the
+image from the repository root:
+
+```bash
+docker build -t gh_copilot:latest .
+```
+
+Run the container while mapping the backup directory on the host. Two
+environment variables are required at startup:
+
+* **`GH_COPILOT_WORKSPACE`** – workspace path inside the container. Defaults to
+  `/app`.
+* **`GH_COPILOT_BACKUP_ROOT`** – external path for logs and backups. Must map to
+  a host directory.
+
+Example run command:
+
+```bash
+docker run \
+  -e GH_COPILOT_BACKUP_ROOT=/path/to/backups \
+  -e GH_COPILOT_WORKSPACE=/app \
+  gh_copilot:latest
+```
+
+The CI workflow `.github/workflows/ci.yml` builds this image as part of the
+automated tests.


### PR DESCRIPTION
Resolves user request to document Docker image usage.

## Summary
- explain Docker build, tag and run steps
- describe `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT`
- point readers to `.github/workflows/ci.yml`

## Testing
- `ruff check docs/DEPLOYMENT_ORCHESTRATOR.md`
- `pyright docs`
- `pytest` *(fails: 42 failed, 243 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a84aa3088833185d4dd7d1bd94e45