### PR TITLE
test: cover package_session behavior for empty tmp dir

### DIFF
--- a/tests/test_artifact_manager.py
+++ b/tests/test_artifact_manager.py
@@ -117,6 +117,26 @@ def test_package_session_empty_dir_returns_none(repo: Path, caplog: pytest.LogCa
         logger.info("Removed empty directory %s", empty_dir)
 
 
+def test_package_session_empty_tmp_dir_no_archive(
+    repo: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Ensure an empty ``tmp`` directory produces no archive."""
+
+    tmp_dir = repo / "tmp"
+    logger.info("Creating tmp directory %s", tmp_dir)
+    tmp_dir.mkdir()
+
+    try:
+        with caplog.at_level(logging.INFO):
+            result = package_session(tmp_dir, repo, LfsPolicy(repo))
+        assert result is None
+        sessions_dir = repo / "codex_sessions"
+        assert not sessions_dir.exists() or not any(sessions_dir.iterdir())
+    finally:
+        tmp_dir.rmdir()
+        logger.info("Removed tmp directory %s", tmp_dir)
+
+
 def test_package_session_missing_tmp_dir_returns_none(
     repo: Path, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## Summary
- add test ensuring `package_session` returns `None` when `tmp` directory is empty and no archive is created

## Testing
- `ruff check tests/test_artifact_manager.py`
- `pytest tests/test_artifact_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ca0a353f8833181383ed19f313e94