### PR TITLE
Clarify experimental systems and update database counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🎯 gh_COPILOT Toolkit v4.0 Enterprise
 ## High-Performance HTTP Archive (HAR) Analysis with Advanced Enterprise Integration
 
-![GitHub Copilot Integration](https://img.shields.io/badge/GitHub_Copilot-Enterprise_Ready-brightgreen)
+![GitHub Copilot Integration](https://img.shields.io/badge/GitHub_Copilot-Enterprise_Integration_Experimental-orange)
 ![Learning Patterns](https://img.shields.io/badge/Learning_Patterns-ongoing-yellow)
 ![DUAL COPILOT](https://img.shields.io/badge/DUAL_COPILOT-Pattern_Validated-orange)
 ![Database First](https://img.shields.io/badge/Database_First-Architecture_Complete-purple)
@@ -14,7 +14,7 @@
 
 ## 📊 SYSTEM OVERVIEW
 
-The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. **Many features remain experimental or stubbed; quantum functionality is simulated only and several modules are still incomplete.**
+The gh_COPILOT toolkit aims to be an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. **Many features remain experimental or stubbed; quantum functionality is simulated only and several modules are still incomplete.**
 
 > **Note**
 > Qiskit-based operations run in **simulation mode** unless hardware access is configured. Install `qiskit-ibm-provider` and set the optional `QISKIT_IBM_TOKEN` environment variable to use real IBM Quantum backends.
@@ -41,7 +41,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 
 ### 🏆 **Enterprise Achievements**
  - ✅ **Script Validation**: 1,679 scripts synchronized
- - **30 Synchronized Databases**: Enterprise data management
+ - **24 Synchronized Databases**: Enterprise data management
 
 ---
 
@@ -51,13 +51,13 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Multiple SQLite Databases:** `databases/production.db`, `databases/analytics.db`, `databases/monitoring.db`
 - [ER Diagrams](docs/ER_DIAGRAMS.md) for key databases
 - **Flask Enterprise Dashboard:** basic endpoints and templates
-- **Template Intelligence Platform:** tracks generated scripts
+ - **Template Intelligence Platform (experimental):** tracks generated scripts
 - **Documentation logs:** rendered templates saved under `logs/template_rendering/`
 - **Script Validation**: automated checks available
 - **Self-Healing Systems:** experimental correction scripts
 - **Autonomous File Management:** see [Using AutonomousFileManager](docs/USING_AUTONOMOUS_FILE_MANAGER.md)
-- **Continuous Operation Mode:** optional monitoring utilities
-- **Quantum Monitoring Scripts:** `scripts/monitoring/continuous_operation_monitor.py`,
+ - **Continuous Operation Mode (experimental):** optional monitoring utilities
+ - **Quantum Monitoring Scripts (experimental):** `scripts/monitoring/continuous_operation_monitor.py`,
     `scripts/monitoring/enterprise_compliance_monitor.py`, and
     `scripts/monitoring/unified_monitoring_optimization_system.py`.
     *(Experimental – not fully implemented)*
@@ -368,7 +368,7 @@ See [docs/WLC_SESSION_MANAGER.md](docs/WLC_SESSION_MANAGER.md) for a full exampl
 
 ### **Primary Databases**
 
-The repository currently maintains **27** active SQLite databases under
+The repository currently maintains **24** active SQLite databases under
 `databases/`:
 
 ```text
@@ -512,7 +512,7 @@ Secondary Validator COPILOT (B)
 ├── Verify visual processing
 └── Approve or reject with feedback
      ↓
-Enterprise-Grade Output
+Toward Enterprise-Grade Output (tests pending)
 ```
 
 Optimization and security scripts must invoke their main logic via
@@ -771,7 +771,7 @@ The project tracks several learning patterns. Current integration status:
 - **DUAL COPILOT Pattern:** 96.8% implementation score
 - **Visual Processing Indicators:** 94.7% implementation score [[docs](docs/GITHUB_COPILOT_INTEGRATION_NOTES.md#visual-processing)]
 - **Autonomous Systems:** 97.2% implementation score [[scheduler](documentation/SYSTEM_OVERVIEW.md#database-synchronization)]
-- **Enterprise Compliance:** 99.1% implementation score [[validation helper](docs/DATABASE_FIRST_USAGE_GUIDE.md#database-first-enforcement)]
+ - **Enterprise Compliance:** 99.1% implementation score (tests failing) [[validation helper](docs/DATABASE_FIRST_USAGE_GUIDE.md#database-first-enforcement)]
 
 **Overall Integration Score: 97.4%** ✅
 


### PR DESCRIPTION
## Summary
- clarify enterprise readiness badges and intro wording
- list experimental systems in README
- correct database count to 24
- adjust enterprise compliance notes
- note pending tests for enterprise-grade output

## Testing
- `ruff check .`
- `pytest -q` *(fails: 31 failed, 320 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688ad7abeb708331aa7c9061d7cbb8e4