### PR TITLE
Add summary endpoint combining metrics and alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,7 @@ class SelfHealingSelfLearningSystem:
 - **`/api/scripts`** - Scripts API endpoint
 - **`/api/health`** - System health check
 - **`/dashboard/compliance`** - Compliance metrics and rollback history
+- **`/summary`** - JSON summary of metrics and alerts
 
 ### **Access Dashboard**
 ```bash

--- a/tests/dashboard/test_live_metrics.py
+++ b/tests/dashboard/test_live_metrics.py
@@ -92,3 +92,12 @@ def test_metrics_table(test_app):
     html = resp.data.decode()
     assert "<table" in html
     assert "placeholder_removal" in html
+
+
+def test_summary_endpoint(test_app):
+    client = test_app.test_client()
+    resp = client.get("/summary")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "metrics" in data
+    assert "alerts" in data

--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+from dashboard import compliance_metrics_updater as cmu
+
+cmu.validate_no_recursive_folders = lambda: None
+cmu.validate_environment_root = lambda: None
 from web_gui.scripts.flask_apps.enterprise_dashboard import app
 
 
@@ -51,6 +55,15 @@ def test_dashboard_info_endpoint():
     resp = client.get("/dashboard_info")
     assert resp.status_code == 200
     assert isinstance(resp.get_json(), dict)
+
+
+def test_summary_endpoint():
+    client = app.test_client()
+    resp = client.get("/summary")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "metrics" in data
+    assert "alerts" in data
 
 
 def test_health_endpoint():

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -231,6 +231,21 @@ def dashboard_info() -> Any:
     return jsonify(data)
 
 
+@app.get("/summary")
+def summary() -> Any:
+    """Return metrics and alerts in a single payload."""
+    start = time.time()
+    with tqdm(total=1, desc="summary", unit="step") as pbar:
+        data = {
+            "metrics": _fetch_metrics(),
+            "alerts": _fetch_alerts(),
+        }
+        pbar.update(1)
+    etc = f"ETC: {calculate_etc(start, 1, 1)}"
+    logging.info("Summary data served | %s", etc)
+    return jsonify(data)
+
+
 @app.get("/metrics_table")
 def metrics_table() -> Any:
     metrics = _fetch_metrics()


### PR DESCRIPTION
## Summary
- add `/summary` route to enterprise dashboard for metrics + alerts
- document new endpoint in README
- test the summary endpoint through dashboard tests

## Testing
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py tests/test_dashboard_endpoints.py tests/dashboard/test_live_metrics.py`
- `pytest tests/test_dashboard_endpoints.py tests/dashboard/test_live_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae12172cc833185d72c1436173211