### PR TITLE
feat: enforce weights mapping for similarity methods

### DIFF
--- a/template_engine/objective_similarity_scorer.py
+++ b/template_engine/objective_similarity_scorer.py
@@ -102,8 +102,15 @@ def compute_similarity_scores(
 
     if methods is None:
         methods = ["tfidf"]
+
     if weights is None:
         weights = [1.0 for _ in methods]
+    elif isinstance(weights, dict):
+        if not all(m in weights for m in methods):
+            missing = [m for m in methods if m not in weights]
+            raise ValueError(f"Missing weights for methods: {missing}")
+        weights = [weights[m] for m in methods]
+
     if len(weights) != len(methods):
         raise ValueError("methods and weights must have the same length")
     # Prepare corpus and vectorizer

--- a/tests/test_objective_similarity_scorer.py
+++ b/tests/test_objective_similarity_scorer.py
@@ -100,3 +100,21 @@ def test_similarity_weights_mismatch(tmp_path: Path) -> None:
             methods=["tfidf", "jaccard"],
             weights=[1.0],
         )
+
+
+def test_weights_dict_missing_key(tmp_path: Path) -> None:
+    prod = tmp_path / "production.db"
+    analytics = tmp_path / "analytics.db"
+    with sqlite3.connect(prod) as conn:
+        conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
+        conn.execute("INSERT INTO code_templates (template_code) VALUES ('foo')")
+
+    with pytest.raises(ValueError):
+        compute_similarity_scores(
+            "foo",
+            prod,
+            analytics,
+            timeout_minutes=1,
+            methods=["tfidf", "jaccard"],
+            weights={"tfidf": 1.0},
+        )


### PR DESCRIPTION
## Summary
- ensure `compute_similarity_scores` validates weight entries per method
- handle weight dictionaries
- add regression test for missing weight mapping

## Testing
- `ruff check template_engine/objective_similarity_scorer.py tests/test_objective_similarity_scorer.py --force-exclude`
- `pytest -q tests/test_objective_similarity_scorer.py`

------
https://chatgpt.com/codex/tasks/task_e_688a8bc8ca4c8331b67eba316923f34c