### PR TITLE
Improve OpenAI client backoff and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ calls using the `OpenAIClient` helper in
 `third_party/openai_client.py`. Set `OPENAI_API_KEY` in your `.env` to enable
 these helpers. Optional variables `OPENAI_RATE_LIMIT` (seconds between
 requests) and `OPENAI_MAX_RETRIES` (number of retries) control the client's
-rate limiting and retry behavior.
+rate limiting and retry behavior. The client now respects `Retry-After` headers
+for HTTP 429 responses and surfaces the message from 4xx errors like invalid
+credentials.
 
 # 3. Initialize databases
 python scripts/database/unified_database_initializer.py


### PR DESCRIPTION
## Summary
- respect `Retry-After` when backing off on HTTP 429
- raise informative errors for non-429 4xx responses
- add tests for 429 Retry-After and authentication failures
- document new behaviors in README

## Testing
- `ruff check third_party/openai_client.py tests/test_openai_client.py github_integration/openai_connector.py`
- `pytest tests/test_openai_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae17cec3883318a053dfee4d0c943