### PR TITLE
fix: validate expected LFS archives

### DIFF
--- a/.github/workflows/artifact_lfs.yml
+++ b/.github/workflows/artifact_lfs.yml
@@ -54,6 +54,22 @@ jobs:
           fi
           git lfs ls-files
         # Fail fast if any policy-defined binary files skip LFS
+      - name: Validate expected LFS archives
+        run: |
+          set -euo pipefail
+          expected_exts=".zip .7z"
+          lfs_list="$(git lfs ls-files | awk '{print $2}')"
+          missing=""
+          for ext in $expected_exts; do
+            if ! echo "$lfs_list" | grep -q "${ext}$"; then
+              missing="$missing $ext"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "Missing expected LFS archives with extensions:$missing" >&2
+            exit 1
+          fi
+        # Parse LFS output; see ARTIFACT_RECOVERY_WORKFLOW.md for troubleshooting and rationale
       - name: Push changes
         run: |
           set -e


### PR DESCRIPTION
## Summary
- enforce presence of required LFS archives in artifact workflow

## Testing
- `ruff check .`
- `pytest` *(fails: test_documentation_manager_templates, test_placeholder_audit/test_summary_creation, test_template_engine/test_template_caching, test_archive_scripts, ...)*

------
https://chatgpt.com/codex/tasks/task_e_688c7cd401648331bdd948cc188e84df