### PR TITLE
feat: integrate lessons into sessions and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ tools/install_clw.sh
 ls -l /usr/local/bin/clw
 /usr/local/bin/clw --help
 
+### Add Lessons After a Run
+Store new insights directly from the gap analyzer:
+
+```bash
+python -m scripts.analysis.lessons_learned_gap_analyzer --lesson "use temp dirs"
+```
+
+Lessons are written to `learning_monitor.db` and automatically applied in future sessions.
+
 ### OpenAI Connector
 The repository provides `github_integration/openai_connector.py` for OpenAI API
 calls using the `OpenAIClient` helper in

--- a/quantum_optimizer.py
+++ b/quantum_optimizer.py
@@ -2,11 +2,12 @@
 # > Generated: 2025-07-24 19:36:07 | Author: mbaetiong
 
 import numpy as np
-from typing import Callable, Optional, Any, Dict, List, Tuple, Union
+from typing import Callable, Optional, Any, Dict, List, Tuple
 from datetime import datetime
 
 from utils.cross_platform_paths import CrossPlatformPathManager
 import os
+from utils.lessons_learned_integrator import fetch_lessons_by_tag
 
 try:
     from qiskit import QuantumCircuit, Aer, execute
@@ -148,6 +149,21 @@ class QuantumOptimizer:
             "history": self.history
         }
         return summary
+
+
+def score_templates(templates: List[str], tag: str) -> List[tuple[str, float]]:
+    """Weight templates based on lessons tagged with ``tag``."""
+    lessons = fetch_lessons_by_tag(tag)
+    if not lessons:
+        return [(t, 1.0) for t in templates]
+    scores: List[tuple[str, float]] = []
+    for tmpl in templates:
+        weight = 1.0
+        for lesson in lessons:
+            if lesson["description"].lower() in tmpl.lower():
+                weight += 1.0
+        scores.append((tmpl, weight))
+    return scores
 
     def _run_simulated_annealing(self, x0: Optional[np.ndarray], max_iter: int = 500, temp: float = 1.0, cooling: float = 0.95) -> Dict[str, Any]:
         """Simple simulated annealing optimizer (classical, for demonstration)."""

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -39,6 +39,7 @@ from tqdm import tqdm
 from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.validation_utils import validate_enterprise_environment
+from utils.lessons_learned_integrator import store_lesson
 
 try:
     from scripts.orchestrators.unified_wrapup_orchestrator import (
@@ -174,6 +175,13 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
             raise
 
         finalize_session_entry(conn, entry_id, compliance_score)
+        store_lesson(
+            description=f"WLC session completed with score {compliance_score:.2f}",
+            source="wlc_session_manager",
+            timestamp=datetime.now(UTC).isoformat(),
+            validation_status="validated",
+            tags="wlc",
+        )
 
         if run_orchestrator:
             orchestrator_cls = UnifiedWrapUpOrchestrator

--- a/template_engine/README.md
+++ b/template_engine/README.md
@@ -1,0 +1,7 @@
+# Template Engine
+
+The template engine combines database patterns with lessons learned templates.
+Lesson templates are returned by `get_lesson_templates()` in
+`learning_templates.py` and merged by `TemplateAutoGenerator` during
+initialization and ranking. To extend behavior, add new entries to the lesson
+store and they will influence template generation automatically.

--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -349,7 +349,9 @@ class TemplateAutoGenerator:
                         db_path=self.analytics_db,
                     )
         if not ranked:
-            candidates = self.templates or self.patterns
+            lesson_templates = list(get_lesson_templates().values())
+            base_candidates = self.templates or self.patterns
+            candidates = base_candidates + lesson_templates
             for tmpl in candidates:
                 vecs = vectorizer.fit_transform([target, tmpl]).toarray()
                 tfidf = float(cosine_similarity([vecs[0]], [vecs[1]])[0][0])

