### PR TITLE
Fix Ruff lint issues and update DBFirst engine

### DIFF
--- a/scripts/comprehensive_script_validator.py
+++ b/scripts/comprehensive_script_validator.py
@@ -26,14 +26,13 @@ import sys
 import time
 import json
 import sqlite3
-import hashlib
 import importlib.util
 import traceback
 import threading
 import psutil
 from pathlib import Path
-from datetime import datetime, timedelta
-from typing import Dict, List, Any, Optional, Tuple
+from datetime import datetime
+from typing import Dict, List, Any, Optional
 from dataclasses import dataclass, field
 from enum import Enum
 from tqdm import tqdm

--- a/scripts/comprehensive_validation_execution_engine.py
+++ b/scripts/comprehensive_validation_execution_engine.py
@@ -14,17 +14,12 @@ VERSION: 1.0 - Comprehensive Validation Execution
 """
 
 import os
-import sys
 import time
-import json
 import sqlite3
-import threading
-import subprocess
 from pathlib import Path
 from datetime import datetime
-from dataclasses import dataclass, asdict
-from typing import Dict, List, Optional, Tuple, Any
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Any
 from tqdm import tqdm
 import logging
 

--- a/scripts/continuous_operation_orchestrator.py
+++ b/scripts/continuous_operation_orchestrator.py
@@ -32,7 +32,6 @@ Created: July 17, 2025
 import argparse
 import logging
 import os
-import shutil
 import sys
 import time
 import traceback

--- a/scripts/database/comprehensive_database_optimization_system.py
+++ b/scripts/database/comprehensive_database_optimization_system.py
@@ -15,7 +15,7 @@ import hashlib
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List
 from tqdm import tqdm
 import time
 import logging

--- a/scripts/database/database_access_layer.py
+++ b/scripts/database/database_access_layer.py
@@ -13,7 +13,6 @@ while maintaining backward compatibility.
 """
 
 import sys
-import logging
 
 # Import from new modular package
 from db_tools.operations.access import DatabaseAccessLayer as ModularDatabaseAccessLayer, TEXT_INDICATORS

--- a/scripts/database/database_consistency_checker.py
+++ b/scripts/database/database_consistency_checker.py
@@ -8,14 +8,13 @@ and prepares for archive migration workflow.
 Enterprise-grade database consistency validation with migration readiness assessment.
 """
 
-import os
 import sys
 import json
 import sqlite3
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional, Set, Any
+from typing import Dict, Any
 import hashlib
 
 class DatabaseConsistencyChecker:

--- a/scripts/database/database_consistency_checker_final.py
+++ b/scripts/database/database_consistency_checker_final.py
@@ -4,12 +4,11 @@ Database Consistency Checker - FINAL CORRECTED VERSION
 Uses EXISTING databases/logs.db with correct column names
 """
 
-import os
 import sqlite3
 import json
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Any
 from tqdm import tqdm
 import logging
 

--- a/scripts/database/database_consolidation_analyzer.py
+++ b/scripts/database/database_consolidation_analyzer.py
@@ -9,14 +9,13 @@ Comprehensive analysis tool for database consolidation strategy
 ================================================================
 """
 
-import os
 import sqlite3
 import hashlib
 import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional, Set
+from typing import Dict, List, Optional
 from collections import defaultdict
 import re
 

--- a/scripts/database/database_consolidation_validator.py
+++ b/scripts/database/database_consolidation_validator.py
@@ -10,13 +10,12 @@ Comprehensive validation of database consolidation results:
 ================================================================
 """
 
-import os
 import sqlite3
 import json
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict
 
 
 class DatabaseConsolidationValidator:

--- a/scripts/database/database_first_correction_engine.py
+++ b/scripts/database/database_first_correction_engine.py
@@ -6,6 +6,7 @@ Enterprise-grade correction system leveraging production.db intelligence
 
 import sys
 import logging
+import os
 import sqlite3
 import subprocess
 from pathlib import Path
@@ -24,7 +25,9 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 class DatabaseFirstCorrectionEngine:
     """🎯 Database-First Correction Engine with Enterprise Compliance"""
 
-    def __init__(self, workspace_path: str = "e:/gh_COPILOT"):
+    def __init__(self, workspace_path: str | None = None):
+        if workspace_path is None:
+            workspace_path = os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd()))
         self.workspace_path = Path(workspace_path)
         self.production_db = self.workspace_path / "production.db"
         self.analytics_db = self.workspace_path / "analytics.db"
@@ -558,7 +561,7 @@ def main():
 
         # Final validation
         logger.info("🔍 Running final validation...")
