### PR TITLE
fix: handle analytics logging and deployment utilities

### DIFF
--- a/scripts/comprehensive_production_deployer.py
+++ b/scripts/comprehensive_production_deployer.py
@@ -13,6 +13,7 @@ import sys
 
 import logging
 import shutil
+import sqlite3
 from pathlib import Path
 from datetime import datetime
 
@@ -51,21 +52,33 @@ class EnterpriseUtility:
     def perform_utility_function(self) -> bool:
         """Perform the utility function"""
         try:
+            db_path = self.workspace_path / "databases" / "production.db"
             deploy_dir = self.workspace_path / "builds" / "production"
             deploy_dir.mkdir(parents=True, exist_ok=True)
-            files = [self.workspace_path / "README.md"]
-
-            for f in files:
-                if not f.exists():
-                    self.logger.error(f"{TEXT_INDICATORS['error']} Missing file {f}")
-                    return False
-                shutil.copy2(f, deploy_dir)
-                self.logger.info(f"{TEXT_INDICATORS['info']} Deployed {f.name}")
-
-            self.logger.info(f"{TEXT_INDICATORS['success']} Production deployment finished")
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT script_path FROM script_repository ORDER BY RANDOM() LIMIT 1"
+                ).fetchone()
+            if not row:
+                self.logger.error(
+                    f"{TEXT_INDICATORS['error']} No scripts found in repository"
+                )
+                return False
+            src = self.workspace_path / row[0]
+            if not src.exists():
+                self.logger.error(f"{TEXT_INDICATORS['error']} Missing file {src}")
+                return False
+            dst = deploy_dir / Path(row[0]).name
+            shutil.copy2(src, dst)
+            self.logger.info(f"{TEXT_INDICATORS['info']} Deployed {dst.name}")
+            self.logger.info(
+                f"{TEXT_INDICATORS['success']} Production deployment finished"
+            )
             return True
         except Exception as exc:
-            self.logger.error(f"{TEXT_INDICATORS['error']} Deployment failed: {exc}")
+            self.logger.error(
+                f"{TEXT_INDICATORS['error']} Deployment failed: {exc}"
+            )
             return False
 
 

--- a/template_engine/template_placeholder_remover.py
+++ b/template_engine/template_placeholder_remover.py
@@ -112,6 +112,7 @@ def remove_unused_placeholders(
         conn.execute(
             "CREATE TABLE IF NOT EXISTS placeholder_removal_events (event TEXT, placeholder TEXT, removal_id INTEGER, removed INTEGER, timestamp TEXT, level TEXT, module TEXT)"
         )
+        conn.commit()
         etc = "N/A"
         with tqdm(total=total_steps, desc="Removing Placeholders", unit="ph") as bar:
             for idx, ph in enumerate(found, 1):

--- a/tests/quantum/test_provider_fallback.py
+++ b/tests/quantum/test_provider_fallback.py
@@ -2,8 +2,6 @@ import builtins
 import sqlite3
 from pathlib import Path
 
-import pytest
-
 from quantum.orchestration.executor import QuantumExecutor
 from quantum.orchestration import executor as qexec
 from quantum.orchestration.registry import register_algorithm


### PR DESCRIPTION
## Summary
- commit placeholder removal events immediately for logging reliability
- deploy scripts based on repository entries instead of static README
- log quantum search events with explicit table creation and JSON params

## Testing
- `ruff check quantum/quantum_database_search.py scripts/comprehensive_production_deployer.py template_engine/template_placeholder_remover.py tests/quantum/test_provider_fallback.py`
- `pytest tests/template_engine/test_placeholder_removal_and_ranking.py tests/test_archive_scripts.py tests/test_audit_codebase_placeholders.py tests/quantum/test_provider_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_688caec2b6b0833185b7c456843a10b7