### PR TITLE
fix: guard analytics inserts against extra columns

### DIFF
--- a/comprehensive_test_results.json
+++ b/comprehensive_test_results.json
@@ -1,8 +1,8 @@
 {
-    "timestamp": "2025-07-31T02:10:28",
-    "tests_executed": 178,
-    "tests_passed": 146,
-    "tests_failed": 29,
+    "timestamp": "2025-08-01T10:41:54",
+    "tests_executed": 393,
+    "tests_passed": 349,
+    "tests_failed": 38,
     "tests_errors": 0,
-    "tests_skipped": 3
+    "tests_skipped": 6
 }


### PR DESCRIPTION
## Summary
- ensure analytics event logging only inserts columns that exist
- update comprehensive test results snapshot

## Testing
- `ruff check utils/log_utils.py`
- `pytest tests/documentation/test_documentation_manager_templates.py::test_template_selection_from_documentation_db -vv`


------
https://chatgpt.com/codex/tasks/task_e_688c9693bb088331b502aea1a2bb03e9