### PR TITLE
feat: add session artifact archiver with LFS

### DIFF
--- a/.codex_lfs_policy.yaml
+++ b/.codex_lfs_policy.yaml
@@ -1,18 +1,18 @@
-# Enables automatic Git LFS setup whenever files are added
+# Enable or disable the automatic Git LFS tracking logic
 enable_autolfs: true
-# Directory for storing session artifacts
+# Directory where temporary session archives are stored
 session_artifact_dir: "codex_sessions/"
-# Files larger than this size (MB) are automatically tracked via LFS
-size_threshold_mb: 99
-# Extensions that should always be stored using Git LFS
+# Any file larger than this size (in megabytes) will be moved to Git LFS
+size_threshold_mb: 50
+# File extensions that should always be committed via Git LFS
 binary_extensions:
-  - .zip
   - .db
   - .7z
+  - .zip
   - .bak
+  - .dot
   - .sqlite
   - .exe
-  - .dot
 # Template used when generating .gitattributes automatically
 gitattributes_template: |
   codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,9 @@
-# Git LFS rules for binary artifacts
+# These patterns enforce automatic Git LFS tracking for large/binary files
 codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text
-*.db filter=lfs diff=lfs merge=lfs -text
 *.7z filter=lfs diff=lfs merge=lfs -text
-*.zip filter=lfs diff=lfs merge=lfs -text
 *.bak filter=lfs diff=lfs merge=lfs -text
-*.sqlite filter=lfs diff=lfs merge=lfs -text
-*.exe filter=lfs diff=lfs merge=lfs -text
+*.db filter=lfs diff=lfs merge=lfs -text
 *.dot filter=lfs diff=lfs merge=lfs -text
-*.bin filter=lfs diff=lfs merge=lfs -text
-# End of LFS patterns
+*.exe filter=lfs diff=lfs merge=lfs -text
+*.sqlite filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/artifact_lfs.yml
+++ b/.github/workflows/artifact_lfs.yml
@@ -1,0 +1,40 @@
+name: artifact LFS
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - artifact_manager.py
+      - .codex_lfs_policy.yaml
+      - .gitattributes
+      - .github/workflows/artifact_lfs.yml
+
+jobs:
+  manage-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install Git LFS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-lfs
+      - name: Setup environment
+        run: bash setup.sh
+      - name: Package session artifacts
+        run: python artifact_manager.py
+      - name: Verify LFS tracking
+        run: git lfs ls-files
+      - name: Commit and push
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add codex_sessions || true
+          if git diff --cached --quiet; then echo "No changes"; else git commit -m "chore: update session artifacts" && git push; fi
+      - name: Restore latest session
+        run: python artifact_manager.py --recover
+        if: always()

--- a/ARTIFACT_RECOVERY_WORKFLOW.md
+++ b/ARTIFACT_RECOVERY_WORKFLOW.md
@@ -15,14 +15,14 @@ Key settings include:
 
 ## Purpose of `.gitattributes`
 
-The `.gitattributes` file explicitly lists patterns that Git LFS should manage. These rules prevent large files from bloating the normal Git history and keep repository clones lightweight.
+The `.gitattributes` file explicitly lists patterns that Git LFS should manage. These rules prevent large files from bloating the normal Git history and keep repository clones lightweight. The patterns are generated from the policy file and include rules for each binary extension and the session archives directory.
 
 ## Workflow
 
 1. **Initial Clone**: When cloning the repository, run `git lfs install` to ensure LFS support is active.
-2. **Creating Artifacts**: Place generated artifacts inside the directory defined by `session_artifact_dir` (`codex_sessions/`).
-3. **Adding Files**: When you add files that match the configured extensions or exceed the size threshold, Git LFS automatically tracks them. Verify with `git lfs status` before committing.
-4. **Committing**: Commit your changes as usual. The large files are stored in LFS, keeping repository history small.
-5. **Recovering Artifacts**: To fetch artifacts from previous sessions, run `git lfs pull`. This downloads the referenced binary objects into your working tree.
+2. **Packaging Artifacts**: Run `python artifact_manager.py` to detect new files in the temp directory and create a timestamped archive. If the archive meets LFS criteria, it is automatically tracked and committed.
+3. **Adding Files**: Files matching the configured extensions or exceeding the size threshold are automatically tracked via Git LFS. Check with `git lfs status` before committing.
+4. **Recovering Artifacts**: To unpack the most recent archive after a fresh clone or CI reset, run `python artifact_manager.py --recover`.
+5. **Committing**: The packaging step commits the archive for you. Ensure CI runs succeed by verifying `git lfs ls-files` lists the new archive.
 
