### PR TITLE
Add SecondaryCopilotValidator calls to tools and scripts

### DIFF
--- a/scripts/file_management/workspace_optimizer.py
+++ b/scripts/file_management/workspace_optimizer.py
@@ -71,18 +71,24 @@ class WorkspaceOptimizer:
                 (str(file_path), original_size, new_size),
             )
 
-    def optimize(self, workspace: Path) -> None:
-        """Archive rarely used files under ``workspace`` and log metrics."""
+    def optimize(self, workspace: Path) -> list[Path]:
+        """Archive rarely used files under ``workspace`` and log metrics.
+
+        Returns the list of archived files.
+        """
         validate_enterprise_environment()
         workspace = workspace.resolve()
         archive_root = CrossPlatformPathManager.get_backup_root() / "workspace_archive"
         files = self._get_old_files(workspace)
+        processed: list[Path] = []
         with tqdm(files, desc="Optimizing", unit="file") as bar:
             for f in bar:
                 bar.set_postfix(file=f.name)
                 orig, new = self._archive_file(f, archive_root)
                 self._log_metric(f, orig, new)
+                processed.append(f)
         self.logger.info("Optimization run complete on %d files", len(files))
+        return processed
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -99,8 +105,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     optimizer = WorkspaceOptimizer()
+    targets: list[str] = []
+
+    def primary() -> bool:
+        targets.extend(str(p) for p in optimizer.optimize(args.workspace))
+        return True
+
     orchestrator = DualCopilotOrchestrator()
-    orchestrator.run(lambda: (optimizer.optimize(args.workspace) or True), [])
+    orchestrator.run(primary, targets)
     return 0
 
 

--- a/scripts/quick_filesystem_check.py
+++ b/scripts/quick_filesystem_check.py
@@ -6,6 +6,7 @@ Quick Filesystem Check Script
 import os
 import sys
 import logging
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 print("FILESYSTEM ISOLATION CHECK")
 print("=" * 50)
@@ -46,3 +47,5 @@ with open('quick_filesystem_check.txt', 'w') as f:
 
 print(
         f"\nResults saved to: {os.path.join(os.getcwd(), 'quick_filesystem_check.txt')}")
+
+SecondaryCopilotValidator().validate_corrections(["quick_filesystem_check.txt"])

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -4,11 +4,22 @@ from pathlib import Path
 from tools.cleanup import cleanup_obsolete_entries
 
 
-def test_cleanup_obsolete_entries(tmp_path: Path) -> None:
+def test_cleanup_obsolete_entries(tmp_path: Path, monkeypatch) -> None:
     db = tmp_path / "test.db"
     with sqlite3.connect(db) as conn:
         conn.execute("CREATE TABLE obsolete_table(id INTEGER)")
         conn.executemany("INSERT INTO obsolete_table(id) VALUES (?)", [(1,), (2,)])
+
+    called = {"v": False}
+
+    def dummy_validate(self, files):
+        called["v"] = True
+        return True
+
+    monkeypatch.setattr(
+        "secondary_copilot_validator.SecondaryCopilotValidator.validate_corrections",
+        dummy_validate,
+    )
 
     deleted, valid = cleanup_obsolete_entries(db)
 
@@ -18,4 +29,5 @@ def test_cleanup_obsolete_entries(tmp_path: Path) -> None:
     with sqlite3.connect(db) as conn:
         remaining = conn.execute("SELECT COUNT(*) FROM obsolete_table").fetchone()[0]
     assert remaining == 0
+    assert called["v"]
 

--- a/tests/test_generate_next_session_prompt.py
+++ b/tests/test_generate_next_session_prompt.py
@@ -18,8 +18,21 @@ def test_generate_next_session_prompt(tmp_path, monkeypatch):
     entropy = tmp_path / "NEXT_SESSION_ENTROPY_RESOLUTION.md"
     entropy.write_text("PRIORITY 1: Task A\n- fix issue A\n- fix issue B\n")
     monkeypatch.chdir(tmp_path)
