### PR TITLE
docs: add env sample and ci guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,9 @@ FLASK_RUN_PORT=5000
 # Other utilities
 CONFIG_PATH=/path/to/config.yml
 
+# Optional variables
+QISKIT_IBM_TOKEN=
+LOG_WEBSOCKET_ENABLED=0
+
 # Maximum line length for the `clw` wrapper (prevents terminal resets)
 CLW_MAX_LINE_LENGTH=1550

--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,22 @@ The automated test suite reports failures for modules that are not yet fully imp
 - Quantum modules run in **simulation mode** by default. Features such as `quantum_database_search` and `quantum_neural_networks_predictive_maintenance` remain partially stubbed.
 - Quantum monitoring scripts are experimental.
 
+## CI/CD Overview
+
+The repository uses GitHub Actions to automate linting, testing, and compliance checks.
+
+- **ci.yml** runs Ruff linting, executes the test suite on multiple Python versions, builds the Docker image, and performs a CodeQL scan.
+- **compliance-audit.yml** validates placeholder cleanup and fails if unresolved TODO markers remain.
+- **docs-validation.yml** checks documentation metrics on docs changes and weekly.
+
+To mimic CI locally, run:
+
+```bash
+bash setup.sh
+make test
+python scripts/run_migrations.py
+```
+
 ---
 
 **🏆 gh_COPILOT Toolkit v4.0 Enterprise**


### PR DESCRIPTION
## Summary
- add optional vars to `.env.example`
- document local CI steps and actions purpose in README

## Testing
- `ruff check .` *(fails: unused imports)*
- `ruff format .`
- `pytest -q` *(fails: 17 failed, 87 passed)*
- `make test` *(failed: missing separator)*
- `python scripts/run_migrations.py` *(failed: no such column: user_id)*

------
https://chatgpt.com/codex/tasks/task_e_688ae9a12fa883318b65c346dc7ea5ee