-Following this workflow ensures consistent handling of binary data and prevents accidental commits of large files outside Git LFS.
+Following this workflow ensures consistent handling of binary data and prevents accidental commits of large files outside Git LFS. Integrate the packaging command into CI so that session artifacts are preserved automatically.

--- a/artifact_manager.py
+++ b/artifact_manager.py
@@ -1,12 +1,16 @@
-"""Utility for packaging session artifacts.
+"""Utility for packaging and recovering session artifacts.
 
-Detects changed files in ``tmp/`` since the last commit and archives them into a
-timestamped zip file under ``codex_sessions/``. Git LFS tracking is applied if
-enabled via ``.codex_lfs_policy.yaml``.
+This module detects changed files within a temporary directory, archives them
+into a timestamped zip stored under ``codex_sessions/`` and optionally tracks
+the archive via Git LFS based on ``.codex_lfs_policy.yaml``. Created archives
+are automatically committed to the repository. The module also provides a
+recovery helper to extract the most recent session archive back into the
+temporary directory.
 """
 
 from __future__ import annotations
 
+import argparse
 import logging
 import subprocess
 from datetime import datetime, timezone
@@ -35,6 +39,7 @@ class LfsPolicy:
             ".sqlite",
             ".exe",
         ]
+        self.session_artifact_dir = "codex_sessions"
         self.root = root
 
         policy_file = root / ".codex_lfs_policy.yaml"
@@ -47,6 +52,7 @@ class LfsPolicy:
                 self.enabled = bool(data.get("enable_autolfs", False))
                 self.size_threshold_mb = int(data.get("size_threshold_mb", 50))
                 self.binary_extensions = list(data.get("binary_extensions", self.binary_extensions))
+                self.session_artifact_dir = str(data.get("session_artifact_dir", self.session_artifact_dir)).rstrip("/")
 
     def requires_lfs(self, path: Path) -> bool:
         if not path.is_file():
@@ -72,6 +78,30 @@ class LfsPolicy:
 
 def _run_git(cmd: Iterable[str], cwd: Path) -> str:
     return subprocess.check_output(["git", *cmd], cwd=cwd, text=True)
+
+
+def commit_archive(repo_root: Path, archive_path: Path) -> bool:
+    """Commit the created archive to Git.
+
+    Parameters
+    ----------
+    repo_root:
+        Root directory of the repository.
+    archive_path:
+        Path to the zip archive to commit.
+    """
+    try:
+        subprocess.run(["git", "add", str(archive_path)], cwd=repo_root, check=True, capture_output=True)
+        subprocess.run([
+            "git",
+            "commit",
+            "-m",
+            f"chore: add session archive {archive_path.name}",
+        ], cwd=repo_root, check=True, capture_output=True)
+    except subprocess.CalledProcessError as exc:  # noqa: BLE001
+        logger.error("Failed to commit archive: %s", exc)
+        return False
+    return True
 
 
 def detect_tmp_changes(tmp_dir: Path, repo_root: Path) -> List[Path]:
@@ -100,7 +130,42 @@ def create_zip(archive_path: Path, files: Iterable[Path], base_dir: Path) -> Non
                 zf.write(file, arcname=file.relative_to(base_dir))
 
 
+def recover_latest_session(
+    tmp_dir: Path, repo_root: Path, lfs_policy: Optional[LfsPolicy] = None
+) -> Optional[Path]:
+    """Extract the most recent session archive into ``tmp_dir``.
+
+    Parameters
+    ----------
+    tmp_dir:
+        Directory where files will be restored.
+    repo_root:
+        Root directory of the repository containing ``codex_sessions``.
+    """
+    sessions_dir = repo_root / (
+        lfs_policy.session_artifact_dir if lfs_policy else "codex_sessions"
+    )
+    if not sessions_dir.exists():
+        logger.info("No session archives found at %s", sessions_dir)
+        return None
+    archives = sorted(sessions_dir.glob("codex-session_*.zip"), reverse=True)
+    if not archives:
+        logger.info("No session archives present in %s", sessions_dir)
+        return None
+    latest = archives[0]
+    try:
+        with ZipFile(latest, "r") as zf:
+            zf.extractall(repo_root)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to extract %s: %s", latest, exc)
+        return None
+    logger.info("Recovered session from %s", latest)
+    return latest
+
+
 def package_session(tmp_dir: Path, repo_root: Path, lfs_policy: Optional[LfsPolicy] = None) -> Optional[Path]:
+    """Archive new/modified files from ``tmp_dir`` and commit the archive."""
+
     changed_files = detect_tmp_changes(tmp_dir, repo_root)
     if not changed_files:
         logger.info("No session artifacts detected in %s", tmp_dir)
@@ -109,7 +174,9 @@ def package_session(tmp_dir: Path, repo_root: Path, lfs_policy: Optional[LfsPoli
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     archive_name = f"codex-session_{timestamp}.zip"
 
-    sessions_dir = repo_root / "codex_sessions"
+    sessions_dir = repo_root / (
+        lfs_policy.session_artifact_dir if lfs_policy else "codex_sessions"
+    )
     sessions_dir.mkdir(parents=True, exist_ok=True)
 
     archive_path = sessions_dir / archive_name
@@ -125,15 +192,37 @@ def package_session(tmp_dir: Path, repo_root: Path, lfs_policy: Optional[LfsPoli
     if lfs_policy and lfs_policy.requires_lfs(archive_path):
         lfs_policy.track(archive_path)
 
+    commit_archive(repo_root, archive_path)
+
     return archive_path
 
 
 def main() -> None:
+    """Entry point for CLI usage."""
+
+    parser = argparse.ArgumentParser(description="Manage session artifacts")
+    parser.add_argument(
+        "--tmp-dir",
+        type=Path,
+        default=Path("tmp"),
+        help="Temporary directory containing artifacts",
+    )
+    parser.add_argument(
+        "--recover",
+        action="store_true",
+        help="Recover the latest session archive instead of packaging",
+    )
+    args = parser.parse_args()
+
     logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
     repo_root = Path(__file__).resolve().parent
-    tmp_dir = repo_root / "tmp"
     policy = LfsPolicy(repo_root)
-    package_session(tmp_dir, repo_root, policy)
+
+    if args.recover:
+        recover_latest_session(args.tmp_dir, repo_root, policy)
+    else:
+        package_session(args.tmp_dir, repo_root, policy)
 
 
 if __name__ == "__main__":

--- a/tests/test_artifact_manager.py
+++ b/tests/test_artifact_manager.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+from pathlib import Path
+
+from artifact_manager import (
+    LfsPolicy,
+    package_session,
+    recover_latest_session,
+)
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "tmp").mkdir(parents=True)
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    policy = repo / ".codex_lfs_policy.yaml"
+    policy.write_text(
+        """\
+# Enable or disable the automatic Git LFS tracking logic
+enable_autolfs: true
+session_artifact_dir: "codex_sessions"
+size_threshold_mb: 1
+binary_extensions:
+  - .zip
+"""
+    )
+    git_attr = repo / ".gitattributes"
+    git_attr.write_text("codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text\n")
+    subprocess.run(["git", "add", str(policy), str(git_attr)], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True)
+    return repo
+
+
+def test_package_and_recover(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    tmp_dir = repo / "tmp"
+    test_file = tmp_dir / "example.txt"
+    test_file.write_text("data")
+    subprocess.run(["git", "add", str(test_file)], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "add tmp file"], cwd=repo, check=True)
+    test_file.write_text("update")
+
+    policy = LfsPolicy(repo)
+    archive = package_session(tmp_dir, repo, policy)
+    assert archive and archive.exists()
+
+    # verify committed
+    log = subprocess.check_output(["git", "log", "-1", "--pretty=%B"], cwd=repo, text=True)
+    assert "session archive" in log
+
+    # ensure lfs tracking
+    lfs_files = subprocess.check_output(["git", "lfs", "ls-files"], cwd=repo, text=True)
+    assert archive.name in lfs_files
+
+    # remove tmp file and recover
+    os.remove(test_file)
+    recover_latest_session(tmp_dir, repo, policy)
+    assert test_file.exists()
+
+
+def test_no_changes(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    policy = LfsPolicy(repo)
+    tmp_dir = repo / "tmp"
+    result = package_session(tmp_dir, repo, policy)
+    assert result is None
+
+
+def test_missing_tmp(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    policy = LfsPolicy(repo)
+    tmp_dir = repo / "absent"
+    result = package_session(tmp_dir, repo, policy)
+    assert result is None


### PR DESCRIPTION
## Summary
- document artifact recovery workflow
- document Git LFS policy and gitattributes
- manage session artifact zips via `artifact_manager.py`
- workflow to package and restore session artifacts
- tests for artifact manager

## Testing
- `ruff check artifact_manager.py tests/test_artifact_manager.py`
- `pytest -q tests/test_artifact_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688be0c9638083318f22cdb89970bcf3