-        subprocess.run(["flake8", "."], capture_output=True, text=True)
+        subprocess.run(["ruff", "check", "."], capture_output=True, text=True)
 
         logger.info("✅ DATABASE-FIRST CORRECTION ENGINE COMPLETED SUCCESSFULLY")
 

--- a/scripts/database/database_schema_enhancer.py
+++ b/scripts/database/database_schema_enhancer.py
@@ -24,12 +24,10 @@ import os
 import sys
 import sqlite3
 import logging
-import hashlib
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any
 from tqdm import tqdm
-import time
 
 # MANDATORY: Visual processing indicators
 start_time = datetime.now()

--- a/scripts/database/database_schema_final_completion.py
+++ b/scripts/database/database_schema_final_completion.py
@@ -18,16 +18,12 @@ with comprehensive template synchronization and intelligent categorization.
 """
 
 import os
-import sys
-import time
 import sqlite3
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Dict, Any
 from tqdm import tqdm
-import hashlib
-import json
 
 # 🛡️ MANDATORY: Anti-recursion workspace validation
 def validate_workspace_integrity():

--- a/scripts/database/database_script_reproduction_validator.py
+++ b/scripts/database/database_script_reproduction_validator.py
@@ -12,16 +12,14 @@ can produce all scripts found via semantic search, while validating:
 DUAL COPILOT validation pattern certified.
 """
 
-import os
 import sys
 import sqlite3
 import json
 import subprocess
 import hashlib
-import tempfile
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Set, Tuple, Optional, Any
+from typing import Dict, Set, Tuple, Any
 import logging
 from tqdm import tqdm
 

--- a/scripts/database/efficient_database_reproducibility_validator.py
+++ b/scripts/database/efficient_database_reproducibility_validator.py
@@ -13,7 +13,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Tuple, Optional, Any
+from typing import Dict, Optional, Any
 import logging
 
 # Configure logging with ASCII-safe format

--- a/scripts/database/enterprise_assets_backup_compressor.py
+++ b/scripts/database/enterprise_assets_backup_compressor.py
@@ -5,7 +5,7 @@ import logging
 import os
 import zipfile
 from datetime import datetime, timezone
-from pathlib import Path, PureWindowsPath
+from pathlib import Path
 
 from enterprise_modules.compliance import validate_enterprise_operation
 

--- a/scripts/database/git_repository_repair_with_database_sync.py
+++ b/scripts/database/git_repository_repair_with_database_sync.py
@@ -14,7 +14,6 @@ Anti-Recursion: VALIDATED
 Enterprise Standards: FULL COMPLIANCE
 """
 
-import os
 import sys
 import sqlite3
 import logging

--- a/scripts/database/ingestion_validator.py
+++ b/scripts/database/ingestion_validator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import sqlite3
 from pathlib import Path
-from typing import Iterable
 
 from template_engine.template_synchronizer import _compliance_score
 from utils.log_utils import _log_event

--- a/scripts/database/quick_database_test.py
+++ b/scripts/database/quick_database_test.py
@@ -13,9 +13,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Any
 import logging
-import time
 
 
 def test_database_reproducibility():

--- a/scripts/database/script_database_validator.py
+++ b/scripts/database/script_database_validator.py
@@ -14,10 +14,9 @@ Enterprise Standards Compliance:
 import hashlib
 import logging
 import sqlite3
-import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {

--- a/scripts/database/test_unicode_compat_backup_20250712_235901.py
+++ b/scripts/database/test_unicode_compat_backup_20250712_235901.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 # -*- coding: utf-8 -*-
 """Unicode compatibility test file"""
 

--- a/scripts/database_integration_enhancer.py
+++ b/scripts/database_integration_enhancer.py
@@ -26,18 +26,14 @@ import sys
 import time
 import json
 import sqlite3
-import hashlib
 import threading
-import psutil
-import shutil
 from pathlib import Path
-from datetime import datetime, timedelta
-from typing import Dict, List, Any, Optional, Tuple, Set
-from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Any, Optional
+from dataclasses import dataclass
 from enum import Enum
 from tqdm import tqdm
 import uuid
-import concurrent.futures
 
 # CRITICAL: Anti-recursion validation
 def validate_enterprise_environment():

--- a/scripts/database_integration_validator_enhancer.py
+++ b/scripts/database_integration_validator_enhancer.py
@@ -17,14 +17,11 @@ VERSION: 1.0 - Comprehensive Integration Enhancement
 """
 
 import os
-import sys
-import time
 import json
 import sqlite3
