### PR TITLE
feat: add placeholder metrics trend analysis

### DIFF
--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -8,6 +8,16 @@
             document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
             document.getElementById('lessons_integration_status').textContent = data.lessons_integration_status;
             document.getElementById('average_query_latency').textContent = data.average_query_latency.toFixed(3);
+            const pb = document.getElementById('placeholder_breakdown');
+            pb.innerHTML = '';
+            if (data.placeholder_breakdown){
+                Object.entries(data.placeholder_breakdown).forEach(([type,count])=>{
+                    const li = document.createElement('li');
+                    li.textContent = type+': '+count;
+                    pb.appendChild(li);
+                });
+            }
+            document.getElementById('compliance_trend').textContent = (data.compliance_trend||[]).join(', ');
         }
         function updateRollbacks(logs){
             const list = document.getElementById('rollbacks');
@@ -42,6 +52,10 @@
     <strong>Compliance Score:</strong> <span id="compliance_score">0</span><br>
     <strong>Lessons Integration Status:</strong> <span id="lessons_integration_status">UNKNOWN</span><br>
     <strong>Average Query Latency (ms):</strong> <span id="average_query_latency">0</span>
+    <h3>Placeholder Types</h3>
+    <ul id="placeholder_breakdown"></ul>
+    <h3>Compliance Trend</h3>
+    <span id="compliance_trend"></span>
 </div>
 <h2>Recent Rollbacks</h2>
 <ul id="rollbacks"></ul>

--- a/tests/dashboard/test_placeholder_trend_metrics.py
+++ b/tests/dashboard/test_placeholder_trend_metrics.py
@@ -1,0 +1,61 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dashboard import compliance_metrics_updater as cmu
+
+
+@pytest.fixture()
+def app(tmp_path: Path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking (placeholder_type TEXT, status TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO todo_fixme_tracking VALUES (?, 'open')",
+            [("TODO",), ("FIXME",), ("TODO",)],
+        )
+        conn.execute(
+            "CREATE TABLE correction_logs (event TEXT, score REAL, timestamp TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO correction_logs VALUES ('update', ?, ?)",
+            [(0.1, "2024-01-01"), (0.2, "2024-01-02")],
+        )
+        conn.execute(
+            "CREATE TABLE violation_logs (details TEXT, timestamp TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE rollback_logs (target TEXT, backup TEXT, timestamp TEXT)"
+        )
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "ANALYTICS_DB", db)
+    from web_gui.scripts.flask_apps import enterprise_dashboard as ed
+
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+    monkeypatch.setattr(
+        ed,
+        "metrics_updater",
+        cmu.ComplianceMetricsUpdater(tmp_path, test_mode=True),
+    )
+    return ed.app
+
+
+def test_metrics_endpoint_includes_new_fields(app):
+    client = app.test_client()
+    data = client.get("/metrics").get_json()
+    assert data["placeholder_breakdown"]["TODO"] == 2
+    assert data["compliance_trend"] == [0.1, 0.2]
+
+
+def test_dashboard_template_has_new_elements(app):
+    client = app.test_client()
+    html = client.get("/").data.decode()
+    assert 'id="placeholder_breakdown"' in html
+    assert 'id="compliance_trend"' in html
+

--- a/web_gui/templates/dashboard.html
+++ b/web_gui/templates/dashboard.html
@@ -5,7 +5,11 @@
 <div>
     <strong>Placeholder Removals:</strong> <span id="placeholder_removal">0</span><br>
     <strong>Open Placeholders:</strong> <span id="open_placeholders">0</span><br>
-    <strong>Compliance Score:</strong> <span id="compliance_score">0.000</span>
+    <strong>Compliance Score:</strong> <span id="compliance_score">0.000</span><br>
+    <h3>Placeholder Types</h3>
+    <ul id="placeholder_breakdown"></ul>
+    <h3>Compliance Trend</h3>
+    <span id="compliance_trend"></span>
 </div>
 <h2>Violations</h2>
 <ul id="violations"></ul>
@@ -17,6 +21,16 @@ function updateMetrics(data){
     document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
     document.getElementById('open_placeholders').textContent = data.open_placeholders;
     document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
+    const pb = document.getElementById('placeholder_breakdown');
+    pb.innerHTML = '';
+    if(data.placeholder_breakdown){
+        Object.entries(data.placeholder_breakdown).forEach(([type,count])=>{
+            const li = document.createElement('li');
+            li.textContent = type+': '+count;
+            pb.appendChild(li);
+        });
+    }
+    document.getElementById('compliance_trend').textContent = (data.compliance_trend||[]).join(', ');
 }
 function updateAlerts(data){
     const v = document.getElementById('violations');


### PR DESCRIPTION
## Summary
- track placeholder type breakdown and compliance score trend in dashboard metrics
- surface new metrics on dashboard endpoints and pages
- test endpoint outputs and dashboard rendering

## Testing
- `ruff check dashboard/compliance_metrics_updater.py web_gui/scripts/flask_apps/enterprise_dashboard.py tests/dashboard/test_placeholder_trend_metrics.py`
- `pytest tests/dashboard/test_placeholder_trend_metrics.py tests/dashboard/test_additional_metrics.py tests/dashboard/test_live_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_688cf81e31688331aba16a474709594a