### PR TITLE
fix: ensure atomic session archive packaging

### DIFF
--- a/tests/test_artifact_manager.py
+++ b/tests/test_artifact_manager.py
@@ -432,8 +432,9 @@ def test_package_session_logs_sessions_dir(repo: Path, caplog: pytest.LogCapture
 
     with caplog.at_level(logging.INFO):
         package_session(tmp_dir, repo, LfsPolicy(repo))
-
-    assert any("Session artifacts directory" in m for m in caplog.messages)
+    session_logs = [m for m in caplog.messages if "Session artifacts directory" in m]
+    assert any("resolved" in m for m in session_logs)
+    assert any("finalized" in m for m in session_logs)
 
 
 def test_invalid_session_dir_value(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary
- create session archives via temporary `.tmp` file then atomically rename
- log session directory resolution and finalization; handle mkdir race conditions
- test logging around session directory creation and finalization

## Testing
- `ruff check artifact_manager.py tests/test_artifact_manager.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install PyYAML`
- `pytest tests/test_artifact_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_688ca09b230c83318222166206e37365