-import threading
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Any, Optional
+from typing import Dict, List
 from dataclasses import dataclass
 from tqdm import tqdm
 import logging

--- a/scripts/deployment/quick_filesystem_check.py
+++ b/scripts/deployment/quick_filesystem_check.py
@@ -5,7 +5,6 @@ Quick Filesystem Check Script
 
 import os
 import sys
-import logging
 
 print("FILESYSTEM ISOLATION CHECK")
 print("=" * 50)

--- a/scripts/docker_healthcheck.py
+++ b/scripts/docker_healthcheck.py
@@ -8,7 +8,6 @@ dashboard is responding on the configured port.
 from __future__ import annotations
 
 import os
-from urllib.error import URLError
 from urllib.request import urlopen
 
 from utils.validation_utils import validate_enterprise_environment

--- a/scripts/enhanced_recommendation_processor.py
+++ b/scripts/enhanced_recommendation_processor.py
@@ -6,13 +6,10 @@ Process and action all remaining system recommendations
 """
 
 import os
-import sys
 import sqlite3
 import json
-import shutil
 from datetime import datetime
 from pathlib import Path
-import hashlib
 
 def process_recommendations():
     """🔧 Process and action all remaining recommendations"""

--- a/scripts/enterprise_completion_summary.py
+++ b/scripts/enterprise_completion_summary.py
@@ -27,10 +27,7 @@ Created: July 17, 2025
 
 import os
 import sys
-import json
 from datetime import datetime
-from pathlib import Path
-import logging
 
 from enterprise_modules.compliance import validate_enterprise_operation
 from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator

--- a/scripts/enterprise_orchestration_engine.py
+++ b/scripts/enterprise_orchestration_engine.py
@@ -32,12 +32,10 @@ import time
 import json
 import sqlite3
 import logging
-import hashlib
 import threading
-import subprocess
 from pathlib import Path
-from datetime import datetime, timedelta
-from typing import Dict, List, Any, Optional, Tuple, Union
+from datetime import datetime
+from typing import Dict, List, Any, Optional
 from dataclasses import dataclass, field
 from enum import Enum
 import argparse

--- a/scripts/final_root_assessment.py
+++ b/scripts/final_root_assessment.py
@@ -6,7 +6,6 @@ Corrected assessment including configuration files
 """
 
 import os
-import json
 from datetime import datetime
 from pathlib import Path
 

--- a/scripts/github_copilot_instruction_alignment_confirmer.py
+++ b/scripts/github_copilot_instruction_alignment_confirmer.py
@@ -11,7 +11,6 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
-import os
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager

--- a/scripts/perfect_100_excellence_booster.py
+++ b/scripts/perfect_100_excellence_booster.py
@@ -6,10 +6,7 @@ Ultra-optimization to achieve perfect 100% enterprise excellence
 """
 
 import os
-import sys
-import time
 from datetime import datetime
-from pathlib import Path
 
 def achieve_perfect_100_excellence():
     """🏆 Apply final optimization boost to achieve perfect 100% enterprise excellence"""

--- a/scripts/phase10_universal_mastery_intelligence.py
+++ b/scripts/phase10_universal_mastery_intelligence.py
@@ -27,13 +27,9 @@ import os
 import sys
 import time
 import logging
-import sqlite3
-import threading
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Optional
-import json
-import hashlib
+from typing import Dict, Any, Optional
 import uuid
 
 # 🏆 UNIVERSAL MASTERY INTELLIGENCE SYSTEM

--- a/scripts/phase6_continuous_operation_demo.py
+++ b/scripts/phase6_continuous_operation_demo.py
@@ -19,11 +19,8 @@ Demonstrating advanced Phase 6 capabilities building on 96.4% validation scores
 """
 
 import os
-import sys
 import time
-import json
-from datetime import datetime, timedelta
-from pathlib import Path
+from datetime import datetime
 import logging
 
 # Setup logging

