### PR TITLE
Enable real analytics logging and streaming

### DIFF
--- a/tests/test_log_utils_manage.py
+++ b/tests/test_log_utils_manage.py
@@ -1,0 +1,47 @@
+from utils.log_utils import (
+    _clear_log,
+    _list_events,
+    ensure_tables,
+    log_event,
+    sse_event_stream,
+    start_websocket_broadcast,
+)
+
+
+def test_list_and_clear(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "0")
+    db = tmp_path / "events.db"
+    ensure_tables(db, ["violation_logs"], test_mode=False)
+    for i in range(3):
+        log_event({"details": str(i)}, table="violation_logs", db_path=db)
+    events = _list_events("violation_logs", db_path=db, order="ASC", test_mode=False)
+    assert len(events) == 3
+    assert events[0]["details"] == "0"
+    assert _clear_log("violation_logs", db_path=db, test_mode=False)
+    assert _list_events("violation_logs", db_path=db, test_mode=False) == []
+
+
+def test_sse_category(tmp_path):
+    db = tmp_path / "sse.db"
+    ensure_tables(db, ["violation_logs"], test_mode=False)
+    log_event({"details": "a"}, table="violation_logs", db_path=db)
+    gen = sse_event_stream("violation_logs", db_path=db, poll_interval=0.01)
+    first = next(gen)
+    assert "event: violation_logs" in first
+    assert "data:" in first
+
+
+def test_websocket_broadcast_skips(monkeypatch):
+    monkeypatch.setenv("LOG_WEBSOCKET_ENABLED", "1")
+    import builtins as blt
+
+    orig_import = blt.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "websockets":
+            raise ImportError
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(blt, "__import__", fake_import)
+    start_websocket_broadcast(port=8766)
+    monkeypatch.setattr(blt, "__import__", orig_import)

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -168,12 +168,20 @@ def _can_create_analytics_db(db_path: Path = DEFAULT_ANALYTICS_DB) -> bool:
     return False
 
 
-def ensure_tables(db_path: Path, tables: Iterable[str], *, test_mode: bool = True) -> None:
+def ensure_tables(
+    db_path: Path,
+    tables: Iterable[str],
+    *,
+    test_mode: Optional[bool] = None,
+) -> None:
     """Ensure the specified tables exist in ``db_path``.
 
     When ``test_mode`` is ``True`` the function simulates table creation using
     :func:`_log_event` and performs no writes.
     """
+    if test_mode is None:
+        test_mode = os.environ.get("GH_COPILOT_TEST_MODE", "1") == "1"
+
     for table in tables:
         schema = TABLE_SCHEMAS.get(table)
         if not schema:
@@ -192,9 +200,12 @@ def insert_event(
     table: str,
     *,
     db_path: Path = DEFAULT_ANALYTICS_DB,
-    test_mode: bool = True,
+    test_mode: Optional[bool] = None,
 ) -> int:
     """Insert ``event`` into the specified table and return the new row id."""
+    if test_mode is None:
+        test_mode = os.environ.get("GH_COPILOT_TEST_MODE", "1") == "1"
+
     ensure_tables(db_path, [table], test_mode=test_mode)
     if test_mode:
         logging.getLogger(__name__).debug("Simulated insert into %s: %s", table, event)
@@ -303,7 +314,7 @@ def _log_audit_event(
     db_path: Path = DEFAULT_ANALYTICS_DB,
     table: str = "audit_log",
     echo: bool = False,
-    test_mode: bool = True,
+    test_mode: Optional[bool] = None,
 ) -> bool:
     """Record an audit event in the analytics log.
 
@@ -330,13 +341,23 @@ def _log_audit_event(
     bool
         ``True`` when the analytics database could be created at ``db_path``.
     """
+    if test_mode is None:
+        test_mode = os.environ.get("GH_COPILOT_TEST_MODE", "1") == "1"
+
     event = {
         "description": description,
         "details": details or {},
         "timestamp": datetime.utcnow().isoformat(),
         "level": level,
     }
