### PR TITLE
Fix import for cross-reference validator

### DIFF
--- a/scripts/cross_reference_validator.py
+++ b/scripts/cross_reference_validator.py
@@ -25,7 +25,7 @@ from typing import Dict, List, Optional, Set
 from tqdm import tqdm
 
 from enterprise_modules.compliance import validate_enterprise_operation
-from utils.log_utils import _log_event
+from utils.log_utils import _log_event, ensure_tables, log_event
 from utils.cross_platform_paths import CrossPlatformPathManager
 
 workspace_root = CrossPlatformPathManager.get_workspace_path()


### PR DESCRIPTION
## Summary
- add missing imports for logging utilities in CrossReferenceValidator

## Testing
- `pyright scripts/cross_reference_validator.py`
- `pytest tests/test_complete_template_generator.py -q` *(fails: Recursive folder violation)*

------
https://chatgpt.com/codex/tasks/task_e_688b00ca46548331b7c428b9466c7ea0