--- a/scripts/phase8_advanced_enterprise_intelligence.py
+++ b/scripts/phase8_advanced_enterprise_intelligence.py
@@ -23,21 +23,14 @@ Created: July 17, 2025
 """
 
 import os
-import sys
-import json
-import sqlite3
-import threading
-import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager
-from typing import Dict, List, Any, Optional, Tuple
-from dataclasses import dataclass, field
+from typing import Dict, List, Any, Optional
+from dataclasses import dataclass
 import logging
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
-import numpy as np
 
 # MANDATORY: Enterprise logging setup
 logging.basicConfig(

--- a/scripts/phase9_quantum_enterprise_intelligence.py
+++ b/scripts/phase9_quantum_enterprise_intelligence.py
@@ -25,13 +25,9 @@ import os
 import sys
 import time
 import logging
-import sqlite3
-import threading
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Optional
-import json
-import hashlib
+from typing import Dict, Any, Optional
 import uuid
 
 # 🔬 QUANTUM ENTERPRISE INTELLIGENCE SYSTEM

--- a/scripts/phase9_quantum_intelligence_demo.py
+++ b/scripts/phase9_quantum_intelligence_demo.py
@@ -6,11 +6,7 @@ Clear demonstration of quantum enterprise intelligence results
 """
 
 import os
-import sys
-import time
-import logging
 from datetime import datetime
-from pathlib import Path
 
 def demonstrate_phase9_quantum_intelligence():
     """Demonstrate Phase 9 Quantum Enterprise Intelligence"""

--- a/scripts/quick_filesystem_check.py
+++ b/scripts/quick_filesystem_check.py
@@ -5,7 +5,6 @@ Quick Filesystem Check Script
 
 import os
 import sys
-import logging
 from secondary_copilot_validator import SecondaryCopilotValidator
 
 print("FILESYSTEM ISOLATION CHECK")

--- a/scripts/refined_production_builder.py
+++ b/scripts/refined_production_builder.py
@@ -11,7 +11,6 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
-import os
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager

--- a/scripts/regenerated/ENTERPRISE_QUALITY_ENHANCEMENT.py
+++ b/scripts/regenerated/ENTERPRISE_QUALITY_ENHANCEMENT.py
@@ -11,7 +11,6 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
-import os
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager

--- a/scripts/regenerated/enterprise_deployment/executive_alerts_test_suite.py
+++ b/scripts/regenerated/enterprise_deployment/executive_alerts_test_suite.py
@@ -11,7 +11,6 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
-import os
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager

--- a/scripts/regenerated/enterprise_deployment/quantum_enhanced_cache.py
+++ b/scripts/regenerated/enterprise_deployment/quantum_enhanced_cache.py
@@ -11,7 +11,6 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
-import os
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager

--- a/scripts/regenerated/integrated_deployment_orchestrator.py
+++ b/scripts/regenerated/integrated_deployment_orchestrator.py
@@ -11,7 +11,6 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
-import os
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager

--- a/scripts/regenerated/ml_models/recommendation_api.py
+++ b/scripts/regenerated/ml_models/recommendation_api.py
@@ -11,7 +11,6 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
-import os
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager

--- a/scripts/regenerated/monitoring/scripts/data_privacy_compliance_compliance.py
+++ b/scripts/regenerated/monitoring/scripts/data_privacy_compliance_compliance.py
@@ -11,7 +11,6 @@ Enterprise Standards Compliance:
 """
 from datetime import datetime
 from pathlib import Path
-import os
 
 from utils.cross_platform_paths import CrossPlatformPathManager
 from tqdm import tqdm

--- a/scripts/regenerated/scaling_innovation_framework.py
+++ b/scripts/regenerated/scaling_innovation_framework.py
@@ -11,7 +11,6 @@ Enterprise Standards Compliance:
 import sys
 
 import logging
-import os
 from pathlib import Path
 
 from utils.cross_platform_paths import CrossPlatformPathManager

--- a/scripts/root_organization_validator.py
+++ b/scripts/root_organization_validator.py
@@ -9,7 +9,6 @@ import os
 import json
 from datetime import datetime
 from pathlib import Path
-import hashlib
 
 def validate_root_organization():
     """📁 Validate root folder organization and file placement"""

--- a/scripts/session_wrap_up_engine.py
+++ b/scripts/session_wrap_up_engine.py
@@ -6,10 +6,7 @@ Comprehensive session termination with integrity validation
 """
 
 import os
-import sys
 import sqlite3
-import hashlib
-import shutil
 from datetime import datetime
 from pathlib import Path
 import json

--- a/scripts/ultimate_100_perfect_achievement.py
+++ b/scripts/ultimate_100_perfect_achievement.py
@@ -6,10 +6,7 @@ Final ultra-optimization to achieve exactly 100.0% enterprise excellence
 """
 
 import os
-import sys
-import time
 from datetime import datetime
-from pathlib import Path
 
 def achieve_exact_100_perfect():
     """🏆 Achieve exactly 100.0% perfect enterprise excellence"""

--- a/scripts/validation/actual_critical_script_tester.py
+++ b/scripts/validation/actual_critical_script_tester.py
@@ -5,14 +5,10 @@ DUAL COPILOT PATTERN - Fast validation of essential script functionality
 Tests actual scripts that exist after organization
 """
 
