### PR TITLE
fix: use correction_logs table in dashboard

### DIFF
--- a/documentation/ENTERPRISE_VIOLATION_PROCESSING_SUMMARY.md
+++ b/documentation/ENTERPRISE_VIOLATION_PROCESSING_SUMMARY.md
@@ -154,7 +154,7 @@ Batch Processing: 77 batches for systematic processing
 
 ### **Database Schema**
 ✅ **violations table** - Complete violation records with metadata  
-✅ **corrections table** - Applied fix tracking and validation  
+✅ **correction_logs table** - Applied fix tracking and validation
 ✅ **processing_sessions table** - Session-based operation tracking  
 ✅ **monitoring_snapshots table** - Real-time monitoring data  
 ✅ **alerts table** - Alert management and acknowledgment  

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -54,7 +54,7 @@ def _fetch_metrics() -> Dict[str, Any]:
                 metrics["resolved_placeholders"] = metrics["placeholder_removal"]
                 cur.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE resolved=0")
                 metrics["open_placeholders"] = cur.fetchone()[0]
-                cur.execute("SELECT AVG(compliance_score) FROM corrections")
+                cur.execute("SELECT AVG(compliance_score) FROM correction_logs")
                 val = cur.fetchone()[0]
                 metrics["compliance_score"] = float(val) if val is not None else 0.0
             except sqlite3.Error as exc:


### PR DESCRIPTION
## Summary
- use `correction_logs` table for compliance score query
- update violation processing docs to reference `correction_logs`

## Testing
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py`
- `pytest -q tests/dashboard/test_live_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_688aca77e6d883318b250a1e67686275