### PR TITLE
Prevent recursive backup in disaster recovery

### DIFF
--- a/scripts/utilities/unified_disaster_recovery_system.py
+++ b/scripts/utilities/unified_disaster_recovery_system.py
@@ -31,6 +31,17 @@ class UnifiedDisasterRecoverySystem:
         """Restore files from ``GH_COPILOT_BACKUP_ROOT``."""
         start_time = datetime.now()
         backup_root = Path(os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups"))
+        workspace = self.workspace_path.resolve()
+        backup_root_resolved = backup_root.resolve()
+
+        if workspace == backup_root_resolved or workspace in backup_root_resolved.parents:
+            self.logger.error(
+                "%s Backup root %s cannot reside within workspace %s",
+                TEXT_INDICATORS["error"],
+                backup_root_resolved,
+                workspace,
+            )
+            return False
         source = backup_root / "production_backup"
         restore_dir = self.workspace_path / "restored"
         restore_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_unified_disaster_recovery_system.py
+++ b/tests/test_unified_disaster_recovery_system.py
@@ -1,0 +1,36 @@
+import logging
+from unified_disaster_recovery_system import UnifiedDisasterRecoverySystem
+
+
+def _create_backup_structure(root):
+    prod = root / "production_backup"
+    prod.mkdir(parents=True)
+    (prod / "sample.txt").write_text("data")
+
+
+def test_recovery_from_external_backup(tmp_path, monkeypatch):
+    ws = tmp_path / "ws"
+    bk = tmp_path / "bk"
+    ws.mkdir()
+    bk.mkdir()
+    _create_backup_structure(bk)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
+    system = UnifiedDisasterRecoverySystem(str(ws))
+    assert system.perform_recovery()
+    restored = ws / "restored" / "sample.txt"
+    assert restored.exists()
+
+
+def test_recovery_aborts_when_backup_inside_workspace(tmp_path, monkeypatch, caplog):
+    ws = tmp_path / "ws"
+    bk = ws / "bk"
+    ws.mkdir()
+    bk.mkdir()
+    _create_backup_structure(bk)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
+    caplog.set_level(logging.ERROR)
+    system = UnifiedDisasterRecoverySystem(str(ws))
+    assert not system.perform_recovery()
+    assert "cannot reside within workspace" in caplog.text


### PR DESCRIPTION
## Summary
- validate that backups are outside the workspace in `unified_disaster_recovery_system`
- test recovery works only with external backup path

## Testing
- `ruff check .`
- `pytest tests/test_unified_disaster_recovery_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688b4abda4548331b537368c25b21d69