### PR TITLE
feat: add dual-copilot validation to consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Dual Copilot Enforcement:** automation scripts now trigger secondary
   validation via `SecondaryCopilotValidator` with aggregated results.
 - **Archive Migration Executor:** dual-copilot validation added for log archival workflows.
+- **Analytics Consolidation:** `database_consolidation_migration.py` now performs secondary validation after merging sources.
 - **Full Validation Coverage:** ingestion, placeholder audits and migration scripts now run SecondaryCopilotValidator by default.
 - **Visual Processing Indicators:** progress bar utilities implemented
 - **Autonomous Systems:** early self-healing scripts included

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.1.11] - 2025-08-02
+- Added dual-copilot validation to `database_consolidation_migration.py`.
+- Documented analytics consolidation milestone in README.
+
 ## [4.1.10] - 2025-08-01
 - Updated `STUB_MODULE_STATUS.md` to mark `DBFirstCodeGenerator`,
   `documentation_db_analyzer` and `workflow_enhancer` as incomplete.

--- a/tests/test_database_consolidation_run.py
+++ b/tests/test_database_consolidation_run.py
@@ -1,0 +1,37 @@
+import logging
+import sqlite3
+from pathlib import Path
+
+from scripts.database import database_consolidation_migration as dcm
+
+
+def test_run_dual_validation(tmp_path: Path, monkeypatch, caplog) -> None:
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    target = db_dir / "analytics.db"
+    with sqlite3.connect(target):
+        pass
+    for name in dcm.ANALYTICS_SOURCES:
+        src = db_dir / name
+        with sqlite3.connect(src) as conn:
+            conn.execute("CREATE TABLE t (id INTEGER)")
+            conn.execute("INSERT INTO t (id) VALUES (1)")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(dcm, "ensure_db_reference", lambda path: True)
+    monkeypatch.setattr(dcm, "validate_enterprise_operation", lambda path=None: True)
+
+    class DummyValidator:
+        def __init__(self, logger=None):
+            pass
+
+        def validate_corrections(self, files):
+            logging.info("SECONDARY validation executed")
+            return True
+
+    monkeypatch.setattr(dcm, "SecondaryCopilotValidator", DummyValidator)
+    caplog.set_level(logging.INFO)
+    dcm.run()
+    logs = caplog.text
+    assert "PRIMARY VALIDATION" in logs
+    assert "SECONDARY validation executed" in logs


### PR DESCRIPTION
## Summary
- integrate `SecondaryCopilotValidator` into `database_consolidation_migration.py`
- log primary and secondary validation steps for analytics consolidation
- document analytics consolidation milestone in README and changelog
- add regression test covering new secondary validation hook

## Testing
- `ruff check scripts/database/database_consolidation_migration.py tests/test_database_consolidation_run.py`
- `pyright scripts/database/database_consolidation_migration.py tests/test_database_consolidation_run.py`
- `pytest tests/test_database_consolidation_migration.py tests/test_database_consolidation_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab41f4f18833184a3d3e39af5467c