### PR TITLE
feat: add git safe commit utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,6 +971,11 @@ The `compliance-audit.yml` workflow now installs dependencies, including
 # Generate scored documentation templates
 python docs/quantum_template_generator.py
 
+# Safely commit staged changes with Git LFS auto-tracking
+ALLOW_AUTOLFS=1 tools/git_safe_add_commit.py "<commit message>"
+# Bash fallback:
+ALLOW_AUTOLFS=1 tools/git_safe_add_commit.sh "<commit message>"
+
 The audit results are used by the `/dashboard/compliance` endpoint to
 report ongoing placeholder removal progress and overall compliance
 metrics. A machine-readable summary is also written to

--- a/tests/test_git_safe_add_commit.py
+++ b/tests/test_git_safe_add_commit.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "git_safe_add_commit.py"
+
+
+def run(cmd, cwd, env=None):
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, env=env, check=True)
+
+
+def test_git_safe_add_commit(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run(["git", "init"], cwd=repo)
+    run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    run(["git", "config", "user.name", "Tester"], cwd=repo)
+
+    (repo / "file.txt").write_text("hello")
+    (repo / "bin.bin").write_bytes(b"\x00\x01\x02")
+    run(["git", "add", "file.txt", "bin.bin"], cwd=repo)
+
+    env = os.environ.copy()
+    env["ALLOW_AUTOLFS"] = "1"
+    run(["python", str(SCRIPT), "test commit"], cwd=repo, env=env)
+
+    attrs = (repo / ".gitattributes").read_text()
+    assert "*.bin" in attrs
+    log = run(["git", "log", "-1", "--pretty=%B"], cwd=repo)
+    assert "test commit" in log.stdout

--- a/tools/git_safe_add_commit.py
+++ b/tools/git_safe_add_commit.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Safely commit staged files with optional Git LFS auto-tracking."""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SIZE_LIMIT = 50 * 1024 * 1024  # 50MB
+ALLOW_AUTOLFS = os.getenv("ALLOW_AUTOLFS") == "1"
+
+
+def run(cmd: list[str], cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Run command and return completed process."""
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def is_binary(path: Path) -> bool:
+    """Detect if a file is binary using git diff --numstat or mimetypes."""
+    result = run(["git", "diff", "--numstat", str(path)])
+    if result.stdout.startswith("-\t"):
+        return True
+    mime, _ = mimetypes.guess_type(path.name)
+    return mime is None or ("text" not in mime and "json" not in mime)
+
+
+def in_gitattributes(path: Path) -> bool:
+    result = run(["git", "check-attr", "filter", "--", str(path)])
+    return result.stdout.strip().endswith("lfs")
+
+
+def track_lfs(pattern: str) -> None:
+    run(["git", "lfs", "install"])
+    run(["git", "lfs", "track", pattern])
+    run(["git", "add", ".gitattributes"])
+    print(f"[LFS] Tracking {pattern}")
+
+
+def main() -> None:
+    message = sys.argv[1] if len(sys.argv) > 1 else "auto commit"
+    files = run(["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"]).stdout.splitlines()
+    for fname in files:
+        path = Path(fname)
+        if not path.exists():
+            continue
+        size = path.stat().st_size
+        if (is_binary(path) or size > SIZE_LIMIT) and not in_gitattributes(path):
+            if not ALLOW_AUTOLFS:
+                print(f"Binary or large file detected: {fname}. Set ALLOW_AUTOLFS=1 to auto-track with git lfs.")
+                sys.exit(1)
+            ext = path.suffix or os.path.splitext(fname)[1]
+            pattern = f"*{ext}"
+            track_lfs(pattern)
+            run(["git", "add", fname])
+    commit = run(["git", "commit", "-m", message])
+    if commit.returncode != 0:
+        sys.stdout.write(commit.stdout)
+        sys.stderr.write(commit.stderr)
+        sys.exit(commit.returncode)
+    print("✅ Commit successful.")
+    if "--push" in sys.argv:
+        push = run(["git", "push"])
+        sys.stdout.write(push.stdout)
+        sys.stderr.write(push.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/git_safe_add_commit.sh
+++ b/tools/git_safe_add_commit.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Safely commit staged files with optional Git LFS auto-tracking.
+set -euo pipefail
+
+ALLOW="${ALLOW_AUTOLFS:-0}"
+SIZE_LIMIT=$((50*1024*1024))
+
+files=$(git diff --cached --name-only --diff-filter=ACM)
+for f in $files; do
+  [ -f "$f" ] || continue
+  if file "$f" | grep -q binary || [ $(wc -c <"$f") -gt "$SIZE_LIMIT" ]; then
+    if ! git check-attr filter -- "$f" | grep -q lfs; then
+      if [ "$ALLOW" = "1" ]; then
+        ext="${f##*.}"
+        git lfs install
+        git lfs track "*.${ext}"
+        git add .gitattributes
+        git add "$f"
+        echo "[LFS] Tracking *.${ext}"
+      else
+        echo "ERROR: $f is binary or large. Set ALLOW_AUTOLFS=1 to auto-fix." >&2
+        exit 1
+      fi
+    fi
+  fi
+done
+
+msg=${1:-"auto commit"}
+shift || true
+
+git commit -m "$msg"
+if [ "$#" -gt 0 ] && [ "$1" = "--push" ]; then
+  git push
+fi


### PR DESCRIPTION
## Summary
- add git_safe_add_commit.py to wrap git commit and autotrack binaries in Git LFS
- add bash fallback script git_safe_add_commit.sh
- document new commands in README
- test git safe commit utility

## Testing
- `ruff format tools/git_safe_add_commit.py tests/test_git_safe_add_commit.py`
- `ruff check tools/git_safe_add_commit.py tests/test_git_safe_add_commit.py`
- `pytest tests/test_git_safe_add_commit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688b95f9f258833194bb47d68ef39a2a