### PR TITLE
Add SQL migrations for missing tables

### DIFF
--- a/databases/migrations/README.md
+++ b/databases/migrations/README.md
@@ -12,17 +12,26 @@ Before applying migrations, ensure the following:
 Migrations are executed alphabetically by `scripts/run_migrations.py`. Apply them
 in the following order to satisfy foreign key constraints:
 
-1. `add_code_audit_history.sql`
-2. `add_code_audit_log.sql`
-3. `add_correction_history.sql`
-4. `add_corrections.sql`
-5. `add_placeholder_removals.sql`
-6. `add_rollback_logs.sql`
-7. `add_size_violations.sql`
-8. `add_unified_wrapup_sessions.sql`
-9. `add_violation_logs.sql`
-10. `create_todo_fixme_tracking.sql`
-11. `extend_todo_fixme_tracking.sql`
+1. `add_audit_log.sql`
+2. `add_code_audit_history.sql`
+3. `add_code_audit_log.sql`
+4. `add_correction_history.sql`
+5. `add_correction_logs.sql`
+6. `add_corrections.sql`
+7. `add_cross_link_events.sql`
+8. `add_cross_link_suggestions.sql`
+9. `add_cross_link_summary.sql`
+10. `add_dashboard_alerts.sql`
+11. `add_placeholder_removals.sql`
+12. `add_rollback_failures.sql`
+13. `add_rollback_logs.sql`
+14. `add_rollback_strategy_history.sql`
+15. `add_size_violations.sql`
+16. `add_sync_events_log.sql`
+17. `add_unified_wrapup_sessions.sql`
+18. `add_violation_logs.sql`
+19. `create_todo_fixme_tracking.sql`
+20. `extend_todo_fixme_tracking.sql`
 
 `extend_todo_fixme_tracking.sql` depends on both `create_todo_fixme_tracking.sql`
 and `add_placeholder_removals.sql` because it references the `placeholder_removals`

--- a/databases/migrations/add_audit_log.sql
+++ b/databases/migrations/add_audit_log.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    db_name TEXT,
+    details TEXT,
+    ts TEXT
+);

--- a/databases/migrations/add_correction_logs.sql
+++ b/databases/migrations/add_correction_logs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS correction_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event TEXT,
+    doc_id TEXT,
+    path TEXT,
+    asset_type TEXT,
+    compliance_score REAL,
+    timestamp TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_correction_logs_timestamp
+    ON correction_logs(timestamp);

--- a/databases/migrations/add_cross_link_events.sql
+++ b/databases/migrations/add_cross_link_events.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS cross_link_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path TEXT NOT NULL,
+    linked_path TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);

--- a/databases/migrations/add_cross_link_suggestions.sql
+++ b/databases/migrations/add_cross_link_suggestions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS cross_link_suggestions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path TEXT NOT NULL,
+    suggested_link TEXT NOT NULL,
+    score REAL,
+    timestamp TEXT NOT NULL
+);

--- a/databases/migrations/add_cross_link_summary.sql
+++ b/databases/migrations/add_cross_link_summary.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS cross_link_summary (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    actions INTEGER,
+    links INTEGER,
+    summary_path TEXT,
+    timestamp TEXT NOT NULL
+);

--- a/databases/migrations/add_dashboard_alerts.sql
+++ b/databases/migrations/add_dashboard_alerts.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS dashboard_alerts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    db TEXT,
+    table_name TEXT,
+    size_mb REAL,
+    threshold REAL,
+    timestamp TEXT
+);

--- a/databases/migrations/add_rollback_failures.sql
+++ b/databases/migrations/add_rollback_failures.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS rollback_failures (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event TEXT,
+    module TEXT,
+    level TEXT,
+    target TEXT NOT NULL,
+    details TEXT,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rollback_failures_timestamp
+    ON rollback_failures(timestamp);

--- a/databases/migrations/add_rollback_strategy_history.sql
+++ b/databases/migrations/add_rollback_strategy_history.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS rollback_strategy_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target TEXT NOT NULL,
+    strategy TEXT NOT NULL,
+    outcome TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rsh_target
+    ON rollback_strategy_history(target);

--- a/databases/migrations/add_sync_events_log.sql
+++ b/databases/migrations/add_sync_events_log.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS sync_events_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT,
+    target TEXT,
+    ts TEXT
+);


### PR DESCRIPTION
## Summary
- create migration scripts for missing analytics tables
- document all migration files in alphabetical order

## Testing
- `pytest -q` *(fails: 34 failed, 333 passed, 5 skipped)*
- `ruff check .` *(fails: Found 252 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ae1007ea0833191a3e38c844f947b