### PR TITLE
Add dual copilot validation to archive migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **DUAL COPILOT Pattern:** primary/secondary validation framework available
 - **Dual Copilot Enforcement:** automation scripts now trigger secondary
   validation via `SecondaryCopilotValidator` with aggregated results.
+- **Archive Migration Executor:** dual-copilot validation added for log archival workflows.
 - **Visual Processing Indicators:** progress bar utilities implemented
 - **Autonomous Systems:** early self-healing scripts included
 - **Placeholder Auditing:** detection script logs findings to `analytics.db:code_audit_log`

--- a/scripts/automation/archive_migration_executor.py
+++ b/scripts/automation/archive_migration_executor.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 import hashlib
 
+from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
+
 class ArchiveMigrationExecutor:
     def __init__(self):
         self.workspace_root = Path("e:/gh_COPILOT")
@@ -393,6 +395,11 @@ class ArchiveMigrationExecutor:
         self.logger.info(f"📄 Migration report saved: {report_path}")
         return report
 
+    def secondary_validate(self) -> bool:
+        """Run flake8 secondary validation for this script."""
+        validator = SecondaryCopilotValidator(self.logger)
+        return validator.validate_corrections([__file__])
+
 def main():
     """Main execution function."""
     print("📦 ARCHIVE MIGRATION EXECUTOR")
@@ -438,11 +445,17 @@ def main():
         # For safety, we'll generate the report but NOT execute the actual migration
         # User would need to manually set dry_run=False to execute
         report = executor.generate_migration_report(dry_run_results)
-        
+
+        # Secondary validation ensures script compliance
+        if executor.secondary_validate():
+            print("✅ Secondary Copilot validation passed")
+        else:
+            print("❌ Secondary Copilot validation failed")
+
         print(f"\n✅ MIGRATION PREPARATION COMPLETE")
         print(f"📄 Report saved with migration plan")
         print(f"🔒 Actual migration requires manual confirmation (change dry_run=False)")
-        
+
         return True
         
     except Exception as e:


### PR DESCRIPTION
## Summary
- integrate `SecondaryCopilotValidator` into `archive_migration_executor.py`
- log secondary validation outcome in main workflow
- document archive migration dual-copilot support in README

## Testing
- `ruff check scripts/automation/archive_migration_executor.py`
- `pyright scripts/automation/archive_migration_executor.py`
- `pytest -k SecondaryCopilotValidator -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa5a3d71c8331acc48cfcc0b72cdc