### PR TITLE
Enforce enterprise validation in orchestrators

### DIFF
--- a/scripts/enterprise_deployment_orchestrator.py
+++ b/scripts/enterprise_deployment_orchestrator.py
@@ -41,6 +41,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from enterprise_modules.compliance import validate_enterprise_operation
 from utils.cross_platform_paths import CrossPlatformPathManager
 
 
@@ -130,6 +132,9 @@ class EnterpriseDeploymentOrchestrator:
     """
 
     def __init__(self, workspace_path: Optional[str] = None):
+        # Validate enterprise operation before initializing
+        validate_enterprise_operation()
+
         # 🚀 MANDATORY: Start time logging with enterprise formatting
         self.start_time = datetime.now()
         self.session_id = f"DEPLOY_{self.start_time.strftime('%Y%m%d_%H%M%S')}"
@@ -190,6 +195,7 @@ class EnterpriseDeploymentOrchestrator:
     def execute_enterprise_deployment(self) -> Dict[str, Any]:
         """🚀 Execute comprehensive enterprise deployment"""
 
+        validate_enterprise_operation()
         primary_validate()
 
         # 🚀 MANDATORY: Visual processing indicators

--- a/scripts/enterprise_validation_orchestrator.py
+++ b/scripts/enterprise_validation_orchestrator.py
@@ -60,6 +60,8 @@ from typing import Any, Dict, List, Optional
 import psutil
 from tqdm import tqdm
 
+from enterprise_modules.compliance import validate_enterprise_operation
+
 # Configure comprehensive logging
 logging.basicConfig(
     level=logging.INFO,
@@ -201,6 +203,7 @@ class EnterpriseValidationOrchestrator:
 
     def __init__(self, workspace_path: Optional[str] = None, config: Optional[ValidationConfiguration] = None):
         """Initialize Enterprise Validation Orchestrator with comprehensive capabilities"""
+        validate_enterprise_operation()
         primary_validate()
         # CRITICAL: Anti-recursion validation
         self.validate_workspace_integrity()

--- a/tests/test_orchestrator_validation_calls.py
+++ b/tests/test_orchestrator_validation_calls.py
@@ -1,0 +1,48 @@
+import importlib
+
+import pytest
+
+from enterprise_modules import compliance
+
+
+@pytest.mark.parametrize(
+    "module_name,class_name,method_name",
+    [
+        ("scripts.enterprise_deployment_orchestrator", "EnterpriseDeploymentOrchestrator", "execute_enterprise_deployment"),
+        ("scripts.enterprise_validation_orchestrator", "EnterpriseValidationOrchestrator", None),
+        ("scripts.orchestrators.unified_wrapup_orchestrator", "UnifiedWrapUpOrchestrator", None),
+    ],
+)
+def test_orchestrators_call_validate(monkeypatch, tmp_path, module_name, class_name, method_name):
+    calls = []
+
+    def fake_validate(*_a, **_k):
+        calls.append(True)
+        return True
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path.parent / "backups"))
+    monkeypatch.setattr(compliance, "validate_enterprise_operation", fake_validate)
+
+    module = importlib.import_module(module_name)
+    cls = getattr(module, class_name)
+
+    if method_name is None:
+        cls(str(tmp_path))
+        assert calls
+    else:
+        # patch heavy operations
+        if module_name.endswith("enterprise_deployment_orchestrator"):
+            monkeypatch.setattr(cls, "_execute_pre_deployment_validation", lambda self: {"status": "OK", "score": 100})
+            monkeypatch.setattr(cls, "_deploy_core_systems", lambda self: {"status": "OK", "score": 100})
+            monkeypatch.setattr(cls, "_deploy_database_systems", lambda self: {"status": "OK", "score": 100})
+            monkeypatch.setattr(cls, "_deploy_integration_systems", lambda self: {"status": "OK", "score": 100})
+            monkeypatch.setattr(cls, "_deploy_security_systems", lambda self: {"status": "OK", "score": 100})
+            monkeypatch.setattr(cls, "_deploy_monitoring_systems", lambda self: {"status": "OK", "score": 100})
+            monkeypatch.setattr(cls, "_execute_post_deployment_validation", lambda self: {"status": "OK", "score": 100})
+            monkeypatch.setattr(cls, "_log_deployment_summary", lambda self, *_a, **_k: None)
+        obj = cls(str(tmp_path))
+        assert calls
+        calls.clear()
+        getattr(obj, method_name)()
+        assert calls


### PR DESCRIPTION
## Summary
- call `validate_enterprise_operation()` in enterprise deployment, validation and wrapup orchestrators
- add unit tests to ensure the orchestrators trigger validation

## Testing
- `ruff check scripts/enterprise_deployment_orchestrator.py scripts/enterprise_validation_orchestrator.py scripts/orchestrators/unified_wrapup_orchestrator.py tests/test_orchestrator_validation_calls.py`
- `pytest tests/test_orchestrator_validation_calls.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad6bb5360833183865f7c2940f800