### PR TITLE
Add timeout handling for pattern mining

### DIFF
--- a/template_engine/pattern_mining_engine.py
+++ b/template_engine/pattern_mining_engine.py
@@ -164,6 +164,7 @@ def mine_patterns(
     validate_no_recursive_folders()
     start_dt = datetime.now()
     start_ts = time.time()
+    timeout_seconds = timeout_minutes * 60
     process_id = os.getpid()
     logging.info("PROCESS STARTED: Pattern Mining Engine")
     logging.info(f"Start Time: {start_dt.strftime('%Y-%m-%d %H:%M:%S')}")
@@ -199,6 +200,10 @@ def mine_patterns(
                 )
                 _log_pattern(analytics_db, pat)
                 etc = calculate_etc(start_ts, idx, total_steps)
+                if time.time() - start_ts > timeout_seconds:
+                    raise TimeoutError(
+                        f"Process exceeded {timeout_minutes} minute timeout"
+                    )
                 if idx % 10 == 0 or idx == total_steps:
                     logging.info(f"Pattern {idx}/{total_steps} stored | ETC: {etc}")
             conn.commit()
@@ -217,6 +222,10 @@ def mine_patterns(
                 )"""
             )
             for pat, label in zip(patterns, labels):
+                if time.time() - start_ts > timeout_seconds:
+                    raise TimeoutError(
+                        f"Process exceeded {timeout_minutes} minute timeout"
+                    )
                 conn.execute(
                     "INSERT INTO pattern_clusters (pattern, cluster, ts) VALUES (?,?,?)",
                     (pat, int(label), datetime.utcnow().isoformat()),

--- a/tests/test_pattern_mining_engine.py
+++ b/tests/test_pattern_mining_engine.py
@@ -1,6 +1,8 @@
 import os
 import sqlite3
 from pathlib import Path
+import types
+import pytest
 
 import template_engine.pattern_mining_engine as pme
 from template_engine.pattern_mining_engine import (
@@ -104,3 +106,49 @@ def test_get_clusters_and_audit_logging(tmp_path: Path, monkeypatch) -> None:
     with sqlite3.connect(analytics) as conn:
         count = conn.execute("SELECT COUNT(*) FROM audit_log").fetchone()[0]
     assert count > 0
+
+
+def test_mine_patterns_timeout_storage(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(pme, "_log_audit_real", lambda *a, **k: None)
+
+    prod = tmp_path / "production.db"
+    with sqlite3.connect(prod) as conn:
+        conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
+        conn.execute("INSERT INTO code_templates (template_code) VALUES ('def x(): pass')")
+    analytics = tmp_path / "analytics.db"
+
+    t = types.SimpleNamespace(count=-1)
+
+    def fake_time() -> int:
+        t.count += 1
+        return t.count
+
+    monkeypatch.setattr(pme.time, "time", fake_time)
+    with pytest.raises(TimeoutError):
+        mine_patterns(prod, analytics, timeout_minutes=0)
+
+
+def test_mine_patterns_timeout_clustering(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(pme, "_log_audit_real", lambda *a, **k: None)
+
+    prod = tmp_path / "production.db"
+    with sqlite3.connect(prod) as conn:
+        conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
+        conn.execute("INSERT INTO code_templates (template_code) VALUES ('def x(): pass')")
+        conn.execute("INSERT INTO code_templates (template_code) VALUES ('def y(): pass')")
+    analytics = tmp_path / "analytics.db"
+
+    monkeypatch.setattr(pme.time, "time", lambda: 0)
+
+    orig_fit = pme.KMeans.fit_predict
+
+    def fake_fit(self, vec):
+        monkeypatch.setattr(pme.time, "time", lambda: 1000)
+        return orig_fit(self, vec)
+
+    monkeypatch.setattr(pme.KMeans, "fit_predict", fake_fit)
+
+    with pytest.raises(TimeoutError):
+        mine_patterns(prod, analytics, timeout_minutes=1)


### PR DESCRIPTION
## Summary
- compute `timeout_seconds` in `mine_patterns`
- abort mining if elapsed time exceeds timeout
- unit tests check timeout for storage and clustering loops

## Testing
- `pyright template_engine/pattern_mining_engine.py tests/test_pattern_mining_engine.py`
- `pytest -q tests/test_pattern_mining_engine.py`
- `ruff check . --exit-zero`

------
https://chatgpt.com/codex/tasks/task_e_688acb4185d083319d410506b9224783