### PR TITLE
feat: add SSE streaming generator and websocket broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,13 @@ python dashboard/enterprise_dashboard.py  # wrapper for web_gui Flask app
 # Features: Real-time metrics, database visualization, system monitoring
 ```
 
+### Enable Streaming
+
+Set the environment variable `LOG_WEBSOCKET_ENABLED=1` to allow real-time
+log broadcasting over WebSockets. The dashboard's `/metrics_stream` endpoint
+uses Server-Sent Events by default and works with Flask's ``Response`` when
+`sse_event_stream` is provided from ``utils.log_utils``.
+
 Compliance metrics are generated with `dashboard/compliance_metrics_updater.py`.
 This script reads from `analytics.db` and writes `dashboard/compliance/metrics.json`.
 The compliance score is averaged from records in the `correction_logs` table.

--- a/tests/test_log_utils_recovery.py
+++ b/tests/test_log_utils_recovery.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sqlite3
+
+from utils.log_utils import _log_event, ensure_tables, log_event
+
+
+def test_log_recovery_with_fallback(tmp_path: Path) -> None:
+    db = tmp_path / "valid" / "analytics.db"
+    ensure_tables(db, ["violation_logs"], test_mode=False)
+
+    log_event({"details": "start"}, table="violation_logs", db_path=db)
+
+    bad_db = tmp_path / "other" / "analytics.db"
+    fallback = tmp_path / "fallback.log"
+
+    result = _log_event(
+        {"details": "offline"},
+        table="violation_logs",
+        db_path=bad_db,
+        fallback_file=fallback,
+        test_mode=False,
+    )
+    assert result is False
+    assert fallback.exists()
+    assert fallback.read_text()
+
+    log_event({"details": "resume"}, table="violation_logs", db_path=db)
+    with sqlite3.connect(db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM violation_logs").fetchone()[0]
+    assert count == 2

--- a/tests/test_log_utils_sse.py
+++ b/tests/test_log_utils_sse.py
@@ -1,0 +1,14 @@
+from itertools import islice
+from pathlib import Path
+
+from utils.log_utils import ensure_tables, log_event, sse_event_stream
+
+
+def test_high_volume_sse(tmp_path: Path) -> None:
+    db = tmp_path / "stream.db"
+    ensure_tables(db, ["violation_logs"], test_mode=False)
+    for i in range(200):
+        log_event({"details": str(i)}, table="violation_logs", db_path=db)
+    gen = sse_event_stream("violation_logs", db_path=db, poll_interval=0.01)
+    events = list(islice(gen, 200))
+    assert len(events) == 200


### PR DESCRIPTION
## Summary
- provide `sse_event_stream` for use with Flask `Response`
- add optional websocket broadcast server guarded by `LOG_WEBSOCKET_ENABLED`
- test high volume SSE generation and logging recovery with fallback file
- document how to enable dashboard streaming

## Testing
- `ruff check utils/log_utils.py tests/test_log_utils_sse.py tests/test_log_utils_recovery.py`
- `pytest tests/test_log_utils.py tests/test_log_utils_stream.py tests/test_log_utils_extended.py tests/test_log_utils_sse.py tests/test_log_utils_recovery.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8be231088331af1da9ddce22132a