### PR TITLE
Remove placeholder_audit flag duplicates

### DIFF
--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -25,14 +25,7 @@ import argparse
 from pathlib import Path
 from typing import Dict, List, Optional
 
-try:
-    from tqdm import tqdm
-except ModuleNotFoundError:  # pragma: no cover - fallback
-    import subprocess
-    import sys
-
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "tqdm"])
-    from tqdm import tqdm
+from tqdm import tqdm
 
 from enterprise_modules.compliance import validate_enterprise_operation
 from scripts.database.add_code_audit_log import ensure_code_audit_log
@@ -543,7 +536,10 @@ def main(
 def parse_args(argv: Optional[List[str]] | None = None) -> argparse.Namespace:
     """Return CLI arguments for the audit script."""
 
-    parser = argparse.ArgumentParser(description="Audit workspace for TODO/FIXME placeholders")
+    parser = argparse.ArgumentParser(
+        description="Audit workspace for TODO/FIXME placeholders",
+        epilog="For cleanup only, run scripts/placeholder_cleanup.py",
+    )
     parser.add_argument("--workspace-path", type=str, help="Workspace to scan")
     parser.add_argument("--analytics-db", type=str, help="analytics.db location")
     parser.add_argument("--production-db", type=str, help="production.db location")
@@ -551,7 +547,10 @@ def parse_args(argv: Optional[List[str]] | None = None) -> argparse.Namespace:
     parser.add_argument("--dataset-path", type=str, help="Optional JSON dataset with additional patterns")
     parser.add_argument("--timeout-minutes", type=int, default=30, help="Scan timeout in minutes")
     parser.add_argument(
-        "--simulate", "--dry-run", action="store_true", dest="simulate", help="Run in test mode without writes"
+        "--simulate",
+        action="store_true",
+        dest="simulate",
+        help="Run in test mode without writes",
     )
     parser.add_argument(
         "--test-mode",
@@ -572,7 +571,6 @@ def parse_args(argv: Optional[List[str]] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--apply-fixes",
-        "--cleanup",
         action="store_true",
         dest="apply_fixes",
         help="Automatically remove placeholders and log corrections",
@@ -583,7 +581,6 @@ def parse_args(argv: Optional[List[str]] | None = None) -> argparse.Namespace:
         help="Rollback the most recent audit entry",
     )
     parser.add_argument("--rollback-id", type=int, help="Rollback a specific entry id")
-    parser.add_argument("--force", action="store_true", help="Disable validation checks")
     parser.add_argument("--export", type=Path, help="Export audit results to JSON")
     return parser.parse_args(argv)
 
@@ -607,8 +604,6 @@ if __name__ == "__main__":
     if args.test_mode:
         os.environ["GH_COPILOT_TEST_MODE"] = "1"
         args.simulate = True
-    if args.force:
-        os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
     success = main(
         workspace_path=args.workspace_path,
         analytics_db=args.analytics_db,

--- a/scripts/placeholder_cleanup.py
+++ b/scripts/placeholder_cleanup.py
@@ -1,6 +1,6 @@
 """Deprecated wrapper for placeholder cleanup.
 
-Please run ``scripts/code_placeholder_audit.py --cleanup`` instead."""
+Please run ``scripts/code_placeholder_audit.py --apply-fixes`` instead."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from scripts import code_placeholder_audit
 
 if __name__ == "__main__":
     print(
-        "DEPRECATED: use 'python scripts/code_placeholder_audit.py --cleanup'",
+        "DEPRECATED: use 'python scripts/code_placeholder_audit.py --apply-fixes'",
         file=sys.stderr,
     )
     code_placeholder_audit.main(*sys.argv[1:])

--- a/tests/placeholder_audit/test_parse_args.py
+++ b/tests/placeholder_audit/test_parse_args.py
@@ -1,16 +1,19 @@
 import scripts.code_placeholder_audit as audit
 
 
-def test_parse_args_dry_run_alias():
-    args = audit.parse_args(["--dry-run"])
-    assert args.simulate is True
+import pytest
 
 
-def test_parse_args_cleanup_alias():
-    args = audit.parse_args(["--cleanup"])
-    assert args.apply_fixes is True
+def test_removed_dry_run_option():
+    with pytest.raises(SystemExit):
+        audit.parse_args(["--dry-run"])
 
 
-def test_parse_args_force():
-    args = audit.parse_args(["--force"])
-    assert args.force is True
+def test_removed_cleanup_option():
+    with pytest.raises(SystemExit):
+        audit.parse_args(["--cleanup"])
+
+
+def test_removed_force_option():
+    with pytest.raises(SystemExit):
+        audit.parse_args(["--force"])


### PR DESCRIPTION
## Summary
- streamline `code_placeholder_audit.py` CLI
- reference placeholder_cleanup wrapper
- update placeholder_cleanup wrapper message
- revise parse_args tests

## Testing
- `ruff check scripts/code_placeholder_audit.py scripts/placeholder_cleanup.py tests/placeholder_audit/test_parse_args.py`
- `pytest -q tests/placeholder_audit`

------
https://chatgpt.com/codex/tasks/task_e_688ae100720c83318892c24fcca95279