### PR TITLE
fix: respect dynamic backup path in cross reference validator

### DIFF
--- a/scripts/cross_reference_validator.py
+++ b/scripts/cross_reference_validator.py
@@ -57,7 +57,6 @@ class CrossReferenceValidator:
         analytics_db: Path = ANALYTICS_DB,
         dashboard_dir: Path = DASHBOARD_DIR,
         task_suggestions_file: Path = TASK_SUGGESTIONS_FILE,
-        backup_root: Path | None = None,
     ) -> None:
         self.production_db = production_db
         self.analytics_db = analytics_db
@@ -148,7 +147,7 @@ class CrossReferenceValidator:
                 validate_enterprise_operation(str(d))
                 for path in d.rglob(file_name):
                     try:
-                        path.relative_to(self.backup_root)
+                        path.relative_to(backup_root)
                     except ValueError:
                         related_paths.add(path)
             for path in sorted(related_paths):


### PR DESCRIPTION
## Summary
- remove unused `backup_root` parameter from `CrossReferenceValidator`
- avoid accessing stale backup path by querying `CrossPlatformPathManager` directly during deep cross-linking

## Testing
- `ruff check scripts/cross_reference_validator.py`
- `pyright scripts/cross_reference_validator.py`
- `pytest`
- `make test` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_688cf81ebda08331bf062576294a03d2