### PR TITLE
fix: add AerSimulator fallback for Grover demo

### DIFF
--- a/quantum/algorithms/expansion.py
+++ b/quantum/algorithms/expansion.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from qiskit import QuantumCircuit
+from qiskit_aer import AerSimulator
 
 from .base import QuantumAlgorithmBase, TEXT_INDICATORS
 from ..utils import get_backend
@@ -53,7 +54,12 @@ class QuantumLibraryExpansion(QuantumAlgorithmBase):
             circuit.h([0, 1])
             circuit.measure([0, 1], [0, 1])
 
-            backend = self.backend or get_backend(use_hardware=self.use_hardware)
+            backend = self.backend
+            if backend is None:
+                if self.use_hardware:
+                    backend = get_backend(use_hardware=True)
+                else:
+                    backend = AerSimulator()
             if backend is None:
                 self.logger.error(f"{TEXT_INDICATORS['error']} No backend available")
                 return False


### PR DESCRIPTION
## Summary
- ensure `QuantumLibraryExpansion` exposes `AerSimulator` and uses it as default backend

## Testing
- `pytest tests/test_quantum_package.py::TestQuantumLibraryExpansion::test_grover_demo -q`
- `ruff check quantum/algorithms/expansion.py`


------
https://chatgpt.com/codex/tasks/task_e_688d1fd1d6888331a48114fa8e13f05c