### PR TITLE
Update docker-compose web GUI path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,16 @@ services:
     command: python dashboard/enterprise_dashboard.py
     environment:
       - GH_COPILOT_WORKSPACE=/app
+      - GH_COPILOT_BACKUP_ROOT=/backup
     volumes:
       - .:/app
       - ${GH_COPILOT_BACKUP_ROOT:-/backup}:/backup
   web_gui:
     build: .
-    command: python web_gui/app.py
+    command: python web_gui/scripts/flask_apps/enterprise_dashboard.py
     environment:
       - GH_COPILOT_WORKSPACE=/app
+      - GH_COPILOT_BACKUP_ROOT=/backup
     volumes:
       - .:/app
       - ${GH_COPILOT_BACKUP_ROOT:-/backup}:/backup
@@ -20,6 +22,11 @@ services:
       - "5000:5000"
       - "5001:5001"
       - "5002:5002"
+      - "5003:5003"
+      - "5004:5004"
+      - "5005:5005"
+      - "5006:5006"
+      - "8080:8080"
     depends_on:
       - app
   monitoring:
@@ -27,6 +34,7 @@ services:
     command: python unified_monitoring_optimization_system.py --verify-continuous-operation
     environment:
       - GH_COPILOT_WORKSPACE=/app
+      - GH_COPILOT_BACKUP_ROOT=/backup
     volumes:
       - .:/app
       - ${GH_COPILOT_BACKUP_ROOT:-/backup}:/backup


### PR DESCRIPTION
## Summary
- update docker-compose to launch Flask dashboard via `enterprise_dashboard.py`
- expose additional ports and set GH_COPILOT_BACKUP_ROOT for all services

## Testing
- `ruff check .`
- `pytest -q` *(fails: 40 failed, 275 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a8c25863c833189347020a61a430c