### PR TITLE
fix: add LFS session archive validation

### DIFF
--- a/.github/workflows/artifact_lfs.yml
+++ b/.github/workflows/artifact_lfs.yml
@@ -59,7 +59,7 @@ jobs:
           set -e
           # Verify expected LFS artifacts are tracked; see ARTIFACT_RECOVERY_WORKFLOW.md for rationale and troubleshooting
           expected_files="tmp_artifacts.zip tmp/test_artifacts.zip"
-          lfs_list="$(git lfs ls-files | awk '{print $2}')"
+          lfs_list="$(git lfs ls-files | tee lfs_files.log | awk '{print $2}')"
           missing=""
           for f in $expected_files; do
             if ! echo "$lfs_list" | grep -qx "$f"; then
@@ -73,6 +73,23 @@ jobs:
           fi
           git lfs ls-files
         # Parse LFS output and verify expected artifacts; see ARTIFACT_RECOVERY_WORKFLOW.md for troubleshooting and rationale
+      - name: Validate session archive pointers
+        run: |
+          set -e
+          # Parse git lfs ls-files output and ensure session archives exist with LFS pointers
+          # See ARTIFACT_RECOVERY_WORKFLOW.md for recovery workflow details
+          while read -r oid marker path; do
+            if [ "$marker" != "*" ]; then
+              echo "Pointer missing for $path" >&2
+              exit 1
+            fi
+            if [ ! -f "$path" ]; then
+              echo "Missing session archive: $path" >&2
+              exit 1
+            fi
+          done < lfs_files.log
+          rm lfs_files.log
+        # Fail if any session archive is missing or pointers are absent; see ARTIFACT_RECOVERY_WORKFLOW.md
       - name: Push changes
         run: |
           set -e


### PR DESCRIPTION
## Summary
- parse git LFS listing and fail if session archives missing or lack pointers
- document recovery workflow check for validating session archives

## Testing
- `ruff check .github/workflows`
- `pytest tests/test_artifact_manager_help.py`


------
https://chatgpt.com/codex/tasks/task_e_688ca09dde2083318f5a97bf7f8b3d53