### PR TITLE
feat: add quantum teleportation algorithm with hardware fallback

### DIFF
--- a/quantum/README.md
+++ b/quantum/README.md
@@ -22,3 +22,12 @@ when `qiskit-ibm-provider` is installed and `QISKIT_IBM_TOKEN` is configured.
 Use the `--hardware` flag in `quantum_integration_orchestrator.py` to enable
 hardware execution. If hardware is unavailable, the modules automatically fall
 back to local simulation.
+
+## Algorithms
+
+- `algorithms.expansion.QuantumLibraryExpansion` – Grover search demonstration.
+- `algorithms.teleportation.QuantumTeleportation` – teleports a qubit state using a Bell pair.
+
+## Backend utilities
+
+- `utils.backend_provider.get_backend` – loads IBM Quantum backends and falls back to `Aer` simulators when hardware is unavailable.

--- a/quantum/algorithms/__init__.py
+++ b/quantum/algorithms/__init__.py
@@ -5,6 +5,7 @@ from .clustering import QuantumClustering
 from .database_search import QuantumDatabaseSearch
 from .expansion import QuantumLibraryExpansion
 from .functional import QuantumFunctional
+from .teleportation import QuantumTeleportation
 
 __all__ = [
     'QuantumAlgorithmBase',
@@ -12,4 +13,5 @@ __all__ = [
     'QuantumDatabaseSearch',
     'QuantumFunctional',
     'QuantumLibraryExpansion',
+    'QuantumTeleportation',
 ]

--- a/quantum/algorithms/expansion.py
+++ b/quantum/algorithms/expansion.py
@@ -7,10 +7,10 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from qiskit_aer import AerSimulator
 from qiskit import QuantumCircuit
 
 from .base import QuantumAlgorithmBase, TEXT_INDICATORS
+from ..utils import get_backend
 
 
 class QuantumLibraryExpansion(QuantumAlgorithmBase):
@@ -53,7 +53,10 @@ class QuantumLibraryExpansion(QuantumAlgorithmBase):
             circuit.h([0, 1])
             circuit.measure([0, 1], [0, 1])
 
-            backend = self.backend or AerSimulator()
+            backend = self.backend or get_backend(use_hardware=self.use_hardware)
+            if backend is None:
+                self.logger.error(f"{TEXT_INDICATORS['error']} No backend available")
+                return False
             result = backend.run(circuit, shots=200).result()
             counts = result.get_counts()
             self.logger.info(f"{TEXT_INDICATORS['info']} Counts: {counts}")

--- a/quantum/algorithms/teleportation.py
+++ b/quantum/algorithms/teleportation.py
@@ -1,0 +1,77 @@
+"""Quantum teleportation demonstration algorithm."""
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from qiskit import QuantumCircuit
+
+from .base import QuantumAlgorithmBase, TEXT_INDICATORS
+from ..utils import get_backend
+
+
+class QuantumTeleportation(QuantumAlgorithmBase):
+    """Teleport the state of one qubit to another using a Bell pair."""
+
+    def __init__(self, workspace_path: Optional[str] = None):
+        if workspace_path is None:
+            workspace_path = os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd()))
+        super().__init__(workspace_path)
+        self.backend = None
+        self.use_hardware = False
+
+    def get_algorithm_name(self) -> str:
+        return "Quantum Teleportation"
+
+    def set_backend(self, backend, use_hardware: bool = False):
+        self.backend = backend
+        self.use_hardware = use_hardware
+
+    def execute_algorithm(self) -> bool:
+        return self.perform_teleportation()
+
+    def perform_teleportation(self) -> bool:
+        """Teleport |1> from qubit 0 to qubit 2."""
+        self.logger.info(f"{TEXT_INDICATORS['info']} Running teleportation demo")
+        try:
+            qc = QuantumCircuit(3, 3)
+            qc.x(0)  # prepare |1>
+            qc.h(1)
+            qc.cx(1, 2)
+            qc.cx(0, 1)
+            qc.h(0)
+            qc.measure(0, 0)
+            qc.measure(1, 1)
+            qc.cz(1, 2)
+            qc.cx(0, 2)
+            qc.measure(2, 2)
+
+            backend = self.backend or get_backend(use_hardware=self.use_hardware)
+            if backend is None:
+                self.logger.error(f"{TEXT_INDICATORS['error']} No backend available")
+                return False
+
+            result = backend.run(qc, shots=128).result()
+            counts = result.get_counts()
+            self.execution_stats["counts"] = counts
+            self.logger.info(f"{TEXT_INDICATORS['info']} Counts: {counts}")
+            success = counts.get("001", 0) + counts.get("101", 0) > 0
+            if success:
+                self.logger.info(f"{TEXT_INDICATORS['success']} Teleportation successful")
+            else:
+                self.logger.info(f"{TEXT_INDICATORS['info']} Teleportation completed with counts: {counts}")
+            return success
+        except Exception as exc:
+            self.logger.error(f"{TEXT_INDICATORS['error']} Teleportation failed: {exc}")
+            return False
+
+
+def main():  # pragma: no cover - CLI entry
+    utility = QuantumTeleportation()
+    success = utility.execute_utility()
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/quantum/orchestration/registry.py
+++ b/quantum/orchestration/registry.py
@@ -7,8 +7,9 @@ import logging
 
 from ..algorithms.base import QuantumAlgorithmBase
 from ..algorithms.expansion import QuantumLibraryExpansion
