### PR TITLE
fix: consolidate pattern mining logs

### DIFF
--- a/template_engine/pattern_mining_engine.py
+++ b/template_engine/pattern_mining_engine.py
@@ -84,20 +84,18 @@ def _log_patterns(patterns: List[str], analytics_db: Path) -> None:
 
 
 def _log_pattern(analytics_db: Path, pattern: str) -> None:
-    """
-    Log a single pattern to analytics.db for DUAL COPILOT validation.
-    """
+    """Log a single pattern to ``analytics_db``."""
     analytics_db.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(analytics_db) as conn:
         conn.execute(
-            """CREATE TABLE IF NOT EXISTS pattern_mining_logs (
+            """CREATE TABLE IF NOT EXISTS pattern_mining_log (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 pattern TEXT,
-                timestamp TEXT
+                ts TEXT
             )"""
         )
         conn.execute(
-            "INSERT INTO pattern_mining_logs (pattern, timestamp) VALUES (?, ?)",
+            "INSERT INTO pattern_mining_log (pattern, ts) VALUES (?, ?)",
             (pattern, datetime.utcnow().isoformat()),
         )
         conn.commit()
@@ -184,7 +182,6 @@ def mine_patterns(
                 )
             conn.commit()
     _log_audit_real(str(analytics_db), f"clusters={cluster_count}")
-    _log_patterns(patterns, analytics_db)
     logging.info(
         "Pattern mining completed in %.2fs | ETC: %s",
         time.time() - start_ts,


### PR DESCRIPTION
## Summary
- use `pattern_mining_log` for single pattern inserts
- remove extra table
- avoid duplicate log entries in `mine_patterns`

## Testing
- `ruff check template_engine/pattern_mining_engine.py tests/test_pattern_mining_engine.py`
- `pytest -q tests/test_pattern_mining_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_688a8bc6f7088331982fa71825ecb9b4