### PR TITLE
Fix recursion detection using path resolve

### DIFF
--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -52,10 +52,14 @@ def _log_rollback(target: str, backup: str | None = None) -> None:
 
 
 def _detect_recursion(path: Path) -> bool:
-    """Return True if ``path`` contains recursive subfolders."""
-    root_name = path.name.lower()
-    for folder in path.rglob(root_name):
+    """Return True if ``path`` contains a nested folder matching itself."""
+    root = path.resolve()
+    for folder in path.rglob(path.name):
         if folder.is_dir() and folder != path:
+            try:
+                folder.resolve().relative_to(root)
+            except ValueError:
+                continue
             return True
     return False
 

--- a/tests/test_compliance_module.py
+++ b/tests/test_compliance_module.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from enterprise_modules.compliance import (
     validate_enterprise_operation,
     _log_rollback,
+    _detect_recursion,
 )
 
 
@@ -19,6 +20,15 @@ def test_recursion_detection(tmp_path: Path) -> None:
                 "SELECT details FROM violation_logs"
             ).fetchall()
         assert any("recursive_" in d[0] for d in details)
+
+
+def test_recursion_symlink(tmp_path: Path) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}_outside"
+    outside.mkdir()
+    link = tmp_path / tmp_path.name
+    link.symlink_to(outside, target_is_directory=True)
+
+    assert not _detect_recursion(tmp_path)
 
 
 def test_log_rollback(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- avoid false positives by checking resolved paths in `_detect_recursion`
- extend tests for symlinked directories

## Testing
- `ruff check tests/test_compliance_module.py`
- `pytest -q tests/test_compliance_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688aca73dd6483319a8826d7e2256b0b