### PR TITLE
Add analytics and validator hooks

### DIFF
--- a/template_engine/db_first_code_generator.py
+++ b/template_engine/db_first_code_generator.py
@@ -24,6 +24,7 @@ from sklearn.metrics.pairwise import cosine_similarity
 from tqdm import tqdm
 
 from utils.log_utils import _log_event
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 from .placeholder_utils import DEFAULT_PRODUCTION_DB, replace_placeholders
 from .objective_similarity_scorer import compute_similarity_scores
@@ -397,6 +398,7 @@ class DBFirstCodeGenerator(TemplateAutoGenerator):
                 db_path=self.analytics_db,
                 test_mode=False,
             )
+            SecondaryCopilotValidator().validate_corrections([str(path)])
         except Exception as exc:  # pragma: no cover - error handling
             if "conn" in locals():
                 conn.rollback()

--- a/template_engine/workflow_enhancer.py
+++ b/template_engine/workflow_enhancer.py
@@ -26,6 +26,7 @@ from sklearn.cluster import KMeans
 from tqdm import tqdm
 from enterprise_modules.compliance import validate_enterprise_operation
 from utils.log_utils import DEFAULT_ANALYTICS_DB, _log_event
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 LOGS_DIR = CrossPlatformPathManager.get_workspace_path() / "logs" / "workflow_enhancer"
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
@@ -147,6 +148,15 @@ class TemplateWorkflowEnhancer:
             table="workflow_events",
             db_path=DEFAULT_ANALYTICS_DB,
         )
+        _log_event(
+            {
+                "event": "workflow_report",
+                "template_count": len(templates),
+                "cluster_count": len(clusters),
+            },
+            table="workflow_events",
+            db_path=DEFAULT_ANALYTICS_DB,
+        )
 
     def enhance(self, timeout_minutes: int = 30) -> bool:
         """Enhance workflow using stored templates and patterns.
@@ -194,6 +204,7 @@ class TemplateWorkflowEnhancer:
             logging.info("DUAL COPILOT validation passed: Workflow enhancement integrity confirmed.")
         else:
             logging.error("DUAL COPILOT validation failed: Workflow enhancement mismatch.")
+        SecondaryCopilotValidator().validate_corrections([__file__])
         return valid
 
     def _calculate_etc(self, elapsed: float, current_progress: int, total_work: int) -> str:

--- a/tests/test_documentation_db_analyzer.py
+++ b/tests/test_documentation_db_analyzer.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from scripts.database.documentation_db_analyzer import (
     analyze_documentation_gaps,
+    analyze_documentation_tables,
     validate_analysis,
 )
 
@@ -21,3 +22,21 @@ def test_documentation_db_analyzer(tmp_path: Path) -> None:
     assert results[0]["gaps"] == 1
     assert any(log_dir.iterdir())
     assert validate_analysis(analytics, 1)
+
+
+def test_analyzer_runs_validator_and_logs(tmp_path: Path, monkeypatch) -> None:
+    db = tmp_path / "doc.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE enterprise_documentation (title TEXT, content TEXT)")
+        conn.execute("INSERT INTO enterprise_documentation VALUES ('A', 'foo')")
+    analytics = tmp_path / "analytics.db"
+    dummy = type("D", (), {"called": False, "validate_corrections": lambda self, files: setattr(self, "called", True) or True})()
+    import importlib
+    module = importlib.import_module("scripts.database.documentation_db_analyzer")
+    monkeypatch.setattr(module, "SecondaryCopilotValidator", lambda: dummy)
+    module.ANALYTICS_DB = analytics
+    analyze_documentation_tables([db], analytics)
+    assert dummy.called
+    with sqlite3.connect(analytics) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM doc_analysis").fetchone()[0]
+    assert count == 1

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -155,6 +155,41 @@ TABLE_SCHEMAS: Dict[str, str] = {
             timestamp TEXT NOT NULL
         );
     """,
+    "doc_analysis": """
+        CREATE TABLE IF NOT EXISTS doc_analysis (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event TEXT,
+            db TEXT,
+            level TEXT,
+            module TEXT,
+            gaps INTEGER,
+            before INTEGER,
+            after INTEGER,
+            removed_backups INTEGER,
+            removed_duplicates INTEGER,
+            placeholders INTEGER,
+            row_count INTEGER,
+            table_name TEXT,
+            report TEXT,
+            rollback TEXT,
+            rollback_restored INTEGER,
+            ts TEXT,
+            timestamp TEXT
+        );
+    """,
+    "workflow_events": """
+        CREATE TABLE IF NOT EXISTS workflow_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event TEXT,
+            level TEXT,
+            module TEXT,
+            template_count INTEGER,
+            cluster_count INTEGER,
+            avg_score REAL,
+            duration REAL,
+            timestamp TEXT
+        );
+    """,
     "correction_summaries": """
         CREATE TABLE IF NOT EXISTS correction_summaries (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- enhance workflow_enhancer with workflow report logging and secondary validation
- extend db_first_code_generator with secondary validation
- expand documentation_db_analyzer analytics utilities and validator use
- update logging schemas for workflow_events and doc_analysis
- cover new features with tests

## Testing
- `ruff check template_engine/db_first_code_generator.py template_engine/workflow_enhancer.py scripts/database/documentation_db_analyzer.py tests/test_db_first_codegen_analytics.py tests/test_documentation_db_analyzer.py tests/test_workflow_enhancer_extended.py utils/log_utils.py`
- `pytest tests/test_db_first_codegen_analytics.py tests/test_documentation_db_analyzer.py tests/test_workflow_enhancer.py tests/test_workflow_enhancer_extended.py tests/test_workflow_enhancer_logging.py tests/test_workflow_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b01557ff883319cdd2fdda86d838a