### PR TITLE
fix: adjust compliance scoring formula

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -90,7 +90,7 @@ class ComplianceMetricsUpdater:
             "placeholder_removal": 0,
             "open_placeholders": 0,
             "resolved_placeholders": 0,
-            "compliance_score": 0.0,
+            "compliance_score": 1.0,
             "violation_count": 0,
             "rollback_count": 0,
             "progress_status": "unknown",
@@ -122,7 +122,7 @@ class ComplianceMetricsUpdater:
                 resolved_ph = metrics["resolved_placeholders"]
                 total_ph = resolved_ph + open_ph
                 metrics["compliance_score"] = (
-                    resolved_ph / total_ph if total_ph else 0.0
+                    resolved_ph / total_ph if total_ph else 1.0
                 )
                 cur.execute("SELECT COUNT(*) FROM correction_logs")
                 metrics["correction_count"] = cur.fetchone()[0]

--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -286,7 +286,8 @@ def update_dashboard(
             )
             placeholder_counts = {row[0]: row[1] for row in cur.fetchall()}
 
-    compliance = max(0, 100 - open_count)
+    total = open_count + resolved
+    compliance = resolved / total if total else 1.0
     status = "complete" if open_count == 0 else "issues_pending"
     compliance_status = "compliant" if open_count == 0 else "non_compliant"
     data = {

--- a/tests/placeholder_audit/test_summary_creation.py
+++ b/tests/placeholder_audit/test_summary_creation.py
@@ -27,7 +27,9 @@ def test_summary_file_created_after_runs(tmp_path):
     data1 = json.loads(summary.read_text())
     assert data1.get("findings", 0) >= 1
     assert data1.get("resolved_count") == 0
-    assert "compliance_score" in data1
+    total1 = data1["findings"] + data1["resolved_count"]
+    expected1 = data1["resolved_count"] / total1 if total1 else 1.0
+    assert data1["compliance_score"] == expected1
     assert "progress_status" in data1
     assert "compliance_status" in data1
     assert isinstance(data1.get("placeholder_counts"), dict)
@@ -45,4 +47,30 @@ def test_summary_file_created_after_runs(tmp_path):
     data2 = json.loads(summary2.read_text())
     assert "findings" in data2
     assert "resolved_count" in data2
+    total2 = data2["findings"] + data2["resolved_count"]
+    expected2 = data2["resolved_count"] / total2 if total2 else 1.0
+    assert data2["compliance_score"] == expected2
     assert "placeholder_counts" in data2
+
+
+def test_compliance_score_zero_denominator(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "clean.py").write_text("print('clean')\n")
+
+    analytics = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dashboard"
+    dash_compliance = dash_dir / "compliance"
+
+    assert main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(dash_compliance),
+    )
+
+    summary = dash_compliance / "placeholder_summary.json"
+    data = json.loads(summary.read_text())
+    assert data["findings"] == 0
+    assert data["resolved_count"] == 0
+    assert data["compliance_score"] == 1.0


### PR DESCRIPTION
## Summary
- compute compliance score based on resolved and total findings
- default compliance score to 1 when no placeholders exist
- test updated placeholder audit compliance scoring

## Testing
- `ruff check scripts/code_placeholder_audit.py dashboard/compliance_metrics_updater.py tests/placeholder_audit/test_summary_creation.py`
- `pytest tests/placeholder_audit`


------
https://chatgpt.com/codex/tasks/task_e_688cf81cac7c8331a30e04800a8f52a5