### PR TITLE
Improve entrypoint robustness

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+terminate() {
+    echo "Received termination signal. Stopping children..." >&2
+    kill $(jobs -p) 2>/dev/null || true
+}
+
+trap terminate INT TERM
+
+# Validate enterprise environment before starting services
+python - <<'PY'
+from utils.validation_utils import validate_enterprise_environment
+validate_enterprise_environment()
+PY
 
 # Ensure workspace and backup environment variables are exported
 export GH_COPILOT_WORKSPACE="${GH_COPILOT_WORKSPACE:-/app}"
@@ -10,6 +23,20 @@ python scripts/database/unified_database_initializer.py
 
 # Start background workers
 python dashboard/compliance_metrics_updater.py &
+worker_pid=$!
 
-# Launch the Flask dashboard in the foreground
-exec python scripts/docker_entrypoint.py
+python scripts/docker_entrypoint.py &
+dashboard_pid=$!
+
+# Wait for child processes to exit and log errors
+wait $worker_pid
+status=$?
+if [ $status -ne 0 ]; then
+    echo "compliance_metrics_updater exited with status $status" >&2
+fi
+
+wait $dashboard_pid
+status=$?
+if [ $status -ne 0 ]; then
+    echo "docker_entrypoint exited with status $status" >&2
+fi

--- a/tests/test_entrypoint_env.py
+++ b/tests/test_entrypoint_env.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_entrypoint_has_validation_call():
+    text = Path('entrypoint.sh').read_text()
+    assert 'validate_enterprise_environment' in text
+
+
+def test_entrypoint_requires_env(tmp_path):
+    env = os.environ.copy()
+    env['GH_COPILOT_WORKSPACE'] = str(tmp_path)
+    env.pop('GH_COPILOT_BACKUP_ROOT', None)
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(['bash', 'entrypoint.sh'], cwd=repo_root, env=env, capture_output=True, text=True)
+    assert result.returncode != 0
+    assert 'GH_COPILOT_BACKUP_ROOT is not set' in result.stderr


### PR DESCRIPTION
## Summary
- trap signals and stop child processes in `entrypoint.sh`
- validate env vars before starting workers
- wait on worker and dashboard processes and log failures
- add tests confirming env validation

## Testing
- `ruff check tests/test_entrypoint_env.py`
- `pytest tests/test_entrypoint_env.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8c2053c88331be47d33adfdc6e57