### PR TITLE
feat: enforce policy-driven path validation

### DIFF
--- a/config/enterprise.json
+++ b/config/enterprise.json
@@ -1,0 +1,3 @@
+{
+  "forbidden_paths": ["*temp*"]
+}

--- a/docs/ENVIRONMENT_CONFIGURATION.md
+++ b/docs/ENVIRONMENT_CONFIGURATION.md
@@ -46,3 +46,15 @@ ls -l /usr/local/bin/clw
 
 ## Archival Databases
 `archive.db` and `staging.db` are no longer included by default. They have been moved to `archived_databases/` and are also available in the project's GitHub releases. Download them if legacy analysis is required and place them under the `archived_databases/` directory.
+
+## Enterprise Configuration
+
+Workspace policies are defined in `config/enterprise.json`. The file currently specifies path patterns that compliance checks remove or block:
+
+```json
+{
+  "forbidden_paths": ["*temp*"]
+}
+```
+
+Set `CONFIG_PATH` to load a custom configuration file.

--- a/tests/test_disallowed_paths.py
+++ b/tests/test_disallowed_paths.py
@@ -11,8 +11,13 @@ def test_validate_enterprise_operation_disallowed_path(tmp_path: Path) -> None:
     disallowed_dir = tmp_path / "temp"
     disallowed_dir.mkdir()
     (disallowed_dir / "dummy.txt").write_text("data")
+    (tmp_path / "logs").mkdir()
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    (cfg_dir / "enterprise.json").write_text('{"forbidden_paths": ["*temp*"]}')
 
-    with patch.dict(os.environ, {"GH_COPILOT_WORKSPACE": str(tmp_path)}):
+    env = {"GH_COPILOT_WORKSPACE": str(tmp_path), "CONFIG_PATH": str(cfg_dir / "enterprise.json")}
+    with patch.dict(os.environ, env):
         with patch("os.getcwd", return_value=str(tmp_path)):
             assert not validate_enterprise_operation()
 
@@ -22,7 +27,23 @@ def test_validate_enterprise_operation_disallowed_path(tmp_path: Path) -> None:
 def test_validate_enterprise_operation_ignores_venv(tmp_path: Path) -> None:
     venv_backup = tmp_path / ".venv" / "lib" / "python" / "site-packages" / "botocore" / "data" / "backup"
     venv_backup.mkdir(parents=True)
+    (tmp_path / "logs").mkdir()
 
     with patch.dict(os.environ, {"GH_COPILOT_WORKSPACE": str(tmp_path)}):
         with patch("os.getcwd", return_value=str(tmp_path)):
             assert validate_enterprise_operation()
+
+
+def test_validate_enterprise_operation_policy_paths(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "enterprise.json").write_text('{"forbidden_paths": ["*secret*"]}')
+    secret = tmp_path / "secret"
+    secret.mkdir()
+    (tmp_path / "logs").mkdir()
+
+    env = {"GH_COPILOT_WORKSPACE": str(tmp_path), "CONFIG_PATH": str(config_dir / "enterprise.json")}
+    with patch.dict(os.environ, env):
+        with patch("os.getcwd", return_value=str(tmp_path)):
+            assert not validate_enterprise_operation()
+    assert not secret.exists()


### PR DESCRIPTION
## Summary
- read `forbidden_paths` from `config/enterprise.json`
- ignore `.venv` when cleaning backup folders
- update docs on enterprise configuration
- test policy-based forbidden paths

## Testing
- `ruff check enterprise_modules/compliance.py`
- `ruff format enterprise_modules/compliance.py tests/test_disallowed_paths.py`
- `pytest tests/test_disallowed_paths.py`

------
https://chatgpt.com/codex/tasks/task_e_688ad6c378948331904b80abaa6a9bec