### PR TITLE
feat: ingest and select learning templates

### DIFF
--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -66,6 +66,7 @@ TABLES: dict[str, str] = {
         "id INTEGER PRIMARY KEY,"
         "pattern TEXT NOT NULL,"
         "usage_count INTEGER DEFAULT 0,"
+        "lesson_name TEXT,"
         "created_at TEXT NOT NULL"
         ")"
     ),

--- a/template_engine/db_first_code_generator.py
+++ b/template_engine/db_first_code_generator.py
@@ -31,6 +31,7 @@ from .placeholder_utils import DEFAULT_PRODUCTION_DB, replace_placeholders
 from .template_placeholder_remover import remove_unused_placeholders
 from .objective_similarity_scorer import compute_similarity_scores
 from .pattern_mining_engine import extract_patterns
+from .learning_templates import get_lesson_templates
 
 # Quantum scoring helper
 try:
@@ -125,6 +126,7 @@ class TemplateAutoGenerator:
                 "Loaded %s default templates from pattern_templates",
                 len(templates),
             )
+        templates += list(get_lesson_templates().values())
         _log_event(
             {"event": "load_templates", "count": len(templates)},
             table="generator_events",

--- a/tests/test_template_asset_ingestor.py
+++ b/tests/test_template_asset_ingestor.py
@@ -1,12 +1,15 @@
+import os
 import sqlite3
 from pathlib import Path
 
 from scripts.database.template_asset_ingestor import ingest_templates
 from scripts.database.unified_database_initializer import initialize_database
+from template_engine.learning_templates import get_lesson_templates
 
 
 def test_ingest_templates(tmp_path: Path) -> None:
     workspace = tmp_path
+    os.environ["GH_COPILOT_WORKSPACE"] = str(workspace)
     db_dir = workspace / "databases"
     db_dir.mkdir()
     db_path = db_dir / "enterprise_assets.db"
@@ -19,5 +22,10 @@ def test_ingest_templates(tmp_path: Path) -> None:
     with sqlite3.connect(db_path) as conn:
         t_count = conn.execute("SELECT COUNT(*) FROM template_assets").fetchone()[0]
         p_count = conn.execute("SELECT COUNT(*) FROM pattern_assets").fetchone()[0]
+        lesson_count = conn.execute(
+            "SELECT COUNT(*) FROM pattern_assets WHERE lesson_name IS NOT NULL"
+        ).fetchone()[0]
+    expected_lessons = len(get_lesson_templates())
     assert t_count == 1
-    assert p_count == 1
+    assert p_count == 1 + expected_lessons
+    assert lesson_count == expected_lessons


### PR DESCRIPTION
## Summary
- load lesson templates when assembling DB-first code templates
- ingest lesson patterns into enterprise assets database
- add lesson-aware integration tests for template selection and ingestion

## Testing
- `ruff check template_engine/db_first_code_generator.py scripts/database/template_asset_ingestor.py scripts/database/unified_database_initializer.py tests/test_template_asset_ingestor.py tests/test_db_first_code_generator.py`
- `pytest tests/test_template_asset_ingestor.py tests/test_db_first_code_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_688cf81d62ac8331a0444863c46cd3ff