### PR TITLE
feat: enhance artifact manager help text and docstrings

### DIFF
--- a/tests/test_artifact_manager_help.py
+++ b/tests/test_artifact_manager_help.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_help_lists_all_options() -> None:
+    script = Path(__file__).resolve().parents[1] / "artifact_manager.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    help_text = result.stdout
+    options = {
+        "--package": "create a session archive",
+        "--recover": "restore the most recent session archive",
+        "--commit": "commit the created archive",
+        "--message": "commit message",
+        "--tmp-dir": "working directory for session files",
+        "--sync-gitattributes": "regenerate .gitattributes",
+    }
+    for opt, snippet in options.items():
+        assert opt in help_text
+        assert snippet in help_text


### PR DESCRIPTION
## Summary
- clarify package_session and recover_latest_session docstrings to explain `.codex_lfs_policy.yaml` interactions
- expand CLI help text for `--tmp-dir`, `--sync-gitattributes`, and `--commit`
- add unit test ensuring `artifact_manager.py --help` documents all options

## Testing
- `ruff check artifact_manager.py tests/test_artifact_manager_help.py`
- `pytest tests/test_artifact_manager.py::test_package_and_recover tests/test_artifact_manager_help.py::test_help_lists_all_options`


------
https://chatgpt.com/codex/tasks/task_e_688c9786632c8331935eba57ec24fb07