### PR TITLE
fix: adjust stub quantum scoring indentation

### DIFF
--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -44,7 +44,9 @@ except ImportError:  # pragma: no cover - optional dependency
     def quantum_similarity_score(a: Iterable[float], b: Iterable[float]) -> float:
         """Gracefully degrade when quantum library is unavailable."""
         return 0.0
+
     def quantum_cluster_score(matrix: np.ndarray) -> float:
+        """Gracefully degrade when quantum library is unavailable."""
         return 0.0
 
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")


### PR DESCRIPTION
## Summary
- address indentation within optional quantum stub block in `auto_generator.py`
- add missing docstring for `quantum_cluster_score`

## Testing
- `ruff check template_engine/auto_generator.py`
- `pyright template_engine/auto_generator.py`
- `python -m py_compile template_engine/auto_generator.py`
- `pytest -k "" -q` *(fails: test_template_selection_from_documentation_db and others)*

------
https://chatgpt.com/codex/tasks/task_e_688a8bde35d883319f98658ca3408612