### PR TITLE
docs: add safe commit workflow instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,13 +300,27 @@ python scripts/file_management/workspace_optimizer.py
 Use the helper scripts to automatically track binary or large files via Git LFS.
 
 ```bash
+export GH_COPILOT_BACKUP_ROOT=/path/to/backups
 export ALLOW_AUTOLFS=1
 tools/git_safe_add_commit.py "your commit message"
 ```
 
 The shell version `tools/git_safe_add_commit.sh` provides the same behaviour and
-can push when invoked with `--push`. See
-[docs/GIT_LFS_WORKFLOW.md](docs/GIT_LFS_WORKFLOW.md) for details.
+can push when invoked with `--push`.
+
+`GH_COPILOT_BACKUP_ROOT` should already contain your external backups before you
+commit. When `ALLOW_AUTOLFS` is set, the commit utilities run `git lfs track` on
+detected binary or large files so they don't bloat the repository.
+
+Troubleshooting tips:
+
+* **Binary file detected** – ensure `ALLOW_AUTOLFS=1` and re-run the command.
+* **Git LFS missing** – install with `git lfs install` if the helper reports an
+  error.
+* **Backup path not found** – verify `$GH_COPILOT_BACKUP_ROOT` points outside
+  the repo and that backups exist.
+
+See [docs/GIT_LFS_WORKFLOW.md](docs/GIT_LFS_WORKFLOW.md) for full details.
 
 ### Docker Usage
 Build and run the container with Docker:
@@ -984,6 +998,7 @@ The `compliance-audit.yml` workflow now installs dependencies, including
 python docs/quantum_template_generator.py
 
 # Safely commit staged changes with Git LFS auto-tracking
+export GH_COPILOT_BACKUP_ROOT=/path/to/backups
 ALLOW_AUTOLFS=1 tools/git_safe_add_commit.py "<commit message>"
 # Bash fallback:
 ALLOW_AUTOLFS=1 tools/git_safe_add_commit.sh "<commit message>"

--- a/docs/BACKUP_COMPLIANCE_GUIDE.md
+++ b/docs/BACKUP_COMPLIANCE_GUIDE.md
@@ -83,3 +83,34 @@ The script queries the `backup_operations` table to confirm that backups complet
 
 ---
 Ensure all commands are executed from the project root with the virtual environment activated.
+
+## Safe Commit Workflow
+
+After creating a backup you can safely commit the snapshot using the bundled Git
+LFS helper scripts. These utilities prevent accidental commits of large or
+binary files by scanning the staged changes.
+
+1. Ensure both environment variables are set:
+   ```bash
+   export GH_COPILOT_BACKUP_ROOT=/path/to/external/backups
+   export ALLOW_AUTOLFS=1
+   ```
+2. Commit using the Python utility:
+   ```bash
+   tools/git_safe_add_commit.py "backup: $(date +%Y%m%d)"
+   ```
+   Or use the shell version with optional push support:
+   ```bash
+   tools/git_safe_add_commit.sh "backup" --push
+   ```
+   When `ALLOW_AUTOLFS` is `1`, any detected binary or oversized files are
+   automatically tracked with Git LFS before the commit proceeds.
+
+### Troubleshooting
+
+* **Commit aborted with a binary file warning** – confirm `ALLOW_AUTOLFS=1` and
+  rerun the command. Without this variable set the script refuses to continue.
+* **LFS not installed** – the utilities attempt `git lfs install` but you can
+  run it manually if errors persist.
+* **Backups missing** – verify `$GH_COPILOT_BACKUP_ROOT` points outside the
+  repository and that the backup manager has populated the directory.


### PR DESCRIPTION
## Summary
- document git_safe_add_commit usage in backup guide and README
- describe GH_COPILOT_BACKUP_ROOT and ALLOW_AUTOLFS with tips

## Testing
- `ruff check .`
- `pytest tests/test_git_safe_add_commit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688baa8772ac833180ee87c6c82565a1