### PR TITLE
fix: resolve linter warnings

### DIFF
--- a/scripts/cross_reference_validator.py
+++ b/scripts/cross_reference_validator.py
@@ -25,7 +25,7 @@ from typing import Dict, List, Optional, Set
 from tqdm import tqdm
 
 from enterprise_modules.compliance import validate_enterprise_operation
-from utils.log_utils import _log_event
+from utils.log_utils import _log_event, ensure_tables, log_event
 from utils.cross_platform_paths import CrossPlatformPathManager
 
 workspace_root = CrossPlatformPathManager.get_workspace_path()

--- a/scripts/validation/workspace_integrity_validator.py
+++ b/scripts/validation/workspace_integrity_validator.py
@@ -20,13 +20,11 @@ Compliance: Enterprise Standards 2025
 """
 
 import os
-import sys
 import sqlite3
-import hashlib
 import json
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Any, Dict, List
 from dataclasses import dataclass, asdict
 from tqdm import tqdm
 import time


### PR DESCRIPTION
Fixes lint issues in core validation scripts.

- import missing helpers in `cross_reference_validator.py`
- clean unused imports in workspace integrity validator

Lint and type checks now pass for these modules, though some tests fail due to environment constraints.

------
https://chatgpt.com/codex/tasks/task_e_688afed8837883319b38d742bdd6483c