### PR TITLE
Fix event_log schema and update tests

### DIFF
--- a/comprehensive_test_results.json
+++ b/comprehensive_test_results.json
@@ -1,8 +1,8 @@
 {
-    "timestamp": "2025-07-31T02:10:28",
-    "tests_executed": 178,
-    "tests_passed": 146,
-    "tests_failed": 29,
+    "timestamp": "2025-07-31T11:31:59",
+    "tests_executed": 353,
+    "tests_passed": 295,
+    "tests_failed": 52,
     "tests_errors": 0,
-    "tests_skipped": 3
+    "tests_skipped": 6
 }

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -29,6 +29,18 @@ _log_lock = threading.Lock()
 # explicitly requested. The tables mirror the SQL migrations under
 # ``databases/migrations``.
 TABLE_SCHEMAS: Dict[str, str] = {
+    "event_log": """
+        CREATE TABLE IF NOT EXISTS event_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event TEXT,
+            session TEXT,
+            module TEXT,
+            level TEXT,
+            timestamp TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_event_log_timestamp
+            ON event_log(timestamp);
+    """,
     "violation_logs": """
         CREATE TABLE IF NOT EXISTS violation_logs (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- add missing event_log table schema in utils
- update comprehensive_test_results.json with latest pytest results

## Testing
- `pytest tests/test_dual_copilot_coverage.py tests/test_enterprise_orchestrator.py -q`
- `pytest -q` *(fails: 52 failed, 295 passed, 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688b4abb9248833191a90070bab69056