### PR TITLE
feat: log correction summaries

### DIFF
--- a/scripts/correction_logger_and_rollback.py
+++ b/scripts/correction_logger_and_rollback.py
@@ -90,9 +90,7 @@ class CorrectionLoggerRollback:
             )
             rows = cur.fetchall()
             if not rows:
-                cur = conn.execute(
-                    "SELECT strategy, outcome FROM rollback_strategy_history"
-                )
+                cur = conn.execute("SELECT strategy, outcome FROM rollback_strategy_history")
                 rows = cur.fetchall()
 
         stats: Dict[str, Dict[str, int]] = {}
@@ -363,6 +361,14 @@ class CorrectionLoggerRollback:
                 md.write(f"  - Rollback Reference: {corr['rollback_reference']}\n")
                 md.write(f"  - Timestamp: {corr['timestamp']}\n\n")
         logging.info(f"Correction summary written to {json_path} and {md_path}")
+        _log_event(
+            {
+                "event": "correction_summary",
+                "count": summary["total_corrections"],
+            },
+            table="correction_summaries",
+            db_path=self.analytics_db,
+        )
         return summary
 
     def _calculate_etc(self, elapsed: float, current_progress: int, total_work: int) -> str:

--- a/tests/test_correction_summary.py
+++ b/tests/test_correction_summary.py
@@ -23,3 +23,19 @@ def test_correction_summary_generation(tmp_path: Path, monkeypatch) -> None:
     data = json.loads((tmp_path / "correction_summary.json").read_text())
     assert data["status"] == "complete"
     assert isinstance(data.get("corrections"), list)
+
+
+def test_correction_summary_event_logged(tmp_path: Path, monkeypatch) -> None:
+    analytics = tmp_path / "analytics.db"
+    with sqlite3.connect(analytics) as conn:
+        conn.execute(
+            "CREATE TABLE corrections (file_path TEXT, rationale TEXT, compliance_score REAL, rollback_reference TEXT, ts TEXT)"
+        )
+        conn.execute("INSERT INTO corrections VALUES ('f.py','test',1.0,'', '2025-01-01')")
+    monkeypatch.setattr("scripts.correction_logger_and_rollback.DASHBOARD_DIR", tmp_path)
+    monkeypatch.setattr(clr, "validate_enterprise_operation", lambda *a, **k: None)
+    events = []
+    monkeypatch.setattr(clr, "_log_event", lambda e, **_: events.append(e) or True)
+    log = CorrectionLoggerRollback(analytics)
+    log.summarize_corrections(max_entries=1)
+    assert any(e.get("event") == "correction_summary" for e in events)

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -145,6 +145,16 @@ TABLE_SCHEMAS: Dict[str, str] = {
             timestamp TEXT NOT NULL
         );
     """,
+    "correction_summaries": """
+        CREATE TABLE IF NOT EXISTS correction_summaries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event TEXT,
+            count INTEGER,
+            timestamp TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_correction_summaries_timestamp
+            ON correction_summaries(timestamp);
+    """,
     "rollback_failures": """
         CREATE TABLE IF NOT EXISTS rollback_failures (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
# Summary
- log `correction_summary` event when generating summaries
- store schema for `correction_summaries` table
- test that `summarize_corrections` logs the summary event

# Testing
- `ruff check utils/log_utils.py scripts/correction_logger_and_rollback.py tests/test_correction_summary.py`
- `pyright utils/log_utils.py scripts/correction_logger_and_rollback.py tests/test_correction_summary.py`
- `pytest tests/test_correction_summary.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae120064883318ffa505f8af15f1f