### PR TITLE
Fix path check for backups

### DIFF
--- a/tests/test_enterprise_validation.py
+++ b/tests/test_enterprise_validation.py
@@ -25,3 +25,15 @@ def test_validate_enterprise_operation_allows_external_backup(tmp_path, monkeypa
 
     assert validate_enterprise_operation(str(workspace / "data")) is True
 
+
+def test_validate_enterprise_operation_allows_opt_backup(tmp_path, monkeypatch):
+    """Ensure /opt/gh_COPILOT_backup is not treated as inside workspace."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", "/opt/gh_COPILOT_backup")
+
+    from enterprise_modules.compliance import validate_enterprise_operation
+
+    assert validate_enterprise_operation(str(workspace / "data")) is True


### PR DESCRIPTION
## Summary
- ensure compliance uses `Path.is_relative_to` to validate external backups
- add regression test for `/opt/gh_COPILOT_backup`

## Testing
- `ruff check enterprise_modules/compliance.py tests/test_enterprise_validation.py`
- `ruff format enterprise_modules/compliance.py tests/test_enterprise_validation.py`
- `pytest tests/test_enterprise_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688aca74f1e88331a1c745b5098157e4