### PR TITLE
docs: document artifact manager flags and examples

### DIFF
--- a/artifact_manager.py
+++ b/artifact_manager.py
@@ -302,33 +302,40 @@ def package_session(
     Parameters
     ----------
     tmp_dir:
-        Temporary directory containing session outputs. This corresponds to the
-        ``--tmp-dir`` CLI flag and is independent of the final archive location
-        governed by ``.codex_lfs_policy.yaml``.
+        Temporary directory containing session outputs. Mirrors the
+        ``--tmp-dir`` flag from :func:`main` and may differ from the final
+        archive location dictated by ``session_artifact_dir`` in
+        ``.codex_lfs_policy.yaml``.
     repo_root:
         Root of the git repository.
     lfs_policy:
         Optional :class:`LfsPolicy` for Git LFS enforcement. If ``None``, the
         policy is loaded from ``.codex_lfs_policy.yaml`` in ``repo_root``.
     commit:
-        If ``True``, commit the created archive to git, honoring any LFS rules
-        from ``.codex_lfs_policy.yaml``.
+        When ``True``, commit the created archive to git and apply tracking
+        rules from ``.codex_lfs_policy.yaml``. Equivalent to passing
+        ``--package --commit`` on the CLI.
     message:
-        Optional commit message. If not provided, a default message using the
-        archive timestamp is used.
+        Optional commit message. If omitted, a timestamped message is used.
 
     Returns
     -------
     Optional[Path]
         Path to the created archive or ``None`` if no changes detected.
 
+    Examples
+    --------
+    Package and commit session outputs located in ``/custom/tmp``::
+
+        package_session(Path("/custom/tmp"), repo_root, commit=True)
+
     Notes
     -----
-    All files packaged into the archive are removed from ``tmp_dir`` to keep the
-    temporary workspace clean. The archive destination derives from
+    Packaged files are removed from ``tmp_dir`` to keep the workspace clean.
+    The archive destination derives from
     ``lfs_policy.session_artifact_dir`` in ``.codex_lfs_policy.yaml``. When
-    ``commit`` is ``True``, the archive is added to git and the policy ensures it
-    is tracked via Git LFS when required.
+    ``commit`` is ``True``, the archive is added to git and the policy ensures
+    it is tracked via Git LFS when required.
     """
 
     if lfs_policy is None:
@@ -437,18 +444,25 @@ def recover_latest_session(
     Parameters
     ----------
     tmp_dir:
-        Destination directory for extracted files. This matches the ``--tmp-dir``
-        CLI option used during packaging.
+        Destination directory for extracted files. This mirrors the
+        ``--tmp-dir`` CLI option and may point to any writable path such as
+        ``/custom/tmp``.
     repo_root:
         Root of the git repository containing session archives.
     lfs_policy:
-        Optional :class:`LfsPolicy` to locate custom session directory. When
+        Optional :class:`LfsPolicy` to locate the session directory. When
         omitted, settings are read from ``.codex_lfs_policy.yaml``.
 
     Returns
     -------
     Optional[Path]
         Path to the extracted archive or ``None`` if none found.
+
+    Examples
+    --------
+    Recover into a custom temporary directory::
+
+        recover_latest_session(Path("/custom/tmp"), repo_root)
 
     Notes
     -----
@@ -488,32 +502,44 @@ def recover_latest_session(
 def main() -> None:
     """Entry point for the artifact manager command line interface.
 
-    ``--tmp-dir`` controls where transient files are gathered for packaging,
-    while the final archive destination is dictated by the
-    ``session_artifact_dir`` setting in ``.codex_lfs_policy.yaml``. Using
-    ``--commit`` commits the generated archive to git and applies any Git LFS
-    tracking rules found in the policy. When ``--sync-gitattributes`` is
-    supplied, the policy's ``gitattributes_template`` and binary extension list
-    regenerate the repository's ``.gitattributes`` file.
+    Flags
+    -----
+    ``--package``
+        Create a session archive from files in the temporary directory. The
+        destination directory comes from ``session_artifact_dir`` in
+        ``.codex_lfs_policy.yaml``.
+    ``--recover``
+        Restore the most recent session archive, also located using
+        ``.codex_lfs_policy.yaml``.
+    ``--commit``
+        Commit the created archive to git and apply tracking rules from
+        ``.codex_lfs_policy.yaml``.
+    ``--message``
+        Commit message to use when ``--commit`` is supplied.
+    ``--tmp-dir``
+        Working directory for session files. Archives always land in the
+        ``session_artifact_dir`` configured in ``.codex_lfs_policy.yaml``.
+    ``--sync-gitattributes``
+        Rebuild ``.gitattributes`` based on ``.codex_lfs_policy.yaml`` and exit.
 
     Examples
     --------
     Package and commit session files using a custom temporary directory::
 
-        python artifact_manager.py --package --tmp-dir build/tmp --commit
+        python artifact_manager.py --package --tmp-dir /custom/tmp --commit
 
     Regenerate the repository's ``.gitattributes`` file from policy::
 
         python artifact_manager.py --sync-gitattributes
 
-    Recover the most recent session into the default temporary directory::
+    Recover the most recent session into a custom temporary directory::
 
-        python artifact_manager.py --recover
+        python artifact_manager.py --recover --tmp-dir /custom/tmp
     """
 
     examples = (
         "Examples:\n"
-        "  python artifact_manager.py --package --tmp-dir build/tmp\n"
+        "  python artifact_manager.py --package --tmp-dir /custom/tmp\n"
         "  python artifact_manager.py --sync-gitattributes"
     )
     parser = argparse.ArgumentParser(
@@ -525,32 +551,34 @@ def main() -> None:
         "--package",
         action="store_true",
         help=(
-            "create a session archive from files in the temporary directory "
-            "(default: %(default)s). Example: --package --tmp-dir build/tmp"
+            "create a session archive from files in the temporary directory and "
+            "store it in the policy's session_artifact_dir from .codex_lfs_policy.yaml "
+            "(default: %(default)s). Example: --package --tmp-dir /custom/tmp"
         ),
     )
     parser.add_argument(
         "--recover",
         action="store_true",
         help=(
-            "restore the most recent session archive back into the temporary "
-            "directory (default: %(default)s). Example: --recover"
+            "restore the most recent session archive defined by .codex_lfs_policy.yaml "
+            "back into the temporary directory (default: %(default)s). Example: "
+            "--recover --tmp-dir /custom/tmp"
         ),
     )
     parser.add_argument(
         "--commit",
         action="store_true",
         help=(
-            "commit the created archive to git and apply LFS policy rules "
-            "(default: %(default)s). Typical use: record session outputs for "
-            "audit trails. Example: --package --commit"
+            "commit the created archive to git and apply rules from .codex_lfs_policy.yaml "
+            "(default: %(default)s). Typical use: record session outputs for audit "
+            "trails. Example: --package --commit"
         ),
     )
     parser.add_argument(
         "--message",
         help=(
-            "commit message when packaging (default: timestamped message). "
-            "Example: --message 'Add session artifacts'"
+            "commit message when packaging; see .codex_lfs_policy.yaml for session_artifact_dir "
+            "(default: timestamped message). Example: --message 'Add session artifacts'"
         ),
     )
     parser.add_argument(
@@ -558,9 +586,9 @@ def main() -> None:
         default="tmp",
         help=(
             "working directory for session files; created if it does not exist "
-            "(default: %(default)s). Archives still go to the policy's "
-            "session_artifact_dir. Typical use: isolate build outputs. "
-            "Example: --tmp-dir build/tmp"
+            "(default: %(default)s). Archives still go to the session_artifact_dir "
+            "in .codex_lfs_policy.yaml. Typical use: isolate build outputs. Example: "
+            "--tmp-dir /custom/tmp"
         ),
     )
     parser.add_argument(

--- a/tests/test_artifact_manager_help.py
+++ b/tests/test_artifact_manager_help.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 
-def test_help_lists_all_options() -> None:
+def test_help_mentions_policy_and_examples() -> None:
     script = Path(__file__).resolve().parents[1] / "artifact_manager.py"
     result = subprocess.run(
         [sys.executable, str(script), "--help"],
@@ -14,14 +14,15 @@ def test_help_lists_all_options() -> None:
         check=True,
     )
     help_text = result.stdout
-    options = {
-        "--package": "create a session archive",
-        "--recover": "restore the most recent session archive",
-        "--commit": "commit the created archive",
-        "--message": "commit message",
-        "--tmp-dir": "working directory for session files",
-        "--sync-gitattributes": "regenerate .gitattributes",
+    option_snippets = {
+        "--package": [".codex_lfs_policy.yaml", "--package --tmp-dir /custom/tmp"],
+        "--recover": [".codex_lfs_policy.yaml", "--recover --tmp-dir /custom/tmp"],
+        "--commit": [".codex_lfs_policy.yaml", "--package --commit"],
+        "--message": [".codex_lfs_policy.yaml", "--message 'Add session artifacts'"],
+        "--tmp-dir": [".codex_lfs_policy.yaml", "--tmp-dir /custom/tmp"],
+        "--sync-gitattributes": [".codex_lfs_policy.yaml", "--sync-gitattributes"],
     }
-    for opt, snippet in options.items():
+    for opt, snippets in option_snippets.items():
         assert opt in help_text
-        assert snippet in help_text
+        for snippet in snippets:
+            assert snippet in help_text


### PR DESCRIPTION
## Summary
- clarify artifact manager CLI docstrings with flag descriptions and examples referencing `.codex_lfs_policy.yaml`
- expand argparse help text to include sample usage like `--tmp-dir /custom/tmp`
- add unit test confirming `--help` output includes policy references and examples

## Testing
- `ruff check artifact_manager.py tests/test_artifact_manager_help.py`
- `pytest tests/test_artifact_manager.py tests/test_artifact_manager_help.py`

------
https://chatgpt.com/codex/tasks/task_e_688ca09baf38833180a11aceb06326d3