### PR TITLE
fix: use compliance log rollback util

### DIFF
--- a/scripts/correction_logger_and_rollback.py
+++ b/scripts/correction_logger_and_rollback.py
@@ -90,9 +90,7 @@ class CorrectionLoggerRollback:
             )
             rows = cur.fetchall()
             if not rows:
-                cur = conn.execute(
-                    "SELECT strategy, outcome FROM rollback_strategy_history"
-                )
+                cur = conn.execute("SELECT strategy, outcome FROM rollback_strategy_history")
                 rows = cur.fetchall()
 
         stats: Dict[str, Dict[str, int]] = {}
@@ -268,22 +266,12 @@ class CorrectionLoggerRollback:
                 strategy = self.suggest_rollback_strategy(target)
                 logging.info(f"Suggested strategy: {strategy}")
                 self._record_strategy_history(target, strategy, "success")
-                with sqlite3.connect(self.analytics_db) as conn:
-                    conn.execute(
-                        "INSERT INTO rollback_logs (target, backup, timestamp) VALUES (?, ?, ?)",
-                        (
-                            str(target),
-                            str(backup_path) if backup_path else None,
-                            datetime.now().isoformat(),
-                        ),
-                    )
-                    conn.commit()
+                _log_rollback(str(target), str(backup_path) if backup_path else None)
                 _log_event(
                     {"event": "rollback", "target": str(target)},
                     table="rollback_logs",
                     db_path=self.analytics_db,
                 )
-                _log_rollback(str(target), str(backup_path) if backup_path else None)
                 return True
             else:
                 logging.error(f"Rollback failed for {target}")

--- a/tests/test_violation_and_rollback_logging.py
+++ b/tests/test_violation_and_rollback_logging.py
@@ -11,6 +11,11 @@ def test_violation_and_rollback_logging(tmp_path, monkeypatch):
         "scripts.correction_logger_and_rollback._log_event",
         lambda evt, **kw: events.append((kw.get("table"), evt)),
     )
+    rollback_calls = []
+    monkeypatch.setattr(
+        "scripts.correction_logger_and_rollback._log_rollback",
+        lambda *a, **kw: rollback_calls.append(a),
+    )
 
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
@@ -40,3 +45,4 @@ def test_violation_and_rollback_logging(tmp_path, monkeypatch):
 
     assert any(t == "violation_logs" for t, _ in events)
     assert any(t == "rollback_logs" for t, _ in events)
+    assert len(rollback_calls) == 1


### PR DESCRIPTION
## Summary
- replace manual rollback entry with `_log_rollback` helper
- assert `_log_rollback` invocation inside auto rollback

## Testing
- `ruff check scripts/correction_logger_and_rollback.py tests/test_violation_and_rollback_logging.py`
- `pyright scripts/correction_logger_and_rollback.py tests/test_violation_and_rollback_logging.py`
- `pytest tests/test_violation_and_rollback_logging.py tests/test_rollback_failure_logging.py tests/test_strategy_adaptation.py`


------
https://chatgpt.com/codex/tasks/task_e_688ae11b92d0833180663045f186eb2f