-    return _log_event(event, table=table, db_path=db_path, echo=echo, level=level, test_mode=test_mode)
+    return _log_event(
+        event,
+        table=table,
+        db_path=db_path,
+        echo=echo,
+        level=level,
+        test_mode=test_mode,
+    )
 
 
 def _log_plain(
@@ -386,21 +407,29 @@ def log_event(event: Dict[str, Any], *, table: str = DEFAULT_LOG_TABLE, db_path:
     insert_event(event, table, db_path=db_path, test_mode=False)
 
 
-def send_dashboard_alert(event: Dict[str, Any], *, table: str = "dashboard_alerts", db_path: Path = DEFAULT_ANALYTICS_DB) -> None:
+def send_dashboard_alert(
+    event: Dict[str, Any], *, table: str = "dashboard_alerts", db_path: Path = DEFAULT_ANALYTICS_DB
+) -> None:
     """Send an alert event to the web dashboard if enabled."""
     if os.getenv("WEB_DASHBOARD_ENABLED") != "1":
         return
     log_event(event, table=table, db_path=db_path)
 
 
-def stream_events(table: str = DEFAULT_LOG_TABLE, *, db_path: Path = DEFAULT_ANALYTICS_DB):
+def stream_events(
+    table: str = DEFAULT_LOG_TABLE,
+    *,
+    db_path: Path = DEFAULT_ANALYTICS_DB,
+):
     """Yield events formatted for Server-Sent Events."""
     if not db_path.exists():
         return
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         for row in conn.execute(f"SELECT * FROM {table} ORDER BY id ASC"):
-            yield f"data: {json.dumps(dict(row))}\n\n"
+            rec = dict(row)
+            category = rec.get("category") or table
+            yield f"event: {category}\ndata: {json.dumps(rec)}\n\n"
 
 
 def log_stream(
@@ -417,10 +446,15 @@ def log_stream(
             continue
         with sqlite3.connect(db_path) as conn:
             conn.row_factory = sqlite3.Row
-            rows = conn.execute(f"SELECT * FROM {table} WHERE id > ? ORDER BY id ASC", (last_id,))
+            rows = conn.execute(
+                f"SELECT * FROM {table} WHERE id > ? ORDER BY id ASC",
+                (last_id,),
+            )
             for row in rows:
                 last_id = row["id"]
-                yield f"data: {json.dumps(dict(row))}\n\n"
+                rec = dict(row)
+                category = rec.get("category") or table
+                yield f"event: {category}\ndata: {json.dumps(rec)}\n\n"
         time.sleep(poll_interval)
 
 
@@ -440,23 +474,45 @@ def sse_event_stream(
 
 
 def _list_events(
-    table: str = DEFAULT_LOG_TABLE, db_path: Path = DEFAULT_ANALYTICS_DB, limit: int = 100, order: str = "DESC"
+    table: str = DEFAULT_LOG_TABLE,
+    db_path: Path = DEFAULT_ANALYTICS_DB,
+    limit: int = 100,
+    order: str = "DESC",
+    *,
+    test_mode: Optional[bool] = None,
 ) -> list:
-    """
-    Simulate listing the most recent events from the log table (no DB access).
-    """
-    tqdm.write(f"[TEST] Listing would query {table} in {db_path} (simulated, no DB access)")
-    return []
+    """Return recent events from ``table`` respecting test mode."""
+    if test_mode is None:
+        test_mode = os.environ.get("GH_COPILOT_TEST_MODE", "1") == "1"
+    if test_mode or not db_path.exists():
+        tqdm.write(f"[TEST] Listing would query {table} in {db_path} (simulated, no DB access)")
+        return []
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            f"SELECT * FROM {table} ORDER BY id {order} LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
 
 
 def _clear_log(
     table: str = DEFAULT_LOG_TABLE,
     db_path: Path = DEFAULT_ANALYTICS_DB,
+    *,
+    test_mode: Optional[bool] = None,
 ) -> bool:
-    """
-    Simulate clearing all events from the log table (no DB access).
-    """
-    tqdm.write(f"[TEST] Clearing would delete all from {table} in {db_path} (simulated, no DB access)")
+    """Remove all rows from ``table`` respecting test mode."""
+    if test_mode is None:
+        test_mode = os.environ.get("GH_COPILOT_TEST_MODE", "1") == "1"
+    if test_mode:
+        tqdm.write(f"[TEST] Clearing would delete all from {table} in {db_path} (simulated, no DB access)")
+        return True
+    if not db_path.exists():
+        return False
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(f"DELETE FROM {table}")
+        conn.commit()
     return True
 
 
@@ -507,8 +563,12 @@ def start_websocket_broadcast(
     if os.environ.get("LOG_WEBSOCKET_ENABLED") != "1":
         return
 
-    import asyncio
-    import websockets
+    try:
+        import asyncio
+        import websockets
+    except ImportError:  # pragma: no cover - optional dependency
+        logging.getLogger(__name__).warning("websockets package not available")
+        return
 
     clients: set = set()
 


### PR DESCRIPTION
## Summary
- update log utilities to respect GH_COPILOT_TEST_MODE
- implement listing/clearing events using the analytics db
- send categorized events via SSE/WebSocket
- add regression tests for log management and streaming

## Testing
- `ruff check utils/log_utils.py tests/test_log_utils_manage.py`
- `pytest tests/test_log_utils.py tests/test_log_utils_stream.py tests/test_log_utils_sse.py tests/test_log_utils_recovery.py tests/test_log_utils_extended.py tests/test_log_utils_manage.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688acb66c2088331a63fb24f5ec0c770