### PR TITLE
docs: consolidate changelog history

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,45 @@
 - Introduced `continuous_operation_monitor` and analytics schema updates.
 - Maintenance improvements across utilities.
 
-For changes prior to version 4.1.0 see `documentation/CHANGELOG.md` starting with
-the [1.0.0] Initial Enterprise Release.
+## [4.0.0] - 2025-07-14
+- **Features:** enterprise readiness milestones with 32-database deployment and comprehensive monitoring.
+- **Breaking:** none.
+- **Compliance:** passed full enterprise audit with enforced anti-recursion.
+- **Contributors:** Copilot, Statix, gh_COPILOT.
+
+## [3.5.0] - 2025-07-13
+- **Features:** Phase 4 continuous optimization and predictive maintenance tools.
+- **Breaking:** none.
+- **Compliance:** updated continuous-operation protocol.
+- **Contributors:** Copilot, Statix, gh_COPILOT.
+
+## [3.0.0] - 2025-07-12
+- **Features:** enterprise foundation with audit and deployment frameworks.
+- **Breaking:** none.
+- **Compliance:** enterprise authentication and session integrity enforced.
+- **Contributors:** Copilot, Statix, gh_COPILOT.
+
+## [2.5.0] - 2025-07-11
+- **Features:** automated optimization engine and improved monitoring.
+- **Breaking:** none.
+- **Compliance:** monitoring expanded for enterprise requirements.
+- **Contributors:** Copilot, Statix, gh_COPILOT.
+
+## [2.0.0] - 2025-07-10
+- **Features:** migration to database-first architecture with real-time analytics.
+- **Breaking:** none.
+- **Compliance:** strengthened data integrity enforcement.
+- **Contributors:** Copilot, Statix, gh_COPILOT.
+
+## [1.5.0] - 2025-07-09
+- **Features:** enterprise web UI integration and role-based access control.
+- **Breaking:** none.
+- **Compliance:** introduced anti-recursion and security protocols.
+- **Contributors:** Copilot, Statix, gh_COPILOT.
+
+## [1.0.0] - 2025-07-07
+- **Features:** initial enterprise toolkit with core analysis and monitoring.
+- **Breaking:** none.
+- **Compliance:** established baseline enterprise processes.
+- **Contributors:** Copilot, Statix, gh_COPILOT.
 


### PR DESCRIPTION
## Summary
- extend docs/CHANGELOG.md with entries from v1.0.0 onward
- include features, breaking change notes, compliance updates, and contributor credits

## Testing
- `ruff check . | head -n 3`
- `pytest tests/test_add_code_audit_log.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a9604dc90833193965dcf3c3c4179