### PR TITLE
Add alerts streaming and metrics template

### DIFF
--- a/tests/dashboard/test_live_metrics.py
+++ b/tests/dashboard/test_live_metrics.py
@@ -44,3 +44,23 @@ def test_alerts_endpoint(test_app):
     data = resp.get_json()
     assert len(data["violations"]) == 1
     assert len(data["rollbacks"]) == 1
+
+
+def test_alerts_stream_once(test_app):
+    client = test_app.test_client()
+    resp = client.get("/alerts_stream?once=1")
+    assert resp.status_code == 200
+    line = resp.data.decode().split("\n")[0]
+    assert line.startswith("data:")
+    alerts = json.loads(line.split("data: ")[1])
+    assert len(alerts["violations"]) == 1
+    assert len(alerts["rollbacks"]) == 1
+
+
+def test_metrics_table(test_app):
+    client = test_app.test_client()
+    resp = client.get("/metrics_table")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert "<table" in html
+    assert "placeholder_removal" in html

--- a/web_gui/templates/dashboard.html
+++ b/web_gui/templates/dashboard.html
@@ -36,11 +36,15 @@ function updateAlerts(data){
 }
 window.onload = function(){
     if(window.EventSource){
-        const es = new EventSource('/metrics_stream');
-        es.onmessage = function(evt){
+        const esMetrics = new EventSource('/metrics_stream');
+        esMetrics.onmessage = function(evt){
             const metrics = JSON.parse(evt.data);
             updateMetrics(metrics);
-            fetch('/alerts').then(r => r.json()).then(updateAlerts);
+        };
+        const esAlerts = new EventSource('/alerts_stream');
+        esAlerts.onmessage = function(evt){
+            const alerts = JSON.parse(evt.data);
+            updateAlerts(alerts);
         };
     } else {
         setInterval(function(){

--- a/web_gui/templates/metrics_table.html
+++ b/web_gui/templates/metrics_table.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>Metrics Table</title>
+<table border="1">
+    <tr><th>Metric</th><th>Value</th></tr>
+    {% for key, value in metrics.items() %}
+    <tr><td>{{ key }}</td><td>{{ value }}</td></tr>
+    {% endfor %}
+</table>
+


### PR DESCRIPTION
## Summary
- parameterize dashboard paths with `CrossPlatformPathManager`
- stream alerts via new `/alerts_stream` SSE endpoint
- convert metrics table to Jinja template
- update dashboard JS to use the alerts stream
- test alerts stream and metrics table rendering

## Testing
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py tests/dashboard/test_live_metrics.py`
- `ruff format web_gui/scripts/flask_apps/enterprise_dashboard.py tests/dashboard/test_live_metrics.py`
- `pyright web_gui/scripts/flask_apps/enterprise_dashboard.py tests/dashboard/test_live_metrics.py`
- `pytest tests/dashboard/test_live_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_688a8b6fd0e083319f5c86bdb18b1012