### PR TITLE
Generate real PDFs in documentation manager

### DIFF
--- a/tests/test_documentation_manager.py
+++ b/tests/test_documentation_manager.py
@@ -74,6 +74,11 @@ def test_generate_files(tmp_path, monkeypatch):
     assert len(files) == 6
     for f in files:
         assert f.exists()
+    pdfs = [p for p in files if p.suffix == ".pdf"]
+    for pdf in pdfs:
+        data = pdf.read_bytes()
+        assert data.startswith(b"%PDF"), "PDF header missing"
+        assert len(data) > 0
 
 
 def test_generate_files_records_status(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add helper to build simple PDFs
- write actual PDF output when requesting the `pdf` format
- check generated PDF headers in tests

## Testing
- `ruff check scripts/documentation/enterprise_documentation_manager.py tests/test_documentation_manager.py`
- `pytest tests/test_documentation_manager.py -q`
- `pytest -q` *(fails: RuntimeError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ae1508990833194d8de912c30b0ec