### PR TITLE
Enhance scoring persistence and correction metrics

### DIFF
--- a/tests/test_objective_similarity_scorer.py
+++ b/tests/test_objective_similarity_scorer.py
@@ -118,3 +118,22 @@ def test_weights_dict_missing_key(tmp_path: Path) -> None:
             methods=["tfidf", "jaccard"],
             weights={"tfidf": 1.0},
         )
+
+
+def test_similarity_scores_persist_json(tmp_path: Path) -> None:
+    prod = tmp_path / "production.db"
+    analytics = tmp_path / "analytics.db"
+    log_dir = tmp_path / "logs"
+    with sqlite3.connect(prod) as conn:
+        conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
+        conn.execute("INSERT INTO code_templates (template_code) VALUES ('foo')")
+    scores = compute_similarity_scores(
+        "foo",
+        prod,
+        analytics,
+        timeout_minutes=1,
+        persist_json_dir=log_dir,
+    )
+    assert scores
+    files = list(log_dir.glob("similarity_scores_*.json"))
+    assert files


### PR DESCRIPTION
## Summary
- add persistence to objective similarity scorer
- improve correction history with metrics for rollback
- update documentation analyzer to record fix rates
- extend tests for new logging features

## Testing
- `ruff check template_engine/objective_similarity_scorer.py scripts/database/documentation_db_analyzer.py tests/test_objective_similarity_scorer.py tests/test_documentation_db_analyzer_new.py`
- `pytest -q` *(fails: environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688ad76dbe908331862847eba19e3eb1