### PR TITLE
Finalize dual-copilot docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Dual Copilot Enforcement:** automation scripts now trigger secondary
   validation via `SecondaryCopilotValidator` with aggregated results.
 - **Archive Migration Executor:** dual-copilot validation added for log archival workflows.
+- **Full Validation Coverage:** ingestion, placeholder audits and migration scripts now run SecondaryCopilotValidator by default.
 - **Visual Processing Indicators:** progress bar utilities implemented
 - **Autonomous Systems:** early self-healing scripts included
 - **Placeholder Auditing:** detection script logs findings to `analytics.db:code_audit_log`

--- a/tests/placeholder_audit/__init__.py
+++ b/tests/placeholder_audit/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for placeholder audit utilities."""

--- a/tests/quantum/__init__.py
+++ b/tests/quantum/__init__.py
@@ -1,0 +1,1 @@
+"""Quantum module tests run in simulation mode."""


### PR DESCRIPTION
## Summary
- note full validation coverage with SecondaryCopilotValidator
- remove zero-byte test packages

## Testing
- `ruff check tests/placeholder_audit/__init__.py tests/quantum/__init__.py`
- `pytest tests/placeholder_audit tests/quantum -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688ab021c49c8331ba77a7616e257e18