### PR TITLE
fix: centralize path retrieval with CrossPlatformPathManager

### DIFF
--- a/scripts/database/complete_consolidation_orchestrator.py
+++ b/scripts/database/complete_consolidation_orchestrator.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, List, Optional, Sequence, Union, cast
 
+from utils.cross_platform_paths import CrossPlatformPathManager
+
 import py7zr  # pyright: ignore[reportMissingImports]
 from tqdm import tqdm
 
@@ -56,7 +58,7 @@ class ExternalBackupConfiguration:
             raise RuntimeError(f"CRITICAL: Backup location inside workspace: {backup_path}")
 
 
-WORKSPACE_PATH = Path(os.getenv("GH_COPILOT_WORKSPACE", os.getcwd()))
+WORKSPACE_PATH = CrossPlatformPathManager.get_workspace_path()
 BACKUP_ROOT = ExternalBackupConfiguration.get_backup_root()
 BACKUP_DIR = BACKUP_ROOT / "database_consolidation"
 ExternalBackupConfiguration.validate_external_backup_location(BACKUP_DIR, WORKSPACE_PATH)
@@ -280,7 +282,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    workspace = CrossPlatformPathManager.get_workspace_path()
     migrate_and_compress(
         workspace,
         ["analytics.db", "documentation.db", "template_completion.db"],

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -151,7 +151,9 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
                     sleep_time = 0.01
                 time.sleep(sleep_time)
 
-            orchestrator = UnifiedWrapUpOrchestrator(workspace_path=os.getenv("GH_COPILOT_WORKSPACE"))
+            orchestrator = UnifiedWrapUpOrchestrator(
+                workspace_path=str(CrossPlatformPathManager.get_workspace_path())
+            )
             result = orchestrator.execute_unified_wrapup()
             compliance_score = result.compliance_score / 100.0
 
@@ -169,14 +171,18 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
                     UnifiedWrapUpOrchestrator as orchestrator_cls,
                 )
 
-            orchestrator = orchestrator_cls(workspace_path=os.getenv("GH_COPILOT_WORKSPACE"))
+            orchestrator = orchestrator_cls(
+                workspace_path=str(CrossPlatformPathManager.get_workspace_path())
+            )
             orchestrator.execute_unified_wrapup()
 
         validator = SecondaryCopilotValidator()
         validator.validate_corrections([__file__])
 
     if os.getenv("WLC_RUN_ORCHESTRATOR") == "1":
-        orchestrator = UnifiedWrapUpOrchestrator(workspace_path=os.getenv("GH_COPILOT_WORKSPACE"))
+        orchestrator = UnifiedWrapUpOrchestrator(
+            workspace_path=str(CrossPlatformPathManager.get_workspace_path())
+        )
         orchestrator.execute_unified_wrapup()
 
     logging.info("WLC session completed")

--- a/tests/test_docker_healthcheck.py
+++ b/tests/test_docker_healthcheck.py
@@ -1,12 +1,15 @@
-import os
-import subprocess
-import sys
-from pathlib import Path
-
 import scripts.docker_healthcheck as dhc
 
 
 def test_healthcheck_success(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_backup_root",
+        lambda: tmp_path / "backup",
+    )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backup"))
 

--- a/tests/test_init_and_audit.py
+++ b/tests/test_init_and_audit.py
@@ -1,8 +1,15 @@
-from pathlib import Path
 import sqlite3
 
 
 def test_init_and_audit(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_backup_root",
+        lambda: tmp_path / "ext_backups",
+    )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "ext_backups"))
     from scripts.utilities import init_and_audit

--- a/tests/test_new_utils.py
+++ b/tests/test_new_utils.py
@@ -58,6 +58,14 @@ def test_validate_path(tmp_path, monkeypatch):
     bk = tmp_path / "bk"
     ws.mkdir()
     bk.mkdir()
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: ws,
+    )
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_backup_root",
+        lambda: bk,
+    )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
     inside = ws / "a.txt"
@@ -75,6 +83,14 @@ def test_operations_validate_workspace(tmp_path, monkeypatch, capsys):
     bk.mkdir()
     for name in ["databases", "scripts", "utils", "documentation"]:
         (ws / name).mkdir()
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: ws,
+    )
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_backup_root",
+        lambda: bk,
+    )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
     operations_validate_workspace()
@@ -87,6 +103,14 @@ def test_validate_enterprise_environment_accepts_external_path(tmp_path, monkeyp
     bk = tmp_path / "backups"
     ws.mkdir()
     bk.mkdir()
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: ws,
+    )
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_backup_root",
+        lambda: bk,
+    )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
     assert validate_enterprise_environment()
@@ -97,6 +121,14 @@ def test_validate_enterprise_environment_rejects_workspace_path(tmp_path, monkey
     bk = ws / "backups"
     ws.mkdir()
     bk.mkdir()
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: ws,
+    )
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_backup_root",
+        lambda: bk,
+    )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
     with pytest.raises(EnvironmentError):

--- a/tests/test_session_management_consolidation_executor.py
+++ b/tests/test_session_management_consolidation_executor.py
@@ -4,6 +4,10 @@ from session_management_consolidation_executor import EnterpriseUtility
 
 
 def test_consolidation_executor_pass(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: tmp_path,
+    )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     monkeypatch.chdir(tmp_path)
     util = EnterpriseUtility(str(tmp_path))
