### PR TITLE
docs: revise whitepaper modules and DB counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ gh_COPILOT/
 │   ├── validation/          # Enterprise validation framework
 │   ├── database/            # Database management
 │   └── automation/          # Autonomous operations
-├── databases/               # 24 synchronized databases
+├── databases/               # 27 synchronized databases
 ├── web_gui/                 # Flask enterprise dashboard
 ├── documentation/           # Comprehensive documentation
 ├── .github/instructions/    # GitHub Copilot instruction modules

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -8,6 +8,7 @@
 | 2025-07-10 | v4.0 | Initial release |
 | 2025-07-30 | v4.1 | Module audit and testing status updates |
 | 2025-07-31 | v4.2 | Documentation updates for current modules and databases |
+| 2025-08-01 | v4.3 | Module list corrections and database count update |
 
 ---
 
@@ -28,7 +29,7 @@ The gh_COPILOT Toolkit v4.0 represents a revolutionary enterprise-grade automati
 - **Quantum-Enhanced Processing**: placeholder algorithms under exploration
 - *All Qiskit-based functions run in simulation mode by default. Install `qiskit-ibm-provider` and set the optional `QISKIT_IBM_TOKEN` environment variable to use real IBM Quantum hardware.*
 - **Enterprise Security Framework**: Zero-tolerance anti-recursion and comprehensive session integrity
-- *Note: earlier drafts referenced a 32+ database ecosystem. The current repository contains **24** SQLite databases for testing.*
+ - *Note: earlier drafts referenced a 32+ database ecosystem. The current repository contains **27** SQLite databases for testing.*
 
 ---
 
@@ -42,9 +43,9 @@ The gh_COPILOT Toolkit v4.0 represents a revolutionary enterprise-grade automati
 | `unified_script_generation_system.py` | Present |
 | `unified_session_management_system.py` | Present |
 | `unified_database_management_system.py` | Present |
-| `unified_disaster_recovery_system.py` | Experimental – incomplete implementation |
+| `unified_disaster_recovery_system.py` | Planned – partial implementation |
 | `unified_legacy_cleanup_system.py` | Present in `scripts/` directory |
-| `web_gui_integration_system.py` | Experimental – incomplete integration |
+| `web_gui_integration_system.py` | Planned – partial integration |
 
 ### **1. Unified Monitoring & Optimization System**
 **File**: [`unified_monitoring_optimization_system.py`](unified_monitoring_optimization_system.py)
@@ -158,7 +159,7 @@ class UnifiedSessionManagementSystem:
 
 ### **4. Unified Disaster Recovery System**
 **File**: [`unified_disaster_recovery_system.py`](unified_disaster_recovery_system.py)
-*Experimental module – implementation limited to deployment stubs.*
+*Planned module – implementation limited to deployment stubs.*
 
 #### **Technical Intent**
 - **Primary Function**: Enterprise-grade backup, recovery, and business continuity
@@ -233,7 +234,7 @@ class UnifiedLegacyCleanupSystem:
 
 ### **6. Web-GUI Integration System**
 **File**: [`web_gui_integration_system.py`](web_gui_integration_system.py)
-*Experimental module – present only in deployment packages.*
+*Planned module – present only in deployment packages.*
 
 #### **Technical Intent**
 - **Primary Function**: Enterprise-grade web interface for system management and monitoring
@@ -975,7 +976,7 @@ class Phase5AIIntegrationEngine:
 ```
 
 ### **Quantum Optimization Engine (Placeholder)**
-*Experimental placeholder – algorithms not yet implemented.*
+*Planned placeholder – algorithms not yet implemented.*
 ```python
 class QuantumOptimizationEngine:
     """⚛️ Quantum-enhanced processing (aspirational implementation)"""


### PR DESCRIPTION
## Summary
- document module statuses and update version table
- correct database count to 27 in docs and README
- mark Web GUI and quantum routines as planned components

## Testing
- `ruff check documentation/`
- `pyright documentation/`
- `pytest -k template_selection -q` *(fails: OperationalError in log_utils)*

------
https://chatgpt.com/codex/tasks/task_e_688ad7ab39248331a00440f0238e34a9