### PR TITLE
Add Docker build setup and wrapper startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,20 @@ COPY requirements.txt requirements.txt
 RUN chown -R appuser:appgroup /app
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Initialize databases during build
+RUN python scripts/database/unified_database_initializer.py
+
 # Copy application source
 COPY . /app
 RUN chown -R appuser:appgroup /app
 
+# Configure environment file
+RUN cp .env.example .env
+
 # Set default workspace environment variable
 ENV GH_COPILOT_WORKSPACE=/app
 ENV GH_COPILOT_BACKUP_ROOT=/backup
+ENV FLASK_SECRET_KEY=changeme
 
 # Switch to the non-root user
 USER appuser
@@ -32,6 +39,6 @@ EXPOSE 5000 5001 5002 5003 5004 5005 5006 8080
 
 HEALTHCHECK --interval=30s --timeout=5s CMD ["python", "scripts/docker_healthcheck.py"]
 
-COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-CMD ["bash", "/app/entrypoint.sh"]
+COPY docker_wrapper.sh /app/docker_wrapper.sh
+RUN chmod +x /app/docker_wrapper.sh
+CMD ["bash", "/app/docker_wrapper.sh"]

--- a/README.md
+++ b/README.md
@@ -282,14 +282,19 @@ Build and run the container with Docker:
 
 ```bash
 docker build -t gh_copilot .
-docker run -p 5000:5000 -e GH_COPILOT_BACKUP_ROOT=/path/to/backups gh_copilot
+docker run -p 5000:5000 \
+  -e GH_COPILOT_BACKUP_ROOT=/path/to/backups \
+  -e FLASK_SECRET_KEY=supersecret \
+  gh_copilot
 ```
 
 Inside the image `GH_COPILOT_BACKUP_ROOT` defaults to `/backup`. Map this path to a host directory to persist logs and backups.
 
 When launching with Docker Compose, the provided `docker-compose.yml` mounts `${GH_COPILOT_BACKUP_ROOT:-/backup}` at `/backup`. Set `GH_COPILOT_BACKUP_ROOT` on the host before running `docker-compose up` so backups survive container restarts.
 
-The container's `entrypoint.sh` now initializes `analytics.db` automatically before starting the dashboard service, so no manual step is required.
+The image copies `.env.example` to `.env` during build. Override `FLASK_SECRET_KEY` and `GH_COPILOT_BACKUP_ROOT` at runtime as shown above.
+
+The container launches via `docker_wrapper.sh` which validates environment variables and starts the dashboard, metrics updater, and placeholder audits in the background. Databases are initialized during the build step, so no manual setup is required.
 
 ### Wrapping, Logging, and Compliance (WLC)
 Run the session manager after setting the workspace and backup paths:

--- a/docker_wrapper.sh
+++ b/docker_wrapper.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate required environment variables
+: "${GH_COPILOT_WORKSPACE:?GH_COPILOT_WORKSPACE not set}"
+: "${GH_COPILOT_BACKUP_ROOT:?GH_COPILOT_BACKUP_ROOT not set}"
+: "${FLASK_SECRET_KEY:?FLASK_SECRET_KEY not set}"
+
+python - <<'PY'
+from utils.validation_utils import validate_enterprise_environment
+validate_enterprise_environment()
+PY
+
+python scripts/docker_entrypoint.py &
+python dashboard/compliance_metrics_updater.py &
+python scripts/code_placeholder_audit.py &
+
+wait


### PR DESCRIPTION
## Summary
- initialize databases during Docker build
- copy `.env.example` and expose key env vars
- add `docker_wrapper.sh` that validates env vars and starts services
- document updated Docker workflow

## Testing
- `ruff check scripts/docker_entrypoint.py`
- `pyright scripts/docker_entrypoint.py`
- `pytest tests/test_new_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_688a8c1ee008833193990fd72d543017