### PR TITLE
Add rollback failure logging

### DIFF
--- a/tests/test_rollback_failure_logging.py
+++ b/tests/test_rollback_failure_logging.py
@@ -1,0 +1,22 @@
+import sqlite3
+from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
+
+
+def test_rollback_failure_logged(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "1")
+
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    analytics_db = db_dir / "analytics.db"
+    logger = CorrectionLoggerRollback(analytics_db)
+    monkeypatch.setattr(logger, "_record_strategy_history", lambda *a, **k: None)
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "0")
+
+    target = tmp_path / "missing.txt"
+    assert not logger.auto_rollback(target, None)
+
+    with sqlite3.connect(analytics_db) as conn:
+        row = conn.execute("SELECT target FROM rollback_failures").fetchone()
+    assert row[0] == str(target)

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -125,6 +125,19 @@ TABLE_SCHEMAS: Dict[str, str] = {
             timestamp TEXT NOT NULL
         );
     """,
+    "rollback_failures": """
+        CREATE TABLE IF NOT EXISTS rollback_failures (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event TEXT,
+            module TEXT,
+            level TEXT,
+            target TEXT NOT NULL,
+            details TEXT,
+            timestamp TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_rollback_failures_timestamp
+            ON rollback_failures(timestamp);
+    """,
 }
 
 


### PR DESCRIPTION
## Summary
- create rollback_failures table
- record rollback failures with details
- test rollback failure logging

## Testing
- `ruff check utils/log_utils.py scripts/correction_logger_and_rollback.py tests/test_rollback_failure_logging.py`
- `pytest tests/test_rollback_failure_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688a8b720d1883319179b7d4dd55b57b