### PR TITLE
Unify production.db default path

### DIFF
--- a/db_tools/cli/commands.py
+++ b/db_tools/cli/commands.py
@@ -7,6 +7,8 @@ import argparse
 import sys
 from pathlib import Path
 
+from utils.cross_platform_paths import CrossPlatformPathManager
+
 from ..operations.access import DatabaseAccessLayer
 from ..operations.cleanup import DatabaseCleanupProcessor
 from ..operations.compliance import DatabaseComplianceChecker
@@ -46,7 +48,11 @@ class DatabaseCLI:
         )
         access_parser.add_argument(
             '--database',
-            default='production.db',
+            default=str(
+                CrossPlatformPathManager.get_workspace_path()
+                / 'databases'
+                / 'production.db'
+            ),
             help='Database path'
         )
 

--- a/db_tools/operations/access.py
+++ b/db_tools/operations/access.py
@@ -7,7 +7,9 @@ import sys
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+
+from utils.cross_platform_paths import CrossPlatformPathManager
 
 from ..core.connection import DatabaseConnection
 from ..core.exceptions import DatabaseError
@@ -26,7 +28,13 @@ TEXT_INDICATORS = {
 class DatabaseAccessLayer:
     """Enterprise database access layer with enhanced functionality"""
 
-    def __init__(self, database_path: str = "production.db"):
+    def __init__(self, database_path: Optional[str | Path] = None):
+        if database_path is None:
+            database_path = (
+                CrossPlatformPathManager.get_workspace_path()
+                / "databases"
+                / "production.db"
+            )
         self.database_path = Path(database_path)
         self.db_connection = DatabaseConnection(self.database_path)
         self.logger = logging.getLogger(__name__)

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -38,7 +38,8 @@ try:
 except Exception:  # pragma: no cover - allow lazy import
     UnifiedWrapUpOrchestrator = None
 
-DB_PATH = Path(os.getenv("WLC_DB_PATH", "databases/production.db"))
+DEFAULT_DB = CrossPlatformPathManager.get_workspace_path() / "databases" / "production.db"
+DB_PATH = Path(os.getenv("WLC_DB_PATH", str(DEFAULT_DB)))
 
 
 def get_connection(db_path: Path) -> sqlite3.Connection:
@@ -92,7 +93,12 @@ def finalize_session_entry(
 
 def validate_environment() -> bool:
     """Validate enterprise workspace and backup paths."""
-    validate_enterprise_environment()
+    try:
+        validate_enterprise_environment()
+    except EnvironmentError as exc:
+        raise EnvironmentError(
+            "Required environment variables are not set or paths invalid"
+        ) from exc
     return True
 
 

--- a/tests/test_comprehensive_workspace_manager_cli.py
+++ b/tests/test_comprehensive_workspace_manager_cli.py
@@ -30,6 +30,7 @@ def test_cli_start_end(tmp_path):
         env=env,
         capture_output=True,
         text=True,
+        cwd=str(tmp_path),
     )
     assert result.returncode == 0
 
@@ -38,6 +39,7 @@ def test_cli_start_end(tmp_path):
         env=env,
         capture_output=True,
         text=True,
+        cwd=str(tmp_path),
     )
     assert result.returncode == 0
 


### PR DESCRIPTION
## Summary
- ensure wlc_session_manager uses workspace-root database path
- align DatabaseAccessLayer and db-tools CLI with the same default
- make environment validation more consistent
- run COMPREHENSIVE_WORKSPACE_MANAGER CLI tests from the temp workspace

## Testing
- `ruff check scripts/wlc_session_manager.py db_tools/operations/access.py db_tools/cli/commands.py tests/test_comprehensive_workspace_manager_cli.py`
- `pytest -q tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_comprehensive_workspace_manager.py tests/test_comprehensive_workspace_manager_cli.py tests/test_optimization_cli.py tests/test_web_gui_integrator_registration.py tests/test_workspace_optimizer.py tests/test_autonomous_backup_manager.py tests/test_file_manager_organization.py tests/test_new_placeholders.py tests/test_unified_deployment_orchestrator_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_688ad70af0608331b75641b27f50beee