### PR TITLE
feat: add dual validation for utility scripts

### DIFF
--- a/scripts/DATABASE_REDUNDANCY_ANALYZER.py
+++ b/scripts/DATABASE_REDUNDANCY_ANALYZER.py
@@ -8,7 +8,12 @@ Enterprise Standards Compliance:
 - Emoji-free code (text-based indicators only)
 - Database-first architecture
 """
+
 import sys
+
+from scripts.validation.secondary_copilot_validator import (
+    SecondaryCopilotValidator,
+)
 
 import sqlite3
 import logging
@@ -17,11 +22,11 @@ from datetime import datetime
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
-    'start': '[START]',
-    'success': '[SUCCESS]',
-    'error': '[ERROR]',
-    'database': '[DATABASE]',
-    'info': '[INFO]'
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "database": "[DATABASE]",
+    "info": "[INFO]",
 }
 
 
@@ -76,10 +81,11 @@ def main():
     else:
         print(f"{TEXT_INDICATORS['error']} Database processing failed")
 
+    SecondaryCopilotValidator(logging.getLogger(__name__)).validate_corrections([__file__])
+
     return success
 
 
 if __name__ == "__main__":
-
     success = main()
     sys.exit(0 if success else 1)

--- a/scripts/FINAL_PRODUCTION_COMPLETER.py
+++ b/scripts/FINAL_PRODUCTION_COMPLETER.py
@@ -8,20 +8,19 @@ Enterprise Standards Compliance:
 - Emoji-free code (text-based indicators only)
 - Visual processing indicators
 """
+
 import sys
 
 import logging
 from pathlib import Path
 from datetime import datetime
 import sqlite3
+from scripts.validation.secondary_copilot_validator import (
+    SecondaryCopilotValidator,
+)
 
 # Text-based indicators (NO Unicode emojis)
-TEXT_INDICATORS = {
-    'start': '[START]',
-    'success': '[SUCCESS]',
-    'error': '[ERROR]',
-    'info': '[INFO]'
-}
+TEXT_INDICATORS = {"start": "[START]", "success": "[SUCCESS]", "error": "[ERROR]", "info": "[INFO]"}
 
 
 class EnterpriseUtility:
@@ -42,8 +41,7 @@ class EnterpriseUtility:
 
             if success:
                 duration = (datetime.now() - start_time).total_seconds()
-                self.logger.info(
-                    f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s")
+                self.logger.info(f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s")
                 return True
             else:
                 self.logger.error(f"{TEXT_INDICATORS['error']} Utility failed")
@@ -82,10 +80,11 @@ def main():
     else:
         print(f"{TEXT_INDICATORS['error']} Utility failed")
 
+    SecondaryCopilotValidator(logging.getLogger(__name__)).validate_corrections([__file__])
+
     return success
 
 
 if __name__ == "__main__":
-
     success = main()
     sys.exit(0 if success else 1)

--- a/tests/test_dual_validation_scripts.py
+++ b/tests/test_dual_validation_scripts.py
@@ -1,0 +1,50 @@
+import logging
+from scripts import DATABASE_REDUNDANCY_ANALYZER as dra
+from scripts import FINAL_PRODUCTION_COMPLETER as fpc
+
+
+def test_database_redundancy_validation(monkeypatch, tmp_path):
+    called = {"validate": False}
+
+    class DummyValidator:
+        def __init__(self, logger=None):
+            pass
+
+        def validate_corrections(self, files):
+            called["validate"] = True
+            return True
+
+    def dummy_init(self, database_path="production.db"):
+        self.database_path = tmp_path / "db.db"
+        self.logger = logging.getLogger(__name__)
+
+    monkeypatch.setattr(dra, "SecondaryCopilotValidator", DummyValidator)
+    monkeypatch.setattr(dra.EnterpriseDatabaseProcessor, "__init__", dummy_init)
+
+    assert dra.main() is True
+    assert called["validate"]
+
+
+def test_final_production_validation(monkeypatch):
+    called = {"validate": False}
+
+    class DummyValidator:
+        def __init__(self, logger=None):
+            pass
+
+        def validate_corrections(self, files):
+            called["validate"] = True
+            return True
+
+    class DummyUtility:
+        def __init__(self, workspace_path="e:/gh_COPILOT"):
+            pass
+
+        def execute_utility(self) -> bool:
+            return True
+
+    monkeypatch.setattr(fpc, "SecondaryCopilotValidator", DummyValidator)
+    monkeypatch.setattr(fpc, "EnterpriseUtility", DummyUtility)
+
+    assert fpc.main() is True
+    assert called["validate"]


### PR DESCRIPTION
## Summary
- implement SecondaryCopilotValidator in `DATABASE_REDUNDANCY_ANALYZER.py`
- implement SecondaryCopilotValidator in `FINAL_PRODUCTION_COMPLETER.py`
- add tests ensuring these scripts trigger validation

## Testing
- `ruff check scripts/DATABASE_REDUNDANCY_ANALYZER.py scripts/FINAL_PRODUCTION_COMPLETER.py tests/test_dual_validation_scripts.py`
- `pyright scripts/DATABASE_REDUNDANCY_ANALYZER.py scripts/FINAL_PRODUCTION_COMPLETER.py tests/test_dual_validation_scripts.py`
- `pytest tests/test_dual_validation_scripts.py -q`
- `pytest -q` *(fails: test_cross_platform_paths.py::test_workspace_parent_detection etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688afed4f9fc8331b0726454f43372fa