### PR TITLE
feat: add lessons integration metrics

### DIFF
--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -6,6 +6,8 @@
         function updateMetrics(data){
             document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
             document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
+            document.getElementById('lessons_integration_status').textContent = data.lessons_integration_status;
+            document.getElementById('average_query_latency').textContent = data.average_query_latency.toFixed(3);
         }
         function updateRollbacks(logs){
             const list = document.getElementById('rollbacks');
@@ -37,7 +39,9 @@
 <h1>Compliance Dashboard</h1>
 <div>
     <strong>Placeholder Removals:</strong> <span id="placeholder_removal">0</span><br>
-    <strong>Compliance Score:</strong> <span id="compliance_score">0</span>
+    <strong>Compliance Score:</strong> <span id="compliance_score">0</span><br>
+    <strong>Lessons Integration Status:</strong> <span id="lessons_integration_status">UNKNOWN</span><br>
+    <strong>Average Query Latency (ms):</strong> <span id="average_query_latency">0</span>
 </div>
 <h2>Recent Rollbacks</h2>
 <ul id="rollbacks"></ul>

--- a/tests/dashboard/test_additional_metrics.py
+++ b/tests/dashboard/test_additional_metrics.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+import sqlite3
+import pytest
+
+from dashboard import compliance_metrics_updater as cmu
+
+
+@pytest.fixture()
+def test_app(tmp_path: Path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT)")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (1, 'ok')")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (0, 'open')")
+        conn.execute("CREATE TABLE correction_logs (compliance_score REAL, ts TEXT)")
+        conn.execute("INSERT INTO correction_logs VALUES (0.9, '2024-01-01T00:00:00Z')")
+        conn.execute("CREATE TABLE violation_logs (details TEXT, timestamp TEXT)")
+        conn.execute("CREATE TABLE rollback_logs (target TEXT, backup TEXT, timestamp TEXT)")
+        conn.execute(
+            """
+            CREATE TABLE integration_score_calculations (
+                calculation_id TEXT PRIMARY KEY,
+                timestamp TEXT,
+                overall_score REAL,
+                maximum_possible_score REAL,
+                percentage_score REAL,
+                achievement_level TEXT,
+                integration_status TEXT,
+                calculation_passed BOOLEAN,
+                critical_disqualifiers TEXT,
+                component_scores TEXT,
+                recommendations TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO integration_score_calculations (
+                calculation_id, timestamp, overall_score, maximum_possible_score,
+                percentage_score, achievement_level, integration_status,
+                calculation_passed, critical_disqualifiers, component_scores, recommendations
+            ) VALUES ('1', '2024-01-01T00:00:00Z', 0, 0, 0, '', 'FULLY_INTEGRATED', 1, '[]', '{}', '[]')
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE performance_metrics (
+                id INTEGER PRIMARY KEY,
+                metric_name TEXT,
+                metric_value REAL,
+                metric_type TEXT,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO performance_metrics (metric_name, metric_value, metric_type) VALUES ('query_latency', 12.5, 'ms')"
+        )
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
+    from web_gui.scripts.flask_apps import enterprise_dashboard as ed
+
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+    monkeypatch.setattr(
+        ed,
+        "metrics_updater",
+        cmu.ComplianceMetricsUpdater(tmp_path, test_mode=True),
+    )
+    return ed.app
+
+
+def test_additional_metrics_present(test_app):
+    client = test_app.test_client()
+    resp = client.get("/summary")
+    assert resp.status_code == 200
+    metrics = resp.get_json()["metrics"]
+    assert metrics["lessons_integration_status"] == "FULLY_INTEGRATED"
+    assert metrics["average_query_latency"] == pytest.approx(12.5)
+


### PR DESCRIPTION
## Summary
- extend dashboard metrics to include lessons integration status and average query latency
- show new metrics on dashboard template
- cover new metrics with dashboard tests

## Testing
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py tests/dashboard/test_additional_metrics.py`
- `pytest tests/dashboard -q`


------
https://chatgpt.com/codex/tasks/task_e_688cecc6b4d0833183f66b6714642045