### PR TITLE
docs: deprecate placeholder_cleanup wrapper

### DIFF
--- a/scripts/placeholder_cleanup.py
+++ b/scripts/placeholder_cleanup.py
@@ -1,10 +1,15 @@
 """Deprecated wrapper for placeholder cleanup.
 
-Use ``scripts.code_placeholder_audit`` with ``--cleanup`` instead."""
+Please run ``scripts/code_placeholder_audit.py --cleanup`` instead."""
+
 from __future__ import annotations
 
 import sys
 from scripts import code_placeholder_audit
 
 if __name__ == "__main__":
+    print(
+        "DEPRECATED: use 'python scripts/code_placeholder_audit.py --cleanup'",
+        file=sys.stderr,
+    )
     code_placeholder_audit.main(*sys.argv[1:])


### PR DESCRIPTION
## Summary
- direct placeholder_cleanup users to `scripts/code_placeholder_audit.py --cleanup`

## Testing
- `ruff check scripts/placeholder_cleanup.py`
- `pytest tests/test_placeholder_cleanup.py::test_placeholder_cleanup_workflow -q` *(fails: NameError: dataset_path is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688ac9f249d08331828d34d4b9c09f67