+
+    called = {"v": False}
+
+    def dummy_validate(self, files):
+        called["v"] = True
+        return True
+
+    monkeypatch.setattr(
+        "secondary_copilot_validator.SecondaryCopilotValidator.validate_corrections",
+        dummy_validate,
+    )
+
     prompt = generate_next_session_prompt(Path("."))
     assert "Validation Status: FAILED" in prompt
     assert "anti_recursion_compliance" in prompt
     assert "fix issue A" in prompt
     assert "fix issue B" in prompt
+    assert called["v"]

--- a/tests/test_tools_automation_setup.py
+++ b/tests/test_tools_automation_setup.py
@@ -17,6 +17,17 @@ def test_ingest_assets(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path.parent / "backups"))
     monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
 
+    called = {"v": False}
+
+    def dummy_validate(self, files):
+        called["v"] = True
+        return True
+
+    monkeypatch.setattr(
+        "secondary_copilot_validator.SecondaryCopilotValidator.validate_corrections",
+        dummy_validate,
+    )
+
     docs_dir = tmp_path / "documentation"
     docs_dir.mkdir()
     (docs_dir / "doc.md").write_text("# doc")
@@ -44,3 +55,4 @@ def test_ingest_assets(tmp_path: Path, monkeypatch) -> None:
     assert doc_count == 1
     assert template_count == 1
     assert pattern_count == 1
+    assert called["v"]

--- a/tools/automation_setup.py
+++ b/tools/automation_setup.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from tqdm import tqdm
 
 from utils.log_utils import _log_event, DEFAULT_ANALYTICS_DB
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 DB_PATH = Path("databases/production.db")
 ANALYTICS_DB = DEFAULT_ANALYTICS_DB
@@ -110,6 +111,10 @@ def ingest_assets() -> None:
     conn.close()
     _log_event({"event": "templates_ingested", "count": len(tmpl_files)}, db_path=ANALYTICS_DB)
     _log_event({"event": "ingestion_completed", "docs": len(doc_files), "templates": len(tmpl_files)}, db_path=ANALYTICS_DB)
+
+    SecondaryCopilotValidator().validate_corrections(
+        [str(p) for p in doc_files + tmpl_files]
+    )
 
 
 def run_audit() -> None:

--- a/tools/cleanup.py
+++ b/tools/cleanup.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Tuple
 
 from tqdm import tqdm
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 DB_PATH = Path("databases/production.db")
 TABLE = "obsolete_table"
@@ -72,6 +73,8 @@ def cleanup_obsolete_entries(db_path: Path = DB_PATH) -> Tuple[int, bool]:
 
     with sqlite3.connect(db_path) as conn:
         valid = _secondary_validation(conn)
+
+    SecondaryCopilotValidator().validate_corrections([str(db_path)])
 
     logging.info("Rows deleted: %s", deleted)
     logging.info("Validation: %s", "passed" if valid else "failed")

--- a/tools/generate_next_session_prompt.py
+++ b/tools/generate_next_session_prompt.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from secondary_copilot_validator import SecondaryCopilotValidator
 from typing import List, Tuple
 
 
@@ -65,7 +66,15 @@ def generate_next_session_prompt(directory: Path | None = None) -> str:
         prompt_lines.append("Key Tasks:")
         for task in tasks:
             prompt_lines.append(f"- {task}")
-    return "\n".join(prompt_lines)
+    prompt = "\n".join(prompt_lines)
+    files = []
+    if report and report.exists():
+        files.append(str(report))
+    if entropy_file.exists():
+        files.append(str(entropy_file))
+    if files:
+        SecondaryCopilotValidator().validate_corrections(files)
+    return prompt
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- ensure automation_setup, cleanup, and session prompt generator call SecondaryCopilotValidator
- validate quick_filesystem_check results with SecondaryCopilotValidator
- return processed files from workspace optimizer and pass to DualCopilotOrchestrator
- test dual validation for new workflows and tools

## Testing
- `ruff check .` *(fails: 249 errors)*
- `pyright` *(fails to run or produces no output)*
- `pytest -q` *(fails: 3 failed, 48 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688b00c8f8648331a20b941bf0e5c5d4