### PR TITLE
feat: unify placeholder audit CLI aliases

### DIFF
--- a/tests/placeholder_audit/test_parse_args.py
+++ b/tests/placeholder_audit/test_parse_args.py
@@ -1,0 +1,16 @@
+import scripts.code_placeholder_audit as audit
+
+
+def test_parse_args_dry_run_alias():
+    args = audit.parse_args(["--dry-run"])
+    assert args.simulate is True
+
+
+def test_parse_args_cleanup_alias():
+    args = audit.parse_args(["--cleanup"])
+    assert args.apply_fixes is True
+
+
+def test_parse_args_force():
+    args = audit.parse_args(["--force"])
+    assert args.force is True


### PR DESCRIPTION
## Summary
- unify `--cleanup`, `--dry-run`, and `--force` argument handling
- add `parse_args` helper for CLI parsing
- test argument parsing for `code_placeholder_audit`

## Testing
- `ruff format scripts/code_placeholder_audit.py`
- `ruff check scripts/code_placeholder_audit.py`
- `pyright scripts/code_placeholder_audit.py tests/placeholder_audit/test_parse_args.py`
- `pytest tests/placeholder_audit/test_parse_args.py tests/placeholder_audit/test_full_scan.py tests/placeholder_audit/test_history_and_rollback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad60c2c4883318562c2a061f27ab7