### PR TITLE
Consolidate workspace validation

### DIFF
--- a/db_tools/utils/__init__.py
+++ b/db_tools/utils/__init__.py
@@ -2,7 +2,7 @@
 
 from .query_builder import QueryBuilder
 from .validators import DataValidator
-from .enterprise_validation import validate_enterprise_operation
+from enterprise_modules.compliance import validate_enterprise_operation
 
 __all__ = [
     'QueryBuilder',

--- a/db_tools/utils/enterprise_validation.py
+++ b/db_tools/utils/enterprise_validation.py
@@ -1,25 +1,9 @@
-"""Enterprise operation validation helpers."""
+"""Deprecated validation helpers.
 
-from __future__ import annotations
+This module now re-exports :func:`enterprise_modules.compliance.validate_enterprise_operation`
+for backward compatibility.
+"""
 
-import os
-from pathlib import Path
+from enterprise_modules.compliance import validate_enterprise_operation
 
-
-def validate_enterprise_operation(path: str | None = None) -> bool:
-    """Validate operations to prevent internal backup access."""
-
-    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())).resolve()
-    target = Path(path or workspace).resolve()
-    backup_root = Path(
-        os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups")
-    ).resolve()
-
-    if backup_root == workspace or backup_root.is_relative_to(workspace):
-        raise RuntimeError("Backup root cannot be inside the workspace")
-
-    if target.is_relative_to(workspace) and "backup" in target.name.lower():
-        raise RuntimeError("Operations targeting internal backups are forbidden")
-
-    return True
-
+__all__ = ["validate_enterprise_operation"]

--- a/scripts/backup_archiver.py
+++ b/scripts/backup_archiver.py
@@ -20,10 +20,8 @@ def archive_backups() -> Path:
     workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())).resolve()
     backup_root = CrossPlatformPathManager.get_backup_root().resolve()
 
-    if backup_root == workspace or backup_root.is_relative_to(workspace):
-        raise RuntimeError("Backup root cannot be inside the workspace")
-
-    validate_enterprise_operation(str(workspace))
+    if not validate_enterprise_operation(str(workspace)):
+        raise RuntimeError("Invalid workspace or backup configuration")
 
     archive_dir = workspace / "archive"
     archive_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_enterprise_validation.py
+++ b/tests/test_enterprise_validation.py
@@ -1,8 +1,3 @@
-from pathlib import Path
-
-import pytest
-
-
 def test_validate_enterprise_operation_rejects_internal_backup(tmp_path, monkeypatch):
     workspace = tmp_path / "ws"
     workspace.mkdir()
@@ -12,10 +7,9 @@ def test_validate_enterprise_operation_rejects_internal_backup(tmp_path, monkeyp
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
 
-    from db_tools.utils.enterprise_validation import validate_enterprise_operation
+    from enterprise_modules.compliance import validate_enterprise_operation
 
-    with pytest.raises(RuntimeError):
-        validate_enterprise_operation(str(backup_root))
+    assert not validate_enterprise_operation(str(backup_root))
 
 
 def test_validate_enterprise_operation_allows_external_backup(tmp_path, monkeypatch):
@@ -27,7 +21,7 @@ def test_validate_enterprise_operation_allows_external_backup(tmp_path, monkeypa
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
 
-    from db_tools.utils.enterprise_validation import validate_enterprise_operation
+    from enterprise_modules.compliance import validate_enterprise_operation
 
     assert validate_enterprise_operation(str(workspace / "data")) is True
 


### PR DESCRIPTION
## Summary
- point utility init to enterprise compliance validator
- re-export legacy enterprise validation helpers
- use unified validation in backup archiver
- update enterprise validation tests

## Testing
- `ruff check db_tools/utils/__init__.py db_tools/utils/enterprise_validation.py scripts/backup_archiver.py tests/test_enterprise_validation.py`
- `pytest -q` *(fails: 40 failed, 275 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a8b6cf0fc8331a4e73e15b7d757fc