### PR TITLE
fix: clarify audit user variable

### DIFF
--- a/scripts/autonomous_setup_and_audit.py
+++ b/scripts/autonomous_setup_and_audit.py
@@ -57,6 +57,7 @@ def ingest_assets(doc_path: Path, template_path: Path, db_path: Path) -> None:
 
     analytics_db = Path(os.getenv("GH_COPILOT_WORKSPACE", ".")) / "databases" / "analytics.db"
     _log_event({"event": "ingestion_start"}, table="correction_logs", db_path=analytics_db)
+    # Resolve user once for audit trail entries
     user = os.getenv("USER", "system")
     conn = sqlite3.connect(db_path)
     audit_conn = sqlite3.connect(analytics_db)


### PR DESCRIPTION
## Summary
- document purpose of `user` variable for audit logging in `autonomous_setup_and_audit.py`

## Testing
- `ruff check scripts/autonomous_setup_and_audit.py`
- `pytest -q tests/test_autonomous_setup_and_audit.py` *(fails: line length E501 and ingestion tests)*

------
https://chatgpt.com/codex/tasks/task_e_688ad611799c8331925d6d6e3a2e97a8