### PR TITLE
feat: support stopping metrics stream

### DIFF
--- a/tests/test_compliance_metrics_scheduler.py
+++ b/tests/test_compliance_metrics_scheduler.py
@@ -1,5 +1,6 @@
 import sqlite3
 import logging
+import threading
 import pytest
 from dashboard import compliance_metrics_updater as cmu
 
@@ -25,9 +26,9 @@ def test_scheduler_and_stream(tmp_path, monkeypatch):
 
     dash = tmp_path / "dashboard"
     updater = cmu.ComplianceMetricsUpdater(dash)
-    gen = updater.stream_metrics(interval=0)
-    metrics = next(gen)
-    assert "suggestion" in metrics
+    metrics_list = list(updater.stream_metrics(interval=0, iterations=1))
+    assert len(metrics_list) == 1
+    assert "suggestion" in metrics_list[0]
 
     call_count = []
     monkeypatch.setattr(cmu.ComplianceMetricsUpdater, "update", lambda self, simulate=False: call_count.append(1))
@@ -65,3 +66,30 @@ def test_stream_metrics_violation(tmp_path, monkeypatch, caplog):
     with pytest.raises(RuntimeError):
         next(gen)
     assert any("Forbidden operation detected" in rec.message for rec in caplog.records)
+
+
+def test_stream_metrics_stop_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    analytics_db = db_dir / "analytics.db"
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT)")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (1, 'resolved')")
+        conn.execute("CREATE TABLE correction_logs (compliance_score REAL)")
+        conn.execute("INSERT INTO correction_logs VALUES (1.0)")
+
+    monkeypatch.setattr(cmu, "ANALYTICS_DB", analytics_db)
+    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+
+    dash = tmp_path / "dashboard"
+    updater = cmu.ComplianceMetricsUpdater(dash)
+    stop = threading.Event()
+    gen = updater.stream_metrics(interval=0, stop_event=stop)
+    next(gen)
+    stop.set()
+    with pytest.raises(StopIteration):
+        next(gen)


### PR DESCRIPTION
## Summary
- update `ComplianceMetricsUpdater.stream_metrics` to allow early termination via `stop_event` or `iterations`
- adjust scheduler tests to use limited streams
- add new unit test for stopping with an event

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/test_compliance_metrics_scheduler.py`
- `pyright dashboard/compliance_metrics_updater.py tests/test_compliance_metrics_scheduler.py`
- `pytest -q tests/test_compliance_metrics_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_688aca7ac45c8331842f7b4ea0e3b658