### PR TITLE
Fix failing tests for logger and documentation consolidator

### DIFF
--- a/tests/test_cross_database_sync_logger.py
+++ b/tests/test_cross_database_sync_logger.py
@@ -12,13 +12,14 @@ def test_log_sync_operation(tmp_path: Path, monkeypatch) -> None:
         "enterprise_modules.compliance.validate_enterprise_operation",
         lambda: None,
     )
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     db_path = tmp_path / "enterprise_assets.db"
     start = datetime.now(timezone.utc)
     time.sleep(0.01)
     log_sync_operation(db_path, "test_op", status="SUCCESS", start_time=start)
     with sqlite3.connect(db_path) as conn:
         row = conn.execute(
-            "SELECT operation, status, start_time, duration, timestamp FROM cross_database_sync_operations"
+            "SELECT operation, status, start_time, duration, timestamp FROM cross_database_sync_operations ORDER BY id DESC"
         ).fetchone()
     assert row[0] == "test_op"
     assert row[1] == "SUCCESS"

--- a/tests/test_documentation_consolidator.py
+++ b/tests/test_documentation_consolidator.py
@@ -50,8 +50,13 @@ def test_documentation_consolidator(tmp_path, monkeypatch):
     monkeypatch.setenv("DOCUMENTATION_DB_PATH", str(db_dir / "documentation.db"))
     analytics_db = tmp_path / "analytics.db"
     monkeypatch.setenv("ANALYTICS_DB", str(analytics_db))
+
     import importlib
-    consolidate = importlib.import_module("scripts.documentation_consolidator").consolidate
+    import utils.log_utils as log_utils
+    importlib.reload(log_utils)
+    module = importlib.import_module("scripts.documentation_consolidator")
+    importlib.reload(module)
+    consolidate = module.consolidate
     consolidate()
 
     with sqlite3.connect(db_dir / "documentation.db") as conn:


### PR DESCRIPTION
## Summary
- update cross_database_sync_logger test to set workspace and fetch last entry
- reload modules in documentation_consolidator test so ANALYTICS_DB env var is respected

## Testing
- `ruff check .`
- `pytest tests/test_cross_database_sync_logger.py::test_log_sync_operation tests/test_documentation_consolidator.py::test_documentation_consolidator -q`
- `pytest tests/test_cross_platform_paths.py::test_workspace_fallback -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_688ad62127848331b19306bb62d6e1fb