-import os
-import sys
 import ast
-import subprocess
-import importlib.util
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Any, Tuple
+from typing import Dict, Any, Tuple
 import logging
 from tqdm import tqdm
 

--- a/scripts/validation/comprehensive_functionality_revalidator.py
+++ b/scripts/validation/comprehensive_functionality_revalidator.py
@@ -12,15 +12,13 @@ Anti-Recursion Protocols: Validate all operations for safety
 DUAL COPILOT Validation: Ensure all validation meets enterprise standards
 """
 
-import os
 import sys
 import json
-import sqlite3
 import re
 import ast
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional, Any
+from typing import Dict, List, Any
 from tqdm import tqdm
 import logging
 

--- a/scripts/validation/comprehensive_functionality_validator.py
+++ b/scripts/validation/comprehensive_functionality_validator.py
@@ -4,14 +4,12 @@ Comprehensive Functionality Validator
 DUAL COPILOT PATTERN - Validate all moved scripts maintain original functionality
 """
 
-import os
 import sys
-import subprocess
 import importlib.util
 import ast
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Dict, List, Any
 import logging
 from tqdm import tqdm
 

--- a/scripts/validation/comprehensive_pis_validator.py
+++ b/scripts/validation/comprehensive_pis_validator.py
@@ -5,14 +5,11 @@ import os
 import json
 import logging
 import sqlite3
-import time
-import hashlib
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Any, Union
+from typing import Dict, List, Optional
 from dataclasses import dataclass, field
 from tqdm import tqdm
-import uuid
 import re
 
 # 🚨 CRITICAL: Anti-recursion workspace validation

--- a/scripts/validation/comprehensive_validation_summary.py
+++ b/scripts/validation/comprehensive_validation_summary.py
@@ -12,7 +12,6 @@ This includes:
 - Archive migration readiness ✅
 """
 
-import os
 import json
 from datetime import datetime
 from pathlib import Path

--- a/scripts/validation/critical_script_functionality_tester.py
+++ b/scripts/validation/critical_script_functionality_tester.py
@@ -5,14 +5,11 @@ DUAL COPILOT PATTERN - Fast validation of essential script functionality
 Ensures all critical scripts maintain 100% functionality after organization
 """
 
-import os
-import sys
 import ast
-import subprocess
 import importlib.util
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Any, Tuple
+from typing import Dict, Any, Tuple
 import logging
 from tqdm import tqdm
 

--- a/scripts/validation/enterprise_dual_copilot_validator.py
+++ b/scripts/validation/enterprise_dual_copilot_validator.py
@@ -35,7 +35,6 @@ from typing import Any, Dict, List, Optional
 
 from tqdm import tqdm
 import psutil
-from enterprise_modules.compliance import validate_enterprise_operation
 from utils.log_utils import _log_event
 
 # Unicode-compatible file handler (fallback implementation)

--- a/scripts/validation/final_compliance_verifier.py
+++ b/scripts/validation/final_compliance_verifier.py
@@ -6,7 +6,6 @@ MISSION: Verify 100% compliance with 99.9MB database limit
 ================================================================
 """
 
-import os
 from pathlib import Path
 from datetime import datetime
 import sqlite3

--- a/scripts/validation/final_organization_validator.py
+++ b/scripts/validation/final_organization_validator.py
@@ -3,7 +3,6 @@
 Final Modular Organization Validation
 """
 
-import os
 from pathlib import Path
 
 def validate_organization():

--- a/scripts/validation/final_system_validator.py
+++ b/scripts/validation/final_system_validator.py
@@ -11,17 +11,13 @@ CRITICAL: Anti-recursion compliance enforcement
 """
 
 import os
-import sys
 import json
 import sqlite3
 import shutil
-import hashlib
-import subprocess
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Dict, List, Any, Optional
 from tqdm import tqdm
-import time
 
 class FinalSystemValidator:
     """🛡️ Final System Validation with Enterprise Compliance"""

--- a/scripts/validation/functionality_validation_tester.py
+++ b/scripts/validation/functionality_validation_tester.py
@@ -10,14 +10,12 @@ Follows enterprise standards with visual processing indicators and anti-recursio
 import os
 import sys
 import json
-import sqlite3
 import subprocess
 import traceback
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Dict, Any
 from tqdm import tqdm
-import time
 
 class FunctionalityValidationTester:
     """🧠 Enterprise Functionality Validation with Enhanced Cognitive Processing"""

--- a/scripts/validation/future_file_routing_validator.py
+++ b/scripts/validation/future_file_routing_validator.py
@@ -13,16 +13,13 @@ Validates that all future file operations correctly route files to appropriate f
 Enterprise-grade validation with pattern recognition and workflow testing.
 """
 
