### PR TITLE
fix: add default event_log schema to logging utility

### DIFF
--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -79,6 +79,18 @@ TABLE_SCHEMAS: Dict[str, str] = {
             ts TEXT
         );
     """,
+    "event_log": """
+        CREATE TABLE IF NOT EXISTS event_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            module TEXT,
+            level TEXT,
+            description TEXT,
+            details TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_event_log_timestamp
+            ON event_log(timestamp);
+    """,
     "placeholder_removals": """
         CREATE TABLE IF NOT EXISTS placeholder_removals (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- prevent sqlite insertion errors by adding a default `event_log` table schema in `log_utils`

## Testing
- `pytest tests/test_dual_copilot_coverage.py tests/test_log_utils.py`
- `ruff check utils/log_utils.py tests/test_dual_copilot_coverage.py tests/test_log_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_688cecc20134833184b16d0590d66700