### PR TITLE
Clarify Qiskit simulation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. **Many features remain experimental or stubbed; quantum functionality is simulated only and several modules are still incomplete.**
 
 > **Note**
-> Quantum functions remain in **simulation mode** until hardware integration is complete. Install `qiskit-ibm-provider` and set `QISKIT_IBM_TOKEN` to enable real IBM Quantum backends when available.
+> Qiskit-based operations run in **simulation mode** unless hardware access is configured. Install `qiskit-ibm-provider` and set the optional `QISKIT_IBM_TOKEN` environment variable to use real IBM Quantum backends.
 
 ### 🎯 **Recent Milestones**
 - **Lessons Learned Integration:** initial implementation in progress
@@ -32,7 +32,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Analytics Migrations:** run `add_code_audit_log.sql`, `add_correction_history.sql`, `add_code_audit_history.sql`, `add_violation_logs.sql`, and `add_rollback_logs.sql` (use `sqlite3` manually if `analytics.db` shipped without the tables) or use the initializer. The `correction_history` table tracks file corrections with `user_id`, session ID, action, timestamp, and optional details. The new `code_audit_history` table records each audit entry along with the responsible user and timestamp.
 
 - **Quantum Utilities:** see [quantum/README.md](quantum/README.md) for
-  optimizer and search helpers.
+  optimizer and search helpers. These modules are **experimental** and default to simulation mode unless `QISKIT_IBM_TOKEN` is configured.
 
 ### 🏆 **Enterprise Achievements**
  - ✅ **Script Validation**: 1679 scripts synchronized
@@ -234,8 +234,7 @@ By default the orchestrator uses the simulator. To execute algorithms on IBM Qua
 python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
 ```
 
-If the provider cannot be initialized the orchestrator automatically falls back
-to simulation.
+Set `QISKIT_IBM_TOKEN` to your IBM Quantum API token for hardware execution. If the provider cannot be initialized the orchestrator automatically falls back to simulation.
 
 ### Run Template Matcher
 ```bash

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -18,7 +18,7 @@ The gh_COPILOT Toolkit v4.0 represents a revolutionary enterprise-grade automati
 - **Web Interface**: Flask dashboard with basic endpoints and templates
 - **Advanced AI Integration**: tooling supports further automation efforts
 - **Quantum-Enhanced Processing**: placeholder algorithms under exploration
-- *All quantum functions run in simulation mode until hardware integration is completed. Install `qiskit-ibm-provider` and configure `QISKIT_IBM_TOKEN` to enable real IBM Quantum backends when available.*
+- *All Qiskit-based functions run in simulation mode by default. Install `qiskit-ibm-provider` and set the optional `QISKIT_IBM_TOKEN` environment variable to use real IBM Quantum hardware.*
 - **Enterprise Security Framework**: Zero-tolerance anti-recursion and comprehensive session integrity
 - *Note: earlier drafts referenced a 32+ database ecosystem. The current repository ships with a handful of SQLite databases for testing.*
 


### PR DESCRIPTION
## Summary
- document that Qiskit functions run in simulation mode by default
- mention the optional `QISKIT_IBM_TOKEN` environment variable
- mark quantum utilities as experimental

## Testing
- `ruff check .` *(fails: 363 errors)*
- `pytest -q` *(fails: 41 failed, 274 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a84adfc808331a2cfb6f87fdad3a0