### PR TITLE
feat: ensure lessons learned table

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [4.1.15] - 2025-08-06
+- Added migration script to ensure `enhanced_lessons_learned` table exists in `production.db` using schema from `learning_monitor.db`.
+
 ## [4.1.14] - 2025-08-05
 - Updated README to report current lint status and failing tests.
 - Noted outstanding tasks tracked in `docs/STUB_MODULE_STATUS.md`.

--- a/scripts/ensure_enhanced_lessons_learned_table.py
+++ b/scripts/ensure_enhanced_lessons_learned_table.py
@@ -1,0 +1,82 @@
+"""Ensure `enhanced_lessons_learned` exists in production database.
+
+This script checks the ``production.db`` for the
+``enhanced_lessons_learned`` table and creates it using the schema
+from ``learning_monitor.db`` when missing.  Default values are preserved
+to match the reference schema.
+
+The operation follows the database-first pattern: ``production.db`` is
+inspected before any schema is copied from the reference database.
+
+Running the script is idempotent and safe to execute multiple times.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+PRODUCTION_DB = Path("databases/production.db")
+REFERENCE_DB = Path("databases/learning_monitor.db")
+TABLE_NAME = "enhanced_lessons_learned"
+
+
+def ensure_enhanced_lessons_learned_table(
+    production_db: Path = PRODUCTION_DB, reference_db: Path = REFERENCE_DB
+) -> bool:
+    """Ensure the lessons learned table exists in ``production_db``.
+
+    Parameters
+    ----------
+    production_db:
+        Path to the production SQLite database.
+    reference_db:
+        Path to the database containing the reference schema.
+
+    Returns
+    -------
+    bool
+        ``True`` if the table existed or was created successfully.
+    """
+
+    if not production_db.exists():
+        raise FileNotFoundError(f"{production_db} not found")
+
+    with sqlite3.connect(production_db) as prod_conn:
+        cur = prod_conn.cursor()
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (TABLE_NAME,),
+        )
+        if cur.fetchone():
+            return True
+
+        # Fetch creation SQL from the reference database
+        with sqlite3.connect(reference_db) as ref_conn:
+            ref_cur = ref_conn.cursor()
+            ref_cur.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+                (TABLE_NAME,),
+            )
+            row = ref_cur.fetchone()
+            if row is None:
+                raise RuntimeError(
+                    f"Reference table {TABLE_NAME} not found in {reference_db}"
+                )
+            create_sql = row[0]
+
+        prod_conn.executescript(create_sql)
+        prod_conn.commit()
+
+        # Dual-copilot validation: re-check table existence
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (TABLE_NAME,),
+        )
+        return cur.fetchone() is not None
+
+
+if __name__ == "__main__":
+    if ensure_enhanced_lessons_learned_table():
+        print(f"{TABLE_NAME} table ensured in {PRODUCTION_DB}")
+

--- a/tests/test_ensure_enhanced_lessons_learned_table.py
+++ b/tests/test_ensure_enhanced_lessons_learned_table.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import shutil
+import sqlite3
+
+from scripts.ensure_enhanced_lessons_learned_table import (
+    ensure_enhanced_lessons_learned_table,
+    TABLE_NAME,
+)
+
+
+def test_table_created_when_missing(tmp_path):
+    prod_src = Path("databases/production.db")
+    ref_src = Path("databases/learning_monitor.db")
+
+    prod_db = tmp_path / "production.db"
+    ref_db = tmp_path / "learning_monitor.db"
+    shutil.copy(prod_src, prod_db)
+    shutil.copy(ref_src, ref_db)
+
+    # Ensure table is absent
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+
+    assert ensure_enhanced_lessons_learned_table(prod_db, ref_db)
+
+    with sqlite3.connect(prod_db) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+            (TABLE_NAME,),
+        )
+        prod_sql = cur.fetchone()[0]
+
+    with sqlite3.connect(ref_db) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+            (TABLE_NAME,),
+        )
+        ref_sql = cur.fetchone()[0]
+
+    assert prod_sql == ref_sql
+


### PR DESCRIPTION
## Summary
- add script to ensure `enhanced_lessons_learned` table exists in `production.db` with defaults from `learning_monitor.db`
- test table creation against reference schema
- document migration in release notes

## Testing
- `ruff check scripts/ensure_enhanced_lessons_learned_table.py tests/test_ensure_enhanced_lessons_learned_table.py`
- `pytest` *(fails: 205 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_688d1bbedf908331b932d50395596028