### PR TITLE
feat: ignore backup files in cross reference detection

### DIFF
--- a/scripts/cross_reference_validator.py
+++ b/scripts/cross_reference_validator.py
@@ -44,8 +44,6 @@ ANALYTICS_DB = workspace_root / "analytics.db"
 DASHBOARD_DIR = workspace_root / "dashboard" / "compliance"
 TASK_SUGGESTIONS_FILE = workspace_root / "docs" / "DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md"
 
-backup_root = CrossPlatformPathManager.get_backup_root()
-
 
 class CrossReferenceValidator:
     """
@@ -139,8 +137,7 @@ class CrossReferenceValidator:
                 ):
                     past_links.append({"file_path": row[0], "linked_path": row[1]})
 
-        for d in docs_dirs + code_dirs:
-            validate_enterprise_operation(str(d))
+        backup_root = CrossPlatformPathManager.get_backup_root()
 
         existing_pairs: Set[tuple[str, str]] = {
             (pl["file_path"], pl["linked_path"]) for pl in past_links
@@ -150,6 +147,7 @@ class CrossReferenceValidator:
             file_name = Path(act["file_path"]).name
             related_paths: Set[Path] = set()
             for d in docs_dirs + code_dirs:
+                validate_enterprise_operation(str(d))
                 for path in d.rglob(file_name):
                     try:
                         path.relative_to(backup_root)


### PR DESCRIPTION
## Summary
- ensure path scanning skips backup paths
- dynamically fetch backup path during deep cross link step
- run enterprise operation validation on each directory before scanning
- add regression test to cover dynamic backup root handling

## Testing
- `ruff check scripts/cross_reference_validator.py tests/test_cross_reference_validator.py`
- `pytest tests/test_cross_reference_validator.py::test_deep_cross_link_excludes_backup tests/test_cross_reference_validator.py::test_deep_cross_link_respects_updated_backup_env -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae135a96c8331b020255dbeb6433d