### PR TITLE
fix: remove duplicate user assignment

### DIFF
--- a/scripts/autonomous_setup_and_audit.py
+++ b/scripts/autonomous_setup_and_audit.py
@@ -48,11 +48,7 @@ def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
 
     # Gather files
     extensions = [".md", ".txt", ".json", ".sql"]
-    doc_files = (
-        [p for p in doc_path.rglob("*") if p.is_file() and p.suffix in extensions]
-        if doc_path.exists()
-        else []
-    )
+    doc_files = [p for p in doc_path.rglob("*") if p.is_file() and p.suffix in extensions] if doc_path.exists() else []
     tmpl_files = (
         [p for p in template_path.rglob("*") if p.is_file() and p.suffix in extensions]
         if template_path.exists()
@@ -61,8 +57,6 @@ def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
 
     analytics_db = Path(os.getenv("GH_COPILOT_WORKSPACE", ".")) / "databases" / "analytics.db"
     _log_event({"event": "ingestion_start"}, table="correction_logs", db_path=analytics_db)
-    user = os.getenv("USER", "system")
-
     user = os.getenv("USER", "system")
     conn = sqlite3.connect(db_path)
     audit_conn = sqlite3.connect(analytics_db)
@@ -297,6 +291,7 @@ def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
             conn.commit()
         log_sync_operation(db_path, "template_ingestion", start_time=start_tmpl)
         from scripts.database.ingestion_validator import IngestionValidator
+
         validator = IngestionValidator(doc_path.parent, db_path, analytics_db)
         if not validator.validate():
             raise RuntimeError("Asset ingestion validation failed")


### PR DESCRIPTION
## Summary
- keep a single `USER` environment variable lookup in `ingest_assets`

## Testing
- `ruff check scripts/autonomous_setup_and_audit.py`
- `ruff format scripts/autonomous_setup_and_audit.py`
- `ruff check`
- `pytest -q` *(fails: 38 failed, 301 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688ac9eb17a883319f9f30fc8a56ed70