### PR TITLE
Extend Ruff correction logging

### DIFF
--- a/databases/migrations/README.md
+++ b/databases/migrations/README.md
@@ -16,22 +16,23 @@ in the following order to satisfy foreign key constraints:
 2. `add_code_audit_history.sql`
 3. `add_code_audit_log.sql`
 4. `add_correction_history.sql`
-5. `add_correction_logs.sql`
-6. `add_corrections.sql`
-7. `add_cross_link_events.sql`
-8. `add_cross_link_suggestions.sql`
-9. `add_cross_link_summary.sql`
-10. `add_dashboard_alerts.sql`
-11. `add_placeholder_removals.sql`
-12. `add_rollback_failures.sql`
-13. `add_rollback_logs.sql`
-14. `add_rollback_strategy_history.sql`
-15. `add_size_violations.sql`
-16. `add_sync_events_log.sql`
-17. `add_unified_wrapup_sessions.sql`
-18. `add_violation_logs.sql`
-19. `create_todo_fixme_tracking.sql`
-20. `extend_todo_fixme_tracking.sql`
+5. `extend_correction_history.sql`
+6. `add_correction_logs.sql`
+7. `add_corrections.sql`
+8. `add_cross_link_events.sql`
+9. `add_cross_link_suggestions.sql`
+10. `add_cross_link_summary.sql`
+11. `add_dashboard_alerts.sql`
+12. `add_placeholder_removals.sql`
+13. `add_rollback_failures.sql`
+14. `add_rollback_logs.sql`
+15. `add_rollback_strategy_history.sql`
+16. `add_size_violations.sql`
+17. `add_sync_events_log.sql`
+18. `add_unified_wrapup_sessions.sql`
+19. `add_violation_logs.sql`
+20. `create_todo_fixme_tracking.sql`
+21. `extend_todo_fixme_tracking.sql`
 
 `extend_todo_fixme_tracking.sql` depends on both `create_todo_fixme_tracking.sql`
 and `add_placeholder_removals.sql` because it references the `placeholder_removals`

