### PR TITLE
feat: log recursion alerts

### DIFF
--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager
+from utils.log_utils import send_dashboard_alert
 
 from scripts.database.add_violation_logs import ensure_violation_logs
 from scripts.database.add_rollback_logs import ensure_rollback_logs
@@ -79,6 +80,7 @@ def validate_enterprise_operation(
 
     if _detect_recursion(workspace):
         _log_violation("recursive_workspace")
+        send_dashboard_alert({"event": "recursive_workspace", "path": str(workspace)})
         violations.append("recursive_workspace")
 
     # Disallow backup directories inside the workspace
@@ -104,6 +106,7 @@ def validate_enterprise_operation(
 
     if _detect_recursion(path):
         _log_violation("recursive_target")
+        send_dashboard_alert({"event": "recursive_target", "path": str(path)})
         violations.append("recursive_target")
 
     # Cleanup forbidden backup folders within workspace

--- a/tests/test_compliance_module.py
+++ b/tests/test_compliance_module.py
@@ -12,14 +12,21 @@ from enterprise_modules.compliance import (
 def test_recursion_detection(tmp_path: Path) -> None:
     nested = tmp_path / tmp_path.name
     nested.mkdir()
-    with patch.dict('os.environ', {"GH_COPILOT_WORKSPACE": str(tmp_path)}):
+    with patch.dict("os.environ", {"GH_COPILOT_WORKSPACE": str(tmp_path)}):
         assert not validate_enterprise_operation(str(tmp_path))
         db = tmp_path / "databases" / "analytics.db"
         with sqlite3.connect(db) as conn:
-            details = conn.execute(
-                "SELECT details FROM violation_logs"
-            ).fetchall()
+            details = conn.execute("SELECT details FROM violation_logs").fetchall()
         assert any("recursive_" in d[0] for d in details)
+
+
+def test_dashboard_alert_on_recursion(tmp_path: Path) -> None:
+    nested = tmp_path / tmp_path.name
+    nested.mkdir()
+    with patch.dict("os.environ", {"GH_COPILOT_WORKSPACE": str(tmp_path)}):
+        with patch("enterprise_modules.compliance.send_dashboard_alert") as alert:
+            validate_enterprise_operation(str(tmp_path))
+            assert alert.call_count >= 1
 
 
 def test_recursion_symlink(tmp_path: Path) -> None:
@@ -32,11 +39,9 @@ def test_recursion_symlink(tmp_path: Path) -> None:
 
 
 def test_log_rollback(tmp_path: Path) -> None:
-    with patch.dict('os.environ', {"GH_COPILOT_WORKSPACE": str(tmp_path)}):
+    with patch.dict("os.environ", {"GH_COPILOT_WORKSPACE": str(tmp_path)}):
         _log_rollback("file.py", "file.py.bak")
         db = tmp_path / "databases" / "analytics.db"
         with sqlite3.connect(db) as conn:
-            row = conn.execute(
-                "SELECT target, backup FROM rollback_logs"
-            ).fetchone()
+            row = conn.execute("SELECT target, backup FROM rollback_logs").fetchone()
         assert row == ("file.py", "file.py.bak")


### PR DESCRIPTION
## Summary
- log recursion alerts when validating enterprise operations
- assert dashboard alerts triggered when recursion is detected

## Testing
- `ruff check enterprise_modules/compliance.py tests/test_compliance_module.py`
- `pyright enterprise_modules/compliance.py tests/test_compliance_module.py`
- `pytest tests/test_compliance_module.py::test_dashboard_alert_on_recursion tests/test_compliance_module.py::test_recursion_detection tests/test_compliance_module.py::test_recursion_symlink tests/test_compliance_module.py::test_log_rollback`

------
https://chatgpt.com/codex/tasks/task_e_688ad6bff870833180af99679d948828