### PR TITLE
feat: add backend configuration to quantum optimizer

### DIFF
--- a/quantum/README.md
+++ b/quantum/README.md
@@ -10,6 +10,8 @@ gh_COPILOT toolkit.
 - `optimizers.quantum_optimizer.QuantumOptimizer` – classical/quantum hybrid
   optimizer with progress logging. Events are recorded using
   `utils.log_utils._log_event` when executed via higher-level workflows.
+  Use `configure_backend()` to automatically load IBM Quantum credentials from
+  `QISKIT_IBM_TOKEN` and select either hardware or the local simulator.
 
 ## Database Search
 - `quantum.quantum_database_search` – lightweight helpers for SQL, NoSQL and

--- a/tests/quantum/test_optimizer_backend.py
+++ b/tests/quantum/test_optimizer_backend.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from quantum.optimizers import quantum_optimizer as qo
+from quantum.optimizers.quantum_optimizer import QuantumOptimizer
+
+
+def objective(x: np.ndarray) -> float:
+    return float(np.sum(x**2))
+
+
+class MockBackend:
+    def run(self, circ):  # pragma: no cover - interface only
+        class Result:
+            def result(self):
+                return None
+
+        return Result()
+
+
+class MockProvider:
+    def __init__(self, *_, **__):
+        pass
+
+    def get_backend(self, name):  # pragma: no cover - simple mock
+        return MockBackend()
+
+
+@pytest.mark.skipif(not qo.QISKIT_AVAILABLE, reason="Qiskit not available")
+def test_configure_backend_hardware(monkeypatch):
+    monkeypatch.setattr(qo, "IBMProvider", lambda token=None: MockProvider())
+    opt = QuantumOptimizer(objective, [(-1, 1)], method="simulated_annealing")
+    backend = opt.configure_backend("mock_backend", use_hardware=True)
+    assert backend is opt.backend
+    assert opt.use_hardware
+
+
+@pytest.mark.skipif(not qo.QISKIT_AVAILABLE, reason="Qiskit not available")
+def test_configure_backend_fallback(monkeypatch):
+    def bad_provider(*_, **__):
+        raise RuntimeError("bad credentials")
+
+    monkeypatch.setattr(qo, "IBMProvider", bad_provider)
+    opt = QuantumOptimizer(objective, [(-1, 1)], method="simulated_annealing")
+    backend = opt.configure_backend("mock_backend", use_hardware=True)
+    assert backend is opt.backend
+    assert opt.use_hardware is False


### PR DESCRIPTION
## Summary
- add IBM backend configuration helper and hardware fallback
- use configured backend in QAOA and VQE runs
- document backend setup and add tests for hardware and simulator paths

## Testing
- `ruff check quantum/optimizers/quantum_optimizer.py tests/quantum/test_optimizer_backend.py tests/test_quantum_optimizer.py`
- `pytest tests/quantum/test_optimizer_backend.py tests/test_quantum_optimizer.py tests/test_quantum_optimizer_wrapper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688caec9a30c8331b603f139c63bd765