### PR TITLE
feat: dashboard alerts on database size violations

### DIFF
--- a/scripts/database/size_compliance_checker.py
+++ b/scripts/database/size_compliance_checker.py
@@ -13,7 +13,7 @@ from typing import Dict
 from tqdm import tqdm
 
 from utils.enterprise_logging import EnterpriseLoggingManager
-from utils.log_utils import log_event, stream_events
+from utils.log_utils import log_event, send_dashboard_alert, stream_events
 
 ANALYTICS_DB = Path(os.getenv("ANALYTICS_DB", "databases/analytics.db"))
 
@@ -89,6 +89,7 @@ def check_database_sizes(databases_dir: Path, threshold_mb: float = 99.9) -> Dic
                                 "threshold": threshold_mb,
                             }
                             log_event(event, table="size_violations", db_path=ANALYTICS_DB)
+                            send_dashboard_alert(event, db_path=ANALYTICS_DB)
                             for line in stream_events("size_violations", db_path=ANALYTICS_DB):
                                 if f'"db": "{db_file.name}"' in line and f'"table_name": "{table}"' in line:
                                     print(line.strip())
@@ -97,11 +98,9 @@ def check_database_sizes(databases_dir: Path, threshold_mb: float = 99.9) -> Dic
                     logger.warning(
                         f"⚠️ {db_file.name}: {size_mb:.2f} MB > {threshold_mb} MB"
                     )
-                    log_event(
-                        {"db": db_file.name, "table_name": "__database__", "size_mb": size_mb, "threshold": threshold_mb},
-                        table="size_violations",
-                        db_path=ANALYTICS_DB,
-                    )
+                    event = {"db": db_file.name, "table_name": "__database__", "size_mb": size_mb, "threshold": threshold_mb}
+                    log_event(event, table="size_violations", db_path=ANALYTICS_DB)
+                    send_dashboard_alert(event, db_path=ANALYTICS_DB)
                 else:
                     logger.info(f"✅ {db_file.name}: {size_mb:.2f} MB")
             except Exception as e:

--- a/tests/test_size_compliance_checker.py
+++ b/tests/test_size_compliance_checker.py
@@ -46,3 +46,22 @@ def test_table_size_violation(tmp_path: Path, capsys) -> None:
     violations = list(stream_events("size_violations", db_path=db_file))
     assert any("\"table_name\": \"big\"" in v for v in violations)
     assert "data:" in output
+
+
+def test_dashboard_alert_emitted(tmp_path: Path, monkeypatch) -> None:
+    db_file = tmp_path / "analytics.db"
+    monkeypatch.setenv("ANALYTICS_DB", str(db_file))
+    monkeypatch.setenv("WEB_DASHBOARD_ENABLED", "1")
+    checker.ANALYTICS_DB = db_file
+
+    target = tmp_path / "alert.db"
+    with sqlite3.connect(target) as conn:
+        conn.execute("CREATE TABLE big(data TEXT)")
+        payload = "z" * 1024
+        for _ in range(2000):
+            conn.execute("INSERT INTO big(data) VALUES (?)", (payload,))
+        conn.commit()
+
+    checker.check_database_sizes(tmp_path, threshold_mb=0.5)
+    alerts = list(stream_events("dashboard_alerts", db_path=db_file))
+    assert any("\"table_name\": \"big\"" in a for a in alerts)

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -109,6 +109,16 @@ TABLE_SCHEMAS: Dict[str, str] = {
             timestamp TEXT
         );
     """,
+    "dashboard_alerts": """
+        CREATE TABLE IF NOT EXISTS dashboard_alerts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            db TEXT,
+            table_name TEXT,
+            size_mb REAL,
+            threshold REAL,
+            timestamp TEXT
+        );
+    """,
     "cross_link_events": """
         CREATE TABLE IF NOT EXISTS cross_link_events (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -368,6 +378,13 @@ def log_event(event: Dict[str, Any], *, table: str = DEFAULT_LOG_TABLE, db_path:
     insert_event(event, table, db_path=db_path, test_mode=False)
 
 
+def send_dashboard_alert(event: Dict[str, Any], *, table: str = "dashboard_alerts", db_path: Path = DEFAULT_ANALYTICS_DB) -> None:
+    """Send an alert event to the web dashboard if enabled."""
+    if os.getenv("WEB_DASHBOARD_ENABLED") != "1":
+        return
+    log_event(event, table=table, db_path=db_path)
+
+
 def stream_events(table: str = DEFAULT_LOG_TABLE, *, db_path: Path = DEFAULT_ANALYTICS_DB):
     """Yield events formatted for Server-Sent Events."""
     if not db_path.exists():
@@ -442,6 +459,7 @@ __all__ = [
     "insert_event",
     "log_message",
     "log_event",
+    "send_dashboard_alert",
     "stream_events",
     "log_stream",
     "_log_event",


### PR DESCRIPTION
## Summary
- add `dashboard_alerts` table and `send_dashboard_alert` helper
- hook new alert helper into `check_database_sizes`
- test alert emission when the dashboard is enabled

## Testing
- `ruff check .`
- `pytest tests/test_size_compliance_checker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8be433f8833189545d347d4eaa33