### PR TITLE
fix: log mined patterns in batch

### DIFF
--- a/template_engine/pattern_mining_engine.py
+++ b/template_engine/pattern_mining_engine.py
@@ -197,11 +197,11 @@ def mine_patterns(
                     "INSERT INTO mined_patterns (pattern, mined_at) VALUES (?, ?)",
                     (pat, datetime.utcnow().isoformat()),
                 )
-                _log_pattern(analytics_db, pat)
                 etc = calculate_etc(start_ts, idx, total_steps)
                 if idx % 10 == 0 or idx == total_steps:
                     logging.info(f"Pattern {idx}/{total_steps} stored | ETC: {etc}")
             conn.commit()
+        _log_patterns(patterns, analytics_db)
     cluster_count = 0
     if patterns:
         vec = TfidfVectorizer().fit_transform(patterns)

--- a/tests/test_pattern_mining_engine.py
+++ b/tests/test_pattern_mining_engine.py
@@ -33,6 +33,14 @@ def test_extract_patterns():
 def test_mine_patterns(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     monkeypatch.setattr(pme, "_log_audit_real", lambda *a, **k: None)
+    calls = []
+    orig_log_patterns = pme._log_patterns
+
+    def fake_log_patterns(patterns: list[str], analytics_db: Path) -> None:
+        calls.append((patterns, analytics_db))
+        orig_log_patterns(patterns, analytics_db)
+
+    monkeypatch.setattr(pme, "_log_patterns", fake_log_patterns)
     # Start time logging for visual processing indicator
     from datetime import datetime
 
@@ -52,11 +60,13 @@ def test_mine_patterns(tmp_path: Path, monkeypatch) -> None:
         count = conn.execute("SELECT COUNT(*) FROM mined_patterns").fetchone()[0]
     assert count == len(patterns), "Pattern count mismatch in mined_patterns table"
     assert validate_mining(len(patterns), analytics), "DUAL COPILOT validation failed"
+    assert calls == [(patterns, analytics)]
 
 
 def test_mine_patterns_clusters(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     monkeypatch.setattr(pme, "_log_audit_real", lambda *a, **k: None)
+    monkeypatch.setattr(pme, "_log_patterns", lambda *a, **k: None)
     from datetime import datetime
 
     start_time = datetime.now()
@@ -79,6 +89,7 @@ def test_mine_patterns_clusters(tmp_path: Path, monkeypatch) -> None:
 
 def test_get_clusters_and_audit_logging(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(pme, "_log_patterns", lambda *a, **k: None)
     prod = tmp_path / "production.db"
     analytics = tmp_path / "analytics.db"
     with sqlite3.connect(prod) as conn:


### PR DESCRIPTION
## Summary
- call `_log_patterns` from `mine_patterns`
- capture calls to `_log_patterns` in unit tests

## Testing
- `ruff check template_engine/pattern_mining_engine.py tests/test_pattern_mining_engine.py`
- `pytest tests/test_pattern_mining_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688acb43c344833199301d0f53d64dee