### PR TITLE
feat: inject secret key into container builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    env:
+      FLASK_SECRET_KEY: ${{ secrets.FLASK_SECRET_KEY || 'test_secret' }}
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]
@@ -89,6 +91,8 @@ jobs:
   docker-build:
     needs: lint-test
     runs-on: ubuntu-latest
+    env:
+      FLASK_SECRET_KEY: ${{ secrets.FLASK_SECRET_KEY || 'test_secret' }}
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]
@@ -145,6 +149,8 @@ jobs:
 
   codeql:
     runs-on: ubuntu-latest
+    env:
+      FLASK_SECRET_KEY: ${{ secrets.FLASK_SECRET_KEY || 'test_secret' }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/compliance-audit.yml
+++ b/.github/workflows/compliance-audit.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_COPILOT_WORKSPACE: ${{ github.workspace }}
+      FLASK_SECRET_KEY: ${{ secrets.FLASK_SECRET_KEY || 'test_secret' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       GH_COPILOT_WORKSPACE: ${{ github.workspace }}
       GH_COPILOT_BACKUP_ROOT: /tmp/gh_copilot_backup
+      FLASK_SECRET_KEY: ${{ secrets.FLASK_SECRET_KEY || 'test_secret' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -298,12 +298,14 @@ Build and run the container with Docker:
 docker build -t gh_copilot .
 docker run -p 5000:5000 \
   -e GH_COPILOT_BACKUP_ROOT=/path/to/backups \
+  -e FLASK_SECRET_KEY=<generated_secret> \
   gh_copilot
 ```
 
 `entrypoint.sh` sets `GH_COPILOT_WORKSPACE` to `/app` and `GH_COPILOT_BACKUP_ROOT` to `/backup` when unspecified. It then executes `unified_database_initializer.py` to bootstrap `production.db` and `analytics.db` before launching the dashboard. Map `/backup` to a host directory so logs persist.
 
 When launching with Docker Compose, the provided `docker-compose.yml` mounts `${GH_COPILOT_BACKUP_ROOT:-/backup}` at `/backup` and passes environment variables from `.env`. Ensure `GH_COPILOT_BACKUP_ROOT` is configured on the host so backups survive container restarts.
+`FLASK_SECRET_KEY` must also be provided—either via `.env` or by setting the variable when invoking Docker commands.
 
 ### Wrapping, Logging, and Compliance (WLC)
 Run the session manager after setting the workspace and backup paths:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - GH_COPILOT_WORKSPACE=/app
       - GH_COPILOT_BACKUP_ROOT=/backup
+      - FLASK_SECRET_KEY=${FLASK_SECRET_KEY:-your_secret_key}
     volumes:
       - .:/app
       - ${GH_COPILOT_BACKUP_ROOT:-/backup}:/backup
@@ -15,6 +16,7 @@ services:
     environment:
       - GH_COPILOT_WORKSPACE=/app
       - GH_COPILOT_BACKUP_ROOT=/backup
+      - FLASK_SECRET_KEY=${FLASK_SECRET_KEY:-your_secret_key}
     volumes:
       - .:/app
       - ${GH_COPILOT_BACKUP_ROOT:-/backup}:/backup
@@ -35,6 +37,7 @@ services:
     environment:
       - GH_COPILOT_WORKSPACE=/app
       - GH_COPILOT_BACKUP_ROOT=/backup
+      - FLASK_SECRET_KEY=${FLASK_SECRET_KEY:-your_secret_key}
     volumes:
       - .:/app
       - ${GH_COPILOT_BACKUP_ROOT:-/backup}:/backup


### PR DESCRIPTION
## Summary
- pass `FLASK_SECRET_KEY` via docker-compose
- ensure GitHub Actions provide a default secret key
- mention `FLASK_SECRET_KEY` in README Docker instructions

## Testing
- `ruff check copilot`
- `pyright copilot`
- `pytest tests/test_entrypoint_env.py::test_entrypoint_requires_env` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_688ad7712e448331acdbad22dbe2c821