--- a/tests/template_engine/test_lesson_template_merge.py
+++ b/tests/template_engine/test_lesson_template_merge.py
@@ -1,0 +1,20 @@
+import template_engine.auto_generator as ag
+import template_engine.learning_templates as lt
+
+
+def test_lesson_template_merge(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
+    monkeypatch.setattr(ag, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(ag.TemplateAutoGenerator, "_load_patterns", lambda self: ["alpha", "beta"])
+    monkeypatch.setattr(ag.TemplateAutoGenerator, "_load_templates", lambda self: [])
+    monkeypatch.setattr(ag, "compute_similarity_scores", lambda *a, **k: [])
+    monkeypatch.setattr(ag, "extract_patterns", lambda texts: [])
+    monkeypatch.setattr(ag, "quantum_text_score", lambda text: 0.0)
+    monkeypatch.setattr(ag, "quantum_similarity_score", lambda a, b: 0.0)
+    monkeypatch.setattr(ag, "quantum_cluster_score", lambda m: 0.0)
+    lesson_func = lambda: {"l": "lesson snippet"}
+    monkeypatch.setattr(lt, "get_lesson_templates", lesson_func)
+    monkeypatch.setattr(ag, "get_lesson_templates", lesson_func)
+    gen = ag.TemplateAutoGenerator(analytics_db=tmp_path / "a.db", completion_db=tmp_path / "c.db")
+    assert any("lesson snippet" in t for t in gen.templates)

--- a/tests/template_engine/test_lessons_learned.py
+++ b/tests/template_engine/test_lessons_learned.py
@@ -1,0 +1,44 @@
+import logging
+import sqlite3
+from pathlib import Path
+
+from utils.lessons_learned_integrator import (
+    store_lesson,
+    load_lessons,
+    fetch_lessons_by_tag,
+    apply_lessons,
+)
+
+
+def _init_db(path: Path) -> Path:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE enhanced_lessons_learned (
+                description TEXT,
+                source TEXT,
+                timestamp TEXT,
+                validation_status TEXT,
+                tags TEXT
+            )
+            """
+        )
+    return path
+
+
+def test_store_retrieve_apply(tmp_path, caplog):
+    db = _init_db(tmp_path / "lessons.db")
+    store_lesson(
+        "use mock DB",
+        source="unit",
+        timestamp="2024-01-01T00:00:00Z",
+        validation_status="validated",
+        tags="testing",
+        db_path=db,
+    )
+    lessons = fetch_lessons_by_tag("testing", db_path=db)
+    assert lessons and lessons[0]["description"] == "use mock DB"
+    all_lessons = load_lessons(db_path=db)
+    with caplog.at_level(logging.INFO):
+        apply_lessons(logging.getLogger("lesson"), all_lessons)
+    assert any("Lesson applied" in r.getMessage() for r in caplog.records)

--- a/tests/test_lessons_learned_gap_analyzer.py
+++ b/tests/test_lessons_learned_gap_analyzer.py
@@ -24,3 +24,12 @@ def test_dataset_coverage_validation(tmp_path: Path, monkeypatch) -> None:
     with sqlite3.connect(prod_db) as conn:
         conn.execute("DELETE FROM lessons_learned WHERE lesson_key=?", (removed,))
     assert not analyzer.validate_dataset_coverage()
+
+
+def test_append_lesson_cli(monkeypatch):
+    from scripts.analysis import lessons_learned_gap_analyzer as lga
+
+    captured = {}
+    monkeypatch.setattr(lga, "store_lesson", lambda **kw: captured.update(kw))
+    assert lga.main(["--lesson", "new gap lesson"]) == 0
+    assert captured["description"] == "new gap lesson"

--- a/tests/test_session_management_system.py
+++ b/tests/test_session_management_system.py
@@ -1,0 +1,31 @@
+import logging
+from types import SimpleNamespace
+
+import scripts.utilities.unified_session_management_system as usms
+
+
+class DummyValidator:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def validate_startup(self):
+        return SimpleNamespace(is_success=True, errors=[], warnings=[])
+
+    def validate_session_cleanup(self):
+        # introduce a warning to trigger lesson storage
+        return SimpleNamespace(is_success=True, errors=[], warnings=["cleanup warning"])
+
+
+def test_lessons_applied_and_stored(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(usms, "SessionProtocolValidator", lambda *a, **k: DummyValidator())
+    monkeypatch.setattr(usms, "validate_enterprise_environment", lambda: True)
+    monkeypatch.setattr(usms, "detect_zero_byte_files", lambda p: [])
+    monkeypatch.setattr(usms, "load_lessons", lambda: [{"description": "use tmp", "tags": "session"}])
+    stored = []
+    monkeypatch.setattr(usms, "store_lesson", lambda **kwargs: stored.append(kwargs))
+    with caplog.at_level(logging.INFO):
+        system = usms.UnifiedSessionManagementSystem(workspace_root=str(tmp_path))
+        system.start_session()
+        system.end_session()
+    assert any("Lesson applied" in r.getMessage() for r in caplog.records)
+    assert stored and stored[0]["description"] == "cleanup warning"

--- a/tests/test_wlc_session_manager.py
+++ b/tests/test_wlc_session_manager.py
@@ -121,6 +121,18 @@ def test_session_error(tmp_path, monkeypatch):
     assert "boom" in error_details
 
 
+def test_session_persists_lesson(tmp_path, monkeypatch):
+    temp_db = tmp_path / "production.db"
+    shutil.copy(wsm.DB_PATH, temp_db)
+    monkeypatch.setattr(wsm, "DB_PATH", temp_db)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
+    stored = {}
+    monkeypatch.setattr(wsm, "store_lesson", lambda **kw: stored.update(kw))
+    wsm.run_session(1, temp_db, False, run_orchestrator=False)
+    assert stored["source"] == "wlc_session_manager"
+
+
 def test_missing_environment(monkeypatch):
     monkeypatch.delenv("GH_COPILOT_WORKSPACE", raising=False)
     monkeypatch.delenv("GH_COPILOT_BACKUP_ROOT", raising=False)


### PR DESCRIPTION
## Summary
- load and apply stored lessons when session management initializes and persist insights on session close
- expose CLI to append lessons via lessons_learned_gap_analyzer and store WLC session outcomes as lessons
- merge lesson templates into generation pipeline and weight templates using lesson-based scoring

## Testing
- `ruff check quantum_optimizer.py scripts/analysis/lessons_learned_gap_analyzer.py scripts/utilities/complete_template_generator.py scripts/utilities/unified_session_management_system.py scripts/wlc_session_manager.py template_engine/auto_generator.py tests/test_lessons_learned_gap_analyzer.py tests/test_wlc_session_manager.py tests/template_engine/test_lesson_template_merge.py tests/template_engine/test_lessons_learned.py tests/test_session_management_system.py`
- `pytest tests/test_session_management_system.py tests/test_wlc_session_manager.py tests/test_lessons_learned_gap_analyzer.py tests/template_engine/test_lessons_learned.py tests/template_engine/test_lesson_template_merge.py`

------
https://chatgpt.com/codex/tasks/task_e_688d0a3d7da88331aab93a7f9be67312