### PR TITLE
fix: compute compliance score from resolved ratio

### DIFF
--- a/dashboard/compliance/metrics.json
+++ b/dashboard/compliance/metrics.json
@@ -1,11 +1,11 @@
 {
   "metrics": {
     "placeholder_removal": 14,
-    "compliance_score": 0.98,
+    "compliance_score": 0.88,
     "violation_count": 5,
     "rollback_count": 1,
-    "last_update": "2025-07-25T08:59:07.599616"
+    "last_update": "2025-08-01T16:50:44"
   },
   "status": "updated",
-  "timestamp": "2025-07-25T08:59:07.599616"
+  "timestamp": "2025-08-01T16:50:44"
 }

--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -119,7 +119,11 @@ class ComplianceMetricsUpdater:
                 metrics["placeholder_removal"] = metrics["resolved_placeholders"]
 
                 open_ph = metrics["open_placeholders"]
-                metrics["compliance_score"] = max(0.0, 1.0 - open_ph / 100.0)
+                resolved_ph = metrics["resolved_placeholders"]
+                total_ph = resolved_ph + open_ph
+                metrics["compliance_score"] = (
+                    resolved_ph / total_ph if total_ph else 0.0
+                )
                 cur.execute("SELECT COUNT(*) FROM correction_logs")
                 metrics["correction_count"] = cur.fetchone()[0]
 

--- a/tests/test_compliance_metrics_updater.py
+++ b/tests/test_compliance_metrics_updater.py
@@ -25,8 +25,11 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch, simulate, test_mode):
     db_dir.mkdir()
     analytics_db = db_dir / "analytics.db"
     with sqlite3.connect(analytics_db) as conn:
-        conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT, removal_id INTEGER)")
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT, removal_id INTEGER)"
+        )
         conn.execute("INSERT INTO todo_fixme_tracking VALUES (1, 'resolved', 1)")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (0, 'open', 2)")
         conn.execute("CREATE TABLE correction_logs (compliance_score REAL)")
         conn.execute("INSERT INTO correction_logs VALUES (0.9)")
         conn.execute("CREATE TABLE violation_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT, details TEXT)")
@@ -61,7 +64,7 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch, simulate, test_mode):
         return
     data = json.loads(metrics_file.read_text())
     assert data["metrics"]["placeholder_removal"] == 1
-    assert data["metrics"]["compliance_score"] == 1.0
+    assert data["metrics"]["compliance_score"] == 0.5
     assert data["metrics"]["violation_count"] == 1
     assert data["metrics"]["rollback_count"] == 1
     assert data["metrics"]["progress_status"] == "issues_pending"


### PR DESCRIPTION
## Summary
- compute `compliance_score` as resolved vs total placeholders
- adjust compliance metrics test for new ratio formula
- update dashboard metrics JSON to reflect new compliance score

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/test_compliance_metrics_updater.py`
- `pytest tests/test_compliance_metrics_updater.py`


------
https://chatgpt.com/codex/tasks/task_e_688cecc1fb88833194d5207198713fe1