@@ -12,6 +16,10 @@ def test_consolidation_executor_pass(tmp_path, monkeypatch):
 
 
 def test_consolidation_executor_fails_on_zero_byte(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: tmp_path,
+    )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     monkeypatch.chdir(tmp_path)
     (tmp_path / "empty.txt").write_text("")

--- a/tests/test_tools_automation_setup.py
+++ b/tests/test_tools_automation_setup.py
@@ -5,6 +5,14 @@ from tools import automation_setup
 
 
 def test_ingest_assets(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_backup_root",
+        lambda: tmp_path.parent / "backups",
+    )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path.parent / "backups"))
     monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")

--- a/utils/configuration_utils.py
+++ b/utils/configuration_utils.py
@@ -7,12 +7,14 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from utils.cross_platform_paths import CrossPlatformPathManager
+
 import yaml
 
 
 def load_enterprise_configuration(config_path: Optional[str] = None) -> Dict[str, Any]:
     """Load enterprise configuration from JSON or YAML with environment overrides."""
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    workspace_root = CrossPlatformPathManager.get_workspace_path()
 
     if config_path is None:
         config_path = workspace_root / "config" / "enterprise.json"
@@ -55,8 +57,8 @@ def load_enterprise_configuration(config_path: Optional[str] = None) -> Dict[str
 
 def validate_environment_compliance() -> bool:
     """Validate enterprise environment compliance"""
-    workspace = os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())
-    return workspace.endswith("gh_COPILOT")
+    workspace = CrossPlatformPathManager.get_workspace_path()
+    return str(workspace).endswith("gh_COPILOT")
 
 
 def operations___init__(workspace_path: Optional[str] = None,

--- a/utils/database_utils.py
+++ b/utils/database_utils.py
@@ -1,10 +1,8 @@
 """Database utilities for gh_COPILOT Enterprise Toolkit"""
 
-import os
 import sqlite3
 import logging
 from contextlib import contextmanager
-from pathlib import Path
 from typing import Iterator, Optional
 
 from utils.cross_platform_paths import CrossPlatformPathManager
@@ -16,8 +14,8 @@ logger = logging.getLogger(__name__)
 @contextmanager
 def get_enterprise_database_connection(db_name: str = "production.db") -> Iterator[sqlite3.Connection]:
     """Get enterprise database connection with proper handling"""
-    workspace = os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())
-    db_path = Path(workspace) / "databases" / db_name
+    workspace = CrossPlatformPathManager.get_workspace_path()
+    db_path = workspace / "databases" / db_name
 
     conn = None
     try:

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import os
 import sqlite3
 from contextlib import contextmanager
-from pathlib import Path
 from typing import Iterator
+
+from utils.cross_platform_paths import CrossPlatformPathManager
 
 
 @contextmanager
@@ -16,7 +16,7 @@ def get_validated_connection(db_name: str = "production.db") -> Iterator[sqlite3
     The helper ensures the database exists and is within the size limit
     before yielding an SQLite connection.
     """
-    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    workspace = CrossPlatformPathManager.get_workspace_path()
     db_path = workspace / "databases" / db_name
 
     if not db_path.exists():

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -1,9 +1,10 @@
 """Logging utilities for gh_COPILOT Enterprise Toolkit"""
 
 import logging
-import os
 from datetime import datetime
 from pathlib import Path
+
+from utils.cross_platform_paths import CrossPlatformPathManager
 
 
 def setup_enterprise_logging(
@@ -12,8 +13,8 @@ def setup_enterprise_logging(
     """Setup enterprise-grade logging configuration"""
 
     if log_file is None:
-        workspace = os.getenv("GH_COPILOT_WORKSPACE", Path.cwd())
-        log_dir = Path(workspace) / "logs"
+        workspace = CrossPlatformPathManager.get_workspace_path()
+        log_dir = workspace / "logs"
         log_dir.mkdir(exist_ok=True)
         log_file = log_dir / f"enterprise_{datetime.now().strftime('%Y%m%d')}.log"
 

--- a/utils/validation_utils.py
+++ b/utils/validation_utils.py
@@ -10,7 +10,7 @@ from utils.cross_platform_paths import CrossPlatformPathManager
 
 def validate_workspace_integrity() -> Dict[str, Any]:
     """Validate workspace integrity and structure"""
-    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    workspace = CrossPlatformPathManager.get_workspace_path()
 
     validation_results = {
         "workspace_exists": workspace.exists(),
@@ -44,7 +44,7 @@ def validate_workspace_integrity() -> Dict[str, Any]:
 
 def validate_script_organization() -> Dict[str, Any]:
     """Validate script organization structure"""
-    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    workspace = CrossPlatformPathManager.get_workspace_path()
     scripts_dir = workspace / "scripts"
 
     organization_status = {


### PR DESCRIPTION
## Summary
- standardize workspace and backup path lookups through `CrossPlatformPathManager`
- patch scripts to use path manager APIs
- update tests to mock path manager for deterministic paths

## Testing
- `ruff check scripts/database/complete_consolidation_orchestrator.py scripts/wlc_session_manager.py tests/test_docker_healthcheck.py tests/test_init_and_audit.py tests/test_new_utils.py tests/test_session_management_consolidation_executor.py tests/test_tools_automation_setup.py utils/configuration_utils.py utils/database_utils.py utils/db_utils.py utils/logging_utils.py utils/validation_utils.py`
- `pytest tests/test_tools_automation_setup.py tests/test_docker_healthcheck.py tests/test_init_and_audit.py tests/test_session_management_consolidation_executor.py tests/test_new_utils.py -q` *(fails: NameError: dataset_path not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688a8b6c8980833190240489136efca1