### PR TITLE
fix: use cross-platform workspace detection

### DIFF
--- a/template_engine/db_first_code_generator.py
+++ b/template_engine/db_first_code_generator.py
@@ -8,7 +8,7 @@ raised if invalid templates are encountered or if recursion safeguards fail.
 from __future__ import annotations
 
 import logging
-import os
+from utils.cross_platform_paths import CrossPlatformPathManager
 import sqlite3
 import sys
 import time
@@ -66,7 +66,7 @@ logger = logging.getLogger(__name__)
 
 
 def validate_no_recursive_folders() -> None:
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace_root = CrossPlatformPathManager.get_workspace_path()
     forbidden_patterns = ["*backup*", "*_backup_*", "backups", "*temp*"]
     for pattern in forbidden_patterns:
         for folder in workspace_root.rglob(pattern):

--- a/template_engine/pattern_clustering_sync.py
+++ b/template_engine/pattern_clustering_sync.py
@@ -22,13 +22,15 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from utils.cross_platform_paths import CrossPlatformPathManager
+
 import numpy as np
 from sklearn.cluster import KMeans
 from tqdm import tqdm
 
 from enterprise_modules.compliance import validate_enterprise_operation
 
-LOGS_DIR = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "logs" / "pattern_clustering_sync"
+LOGS_DIR = CrossPlatformPathManager.get_workspace_path() / "logs" / "pattern_clustering_sync"
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"pattern_clustering_sync_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 
@@ -38,9 +40,9 @@ logging.basicConfig(
     handlers=[logging.FileHandler(LOG_FILE), logging.StreamHandler()],
 )
 
-PRODUCTION_DB = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "databases" / "production.db"
-TEMPLATE_DB = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "databases" / "template_documentation.db"
-SYNC_AUDIT_DB = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT")) / "databases" / "sync_audit.db"
+PRODUCTION_DB = CrossPlatformPathManager.get_workspace_path() / "databases" / "production.db"
+TEMPLATE_DB = CrossPlatformPathManager.get_workspace_path() / "databases" / "template_documentation.db"
+SYNC_AUDIT_DB = CrossPlatformPathManager.get_workspace_path() / "databases" / "sync_audit.db"
 
 
 class PatternClusteringSync:
@@ -239,9 +241,9 @@ def main(
     logging.info(f"Start Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     logging.info(f"Process ID: {process_id}")
 
-    validate_enterprise_operation(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    validate_enterprise_operation(str(CrossPlatformPathManager.get_workspace_path()))
 
-    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace = CrossPlatformPathManager.get_workspace_path()
     production_db = Path(production_db_path or workspace / "databases" / "production.db")
     template_db = Path(template_db_path or workspace / "databases" / "template_documentation.db")
     audit_db = Path(audit_db_path or workspace / "databases" / "sync_audit.db")

--- a/template_engine/template_placeholder_remover.py
+++ b/template_engine/template_placeholder_remover.py
@@ -19,6 +19,7 @@ from typing import List
 
 from tqdm import tqdm
 from utils.log_utils import ensure_tables
+from utils.cross_platform_paths import CrossPlatformPathManager
 
 DEFAULT_PRODUCTION_DB = Path("databases/production.db")
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
@@ -36,7 +37,7 @@ _PLACEHOLDER_RE = re.compile(r"{{\s*([A-Z0-9_]+)\s*}}")
 
 
 def validate_no_recursive_folders() -> None:
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace_root = CrossPlatformPathManager.get_workspace_path()
     forbidden_patterns = ["*backup*", "*_backup_*", "backups", "*temp*"]
     for pattern in forbidden_patterns:
         for folder in workspace_root.rglob(pattern):


### PR DESCRIPTION
## Summary
- use `CrossPlatformPathManager.get_workspace_path()` instead of `"e:/gh_COPILOT"` fallback
- apply updates in `db_first_code_generator`, `pattern_clustering_sync`, and `template_placeholder_remover`

## Testing
- `ruff check template_engine/db_first_code_generator.py template_engine/pattern_clustering_sync.py template_engine/template_placeholder_remover.py template_engine/workflow_enhancer.py`
- `pytest -q` *(fails: KeyboardInterrupt, 31 failed, 320 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688ad75d88788331ad3c8675757ffe2e