### PR TITLE
docs: sync status with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,7 +1051,7 @@ Set these variables in your `.env` file or shell before running scripts:
 
 ## ✅ Project Status
 
-All modules pass the automated test suite. Dual-copilot validation now covers 100% of workflows. Quantum features continue to run in simulation mode.
+Ruff linting passes cleanly, but the test suite currently reports failures (`41 failed, 339 passed` from `pytest`). Outstanding tasks—including fixes for failing modules like `documentation_manager` and `cross_database_sync_logger`—are tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Dual-copilot validation remains in place and quantum features continue to run in simulation mode.
 The repository uses GitHub Actions to automate linting, testing, and compliance checks.
 
 - **ci.yml** runs Ruff linting, executes the test suite on multiple Python versions, builds the Docker image, and performs a CodeQL scan.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.1.14] - 2025-08-05
+- Updated README to report current lint status and failing tests.
+- Noted outstanding tasks tracked in `docs/STUB_MODULE_STATUS.md`.
+
 ## [4.1.13] - 2025-08-04
 - Updated README and technical whitepaper to remove outdated warnings about DBFirstCodeGenerator, documentation_db_analyzer, and workflow_enhancer.
 - Updated project status to reflect 100% dual-copilot coverage and all tests passing.


### PR DESCRIPTION
## Summary
- document current lint pass and failing pytest status
- note outstanding tasks from STUB_MODULE_STATUS

## Testing
- `ruff check`
- `pytest` *(fails: 41 failed, 339 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688c7d677a7c8331b8a37d5cfd3f8662