### PR TITLE
feat: add record_lesson helper

### DIFF
--- a/tests/test_session_db_tools.py
+++ b/tests/test_session_db_tools.py
@@ -1,0 +1,58 @@
+import sqlite3
+from pathlib import Path
+
+from session_db_tools import record_lesson
+
+
+def _create_table(db: Path) -> None:
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE enhanced_lessons_learned (
+                description TEXT,
+                source TEXT,
+                timestamp TEXT,
+                validation_status TEXT,
+                tags TEXT
+            )
+            """
+        )
+
+
+def test_record_lesson_success(tmp_path):
+    db = tmp_path / "lessons.db"
+    _create_table(db)
+    result = record_lesson(
+        db,
+        "Ensure backups",
+        source="tests",
+        timestamp="2024-01-01",
+        validation_status="validated",
+        tags="testing",
+    )
+    assert result is True
+    with sqlite3.connect(db) as conn:
+        row = conn.execute(
+            "SELECT description, source, timestamp, validation_status, tags FROM enhanced_lessons_learned"
+        ).fetchone()
+    assert row == (
+        "Ensure backups",
+        "tests",
+        "2024-01-01",
+        "validated",
+        "testing",
+    )
+
+
+def test_record_lesson_failure(tmp_path):
+    db = tmp_path / "lessons.db"
+    # Table is not created to trigger failure
+    result = record_lesson(
+        db,
+        "Missing table",
+        source="tests",
+        timestamp="2024-01-01",
+        validation_status="validated",
+        tags="testing",
+    )
+    assert result is False


### PR DESCRIPTION
## Summary
- add record_lesson helper to session_db_tools for storing lessons
- expose public helpers through module `__all__`
- test lesson recording success and failure paths

## Testing
- `ruff check session_db_tools.py tests/test_session_db_tools.py`
- `pytest tests/test_session_db_tools.py tests/test_lessons_learned_integrator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0e3111ec833189c3505502f17eff