### PR TITLE
fix: resolve ruff F821 errors

### DIFF
--- a/scripts/cross_reference_validator.py
+++ b/scripts/cross_reference_validator.py
@@ -25,10 +25,11 @@ from typing import Dict, List, Optional, Set
 from tqdm import tqdm
 
 from enterprise_modules.compliance import validate_enterprise_operation
-from utils.log_utils import _log_event
+from utils.log_utils import _log_event, log_event
 from utils.cross_platform_paths import CrossPlatformPathManager
 
 workspace_root = CrossPlatformPathManager.get_workspace_path()
+BACKUP_ROOT = CrossPlatformPathManager.get_backup_root()
 LOGS_DIR = workspace_root / "logs" / "cross_reference"
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"cross_reference_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
@@ -132,7 +133,7 @@ class CrossReferenceValidator:
             for d in docs_dirs + code_dirs:
                 for path in d.rglob(file_name):
                     try:
-                        path.relative_to(backup_root)
+                        path.relative_to(BACKUP_ROOT)
                     except ValueError:
                         related_paths.add(path)
             for path in sorted(related_paths):

--- a/tests/test_compliance_metrics_updater.py
+++ b/tests/test_compliance_metrics_updater.py
@@ -10,8 +10,14 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch, simulate, test_mode):
     module = importlib.import_module("dashboard.compliance_metrics_updater")
     importlib.reload(module)
     modes = []
+    events = []
     monkeypatch.setattr(module, "ensure_tables", lambda *a, **k: None)
-    monkeypatch.setattr(module, "insert_event", lambda e, table, **k: modes.append(k.get("test_mode")))
+
+    def _capture_event(event, table, **k):
+        modes.append(k.get("test_mode"))
+        events.append(table)
+
+    monkeypatch.setattr(module, "insert_event", _capture_event)
     monkeypatch.setattr(module, "validate_no_recursive_folders", lambda: None)
     monkeypatch.setattr(module, "validate_environment_root", lambda: None)
 


### PR DESCRIPTION
## Summary
- fix undefined names in cross_reference_validator
- capture insert events during compliance metrics updater test

## Testing
- `ruff check scripts/cross_reference_validator.py tests/test_compliance_metrics_updater.py`
- `ruff format scripts/cross_reference_validator.py tests/test_compliance_metrics_updater.py`
- `pyright` *(failed: KeyboardInterrupt)*
- `pytest -q` *(failed: 37 failed, 252 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688ac4370a0c83318d908c5ddb96e358