### PR TITLE
Fix WLC session manager imports

### DIFF
--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -4,14 +4,19 @@
 """WLC Session Manager
 
 Implements the Wrapping, Logging, and Compliance (WLC) methodology.
-- Wraps session operations with environment validation
-- Logs progress to the production database
-- Records compliance scores for auditing
+ - Wraps session operations with environment validation
+ - Logs progress to the production database
+ - Records compliance scores for auditing
 
 Enterprise features:
-- Database-driven configuration
-- Progress indicators via tqdm
-- Designed for continuous operation and dual validation
+ - Database-driven configuration
+ - Progress indicators via tqdm
+ - Designed for continuous operation and dual validation
+
+When run as a standalone script, the repository root is automatically added to
+``sys.path`` so project modules resolve correctly. Ensure the
+``GH_COPILOT_WORKSPACE`` and ``GH_COPILOT_BACKUP_ROOT`` environment variables are
+set before execution.
 """
 
 from __future__ import annotations
@@ -21,9 +26,13 @@ import argparse
 import logging
 import os
 import sqlite3
+import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
+
+if __package__ is None:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from tqdm import tqdm
 
@@ -151,9 +160,7 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
                     sleep_time = 0.01
                 time.sleep(sleep_time)
 
-            orchestrator = UnifiedWrapUpOrchestrator(
-                workspace_path=str(CrossPlatformPathManager.get_workspace_path())
-            )
+            orchestrator = UnifiedWrapUpOrchestrator(workspace_path=str(CrossPlatformPathManager.get_workspace_path()))
             result = orchestrator.execute_unified_wrapup()
             compliance_score = result.compliance_score / 100.0
 
@@ -171,18 +178,14 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
                     UnifiedWrapUpOrchestrator as orchestrator_cls,
                 )
 
-            orchestrator = orchestrator_cls(
-                workspace_path=str(CrossPlatformPathManager.get_workspace_path())
-            )
+            orchestrator = orchestrator_cls(workspace_path=str(CrossPlatformPathManager.get_workspace_path()))
             orchestrator.execute_unified_wrapup()
 
         validator = SecondaryCopilotValidator()
         validator.validate_corrections([__file__])
 
     if os.getenv("WLC_RUN_ORCHESTRATOR") == "1":
-        orchestrator = UnifiedWrapUpOrchestrator(
-            workspace_path=str(CrossPlatformPathManager.get_workspace_path())
-        )
+        orchestrator = UnifiedWrapUpOrchestrator(workspace_path=str(CrossPlatformPathManager.get_workspace_path()))
         orchestrator.execute_unified_wrapup()
 
     logging.info("WLC session completed")

--- a/tests/test_wlc_session_manager_cli.py
+++ b/tests/test_wlc_session_manager_cli.py
@@ -88,4 +88,5 @@ def test_cli_invalid_env(tmp_path):
         text=True,
     )
     assert result.returncode != 0
-    assert "environment variables" in result.stderr.lower()
+    err = result.stderr.lower()
+    assert "environment variables" in err or "backup root" in err

--- a/tests/test_wlc_session_manager_importpath.py
+++ b/tests/test_wlc_session_manager_importpath.py
@@ -1,0 +1,29 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "wlc_session_manager.py"
+DEFAULT_DB = Path("databases/production.db")
+
+
+def test_cli_import_path(tmp_path):
+    temp_db = tmp_path / "production.db"
+    shutil.copy(DEFAULT_DB, temp_db)
+    env = os.environ.copy()
+    env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    env["GH_COPILOT_BACKUP_ROOT"] = str(tmp_path / "backups")
+    result = subprocess.run(
+        [
+            "python",
+            str(SCRIPT),
+            "--steps",
+            "1",
+            "--db-path",
+            str(temp_db),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- ensure `wlc_session_manager.py` resolves project modules when executed directly
- document environment requirements in the script
- relax CLI test to support new error message
- add regression test for running the script without manual `PYTHONPATH`

## Testing
- `ruff check scripts/wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py`
- `pyright scripts/wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad615bca08331805f136704044e9d