### PR TITLE
feat: limit correction summary entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,8 +685,11 @@ uses Server-Sent Events by default and works with Flask's ``Response`` when
 Compliance metrics are generated with `dashboard/compliance_metrics_updater.py`.
 This script reads from `analytics.db` and writes `dashboard/compliance/metrics.json`.
 The compliance score is averaged from records in the `correction_logs` table.
-Correction history is summarized via `scripts/correction_logger_and_rollback.py`,
-producing `dashboard/compliance/correction_summary.json`.
+Correction history is summarized via `scripts/correction_logger_and_rollback.py`.
+The `summarize_corrections()` routine now keeps only the most recent entries
+(configurable via the `max_entries` argument). Existing summary files are moved
+to `dashboard/compliance/archive/` before new summaries are written. The main
+report remains `dashboard/compliance/correction_summary.json`.
 Set `GH_COPILOT_WORKSPACE` before running these utilities:
 
 ```bash

--- a/tests/test_correction_summary.py
+++ b/tests/test_correction_summary.py
@@ -14,13 +14,11 @@ def test_correction_summary_generation(tmp_path: Path, monkeypatch) -> None:
         conn.execute(
             "CREATE TABLE corrections (file_path TEXT, rationale TEXT, compliance_score REAL, rollback_reference TEXT, ts TEXT)"
         )
-        conn.execute(
-            "INSERT INTO corrections VALUES ('f.py','test',1.0,'', '2025-01-01')"
-        )
+        conn.execute("INSERT INTO corrections VALUES ('f.py','test',1.0,'', '2025-01-01')")
     monkeypatch.setattr("scripts.correction_logger_and_rollback.DASHBOARD_DIR", tmp_path)
     monkeypatch.setattr(clr, "validate_enterprise_operation", lambda *a, **k: None)
     log = CorrectionLoggerRollback(analytics)
-    summary = log.summarize_corrections()
+    summary = log.summarize_corrections(max_entries=1)
     assert summary["total_corrections"] == 1
     data = json.loads((tmp_path / "correction_summary.json").read_text())
     assert data["status"] == "complete"


### PR DESCRIPTION
## Summary
- keep only the most recent corrections when summarizing
- archive older correction summary files automatically
- update docs about the new behavior
- adjust correction summary test

## Testing
- `ruff check scripts/correction_logger_and_rollback.py tests/test_correction_summary.py`
- `ruff format scripts/correction_logger_and_rollback.py tests/test_correction_summary.py`
- `pyright scripts/correction_logger_and_rollback.py tests/test_correction_summary.py`
- `pytest tests/test_correction_summary.py tests/test_violation_and_rollback_logging.py tests/test_rollback_failure_logging.py tests/test_strategy_adaptation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688aca7d68a883318f9604cec50cb030