### PR TITLE
Add optional websockets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,8 @@ python dashboard/enterprise_dashboard.py  # wrapper for web_gui Flask app
 ### Enable Streaming
 
 Set the environment variable `LOG_WEBSOCKET_ENABLED=1` to allow real-time
-log broadcasting over WebSockets. The dashboard's `/metrics_stream` endpoint
+log broadcasting over WebSockets. Install the optional `websockets` package
+(`pip install websockets`) to enable this feature. The dashboard's `/metrics_stream` endpoint
 uses Server-Sent Events by default and works with Flask's ``Response`` when
 `sse_event_stream` is provided from ``utils.log_utils``.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ qiskit-aer==0.17.1  # Omit if not imported
 
 # --- Any other verified code dependencies can go here ---
 py7zr
+websockets>=10.4  # Optional real-time streaming
 
 # ===========================
 # End of requirements

--- a/tests/test_log_utils_manage.py
+++ b/tests/test_log_utils_manage.py
@@ -1,3 +1,4 @@
+import logging
 from utils.log_utils import (
     _clear_log,
     _list_events,
@@ -31,7 +32,7 @@ def test_sse_category(tmp_path):
     assert "data:" in first
 
 
-def test_websocket_broadcast_skips(monkeypatch):
+def test_websocket_broadcast_skips(monkeypatch, caplog):
     monkeypatch.setenv("LOG_WEBSOCKET_ENABLED", "1")
     import builtins as blt
 
@@ -43,5 +44,7 @@ def test_websocket_broadcast_skips(monkeypatch):
         return orig_import(name, *args, **kwargs)
 
     monkeypatch.setattr(blt, "__import__", fake_import)
-    start_websocket_broadcast(port=8766)
+    with caplog.at_level(logging.WARNING):
+        start_websocket_broadcast(port=8766)
+    assert any("websockets package not available" in rec.getMessage() for rec in caplog.records)
     monkeypatch.setattr(blt, "__import__", orig_import)

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -573,11 +573,12 @@ def start_websocket_broadcast(
         return
 
     try:
-        import asyncio
         import websockets
     except ImportError:  # pragma: no cover - optional dependency
-        logging.getLogger(__name__).warning("websockets package not available")
+        logging.getLogger(__name__).warning("websockets package not available - skipping broadcast")
         return
+
+    import asyncio
 
     clients: set = set()
 


### PR DESCRIPTION
## Summary
- include websockets dependency
- gracefully skip websocket broadcast when websockets isn't installed
- mention websockets dependency in README
- test warning when websockets is missing

## Testing
- `ruff format --check utils/log_utils.py tests/test_log_utils_manage.py`
- `pytest tests/test_log_utils_manage.py::test_websocket_broadcast_skips -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad74428c48331adf675c3c9dfc310