### PR TITLE
feat: validate lesson coverage across datasets

### DIFF
--- a/scripts/database/template_asset_ingestor.py
+++ b/scripts/database/template_asset_ingestor.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from tqdm import tqdm
 
 from enterprise_modules.compliance import validate_enterprise_operation
+from template_engine.learning_templates import get_dataset_sources
 from .cross_database_sync_logger import _table_exists, log_sync_operation
 from .size_compliance_checker import check_database_sizes
 from .unified_database_initializer import initialize_database
@@ -48,6 +49,19 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
     template_dir = template_dir or (workspace / "prompts")
     files = _gather_template_files(template_dir)
 
+    dataset_dbs = get_dataset_sources(str(workspace))
+    existing_paths: set[str] = set()
+    primary_db = dataset_dbs[0] if dataset_dbs else None
+    if primary_db and primary_db.exists():
+        try:
+            with sqlite3.connect(primary_db) as prod_conn:
+                if _table_exists(prod_conn, "template_assets"):
+                    existing_paths = {
+                        row[0] for row in prod_conn.execute("SELECT template_path FROM template_assets")
+                    }
+        except sqlite3.Error:
+            existing_paths = set()
+
     start_time = datetime.now(timezone.utc)
 
     conn = sqlite3.connect(db_path)
@@ -58,12 +72,16 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
             conn = sqlite3.connect(db_path)
         with conn, tqdm(total=len(files), desc="Templates", unit="file") as bar:
             for path in files:
+                rel_path = str(path.relative_to(workspace))
+                if rel_path in existing_paths:
+                    bar.update(1)
+                    continue
                 content = path.read_text(encoding="utf-8")
                 digest = hashlib.sha256(content.encode()).hexdigest()
                 conn.execute(
                     ("INSERT INTO template_assets (template_path, content_hash, created_at) VALUES (?, ?, ?)"),
                     (
-                        str(path.relative_to(workspace)),
+                        rel_path,
                         digest,
                         datetime.now(timezone.utc).isoformat(),
                     ),

--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -29,6 +29,7 @@ from tqdm import tqdm
 from utils.log_utils import _log_event
 
 from .pattern_templates import get_pattern_templates
+from .learning_templates import get_lesson_templates
 from .placeholder_utils import DEFAULT_PRODUCTION_DB
 from .objective_similarity_scorer import compute_similarity_scores
 from .pattern_mining_engine import extract_patterns
@@ -138,7 +139,9 @@ class TemplateAutoGenerator:
         validate_no_recursive_folders()
         # DB-first loading of patterns and templates
         self.patterns = self._load_patterns()
-        self.templates = self._load_templates() + get_pattern_templates()
+        self.templates = self._load_templates() + get_pattern_templates() + list(
+            get_lesson_templates().values()
+        )
         self.cluster_vectorizer = None
         self.cluster_model = self._cluster_patterns()
         self._last_objective: dict[str, Any] | None = None

--- a/template_engine/learning_templates.py
+++ b/template_engine/learning_templates.py
@@ -8,7 +8,9 @@ directly by automation scripts.
 
 from __future__ import annotations
 
-from typing import Dict
+import os
+from pathlib import Path
+from typing import Dict, List
 
 LESSON_TEMPLATES: Dict[str, str] = {
     "database_first": """
@@ -49,6 +51,22 @@ class SelfHealingSystem:
         return self.apply_general_healing_strategy(error_type)
 """,
 }
+
+
+def get_dataset_sources(workspace_path: str | None = None) -> List[Path]:
+    """Return database paths ordered by priority.
+
+    The first entry is always ``production.db`` to satisfy the database-first
+    mandate. Additional databases may be used as fallbacks when present.
+    """
+
+    workspace = Path(workspace_path or os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd())))
+    db_dir = workspace / "databases"
+    return [
+        db_dir / "production.db",
+        db_dir / "template_completion.db",
+        db_dir / "enterprise_assets.db",
+    ]
 
 
 def get_lesson_templates() -> Dict[str, str]:

--- a/tests/test_auto_generator.py
+++ b/tests/test_auto_generator.py
@@ -44,6 +44,19 @@ def test_pattern_templates_loaded(tmp_path: Path) -> None:
     assert any("DatabaseFirstOperator" in t for t in generator.templates)
 
 
+def test_lesson_templates_ranked(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    analytics_db, completion_db = create_test_dbs(tmp_path)
+    gen = TemplateAutoGenerator(analytics_db, completion_db)
+    monkeypatch.setattr(auto_generator, "compute_similarity_scores", lambda *a, **k: [])
+    monkeypatch.setattr(auto_generator, "quantum_similarity_score", lambda *a, **k: 0.0)
+    monkeypatch.setattr(auto_generator, "quantum_cluster_score", lambda *a, **k: 0.0)
+    monkeypatch.setattr(gen, "_quantum_similarity", lambda *a, **k: 0.0)
+    monkeypatch.setattr(gen, "_quantum_score", lambda *a, **k: 0.0)
+    ranked = gen.rank_templates("DatabaseFirstOperator")
+    assert any("DatabaseFirstOperator" in t for t in ranked)
+
+
 def test_cluster_rep_no_dimension_error(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     analytics_db, completion_db = create_test_dbs(tmp_path)

--- a/tests/test_lessons_learned_gap_analyzer.py
+++ b/tests/test_lessons_learned_gap_analyzer.py
@@ -1,0 +1,26 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.analysis.lessons_learned_gap_analyzer import LessonsLearnedGapAnalyzer
+from template_engine.learning_templates import get_lesson_templates
+
+
+def test_dataset_coverage_validation(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.chdir(workspace)
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+    prod_db = db_dir / "production.db"
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute("CREATE TABLE lessons_learned (lesson_key TEXT)")
+        for key in get_lesson_templates().keys():
+            conn.execute("INSERT INTO lessons_learned VALUES (?)", (key,))
+    analyzer = LessonsLearnedGapAnalyzer(str(workspace))
+    assert analyzer.validate_dataset_coverage()
+    # remove one lesson
+    removed = next(iter(get_lesson_templates().keys()))
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute("DELETE FROM lessons_learned WHERE lesson_key=?", (removed,))
+    assert not analyzer.validate_dataset_coverage()


### PR DESCRIPTION
## Summary
- centralize dataset source resolution and prioritize production.db
- cross-check lessons table coverage in gap analyzer
- confirm lessons used during template generation

## Testing
- `ruff check template_engine/learning_templates.py template_engine/auto_generator.py scripts/database/template_asset_ingestor.py scripts/database/documentation_ingestor.py scripts/analysis/lessons_learned_gap_analyzer.py tests/test_auto_generator.py tests/test_lessons_learned_gap_analyzer.py`
- `pytest tests/test_auto_generator.py tests/test_lessons_learned_gap_analyzer.py`
- `pytest` *(fails: OperationalError: no such column: violation_id)*

------
https://chatgpt.com/codex/tasks/task_e_688cecc31f188331ba67e616356a9558