### PR TITLE
Update OpenAI connector to use client

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ chmod +x /usr/local/bin/clw
 ls -l /usr/local/bin/clw
 
 ### OpenAI Connector
-The repository provides `github_integration/openai_connector.py` for OpenAI API calls.
-Set `OPENAI_API_KEY` in your `.env` to enable these helpers.
+The repository provides `github_integration/openai_connector.py` for OpenAI API
+calls using the `OpenAIClient` helper in
+`third_party/openai_client.py`. Set `OPENAI_API_KEY` in your `.env` to enable
+these helpers.
 
 # 3. Initialize databases
 python scripts/database/unified_database_initializer.py

--- a/github_integration/openai_connector.py
+++ b/github_integration/openai_connector.py
@@ -12,10 +12,8 @@ def get_api_key() -> str:
     return api_key
 
 
-client = OpenAIClient(api_key=get_api_key())
-
-
 def send_prompt(prompt: str, model: str = "gpt-3.5-turbo", **kwargs: Any) -> Dict[str, Any]:
     """Send a prompt to the OpenAI API and return the JSON response."""
+    client = OpenAIClient(api_key=get_api_key())
     messages = [{"role": "user", "content": prompt}]
     return client.chat_completion(messages, model=model, **kwargs)

--- a/tests/test_openai_connector.py
+++ b/tests/test_openai_connector.py
@@ -1,0 +1,20 @@
+import importlib
+from unittest import mock
+
+import third_party.openai_client
+
+
+def test_send_prompt(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    module = importlib.reload(importlib.import_module("github_integration.openai_connector"))
+    result = {"choices": [{"message": {"content": "ok"}}]}
+    with mock.patch.object(third_party.openai_client.OpenAIClient, "request") as req:
+        req.return_value.status_code = 200
+        req.return_value.json.return_value = result
+        resp = module.send_prompt("hello", model="gpt-test")
+    assert resp == result
+    assert req.called
+    method, endpoint, payload = req.call_args[0]
+    assert method == "POST"
+    assert endpoint == "chat/completions"
+    assert payload["messages"][0]["content"] == "hello"


### PR DESCRIPTION
## Summary
- refactor `github_integration.openai_connector` to instantiate and use `OpenAIClient`
- add unit test for `send_prompt`
- document the OpenAI client helper in the README

## Testing
- `ruff check github_integration/openai_connector.py`
- `ruff check tests/test_openai_connector.py`
- `pytest -q tests/test_openai_client.py tests/test_env_paths.py tests/test_openai_connector.py`

------
https://chatgpt.com/codex/tasks/task_e_688a8bdf9518833194b0dbfd7a5dfda3