### PR TITLE
docs: update module status and metrics

### DIFF
--- a/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
+++ b/docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md
@@ -158,13 +158,13 @@ implemented consistently.
 | ID | Description | Module/Path | Related Sections |
 |----|-------------|-------------|-----------------|
 | `STUB-001` | Maintain full traversal scanning using `scripts/code_placeholder_audit.py`; ensure each finding is logged to `analytics.db` and surfaced on `/dashboard/compliance` (test-mode via `GH_COPILOT_TEST_MODE=1`) | `scripts/code_placeholder_audit.py` | Audit and Compliance |
-| `STUB-002` | Expand database-first code generation with similarity scoring and template retrieval | `template_engine/auto_generator.py`, `template_engine/db_first_code_generator.py`, `pattern_mining_engine.py`, `objective_similarity_scorer.py` | Code Generation |
+| `STUB-002` | Expand database-first code generation with similarity scoring and template retrieval | `template_engine/auto_generator.py`, `template_engine/db_first_code_generator.py`, `pattern_mining_engine.py`, `objective_similarity_scorer.py` | **Completed** ([ea3df1a](../commit/ea3df1a)) |
 | `STUB-003` | Implement KMeans clustering for template selection and transactional synchronization | `template_engine/template_synchronizer.py`, `copilot/copilot-instructions.md` | **Completed** |
 | `STUB-004` | Log all correction history with rollback design and compliance metrics | `documentation_db_analyzer.py`, `compliance_metrics_updater.py`, `databases/analytics.db` | **Completed** |
-| `STUB-005` | Enhance documentation manager with DB-first templates and multi-format rendering | `archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py`, `README.md`, `DATABASE_FIRST_USAGE_GUIDE.md` | Documentation Framework |
-| `STUB-006` | Integrate quantum-inspired scoring and clustering hooks | `quantum/quantum_algorithm_library_expansion.py`, `template_engine/auto_generator.py` | Quantum Enhancements |
-| `STUB-007` | Extend dashboard to surface real-time metrics and rollback alerts | `enterprise_dashboard.py`, `web_gui/templates/` | Dashboard Integration |
-| `STUB-008` | Add tests and validation scripts for new modules | `tests/`, `validation/` | Testing |
+| `STUB-005` | Enhance documentation manager with DB-first templates and multi-format rendering | `archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py`, `README.md`, `DATABASE_FIRST_USAGE_GUIDE.md` | **Completed** ([642ec69](../commit/642ec69)) |
+| `STUB-006` | Integrate quantum-inspired scoring and clustering hooks | `quantum/quantum_algorithm_library_expansion.py`, `template_engine/auto_generator.py` | **Completed** ([37b3cd9](../commit/37b3cd9)) |
+| `STUB-007` | Extend dashboard to surface real-time metrics and rollback alerts | `enterprise_dashboard.py`, `web_gui/templates/` | **Completed** ([89f11fc](../commit/89f11fc)) |
+| `STUB-008` | Add tests and validation scripts for new modules | `tests/`, `validation/` | **Completed** ([5b43960](../commit/5b43960)) |
 | `STUB-009` | Remove hardcoded placeholders and enable analytics hooks | `workflow_enhancer.py`, `archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py` | **Completed** |
 | `STUB-010` | Update task suggestion file and logs with cross-references | `docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md`, `logs/`, `validation/` | **Completed** |
 | `STUB-011` | Ensure all modules record outputs to `analytics.db` and link to compliance reports | various modules | **Completed** |
@@ -175,7 +175,7 @@ implemented consistently.
 Recent reports confirm several modules have reached production-ready status. Key metrics include:
 
 - **Python Compliance**: [databases_python_compliance_action_statement.md](../reports/databases_python_compliance_action_statement.md) lists 100% compatibility for Python 3.10/3.11, zero flake8 violations and full database reproduction.
-- **Test Coverage**: [`comprehensive_test_results.json`](../comprehensive_test_results.json) records four executed tests with all passing.
+- **Test Coverage**: [`comprehensive_test_results.json`](../comprehensive_test_results.json) recorded 269 tests executed with 246 passing, 18 failing and 5 skipped.
 - **Deployment Verification**: [`ENTERPRISE_DEPLOYMENT_COMPLETION_REPORT.json`](../reports/ENTERPRISE_DEPLOYMENT_COMPLETION_REPORT.json) marks deployment modules as *100% VERIFIED* and *ENTERPRISE READY*.
 
 For modules still labeled `STUB-*`, refer to Issue **8. Catalog missing and incomplete modules** in [`reports/generated_issue_templates.md`](../reports/generated_issue_templates.md). Use these verified metrics to prioritize the unresolved items.


### PR DESCRIPTION
## Summary
- confirm modules exist and mark completed ones in status table
- link to the implementing commits
- update test coverage numbers

## Testing
- `ruff check .`
- `pytest -q` *(fails: 41 failed, 274 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688a84b18a4c83319c07c40020d6a7fe