### PR TITLE
feat: add secondary copilot hooks

### DIFF
--- a/scripts/PRODUCTION_DATABASE_ANALYZER.py
+++ b/scripts/PRODUCTION_DATABASE_ANALYZER.py
@@ -10,10 +10,14 @@ Enterprise Standards Compliance:
 """
 import sys
 
+import os
 import sqlite3
 import logging
 from pathlib import Path
 from datetime import datetime
+
+from enterprise_modules.compliance import validate_enterprise_operation
+from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -80,6 +84,8 @@ def main():
 
 
 if __name__ == "__main__":
-
+    if os.getenv("GH_COPILOT_DISABLE_VALIDATION") != "1":
+        validate_enterprise_operation()
     success = main()
+    SecondaryCopilotValidator().validate_corrections([__file__])
     sys.exit(0 if success else 1)

--- a/scripts/enterprise_completion_summary.py
+++ b/scripts/enterprise_completion_summary.py
@@ -32,6 +32,9 @@ from datetime import datetime
 from pathlib import Path
 import logging
 
+from enterprise_modules.compliance import validate_enterprise_operation
+from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
+
 def generate_enterprise_completion_report():
     """🏆 Generate comprehensive enterprise completion report"""
     
@@ -260,4 +263,8 @@ def main():
         return 1
 
 if __name__ == "__main__":
-    exit(main())
+    if os.getenv("GH_COPILOT_DISABLE_VALIDATION") != "1":
+        validate_enterprise_operation()
+    exit_code = main()
+    SecondaryCopilotValidator().validate_corrections([__file__])
+    sys.exit(exit_code)

--- a/scripts/enterprise_deployment_packager.py
+++ b/scripts/enterprise_deployment_packager.py
@@ -8,6 +8,7 @@ Enterprise Standards Compliance:
 - Emoji-free code (text-based indicators only)
 - Visual processing indicators
 """
+import os
 import sys
 
 import logging
@@ -15,6 +16,9 @@ from pathlib import Path
 from datetime import datetime
 
 from scripts.utilities.production_template_utils import generate_script_from_repository
+
+from enterprise_modules.compliance import validate_enterprise_operation
+from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -74,6 +78,8 @@ def main():
 
 
 if __name__ == "__main__":
-
+    if os.getenv("GH_COPILOT_DISABLE_VALIDATION") != "1":
+        validate_enterprise_operation()
     success = main()
+    SecondaryCopilotValidator().validate_corrections([__file__])
     sys.exit(0 if success else 1)

--- a/scripts/files_and_actions_checklist.py
+++ b/scripts/files_and_actions_checklist.py
@@ -22,6 +22,7 @@ from typing import Dict, List
 from tqdm import tqdm
 
 from enterprise_modules.compliance import validate_enterprise_operation
+from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 
 DEFAULT_FILES = [
     "DATABASE_FIRST_COPILOT_TASK_SUGGESTIONS.md",
@@ -117,4 +118,6 @@ def main(
 
 
 if __name__ == "__main__":
-    raise SystemExit(0 if main() else 1)
+    exit_code = 0 if main() else 1
+    SecondaryCopilotValidator().validate_corrections([__file__])
+    raise SystemExit(exit_code)


### PR DESCRIPTION
## Summary
- add compliance and SecondaryCopilotValidator calls to several top-level scripts
- log compliance checks before main execution

## Testing
- `ruff check scripts/enterprise_completion_summary.py scripts/enterprise_deployment_packager.py scripts/files_and_actions_checklist.py scripts/PRODUCTION_DATABASE_ANALYZER.py`
- `pytest -q` *(fails: 30 failed, 130 passed, 2 skipped, 346 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688b0a80bd008331b81f502e4cee2f3a