### PR TITLE
feat: add event_log schema

### DIFF
--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -33,9 +33,12 @@ TABLE_SCHEMAS: Dict[str, str] = {
         CREATE TABLE IF NOT EXISTS event_log (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             event TEXT,
+            details TEXT,
             session TEXT,
             module TEXT,
             level TEXT,
+            fix_count INTEGER,
+            db TEXT,
             timestamp TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_event_log_timestamp


### PR DESCRIPTION
## Summary
- extend `TABLE_SCHEMAS` with a fuller `event_log` table definition
- ensure table includes details, count, db name, etc.

## Testing
- `ruff check utils/log_utils.py`
- `pyright utils/log_utils.py`
- `pytest tests/test_log_utils_extended.py::test_log_recovery_after_interruption -q`
- `GH_COPILOT_WORKSPACE=/tmp/tmpworkspace python scripts/wlc_session_manager.py --steps 1 --db-path databases/production.db`

------
https://chatgpt.com/codex/tasks/task_e_688b8df53ba88331b77c7800ceb3ff14