### PR TITLE
feat: audit logging for mined patterns

### DIFF
--- a/template_engine/pattern_mining_engine.py
+++ b/template_engine/pattern_mining_engine.py
@@ -200,6 +200,7 @@ def mine_patterns(
                     "INSERT INTO mined_patterns (pattern, mined_at) VALUES (?, ?)",
                     (pat, datetime.utcnow().isoformat()),
                 )
+                _log_audit_real(str(analytics_db), f"pattern_mined:{pat}")
                 etc = calculate_etc(start_ts, idx, total_steps)
                 if time.time() - start_ts > timeout_seconds:
                     raise TimeoutError(


### PR DESCRIPTION
## Summary
- log an audit event for every pattern stored during mining
- verify audit logs count mined patterns

## Testing
- `pytest tests/test_pattern_mining_engine.py::test_mine_patterns_audit_count_matches -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_688ae14dc8788331a1bb401a5f11258b