### PR TITLE
Add log cleanup script and delayed file creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: create-env setup test lint
+.PHONY: create-env setup test lint clean-logs
 
 create-env:
 	python scripts/setup_environment.py
@@ -7,4 +7,7 @@ setup: create-env
 	pip install -r requirements-test.txt
 
 test: setup
-	pytest tests
+        pytest tests
+
+clean-logs:
+        bash scripts/clean_zero_logs.sh logs

--- a/README.md
+++ b/README.md
@@ -614,8 +614,9 @@ logger = setup_enterprise_logging()
 # Custom directory
 logger = setup_enterprise_logging(log_file="/var/log/gh_copilot/custom.log")
 ```
-
-Tests verify this logging mechanism as part of the DUAL COPILOT pattern.
+The underlying `FileHandler` uses delayed creation so log files aren't created
+until the first message, preventing empty logs. Tests verify this logging
+mechanism as part of the DUAL COPILOT pattern.
 
 ---
 
@@ -1019,6 +1020,7 @@ Several small modules provide common helpers:
 - `utils.reporting_utils.generate_json_report` – write data to a JSON file.
 - `utils.reporting_utils.generate_markdown_report` – produce a Markdown report.
 - `utils.validation_utils.detect_zero_byte_files` – find empty files for cleanup.
+- `scripts/clean_zero_logs.sh` – remove empty log files under `logs/` (run `make clean-logs`).
 - `utils.validation_utils.validate_path` – verify a path is inside the workspace and outside the backup root.
 - `scripts.optimization.physics_optimization_engine.PhysicsOptimizationEngine` –
   provides simulated quantum-inspired helpers such as Grover search or Shor factorization for physics-oriented optimizations.

--- a/scripts/clean_zero_logs.sh
+++ b/scripts/clean_zero_logs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${1:-logs}"
+
+if [ ! -d "$TARGET" ]; then
+    echo "Directory '$TARGET' does not exist."
+    exit 0
+fi
+
+zero_files=$(find "$TARGET" -type f -size 0 ! -path "*/.git/*")
+
+if [ -n "$zero_files" ]; then
+    echo "$zero_files" | xargs -r rm -f
+    echo "Removed zero-size log files:" >&2
+    echo "$zero_files" >&2
+else
+    echo "No zero-size log files to remove.";
+fi

--- a/tests/test_clean_zero_logs.py
+++ b/tests/test_clean_zero_logs.py
@@ -1,0 +1,37 @@
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "clean_zero_logs.sh"
+
+
+def run_script(workdir: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "logs",
+        ],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_missing_directory(tmp_path: Path) -> None:
+    result = run_script(tmp_path)
+    assert result.returncode == 0
+    assert "does not exist" in result.stdout
+
+
+def test_cleanup(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    empty = logs / "empty.log"
+    empty.touch()
+    result = run_script(tmp_path)
+    assert result.returncode == 0
+    assert "Removed zero-size" in result.stderr
+    assert not empty.exists()
+    # second run should report no files
+    result = run_script(tmp_path)
+    assert "No zero-size" in result.stdout

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -7,9 +7,7 @@ from pathlib import Path
 from utils.cross_platform_paths import CrossPlatformPathManager
 
 
-def setup_enterprise_logging(
-    level: str = "INFO", log_file: str = None
-) -> logging.Logger:
+def setup_enterprise_logging(level: str = "INFO", log_file: str = None) -> logging.Logger:
     """Setup enterprise-grade logging configuration"""
 
     if log_file is None:
@@ -21,7 +19,7 @@ def setup_enterprise_logging(
     logging.basicConfig(
         level=getattr(logging, level.upper()),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[logging.FileHandler(log_file), logging.StreamHandler()],
+        handlers=[logging.FileHandler(log_file, delay=True), logging.StreamHandler()],
     )
 
     return logging.getLogger("gh_COPILOT")


### PR DESCRIPTION
## Summary
- add `scripts/clean_zero_logs.sh` to remove zero-length files
- expose `clean-logs` target in `Makefile`
- delay creation of log files in `setup_enterprise_logging`
- document log cleanup usage and delayed handler behavior
- test cleanup script

## Testing
- `ruff check utils/logging_utils.py tests/test_clean_zero_logs.py`
- `pytest tests/test_clean_zero_logs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad6293520833180f7ccb129d67119