### PR TITLE
Fix recursion validation for template dirs

### DIFF
--- a/template_engine/pattern_mining_engine.py
+++ b/template_engine/pattern_mining_engine.py
@@ -46,6 +46,9 @@ def validate_no_recursive_folders() -> None:
     for pattern in forbidden_patterns:
         for folder in workspace_root.rglob(pattern):
             if folder.is_dir() and folder != workspace_root:
+                # Avoid false positives for directories like "template_engine" or "templates"
+                if folder.name.startswith("template"):
+                    continue
                 logging.error(f"Recursive folder detected: {folder}")
                 raise RuntimeError(f"CRITICAL: Recursive folder violation: {folder}")
 

--- a/tests/template_engine/test_validate_no_recursive_folders.py
+++ b/tests/template_engine/test_validate_no_recursive_folders.py
@@ -1,0 +1,20 @@
+import os
+from pathlib import Path
+import pytest
+
+from template_engine.pattern_mining_engine import validate_no_recursive_folders
+
+
+def test_no_false_positive_on_template_dirs(tmp_path: Path) -> None:
+    (tmp_path / "template_engine").mkdir()
+    (tmp_path / "templates").mkdir()
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    # Should not raise for template_* directories
+    validate_no_recursive_folders()
+
+
+def test_detection_of_forbidden_dirs(tmp_path: Path) -> None:
+    (tmp_path / "temp_files").mkdir()
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    with pytest.raises(RuntimeError):
+        validate_no_recursive_folders()


### PR DESCRIPTION
## Summary
- avoid matching `template*` dirs when validating recursive folders
- add tests for the recursion validator

## Testing
- `ruff check template_engine/pattern_mining_engine.py tests/template_engine/test_validate_no_recursive_folders.py`
- `ruff format template_engine/pattern_mining_engine.py tests/template_engine/test_validate_no_recursive_folders.py`
- `pyright template_engine/pattern_mining_engine.py tests/template_engine/test_validate_no_recursive_folders.py`
- `pytest tests/template_engine/test_validate_no_recursive_folders.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8bc5cbf083319f97e4ecbafad053