### PR TITLE
Add placeholder audit summary docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,7 +956,10 @@ python docs/quantum_template_generator.py
 
 The audit results are used by the `/dashboard/compliance` endpoint to
 report ongoing placeholder removal progress and overall compliance
-metrics.
+metrics. A machine-readable summary is also written to
+`dashboard/compliance/placeholder_summary.json`. This file tracks total
+findings, resolved counts, and the current compliance score. Refer to
+the JSON schema in [dashboard/README.md](dashboard/README.md#placeholder_summaryjson-schema).
 ```
 
 ### **Contact & Support**

--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -188,7 +188,10 @@ audit the results and perform a rollback if necessary. Commands assume
    ```
 
    The output includes a summary such as `{"placeholders_removed": 3}` and the
-   dashboard reflects the new compliance score.
+   dashboard reflects the new compliance score. A summary file is also written to
+   `dashboard/compliance/placeholder_summary.json` containing the latest
+   finding counts, resolutions, and compliance score. See the schema in
+   [dashboard/README.md](../dashboard/README.md#placeholder_summaryjson-schema).
 
 5. **Rollback a Problematic Entry**
 


### PR DESCRIPTION
## Summary
- document placeholder summary output in README
- show placeholder summary creation in Database First guide

## Testing
- `ruff check README.md docs/DATABASE_FIRST_USAGE_GUIDE.md`
- `pytest -q` *(fails: 31 failed, 320 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688ad7b2810883318cc4ee8fe4108a9a