### PR TITLE
feat: add hardware-aware quantum features

### DIFF
--- a/quantum/README.md
+++ b/quantum/README.md
@@ -23,10 +23,16 @@ Use the `--hardware` flag in `quantum_integration_orchestrator.py` to enable
 hardware execution. If hardware is unavailable, the modules automatically fall
 back to local simulation.
 
+Hardware usage can also be toggled globally by setting the environment
+variable `QUANTUM_USE_HARDWARE` to `"1"`. Modules query this flag when no
+explicit option is provided.
+
 ## Algorithms
 
 - `algorithms.expansion.QuantumLibraryExpansion` – Grover search demonstration.
 - `algorithms.teleportation.QuantumTeleportation` – teleports a qubit state using a Bell pair.
+- `algorithms.hardware_aware.HardwareAwareAlgorithm` – demonstrates automatic
+  hardware selection via `qiskit-ibm-provider` with simulator fallback.
 
 ## Backend utilities
 

--- a/quantum/algorithms/__init__.py
+++ b/quantum/algorithms/__init__.py
@@ -5,6 +5,7 @@ from .clustering import QuantumClustering
 from .database_search import QuantumDatabaseSearch
 from .expansion import QuantumLibraryExpansion
 from .functional import QuantumFunctional
+from .hardware_aware import HardwareAwareAlgorithm
 from .teleportation import QuantumTeleportation
 
 __all__ = [
@@ -12,6 +13,7 @@ __all__ = [
     'QuantumClustering',
     'QuantumDatabaseSearch',
     'QuantumFunctional',
+    'HardwareAwareAlgorithm',
     'QuantumLibraryExpansion',
     'QuantumTeleportation',
 ]

--- a/quantum/algorithms/hardware_aware.py
+++ b/quantum/algorithms/hardware_aware.py
@@ -1,0 +1,53 @@
+"""Hardware-aware quantum algorithm using IBM provider when available."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from tqdm import tqdm
+
+from .base import QuantumAlgorithmBase
+from ..utils.backend_provider import get_backend
+
+try:  # pragma: no cover - optional dependency
+    from qiskit import QuantumCircuit, execute
+except Exception:  # pragma: no cover - qiskit may be missing
+    QuantumCircuit = None  # type: ignore
+    execute = None  # type: ignore
+
+
+class HardwareAwareAlgorithm(QuantumAlgorithmBase):
+    """Minimal demo algorithm that selects hardware or simulation backends."""
+
+    def __init__(self, use_hardware: Optional[bool] = None):
+        super().__init__()
+        self.use_hardware = use_hardware
+
+    def get_algorithm_name(self) -> str:  # pragma: no cover - trivial
+        return "hardware_aware_demo"
+
+    def execute_algorithm(self) -> bool:
+        if QuantumCircuit is None or execute is None:
+            self.logger.warning("Qiskit not available")
+            return False
+
+        backend = get_backend(use_hardware=self.use_hardware)
+        if backend is None:
+            self.logger.warning("No backend available")
+            return False
+
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        qc.measure_all()
+
+        with tqdm(total=1, desc="Hardware-aware execution", unit="job") as bar:
+            job = execute(qc, backend, shots=128)
+            job.result()
+            bar.update(1)
+
+        return True
+
+
+__all__ = ["HardwareAwareAlgorithm"]
+

--- a/quantum/utils/backend_provider.py
+++ b/quantum/utils/backend_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 
 try:  # pragma: no cover - optional dependency
     from qiskit import Aer
@@ -17,15 +18,18 @@ except Exception:  # pragma: no cover - provider may be missing
 LOGGER = logging.getLogger(__name__)
 
 
-def get_backend(name: str = "ibmq_qasm_simulator", use_hardware: bool = False):
-    """Return a Qiskit backend.
+def get_backend(name: str = "ibmq_qasm_simulator", use_hardware: bool | None = None):
+    """Return a Qiskit backend with optional hardware selection.
 
     Attempts to load an IBM Quantum backend when ``use_hardware`` is True and the
-    provider is available. Falls back to the Aer simulator otherwise.
+    provider is available. Falls back to the Aer simulator otherwise. When
+    ``use_hardware`` is ``None`` the ``QUANTUM_USE_HARDWARE`` environment variable
+    ("1" enables hardware mode) controls the behavior.
 
     Args:
         name: Desired backend name when using hardware.
-        use_hardware: If True, attempt to use an IBM Quantum backend.
+        use_hardware: If True, attempt to use an IBM Quantum backend. If ``None``,
+            read the value from ``QUANTUM_USE_HARDWARE``.
 
     Returns:
         The selected backend instance or ``None`` if Qiskit is unavailable.
@@ -33,6 +37,9 @@ def get_backend(name: str = "ibmq_qasm_simulator", use_hardware: bool = False):
     if Aer is None:
         LOGGER.warning("Qiskit Aer not available; no backend returned")
         return None
+
+    if use_hardware is None:
+        use_hardware = os.getenv("QUANTUM_USE_HARDWARE", "0") == "1"
 
     if use_hardware and IBMProvider is not None:
         try:  # pragma: no cover - requires network credentials

--- a/tests/quantum/test_backend_provider_config.py
+++ b/tests/quantum/test_backend_provider_config.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+
+from quantum.utils import backend_provider
+
+
+class DummyBackend:
+    pass
+
+
+class DummyProvider:
+    def get_backend(self, name):
+        return DummyBackend()
+
+
+@pytest.mark.skipif(backend_provider.Aer is None, reason="Qiskit not available")
+def test_env_var_enables_hardware(monkeypatch):
+    monkeypatch.setenv("QUANTUM_USE_HARDWARE", "1")
+    monkeypatch.setattr(backend_provider, "IBMProvider", lambda: DummyProvider())
+    backend = backend_provider.get_backend()
+    assert isinstance(backend, DummyBackend)
+
+
+@pytest.mark.skipif(backend_provider.Aer is None, reason="Qiskit not available")
+def test_env_var_defaults_to_simulator(monkeypatch):
+    monkeypatch.delenv("QUANTUM_USE_HARDWARE", raising=False)
+    monkeypatch.setattr(backend_provider, "IBMProvider", lambda: DummyProvider())
+    backend = backend_provider.get_backend()
+    from qiskit import Aer as _Aer
+
+    assert backend == _Aer.get_backend("qasm_simulator")
+

--- a/tests/quantum/test_hardware_aware_algorithm.py
+++ b/tests/quantum/test_hardware_aware_algorithm.py
@@ -1,0 +1,32 @@
+import pytest
+
+from quantum.algorithms import hardware_aware
+from quantum.utils import backend_provider
+
+
+@pytest.mark.skipif(backend_provider.Aer is None, reason="Qiskit not available")
+def test_hardware_aware_algorithm_respects_flag(monkeypatch):
+    called = {}
+
+    def fake_backend(use_hardware=None):
+        called["flag"] = use_hardware
+
+        class DummyBackend:
+            pass
+
+        return DummyBackend()
+
+    def fake_execute(qc, backend, shots):
+        class DummyJob:
+            def result(self):
+                return None
+
+        return DummyJob()
+
+    monkeypatch.setattr(hardware_aware, "get_backend", fake_backend)
+    monkeypatch.setattr(hardware_aware, "execute", fake_execute)
+
+    algo = hardware_aware.HardwareAwareAlgorithm(use_hardware=True)
+    assert algo.execute_algorithm()
+    assert called["flag"] is True
+

--- a/tests/quantum/test_quantum_compliance_engine_ml.py
+++ b/tests/quantum/test_quantum_compliance_engine_ml.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from quantum.quantum_compliance_engine import QuantumComplianceEngine
+
+
+def test_ml_pattern_recognition(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "quantum.quantum_compliance_engine.validate_no_recursive_folders", lambda: None
+    )
+    target = tmp_path / "sample.txt"
+    target.write_text("quantum compliance pattern pattern analysis quantum compliance")
+    engine = QuantumComplianceEngine(tmp_path)
+    patterns = engine._ml_pattern_recognition(target, top_n=2)
+    assert len(patterns) == 2
+
+
+def test_score_uses_ml_when_no_patterns(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "quantum.quantum_compliance_engine.validate_no_recursive_folders", lambda: None
+    )
+    target = tmp_path / "sample.txt"
+    target.write_text("quantum compliance pattern pattern analysis quantum")
+    engine = QuantumComplianceEngine(tmp_path)
+    monkeypatch.setattr(engine, "_quantum_field_redundancy", lambda s: s)
+    score = engine.score(target, [])
+    assert score >= 0.0
+


### PR DESCRIPTION
## Summary
- extend backend provider to read QUANTUM_USE_HARDWARE
- enable ML pattern recognition and hardware backend selection in quantum compliance engine
- add hardware-aware algorithm and configuration tests

## Testing
- `ruff check quantum/quantum_compliance_engine.py quantum/utils/backend_provider.py quantum/algorithms/hardware_aware.py quantum/algorithms/__init__.py tests/quantum/test_backend_provider_config.py tests/quantum/test_hardware_aware_algorithm.py tests/quantum/test_quantum_compliance_engine_ml.py`
- `pytest tests/quantum/test_backend_provider_config.py tests/quantum/test_hardware_aware_algorithm.py tests/quantum/test_quantum_compliance_engine_ml.py`

------
https://chatgpt.com/codex/tasks/task_e_688cf821840083319625af585f40342b