### PR TITLE
Add enterprise operation validation

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -23,6 +23,7 @@ import threading
 
 from tqdm import tqdm
 from utils.log_utils import ensure_tables, insert_event
+from enterprise_modules.compliance import validate_enterprise_operation
 
 
 # Enterprise logging setup
@@ -305,6 +306,7 @@ class ComplianceMetricsUpdater:
         simulate: bool, optional
             If ``True``, skip writing to the dashboard and log files.
         """
+        validate_enterprise_operation(str(self.dashboard_dir))
         self.status = "UPDATING"
         start_time = time.time()
         with tqdm(total=3, desc="Updating Compliance Metrics", unit="step") as pbar:
@@ -350,6 +352,7 @@ class ComplianceMetricsUpdater:
     def run_scheduler(self, interval: int = 60, iterations: int = 1, simulate: bool = False) -> None:
         """Periodically run :meth:`update` with safety checks."""
         for _ in range(iterations):
+            validate_enterprise_operation(str(self.dashboard_dir))
             validate_no_recursive_folders()
             self._check_forbidden_operations()
             self.update(simulate=simulate)

--- a/tests/test_compliance_metrics_scheduler.py
+++ b/tests/test_compliance_metrics_scheduler.py
@@ -23,6 +23,8 @@ def test_scheduler_and_stream(tmp_path, monkeypatch):
     monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
     monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
     monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    validate_calls = []
+    monkeypatch.setattr(cmu, "validate_enterprise_operation", lambda *a, **k: validate_calls.append(1))
 
     dash = tmp_path / "dashboard"
     updater = cmu.ComplianceMetricsUpdater(dash)
@@ -34,6 +36,7 @@ def test_scheduler_and_stream(tmp_path, monkeypatch):
     monkeypatch.setattr(cmu.ComplianceMetricsUpdater, "update", lambda self, simulate=False: call_count.append(1))
     updater.run_scheduler(interval=0, iterations=3)
     assert len(call_count) == 3
+    assert len(validate_calls) == 3
 
 
 def test_stream_metrics_violation(tmp_path, monkeypatch, caplog):
@@ -53,6 +56,7 @@ def test_stream_metrics_violation(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
     monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
 
+    monkeypatch.setattr(cmu, "validate_enterprise_operation", lambda *a, **k: None)
     def _raise_violation(self) -> None:
         raise RuntimeError("Forbidden operation detected")
 
@@ -85,6 +89,7 @@ def test_stream_metrics_stop_event(tmp_path, monkeypatch):
     monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
     monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
 
+    monkeypatch.setattr(cmu, "validate_enterprise_operation", lambda *a, **k: None)
     dash = tmp_path / "dashboard"
     updater = cmu.ComplianceMetricsUpdater(dash)
     stop = threading.Event()


### PR DESCRIPTION
## Summary
- ensure dashboard updates validate enterprise operations
- expect validation calls in compliance metrics scheduler tests

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/test_compliance_metrics_scheduler.py`
- `pytest -q tests/test_compliance_metrics_scheduler.py tests/test_enterprise_validation.py::test_validate_enterprise_operation_rejects_internal_backup tests/test_enterprise_validation.py::test_validate_enterprise_operation_allows_external_backup`

------
https://chatgpt.com/codex/tasks/task_e_688ae11dd0188331b0c41b8a1bdc3692