### PR TITLE
Use cwd as default workspace

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -25,7 +25,7 @@ from utils.log_utils import ensure_tables, insert_event
 
 
 # Enterprise logging setup
-LOGS_DIR = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "logs" / "dashboard"
+LOGS_DIR = Path(os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd()))) / "logs" / "dashboard"
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"compliance_update_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 
@@ -36,12 +36,12 @@ logging.basicConfig(
 )
 
 # Database paths
-ANALYTICS_DB = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "databases" / "analytics.db"
-DASHBOARD_DIR = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "dashboard" / "compliance"
+ANALYTICS_DB = Path(os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd()))) / "databases" / "analytics.db"
+DASHBOARD_DIR = Path(os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd()))) / "dashboard" / "compliance"
 
 
 def validate_no_recursive_folders() -> None:
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd())))
     forbidden_patterns = ["*backup*", "*_backup_*", "backups", "*temp*"]
     for pattern in forbidden_patterns:
         for folder in workspace_root.rglob(pattern):
@@ -51,7 +51,7 @@ def validate_no_recursive_folders() -> None:
 
 
 def validate_environment_root() -> None:
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd())))
     if not str(workspace_root).replace("\\", "/").endswith("gh_COPILOT"):
         logging.warning(f"Non-standard workspace root: {workspace_root}")
 

--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 
 
 def validate_no_recursive_folders() -> None:
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd())))
     forbidden_patterns = ["*backup*", "*_backup_*", "backups", "*temp*"]
     for pattern in forbidden_patterns:
         for folder in workspace_root.rglob(pattern):

--- a/template_engine/pattern_mining_engine.py
+++ b/template_engine/pattern_mining_engine.py
@@ -41,7 +41,7 @@ logging.basicConfig(
 
 
 def validate_no_recursive_folders() -> None:
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd())))
     forbidden_patterns = ["*backup*", "*_backup_*", "backups", "*temp*"]
     for pattern in forbidden_patterns:
         for folder in workspace_root.rglob(pattern):


### PR DESCRIPTION
## Summary
- use `Path.cwd()` as fallback for GH_COPILOT_WORKSPACE in compliance modules
- update compliance suite test for new default

## Testing
- `ruff check dashboard/compliance_metrics_updater.py template_engine/auto_generator.py template_engine/pattern_mining_engine.py tests/compliance_test_suite.py`
- `pytest tests/test_auto_generator.py tests/test_pattern_mining_engine.py tests/test_compliance_metrics_updater.py tests/compliance_test_suite.py::test_quantum_compliance_engine -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8c2a37608331b6ad5891a3623fd2