### PR TITLE
fix: log all rollbacks

### DIFF
--- a/scripts/correction_logger_and_rollback.py
+++ b/scripts/correction_logger_and_rollback.py
@@ -25,7 +25,10 @@ from typing import Dict, Any, Optional
 
 from tqdm import tqdm
 
-from enterprise_modules.compliance import validate_enterprise_operation
+from enterprise_modules.compliance import (
+    validate_enterprise_operation,
+    _log_rollback,
+)
 from scripts.database.add_violation_logs import ensure_violation_logs
 from scripts.database.add_rollback_logs import ensure_rollback_logs
 from scripts.database.add_rollback_strategy_history import (
@@ -210,6 +213,7 @@ class CorrectionLoggerRollback:
                     table="rollback_failures",
                     db_path=self.analytics_db,
                 )
+                _log_rollback(str(target), str(backup_path) if backup_path else None)
                 pbar.update(100)
                 return False
             pbar.update(25)
@@ -250,6 +254,7 @@ class CorrectionLoggerRollback:
                     table="rollback_logs",
                     db_path=self.analytics_db,
                 )
+                _log_rollback(str(target), str(backup_path) if backup_path else None)
                 return True
             else:
                 logging.error(f"Rollback failed for {target}")
@@ -269,6 +274,7 @@ class CorrectionLoggerRollback:
                     table="rollback_failures",
                     db_path=self.analytics_db,
                 )
+                _log_rollback(str(target), str(backup_path) if backup_path else None)
                 pbar.update(25)
                 return False
 

--- a/tests/test_rollback_failure_logging.py
+++ b/tests/test_rollback_failure_logging.py
@@ -10,6 +10,19 @@ def test_rollback_failure_logged(tmp_path, monkeypatch):
     db_dir = tmp_path / "databases"
     db_dir.mkdir()
     analytics_db = db_dir / "analytics.db"
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute("CREATE TABLE event_log (event TEXT)")
+        conn.commit()
+    def _ensure(db_path):
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS rollback_logs (target TEXT, backup TEXT, timestamp TEXT)"
+            )
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS rollback_failures (target TEXT, details TEXT, timestamp TEXT)"
+            )
+            conn.commit()
+    monkeypatch.setattr("enterprise_modules.compliance.ensure_rollback_logs", _ensure)
     logger = CorrectionLoggerRollback(analytics_db)
     monkeypatch.setattr(logger, "_record_strategy_history", lambda *a, **k: None)
     monkeypatch.setenv("GH_COPILOT_TEST_MODE", "0")
@@ -19,4 +32,6 @@ def test_rollback_failure_logged(tmp_path, monkeypatch):
 
     with sqlite3.connect(analytics_db) as conn:
         row = conn.execute("SELECT target FROM rollback_failures").fetchone()
+        rlog = conn.execute("SELECT target FROM rollback_logs").fetchone()
     assert row[0] == str(target)
+    assert rlog[0] == str(target)


### PR DESCRIPTION
## Summary
- update auto rollback to call compliance `_log_rollback` on success and failure
- ensure tests cover rollback_logs entries

## Testing
- `ruff check scripts/correction_logger_and_rollback.py tests/test_rollback_failure_logging.py tests/test_strategy_adaptation.py`
- `pytest tests/test_rollback_failure_logging.py tests/test_strategy_adaptation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad6bd894c8331983ec6dfe5202ad3