### PR TITLE
fix: make lessons validator workspace dynamic

### DIFF
--- a/docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md
+++ b/docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md
@@ -188,6 +188,14 @@ TEXT_INDICATORS = {
    scripts/documentation/enterprise_compliance_docs_generator.py
    ```
 
+### 🛠 RECENT FIXES
+
+- Updated `scripts/validation/lessons_learned_integration_validator.py` to
+  derive its workspace from `GH_COPILOT_WORKSPACE`, replacing a hard-coded
+  Windows path. The validator now writes logs cross-platform and excludes
+  virtual environment and version-control directories from anti-recursion
+  checks.
+
 ---
 
 ## 🎯 VALIDATION METHODOLOGY


### PR DESCRIPTION
## Summary
- derive lessons validator workspace from environment and ignore venv/git directories
- document validator workspace fix in lessons learned report

## Testing
- `ruff check scripts/validation/lessons_learned_integration_validator.py`
- `python scripts/validation/lessons_learned_integration_validator.py`
- `pytest scripts/validation/test_unicode_compat.py`


------
https://chatgpt.com/codex/tasks/task_e_688caec6a0e08331acffde6fb832030b