--- a/databases/migrations/add_correction_history.sql
+++ b/databases/migrations/add_correction_history.sql
@@ -1,11 +1,15 @@
 CREATE TABLE IF NOT EXISTS correction_history (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    session_id TEXT NOT NULL,
+    user_id INTEGER,
+    session_id TEXT,
     file_path TEXT NOT NULL,
-    action TEXT NOT NULL,
+    action TEXT,
     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-    details TEXT
+    details TEXT,
+    violation_code TEXT,
+    original_line TEXT,
+    corrected_line TEXT,
+    correction_timestamp TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_correction_history_user_id ON correction_history(user_id);
 CREATE INDEX IF NOT EXISTS idx_correction_history_session_id ON correction_history(session_id);

--- a/databases/migrations/extend_correction_history.sql
+++ b/databases/migrations/extend_correction_history.sql
@@ -1,0 +1,4 @@
+ALTER TABLE correction_history ADD COLUMN violation_code TEXT;
+ALTER TABLE correction_history ADD COLUMN original_line TEXT;
+ALTER TABLE correction_history ADD COLUMN corrected_line TEXT;
+ALTER TABLE correction_history ADD COLUMN correction_timestamp TEXT;

--- a/scripts/database/database_driven_ruff_corrector.py
+++ b/scripts/database/database_driven_ruff_corrector.py
@@ -52,6 +52,7 @@ class DatabaseDrivenRuffCorrector:
         self.ruff_validator = EnterpriseFlake8Corrector(self.workspace_path)
         self.start_ts: float | None = None
         self.timeout_seconds = timeout_minutes * 60
+        self.original_lines: Dict[Path, List[str]] = {}
 
     def scan_python_files(self) -> List[Path]:
         files = []
@@ -119,6 +120,7 @@ class DatabaseDrivenRuffCorrector:
         for idx, path in enumerate(files, start=1):
             self._check_timeout()
             original = path.read_text(encoding="utf-8", errors="ignore")
+            self.original_lines[path] = original.splitlines()
             subprocess.run(["ruff", "check", "--fix", str(path)], check=False)
             subprocess.run(["isort", str(path)], check=False)
             subprocess.run(["autopep8", "--in-place", str(path)], check=False)
@@ -162,6 +164,7 @@ class DatabaseDrivenRuffCorrector:
             cursor = conn.cursor()
             for file_path in corrected:
                 corrected_lines = file_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+                original_lines = self.original_lines.get(file_path, [])
                 for line in violations.get(file_path, []):
                     parts = line.split(":", 3)
                     if len(parts) < 4:
@@ -170,10 +173,11 @@ class DatabaseDrivenRuffCorrector:
                     code = rest.strip().split()[0]
                     row_num = int(row)
                     corrected_line = corrected_lines[row_num - 1] if row_num <= len(corrected_lines) else ""
+                    original_line = original_lines[row_num - 1] if row_num <= len(original_lines) else ""
                     cursor.execute(
                         "INSERT INTO correction_history (file_path, violation_code, original_line, corrected_line, correction_timestamp)"
                         " VALUES (?, ?, ?, ?, ?)",
-                        (str(file_path), code, row, corrected_line, timestamp),
+                        (str(file_path), code, original_line, corrected_line, timestamp),
                     )
             conn.commit()
 

--- a/tests/test_analytics_db_creation.py
+++ b/tests/test_analytics_db_creation.py
@@ -7,6 +7,7 @@ MIGRATIONS = [
     Path("databases/migrations/create_todo_fixme_tracking.sql"),
     Path("databases/migrations/add_code_audit_log.sql"),
     Path("databases/migrations/add_correction_history.sql"),
+    Path("databases/migrations/extend_correction_history.sql"),
     Path("databases/migrations/add_code_audit_history.sql"),
     Path("databases/migrations/add_violation_logs.sql"),
     Path("databases/migrations/add_rollback_logs.sql"),

--- a/tests/test_analytics_migration_simulation.py
+++ b/tests/test_analytics_migration_simulation.py
@@ -45,6 +45,7 @@ def test_analytics_migration_simulation(capsys) -> None:
     migration_files = [
         Path("databases/migrations/add_code_audit_log.sql"),
         Path("databases/migrations/add_correction_history.sql"),
+        Path("databases/migrations/extend_correction_history.sql"),
         Path("databases/migrations/add_code_audit_history.sql"),
         Path("databases/migrations/add_violation_logs.sql"),
         Path("databases/migrations/add_rollback_logs.sql"),

--- a/tests/test_analytics_protocol.py
+++ b/tests/test_analytics_protocol.py
@@ -38,6 +38,7 @@ def test_analytics_protocol_dry_run(capsys) -> None:
     migration_files = [
         Path("databases/migrations/add_code_audit_log.sql"),
         Path("databases/migrations/add_correction_history.sql"),
+        Path("databases/migrations/extend_correction_history.sql"),
         Path("databases/migrations/add_code_audit_history.sql"),
         Path("databases/migrations/add_violation_logs.sql"),
         Path("databases/migrations/add_rollback_logs.sql"),

--- a/tests/test_apply_all_migrations.py
+++ b/tests/test_apply_all_migrations.py
@@ -8,6 +8,7 @@ def test_apply_all_migrations(tmp_path: Path) -> None:
         Path("databases/migrations/create_todo_fixme_tracking.sql"),
         Path("databases/migrations/add_code_audit_log.sql"),
         Path("databases/migrations/add_correction_history.sql"),
+        Path("databases/migrations/extend_correction_history.sql"),
         Path("databases/migrations/add_code_audit_history.sql"),
         Path("databases/migrations/add_violation_logs.sql"),
         Path("databases/migrations/add_rollback_logs.sql"),


### PR DESCRIPTION
## Summary
- extend `add_correction_history.sql` with fields for lint code and lines
- create `extend_correction_history.sql` migration
- log original and corrected lines in ruff correction scripts
- include new migration in analytics tests

## Testing
- `ruff check .`
- `pytest tests/test_database_driven_ruff_corrector.py::test_ruff_corrector_runs_fix` *(fails: assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_688b446207f88331b70e66fbe0e95f08