### PR TITLE
Fix cross reference backup root

### DIFF
--- a/scripts/cross_reference_validator.py
+++ b/scripts/cross_reference_validator.py
@@ -29,7 +29,7 @@ from utils.log_utils import _log_event, log_event
 from utils.cross_platform_paths import CrossPlatformPathManager
 
 workspace_root = CrossPlatformPathManager.get_workspace_path()
-BACKUP_ROOT = CrossPlatformPathManager.get_backup_root()
+backup_root = CrossPlatformPathManager.get_backup_root()
 LOGS_DIR = workspace_root / "logs" / "cross_reference"
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"cross_reference_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
@@ -133,7 +133,7 @@ class CrossReferenceValidator:
             for d in docs_dirs + code_dirs:
                 for path in d.rglob(file_name):
                     try:
-                        path.relative_to(BACKUP_ROOT)
+                        path.relative_to(backup_root)
                     except ValueError:
                         related_paths.add(path)
             for path in sorted(related_paths):


### PR DESCRIPTION
## Summary
- define `backup_root` at module level
- use `backup_root` in deep cross-link logic

## Testing
- `ruff check scripts/cross_reference_validator.py`
- `pytest tests/test_cross_reference_validator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688acaf58368833187ce9876b41296bb