-import os
 import sys
 import json
-import sqlite3
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional, Any
+from typing import Dict, List, Any
 import re
-import tempfile
 import shutil
 
 class FutureFileRoutingValidator:

--- a/scripts/validation/intelligent_config_validator.py
+++ b/scripts/validation/intelligent_config_validator.py
@@ -12,14 +12,12 @@ Anti-Recursion Protocols: Validate all operations for safety
 DUAL COPILOT Validation: Ensure all validation meets enterprise standards
 """
 
-import os
 import sys
 import json
 import re
-import ast
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional, Any
+from typing import Dict, List, Any
 from tqdm import tqdm
 import logging
 

--- a/scripts/validation/validate_final_deployment.py
+++ b/scripts/validation/validate_final_deployment.py
@@ -14,7 +14,7 @@ while maintaining backward compatibility.
 import sys
 
 # Import from new modular package
-from validation.protocols.deployment import DeploymentValidator, main
+from validation.protocols.deployment import main
 
 # This script now delegates to the modular implementation
 if __name__ == "__main__":

--- a/temp_db_check.py
+++ b/temp_db_check.py
@@ -3,7 +3,6 @@
 Database Structure Analysis for PIS Development
 """
 import sqlite3
-import sys
 from pathlib import Path
 
 def analyze_production_db():

--- a/tests/compliance_test_suite.py
+++ b/tests/compliance_test_suite.py
@@ -22,7 +22,6 @@ from typing import Any, Dict, List
 
 from tqdm import tqdm
 
-from quantum.quantum_compliance_engine import QuantumComplianceEngine
 from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
 from template_engine.db_first_code_generator import DBFirstCodeGenerator
 from template_engine.pattern_clustering_sync import PatternClusteringSync

--- a/tests/template_engine/test_database_scoring.py
+++ b/tests/template_engine/test_database_scoring.py
@@ -1,4 +1,3 @@
-import os
 import sqlite3
 from pathlib import Path
 

--- a/tests/test_autonomous_audit_validator.py
+++ b/tests/test_autonomous_audit_validator.py
@@ -1,5 +1,3 @@
-import types
-from pathlib import Path
 
 import scripts.autonomous_setup_and_audit as asa
 

--- a/tests/test_autonomous_backup_manager.py
+++ b/tests/test_autonomous_backup_manager.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import sqlite3
 from pathlib import Path

--- a/tests/test_autonomous_setup_and_audit.py
+++ b/tests/test_autonomous_setup_and_audit.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 
 from scripts.autonomous_setup_and_audit import ingest_assets
-from utils import log_utils
 from scripts.database.unified_database_initializer import initialize_database
 
 

--- a/tests/test_backup_archiver.py
+++ b/tests/test_backup_archiver.py
@@ -1,5 +1,3 @@
-import os
-from pathlib import Path
 
 import py7zr
 import pytest

--- a/tests/test_complete_template_generator.py
+++ b/tests/test_complete_template_generator.py
@@ -3,7 +3,6 @@ import sqlite3
 from pathlib import Path
 
 from scripts.utilities.complete_template_generator import CompleteTemplateGenerator
-import logging
 
 
 def create_dbs(tmp_path: Path):

--- a/tests/test_comprehensive_workspace_manager.py
+++ b/tests/test_comprehensive_workspace_manager.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import sqlite3
 from pathlib import Path

--- a/tests/test_continuous_monitoring_engine.py
+++ b/tests/test_continuous_monitoring_engine.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 import logging
 import sqlite3

--- a/tests/test_correction_history.py
+++ b/tests/test_correction_history.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 import shutil
 import sqlite3
 from pathlib import Path

