### PR TITLE
Fix setup exit when backup dir unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ cp .env.example .env
 # The `OPENAI_API_KEY` variable enables modules in `github_integration/openai_connector.py`.
 # Generate strong secrets with `python -c "import secrets; print(secrets.token_hex(32))"`.
 
-# 2. Run setup script (creates `.venv` and installs requirements)
+# 2. Set the external backup directory and run the setup script
+export GH_COPILOT_BACKUP_ROOT=/path/to/external/backups
 bash setup.sh
 # Always run this script before executing tests or automation tasks.
 # The setup process installs packages from all `requirements*.txt` files,

--- a/docs/ENVIRONMENT_CONFIGURATION.md
+++ b/docs/ENVIRONMENT_CONFIGURATION.md
@@ -5,7 +5,7 @@ This guide explains how to configure environment variables for the gh_COPILOT to
 ## Required Variables
 
 - `GH_COPILOT_WORKSPACE`: Absolute path to the repository workspace. Used by tests and scripts to locate databases and configuration files. If unset, tools default to the current working directory.
-- `GH_COPILOT_BACKUP_ROOT`: External directory for backups. Must not reside inside the workspace. Defaults to `E:/temp/gh_COPILOT_Backups` on Windows or `/tmp/<user>/gh_COPILOT_Backups` on Linux.
+- `GH_COPILOT_BACKUP_ROOT`: External directory for backups. **This variable is required.** Set it to a folder outside the workspace before running `setup.sh`.
 
 Set these variables by editing the provided `.env` file:
 

--- a/docs/REPOSITORY_GUIDELINES.md
+++ b/docs/REPOSITORY_GUIDELINES.md
@@ -42,7 +42,7 @@ source .venv/bin/activate
 ### 4. Workspace and Backup Variables
 Set the following environment variables in your shell configuration (or load them dynamically using `.env` files):
 - **`GH_COPILOT_WORKSPACE`:** Specifies the repository workspace.
-- **`GH_COPILOT_BACKUP_ROOT`:** Ensures backups and logs are stored outside the workspace to prevent recursive violations. If unset, the system defaults to `/tmp/<user>/gh_COPILOT_Backups` on Linux.
+- **`GH_COPILOT_BACKUP_ROOT`:** Ensures backups and logs are stored outside the workspace to prevent recursive violations. **This variable must be defined before running `setup.sh`.**
 - **`CLW_MAX_LINE_LENGTH`:** Optional terminal output wrap length. Set to `1550` to avoid exceeding the 1600-byte console limit when using `clw`.
 - **`API_SECRET_KEY`:** Secret used by the Enterprise API. Set this or provide `api_secret_key` in your config file.
 - **`FLASK_ENV`:** Set to `production` to disable debug mode in the Enterprise API server.

--- a/docs/initial_phase_steps.md
+++ b/docs/initial_phase_steps.md
@@ -1,7 +1,7 @@
 # Initial Phase Steps
 
 ## Environment Setup
-- Executed `bash setup.sh` which advised setting `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT`.
+- Executed `bash setup.sh` after defining `GH_COPILOT_BACKUP_ROOT` to an external directory.
 - Activated the project virtual environment.
 - Confirmed `/usr/local/bin/clw` availability for safe output handling.
 

--- a/setup.sh
+++ b/setup.sh
@@ -28,10 +28,10 @@ if [ ! -x /usr/local/bin/clw ]; then
 fi
 
 if [ -z "${GH_COPILOT_BACKUP_ROOT:-}" ]; then
-    echo "GH_COPILOT_BACKUP_ROOT not set. Please set it outside the workspace." >&2
-else
-    export GH_COPILOT_BACKUP_ROOT
+    echo "Error: GH_COPILOT_BACKUP_ROOT not set. Please set it to an external backup directory." >&2
+    exit 1
 fi
+export GH_COPILOT_BACKUP_ROOT
 
 echo "Environment initialized. Activate with 'source .venv/bin/activate'"
 echo "Set GH_COPILOT_WORKSPACE=$WORKSPACE and GH_COPILOT_BACKUP_ROOT to an external path before running tools."


### PR DESCRIPTION
## Summary
- exit `setup.sh` if `GH_COPILOT_BACKUP_ROOT` isn't defined
- document required backup directory in README and docs
- clarify initial steps about defining the variable

## Testing
- `ruff check .` *(fails: F401 unused imports)*
- `pytest -q` *(interrupted: tests running)*

------
https://chatgpt.com/codex/tasks/task_e_688ad76ab1f883319a7abf6d07d3b450