### PR TITLE
Add docs and quantum integrity tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           mkdir -p artifacts
-          coverage run -m pytest -q tests --junitxml=artifacts/test-results.xml
+          coverage run -m pytest -q tests tests/documentation tests/quantum --junitxml=artifacts/test-results.xml
           coverage xml -o artifacts/coverage.xml
 
       - name: Upload artifacts

--- a/tests/documentation/test_link_and_schema.py
+++ b/tests/documentation/test_link_and_schema.py
@@ -1,0 +1,39 @@
+import json
+import re
+from pathlib import Path
+
+DOC_DIRS = [Path("docs"), Path("documentation")]
+
+_link_re = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def _local_links(text):
+    for match in _link_re.finditer(text):
+        link = match.group(1).strip()
+        if link.startswith(("http://", "https://", "#", "file://")) or "commit/" in link or link.endswith(('.py', '.png')) or link == "data" or not link:
+            continue
+        link = link.split("#", 1)[0]
+        yield link
+
+
+def test_markdown_links_exist():
+    for base in DOC_DIRS:
+        if not base.exists():
+            continue
+        for md in base.rglob("*.md"):
+            text = md.read_text(errors="ignore")
+            for link in _local_links(text):
+                target = (md.parent / link).resolve()
+                if not target.exists():
+                    target = Path(link).resolve()
+                assert target.exists(), f"Broken link {link} in {md}"
+
+
+def test_placeholder_summary_schema_present():
+    content = Path("dashboard/README.md").read_text()
+    pattern = r"placeholder_summary\.json`[^`]+```json\n(\{[^`]+\})\n```"
+    m = re.search(pattern, content, flags=re.DOTALL)
+    assert m, "placeholder_summary.json schema missing"
+    data = json.loads(m.group(1))
+    for key in ["timestamp", "findings", "resolved_count", "compliance_score", "progress_status"]:
+        assert key in data

--- a/tests/quantum/test_modules_simulation.py
+++ b/tests/quantum/test_modules_simulation.py
@@ -1,0 +1,40 @@
+import os
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+
+from quantum.quantum_database_search import quantum_search_hybrid, quantum_search_sql
+from quantum.optimizers.quantum_optimizer import QuantumOptimizer
+
+
+def _setup_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE items(name TEXT)")
+        conn.executemany("INSERT INTO items VALUES (?)", [("a",), ("b",)])
+
+
+def test_quantum_search_sql_simulation(tmp_path: Path):
+    db = tmp_path / "db.sqlite"
+    _setup_db(db)
+    os.environ["GH_COPILOT_TEST_MODE"] = "1"
+    results = quantum_search_sql("SELECT name FROM items", db, use_hardware=False)
+    assert {"name": "a"} in results and {"name": "b"} in results
+
+
+def test_quantum_search_hybrid_simulation(tmp_path: Path):
+    db = tmp_path / "db.sqlite"
+    _setup_db(db)
+    os.environ["GH_COPILOT_TEST_MODE"] = "1"
+    results = quantum_search_hybrid("sql", "SELECT name FROM items", db, use_hardware=False)
+    assert len(results) == 2
+
+
+def test_quantum_optimizer_simulation():
+    def obj(x: np.ndarray) -> float:
+        return float(np.sum((x - 1) ** 2))
+
+    opt = QuantumOptimizer(obj, [(-2, 2), (-2, 2)], method="simulated_annealing")
+    out = opt.run(x0=np.array([0.0, 0.0]), max_iter=5)
+    assert "best_result" in out["result"]
+    assert isinstance(out["result"]["best_value"], float)


### PR DESCRIPTION
## Summary
- test docs for broken links and placeholder summary schema
- test quantum modules in simulation mode
- run these tests in CI

## Testing
- `ruff check tests/documentation/test_link_and_schema.py tests/quantum/test_modules_simulation.py`
- `pytest tests/documentation/test_link_and_schema.py tests/quantum/test_modules_simulation.py -q`
- `pytest -q` *(fails: OperationalError, assertion errors, etc.)*
- `ruff check .` *(fails: multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ae9b067a48331b7f8a51b26d900dc