### PR TITLE
Update STUB-013 status

### DIFF
--- a/docs/STUB_MODULE_STATUS.md
+++ b/docs/STUB_MODULE_STATUS.md
@@ -22,7 +22,7 @@ The file `DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md` lists pending tasks marked
 | STUB-010 | Update task suggestion files with cross-references | [docs/DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md](DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md)<br>logs/<br>validation/ | complete | Documentation Team |
 | STUB-011 | Record outputs to analytics.db across modules | various modules | complete | DataOps Team |
 | STUB-012 | Display placeholder removal progress on dashboard | [dashboard/compliance_metrics_updater.py](../dashboard/compliance_metrics_updater.py) | complete | Web Team |
-| STUB-013 | Implement legacy cleanup workflow | [unified_legacy_cleanup_system.py](../unified_legacy_cleanup_system.py) | complete | Compliance Team |
+| STUB-013 | Implement legacy cleanup workflow | [scripts/unified_legacy_cleanup_system.py](../scripts/unified_legacy_cleanup_system.py) | complete | Compliance Team |
 
 
 ## Integration Status Summary
@@ -39,7 +39,6 @@ The file `DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md` lists pending tasks marked
 - **STUB-010:** Cross-reference updates verified in integration tests.
 - **STUB-011:** Analytics logging hooks pass in `tests/test_add_violation_and_rollback_logs.py` (added in commit [7e6171d](../commit/7e6171d)).
 - **STUB-012:** Dashboard progress indicators validated in `tests/test_dashboard_placeholder_metrics.py` (tracked in commit [9cdf0e8](../commit/9cdf0e8)).
-- **STUB-013:** Legacy cleanup workflow implemented via `unified_legacy_cleanup_system.py`.
 
 ## Lint and Type Check Summary
 


### PR DESCRIPTION
## Summary
- mark STUB-013 as complete and fix link to cleanup script
- drop outdated note about missing legacy cleanup module

## Testing
- `pytest -q`
- `ruff check`

------
https://chatgpt.com/codex/tasks/task_e_688b0a72e7b88331851eac76a2022df9