--- a/tests/test_cross_database_sync_logger.py
+++ b/tests/test_cross_database_sync_logger.py
@@ -4,7 +4,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from scripts.database.cross_database_sync_logger import log_sync_operation
-from enterprise_modules.compliance import validate_enterprise_operation
 
 
 def test_log_sync_operation(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_database_consolidation_migration.py
+++ b/tests/test_database_consolidation_migration.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 import sqlite3
 from pathlib import Path
 

--- a/tests/test_database_driven_flake8_corrector_functional.py
+++ b/tests/test_database_driven_flake8_corrector_functional.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 import sqlite3
 
 from scripts.database.database_driven_flake8_corrector_functional import \

--- a/tests/test_database_driven_flake8_validator_new.py
+++ b/tests/test_database_driven_flake8_validator_new.py
@@ -3,7 +3,6 @@ import pytest
 import scripts.database.database_driven_flake8_corrector_functional as mod
 from scripts.database.database_driven_flake8_corrector_functional import DatabaseDrivenFlake8CorrectorFunctional
 from pathlib import PureWindowsPath
-import logging
 
 
 def test_validate_workspace_detects_recursion(tmp_path):

--- a/tests/test_database_list.py
+++ b/tests/test_database_list.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 
 from scripts.database.unified_database_management_system import UnifiedDatabaseManager
-import logging
 
 
 def test_verify_expected_databases(monkeypatch):

--- a/tests/test_dual_copilot_orchestrator_scripts.py
+++ b/tests/test_dual_copilot_orchestrator_scripts.py
@@ -1,5 +1,4 @@
 import runpy
-from pathlib import Path
 
 
 def _runs_with_dual_validation(module: str, monkeypatch) -> bool:

--- a/tests/test_enterprise_api_auth.py
+++ b/tests/test_enterprise_api_auth.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from scripts.enterprise.enterprise_api_infrastructure_framework import EnterpriseAuthentication
 

--- a/tests/test_enterprise_api_server.py
+++ b/tests/test_enterprise_api_server.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 from scripts.enterprise.enterprise_api_infrastructure_framework import EnterpriseAPIServer

--- a/tests/test_enterprise_orchestrator.py
+++ b/tests/test_enterprise_orchestrator.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 
 from copilot.core.enterprise_orchestrator import EnterpriseUtility
 

--- a/tests/test_env_paths.py
+++ b/tests/test_env_paths.py
@@ -1,6 +1,4 @@
 import importlib
-import os
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_expanded_quantum_algorithm_library.py
+++ b/tests/test_expanded_quantum_algorithm_library.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from scripts.utilities.expanded_quantum_algorithm_library import EnterpriseUtility
-import logging
 
 
 def test_perform_utility_function_runs():

--- a/tests/test_final_deployment_validator.py
+++ b/tests/test_final_deployment_validator.py
@@ -1,5 +1,4 @@
 import sqlite3
-from pathlib import Path
 from deployment.deployment_package_20250710_182951.scripts.final_deployment_validator import EnterpriseUtility
 
 

--- a/tests/test_flake8_corrector.py
+++ b/tests/test_flake8_corrector.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 from pathlib import Path
 
 import pytest

--- a/tests/test_legacy_cleanup_system.py
+++ b/tests/test_legacy_cleanup_system.py
@@ -1,5 +1,4 @@
 import sqlite3
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_migrate_hard_coded_paths.py
+++ b/tests/test_migrate_hard_coded_paths.py
@@ -1,7 +1,5 @@
-import os
-from pathlib import Path
 
-from utils.cross_platform_paths import migrate_hard_coded_paths, CrossPlatformPathManager
+from utils.cross_platform_paths import migrate_hard_coded_paths
 
 
 def test_migrate_creates_backup(tmp_path, monkeypatch):

--- a/tests/test_new_placeholders.py
+++ b/tests/test_new_placeholders.py
@@ -1,9 +1,7 @@
-import importlib
 import os
 import shutil
 import sqlite3
 from pathlib import Path
-from unittest.mock import patch
 import pytest
 
 from scripts.session.COMPREHENSIVE_WORKSPACE_MANAGER import ComprehensiveWorkspaceManager

--- a/tests/test_optimization_cli.py
+++ b/tests/test_optimization_cli.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import os
 import shutil
 
 from scripts.optimization.automated_optimization_engine import main as opt_main

--- a/tests/test_performance_tracker.py
+++ b/tests/test_performance_tracker.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 import sqlite3
 from pathlib import Path
 

--- a/tests/test_performance_validation_framework.py
+++ b/tests/test_performance_validation_framework.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 import sqlite3
 import time
 from pathlib import Path

--- a/tests/test_placeholder_cleanup.py
+++ b/tests/test_placeholder_cleanup.py
@@ -1,5 +1,4 @@
 import sqlite3
-import json
 
 def test_placeholder_cleanup_workflow(tmp_path, monkeypatch):
     monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")

--- a/tests/test_primary_executor_orchestrator.py
+++ b/tests/test_primary_executor_orchestrator.py
@@ -1,4 +1,3 @@
-import builtins
 import types
 
 from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator

--- a/tests/test_qiskit_imports.py
+++ b/tests/test_qiskit_imports.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import importlib
-import logging
 
 
 def test_qiskit_and_qml_import():

--- a/tests/test_quantum_algorithm_library_expansion.py
+++ b/tests/test_quantum_algorithm_library_expansion.py
@@ -10,7 +10,6 @@ from quantum_algorithm_library_expansion import (
     quantum_cluster_representatives,
     quantum_similarity_score,
 )
-import numpy as np
 
 
 def test_perform_utility_function_runs():

--- a/tests/test_quantum_algorithms_functional.py
+++ b/tests/test_quantum_algorithms_functional.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
 
 from scripts.utilities.quantum_algorithms_functional import (
     run_grover_search,

--- a/tests/test_quantum_benchmarking.py
+++ b/tests/test_quantum_benchmarking.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import logging
 
 import pytest
 from qiskit_machine_learning.neural_networks import EstimatorQNN

--- a/tests/test_quantum_optimization.py
+++ b/tests/test_quantum_optimization.py
@@ -4,7 +4,6 @@
 import logging
 from typing import Any, Dict, List
 
-import pytest
 
 from quantum.quantum_optimization import EnterpriseUtility
 

--- a/tests/test_quantum_package.py
+++ b/tests/test_quantum_package.py
@@ -2,7 +2,6 @@
 Tests for the quantum package.
 """
 
-import pytest
 import tempfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock

--- a/tests/test_quantum_performance_integration_tester.py
+++ b/tests/test_quantum_performance_integration_tester.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from quantum_performance_integration_tester import EnterpriseUtility
-import logging
 
 
 def test_perform_utility_function_runs():

--- a/tests/test_quantum_template_generator.py
+++ b/tests/test_quantum_template_generator.py
@@ -1,6 +1,5 @@
 import sqlite3
 from pathlib import Path
-import importlib.util
 
 from docs.quantum_template_generator import generate_default_templates
 

--- a/tests/test_relocation_logging.py
+++ b/tests/test_relocation_logging.py
@@ -1,6 +1,5 @@
 import importlib
 
-import pytest
 
 
 def test_relocation_logs_events(tmp_path, monkeypatch):

--- a/tests/test_secret_manager.py
+++ b/tests/test_secret_manager.py
@@ -1,4 +1,3 @@
-import os
 from config.secret_manager import get_secret
 
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from datetime import datetime
 from copilot.core.enterprise_json_serialization_fix import EnterpriseJSONSerializer
-import logging
 
 
 def test_round_trip_datetime(tmp_path, monkeypatch):

--- a/tests/test_sync_logging.py
+++ b/tests/test_sync_logging.py
@@ -1,6 +1,5 @@
 import sqlite3
 from pathlib import Path
-import pytest
 from template_engine import template_synchronizer
 
 

--- a/tests/test_unified_script_generation_system.py
+++ b/tests/test_unified_script_generation_system.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import shutil
 
 from scripts.utilities.unified_script_generation_system import EnterpriseUtility
-import logging
 
 
 def test_template_generation(tmp_path):

--- a/tests/test_web_gui_integrator_registration.py
+++ b/tests/test_web_gui_integrator_registration.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 from pathlib import Path
 

--- a/tests/test_workflow_logging.py
+++ b/tests/test_workflow_logging.py
@@ -1,8 +1,4 @@
-import json
-import os
-from pathlib import Path
 
-import pytest
 
 from template_engine.workflow_enhancer import TemplateWorkflowEnhancer
 

--- a/tests/test_workspace_from_env.py
+++ b/tests/test_workspace_from_env.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
 
 from scripts.database.database_purification_engine import DatabasePurificationEngine
 

--- a/tests/test_workspace_optimizer.py
+++ b/tests/test_workspace_optimizer.py
@@ -1,4 +1,3 @@
-import os
 import sqlite3
 import shutil
 from pathlib import Path

--- a/tests/test_workspace_utils.py
+++ b/tests/test_workspace_utils.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
 from pathlib import Path
 
 from copilot.common.workspace_utils import (_within_workspace,


### PR DESCRIPTION
## Summary
- apply `ruff --fix` across the repo to clear all lints
- update `DatabaseFirstCorrectionEngine` to use environment variable for workspace
- ensure final validation uses `ruff` instead of `flake8`

## Testing
- `ruff check --output-format=concise`
- `pyright` *(failed: process interrupted)*
- `pytest -q` *(failed: 40 failed, 259 passed, 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688b2bf9db2c8331b1ca1ef9692559f5