### PR TITLE
docs: add 3.8 and 3.9 releases to changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,6 +68,18 @@
 - **Compliance:** passed full enterprise audit with enforced anti-recursion.
 - **Contributors:** Copilot, Statix, gh_COPILOT.
 
+## [3.9.0] - 2025-07-13
+- **Features:** finalized disaster recovery tooling and expanded monitoring hooks.
+- **Breaking:** refactored database schema to unify archival tables.
+- **Compliance:** updated security policy and documentation.
+- **Contributors:** Copilot, Statix, gh_COPILOT.
+
+## [3.8.0] - 2025-07-13
+- **Features:** introduced unified script generation with session tracking.
+- **Breaking:** deprecated legacy monitoring interface.
+- **Compliance:** documentation revisions for database-first operations.
+- **Contributors:** Copilot, Statix, gh_COPILOT.
+
 ## [3.5.0] - 2025-07-13
 - **Features:** Phase 4 continuous optimization and predictive maintenance tools.
 - **Breaking:** none.


### PR DESCRIPTION
## Summary
- audit commits back to the repository rebuild
- document new 3.8 and 3.9 releases in the changelog

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError, assertion errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_688ae98178b48331ad23887e56430f07