### PR TITLE
feat: support storing and querying lessons

### DIFF
--- a/tests/test_lessons_learned_integrator.py
+++ b/tests/test_lessons_learned_integrator.py
@@ -1,16 +1,79 @@
 import sqlite3
+from pathlib import Path
 
-from utils.lessons_learned_integrator import load_lessons
+from utils.lessons_learned_integrator import (
+    load_lessons,
+    store_lesson,
+    store_lessons,
+    fetch_lessons_by_tag,
+)
+
+def _create_table(db: Path) -> None:
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE enhanced_lessons_learned (
+                description TEXT,
+                source TEXT,
+                timestamp TEXT,
+                validation_status TEXT,
+                tags TEXT
+            )
+            """
+        )
+
 
 def test_load_lessons(tmp_path):
     db = tmp_path / "lessons.db"
-    with sqlite3.connect(db) as conn:
-        conn.execute(
-            "CREATE TABLE enhanced_lessons_learned (description TEXT, tags TEXT)"
-        )
-        conn.execute(
-            "INSERT INTO enhanced_lessons_learned (description, tags) VALUES (?, ?)",
-            ("Use temp dirs", "testing"),
-        )
+    _create_table(db)
+    store_lesson(
+        "Use temp dirs",
+        source="tests",
+        timestamp="2024-01-01",
+        validation_status="validated",
+        tags="testing",
+        db_path=db,
+    )
     lessons = load_lessons(db)
     assert lessons == [{"description": "Use temp dirs", "tags": "testing"}]
+
+
+def test_store_lesson_and_fetch_by_tag(tmp_path):
+    db = tmp_path / "lessons.db"
+    _create_table(db)
+    store_lesson(
+        "Add more docs",
+        source="review",
+        timestamp="2024-01-02",
+        validation_status="pending",
+        tags="docs",
+        db_path=db,
+    )
+    fetched = fetch_lessons_by_tag("docs", db_path=db)
+    assert fetched[0]["description"] == "Add more docs"
+
+
+def test_store_lessons_batch(tmp_path):
+    db = tmp_path / "lessons.db"
+    _create_table(db)
+    lessons = [
+        {
+            "description": "Use context managers",
+            "source": "review",
+            "timestamp": "2024-01-03",
+            "validation_status": "validated",
+            "tags": "style",
+        },
+        {
+            "description": "Avoid globals",
+            "source": "review",
+            "timestamp": "2024-01-04",
+            "validation_status": "validated",
+        },
+    ]
+    store_lessons(lessons, db_path=db)
+    with sqlite3.connect(db) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM enhanced_lessons_learned"
+        ).fetchone()[0]
+    assert count == 2

--- a/utils/lessons_learned_integrator.py
+++ b/utils/lessons_learned_integrator.py
@@ -1,9 +1,32 @@
-"""Utilities for integrating lessons learned into runtime systems."""
+"""Utilities for integrating lessons learned into runtime systems.
+
+This module provides helpers for persisting and retrieving lessons in the
+``enhanced_lessons_learned`` table.  The table stores each lesson's
+``description``, ``source``, ``timestamp``, ``validation_status`` and optional
+``tags``.
+
+Examples
+--------
+>>> store_lesson(
+...     "Prefer temp directories",
+...     source="unit_test",
+...     timestamp="2024-01-01T00:00:00Z",
+...     validation_status="validated",
+...     tags="testing",
+...     db_path=Path("example.db"),
+... )
+>>> fetch_lessons_by_tag("testing", db_path=Path("example.db"))
+[{'description': 'Prefer temp directories',
+  'source': 'unit_test',
+  'timestamp': '2024-01-01T00:00:00Z',
+  'validation_status': 'validated',
+  'tags': 'testing'}]
+"""
 from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Iterable, Optional
 
 from utils.log_utils import _log_event
 
@@ -45,3 +68,150 @@ def apply_lessons(logger, lessons: List[Dict[str, str]]) -> None:
     """Apply loaded lessons by logging them for transparency."""
     for lesson in lessons:
         logger.info("[INFO] Lesson applied: %s | tags=%s", lesson["description"], lesson["tags"])
+
+
+def store_lesson(
+    description: str,
+    source: str,
+    timestamp: str,
+    validation_status: str,
+    *,
+    tags: Optional[str] = None,
+    db_path: Path = DEFAULT_DB,
+) -> None:
+    """Store a single lesson in the lessons learned table.
+
+    Parameters
+    ----------
+    description, source, timestamp, validation_status:
+        Fields describing the lesson entry.
+    tags:
+        Optional comma-separated tags.
+    db_path:
+        Path to the SQLite database.
+
+    Examples
+    --------
+    >>> store_lesson(
+    ...     "Document error handling",
+    ...     source="docs",
+    ...     timestamp="2024-01-02T00:00:00Z",
+    ...     validation_status="pending",
+    ...     tags="documentation",
+    ...     db_path=Path("example.db"),
+    ... )
+    """
+    try:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                f"""
+                INSERT INTO {TABLE}
+                    (description, source, timestamp, validation_status, tags)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (description, source, timestamp, validation_status, tags),
+            )
+    except sqlite3.Error as exc:  # pragma: no cover - log unexpected DB errors
+        _log_event({"error": str(exc)}, table="lessons_learned_errors", db_path=db_path)
+
+
+def store_lessons(
+    lessons: Iterable[Dict[str, str]],
+    db_path: Path = DEFAULT_DB,
+) -> None:
+    """Store multiple lessons using a batch insert.
+
+    Parameters
+    ----------
+    lessons:
+        Iterable of lesson dictionaries containing ``description``, ``source``,
+        ``timestamp``, ``validation_status`` and optional ``tags``.
+    db_path:
+        Path to the SQLite database.
+
+    Examples
+    --------
+    >>> lessons = [
+    ...     {
+    ...         "description": "Use context managers",
+    ...         "source": "review",
+    ...         "timestamp": "2024-01-03T00:00:00Z",
+    ...         "validation_status": "validated",
+    ...         "tags": "style",
+    ...     }
+    ... ]
+    >>> store_lessons(lessons, db_path=Path("example.db"))
+    """
+    records = [
+        (
+            lesson["description"],
+            lesson["source"],
+            lesson["timestamp"],
+            lesson["validation_status"],
+            lesson.get("tags"),
+        )
+        for lesson in lessons
+    ]
+    try:
+        with sqlite3.connect(db_path) as conn:
+            conn.executemany(
+                f"""
+                INSERT INTO {TABLE}
+                    (description, source, timestamp, validation_status, tags)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                records,
+            )
+    except sqlite3.Error as exc:  # pragma: no cover
+        _log_event({"error": str(exc)}, table="lessons_learned_errors", db_path=db_path)
+
+
+def fetch_lessons_by_tag(tag: str, db_path: Path = DEFAULT_DB) -> List[Dict[str, str]]:
+    """Fetch lessons that contain a given tag.
+
+    Parameters
+    ----------
+    tag:
+        Tag to search for within the ``tags`` field.
+    db_path:
+        Path to the SQLite database.
+
+    Returns
+    -------
+    list of dict
+        Matching rows with all lesson fields.
+
+    Examples
+    --------
+    >>> fetch_lessons_by_tag("style", db_path=Path("example.db"))
+    []
+    """
+    results: List[Dict[str, str]] = []
+    if not db_path.exists():
+        return results
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f"""
+                SELECT description, source, timestamp, validation_status,
+                       COALESCE(tags, '') AS tags
+                FROM {TABLE}
+                WHERE tags LIKE ?
+                """,
+                (f"%{tag}%",),
+            )
+            for row in cur.fetchall():
+                results.append(
+                    {
+                        "description": row["description"],
+                        "source": row["source"],
+                        "timestamp": row["timestamp"],
+                        "validation_status": row["validation_status"],
+                        "tags": row["tags"],
+                    }
+                )
+        except sqlite3.Error as exc:  # pragma: no cover
+            _log_event({"error": str(exc)}, table="lessons_learned_errors", db_path=db_path)
+    return results


### PR DESCRIPTION
## Summary
- extend lessons learned integrator to store single and multiple lessons and fetch them by tag
- document new lesson storage APIs with usage examples
- cover lesson storage utilities with unit tests

## Testing
- `ruff check utils/lessons_learned_integrator.py tests/test_lessons_learned_integrator.py`
- `pytest tests/test_lessons_learned_integrator.py` *(fails: ModuleNotFoundError: No module named 'tqdm')*


------
https://chatgpt.com/codex/tasks/task_e_688d00e57a14833196d1bf76fadc400b