-from ..algorithms.functional import QuantumFunctional  
+from ..algorithms.functional import QuantumFunctional
 from ..algorithms.clustering import QuantumClustering
+from ..algorithms.teleportation import QuantumTeleportation
 
 
 class QuantumAlgorithmRegistry:
@@ -24,6 +25,7 @@ class QuantumAlgorithmRegistry:
         self.register_algorithm("expansion", QuantumLibraryExpansion)
         self.register_algorithm("functional", QuantumFunctional)
         self.register_algorithm("clustering", QuantumClustering)
+        self.register_algorithm("teleportation", QuantumTeleportation)
     
     def register_algorithm(self, name: str, algorithm_class: Type[QuantumAlgorithmBase]):
         """Register a quantum algorithm"""

--- a/quantum/utils/__init__.py
+++ b/quantum/utils/__init__.py
@@ -2,5 +2,6 @@
 
 from .quantum_math import QuantumMath
 from .optimization import PerformanceOptimizer
+from .backend_provider import get_backend
 
-__all__ = ['QuantumMath', 'PerformanceOptimizer']
+__all__ = ['QuantumMath', 'PerformanceOptimizer', 'get_backend']

--- a/quantum/utils/backend_provider.py
+++ b/quantum/utils/backend_provider.py
@@ -1,0 +1,44 @@
+"""Backend provider utilities with IBM Quantum integration and simulator fallback."""
+
+from __future__ import annotations
+
+import logging
+
+try:  # pragma: no cover - optional dependency
+    from qiskit import Aer
+except Exception:  # pragma: no cover - qiskit may be missing
+    Aer = None
+
+try:  # pragma: no cover - optional dependency
+    from qiskit_ibm_provider import IBMProvider
+except Exception:  # pragma: no cover - provider may be missing
+    IBMProvider = None
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_backend(name: str = "ibmq_qasm_simulator", use_hardware: bool = False):
+    """Return a Qiskit backend.
+
+    Attempts to load an IBM Quantum backend when ``use_hardware`` is True and the
+    provider is available. Falls back to the Aer simulator otherwise.
+
+    Args:
+        name: Desired backend name when using hardware.
+        use_hardware: If True, attempt to use an IBM Quantum backend.
+
+    Returns:
+        The selected backend instance or ``None`` if Qiskit is unavailable.
+    """
+    if Aer is None:
+        LOGGER.warning("Qiskit Aer not available; no backend returned")
+        return None
+
+    if use_hardware and IBMProvider is not None:
+        try:  # pragma: no cover - requires network credentials
+            provider = IBMProvider()
+            return provider.get_backend(name)
+        except Exception as exc:  # pragma: no cover - provider may fail
+            LOGGER.warning("IBM backend unavailable: %s; using simulator", exc)
+
+    return Aer.get_backend("qasm_simulator")

--- a/tests/quantum/test_backend_provider.py
+++ b/tests/quantum/test_backend_provider.py
@@ -1,0 +1,26 @@
+import pytest
+
+from quantum.utils import backend_provider
+
+
+class DummyBackend:
+    pass
+
+
+class DummyProvider:
+    def get_backend(self, name):
+        return DummyBackend()
+
+
+@pytest.mark.skipif(backend_provider.Aer is None, reason="Qiskit not available")
+def test_get_backend_uses_provider(monkeypatch):
+    monkeypatch.setattr(backend_provider, "IBMProvider", lambda: DummyProvider())
+    backend = backend_provider.get_backend("dummy", use_hardware=True)
+    assert isinstance(backend, DummyBackend)
+
+
+@pytest.mark.skipif(backend_provider.Aer is None, reason="Qiskit not available")
+def test_get_backend_falls_back(monkeypatch):
+    monkeypatch.setattr(backend_provider, "IBMProvider", None)
+    backend = backend_provider.get_backend(use_hardware=True)
+    assert backend is not None

--- a/tests/quantum/test_teleportation.py
+++ b/tests/quantum/test_teleportation.py
@@ -1,0 +1,14 @@
+import pytest
+
+from quantum.orchestration.executor import QuantumExecutor
+from quantum.orchestration import executor as qexec
+
+
+@pytest.mark.skipif(
+    (not qexec.QISKIT_AVAILABLE) or (qexec.Aer is None),
+    reason="Qiskit not available",
+)
+def test_teleportation_runs():
+    exec_ = QuantumExecutor()
+    result = exec_.execute_algorithm("teleportation")
+    assert result["success"]


### PR DESCRIPTION
## Summary
- add backend provider utility supporting IBM Quantum hardware with simulator fallback
- implement quantum teleportation algorithm leveraging backend hooks
- cover provider fallback and teleportation execution with tests

## Testing
- `pytest tests/quantum/test_backend_provider.py tests/quantum/test_teleportation.py tests/quantum/test_provider_fallback.py tests/quantum/test_executor_hardware.py`

------
https://chatgpt.com/codex/tasks/task_e_688cecc50034833184def94c566419d3