### PR TITLE
feat: integrate lessons dataset into template generation

### DIFF
--- a/docs/LESSONS_LEARNED_DATASET_INTEGRATION.md
+++ b/docs/LESSONS_LEARNED_DATASET_INTEGRATION.md
@@ -1,0 +1,5 @@
+# Lessons Learned Dataset Integration
+
+The template generation pipeline now queries the curated `enhanced_lessons_learned` dataset before building templates. During `TemplateAutoGenerator` initialization, lessons are loaded from `databases/learning_monitor.db` and logged using the lessons integrator utilities. The lesson descriptions are combined with existing patterns and templates to guide synthesis.
+
+The validator at `scripts/validation/lessons_learned_integration_validator.py` includes a compliance check that ensures the dataset is present and non-empty, confirming that historical insights inform template generation.

--- a/scripts/validation/lessons_learned_integration_validator.py
+++ b/scripts/validation/lessons_learned_integration_validator.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Any, Optional
 from dataclasses import dataclass
 from tqdm import tqdm
 import logging
+from utils.lessons_learned_integrator import load_lessons
 
 # MANDATORY: Text indicators for cross-platform compatibility
 TEXT_INDICATORS = {
@@ -346,17 +347,18 @@ class LessonsLearnedIntegrationValidator:
                 self.check_visual_processing_standards(),
                 self.check_session_integrity_systems(),
                 self.check_database_integration(),
+                self.check_lessons_dataset_usage(),
             ]
-
             compliance_score = sum(compliance_checks) / len(compliance_checks)
             is_compliant = compliance_score >= 0.8
-
-            self.logger.info(f"{TEXT_INDICATORS['validation']} Enterprise compliance: {compliance_score:.1%}")
-
+            self.logger.info(
+                f"{TEXT_INDICATORS['validation']} Enterprise compliance: {compliance_score:.1%}"
+            )
             return is_compliant
-
         except Exception as e:
-            self.logger.error(f"{TEXT_INDICATORS['error']} Enterprise compliance validation failed: {str(e)}")
+            self.logger.error(
+                f"{TEXT_INDICATORS['error']} Enterprise compliance validation failed: {str(e)}"
+            )
             return False
 
     def validate_dual_copilot_pattern(self) -> bool:
@@ -399,6 +401,24 @@ class LessonsLearnedIntegrationValidator:
         return self.search_pattern_evidence("session_integrity") or self.search_pattern_evidence(
             "comprehensive_session"
         )
+
+    def check_lessons_dataset_usage(self) -> bool:
+        """Confirm curated lessons dataset is present and non-empty."""
+        try:
+            lessons = load_lessons()
+            count = len(lessons)
+            if count:
+                self.logger.info(
+                    f"{TEXT_INDICATORS['info']} Lessons dataset entries: {count}"
+                )
+                return True
+            self.logger.warning(f"{TEXT_INDICATORS['warning']} Lessons dataset empty")
+            return False
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            self.logger.error(
+                f"{TEXT_INDICATORS['error']} Lessons dataset check failed: {exc}"
+            )
+            return False
 
     def check_database_integration(self) -> bool:
         """Check database integration implementation"""

--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -27,6 +27,7 @@ from sklearn.metrics.pairwise import cosine_similarity
 from tqdm import tqdm
 
 from utils.log_utils import _log_event
+from utils.lessons_learned_integrator import load_lessons, apply_lessons
 
 from .pattern_templates import get_pattern_templates
 from .learning_templates import get_lesson_templates
@@ -137,10 +138,16 @@ class TemplateAutoGenerator:
         logger.info(f"Start Time: {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
         logger.info(f"Process ID: {os.getpid()}")
         validate_no_recursive_folders()
-        # DB-first loading of patterns and templates
+        # DB-first loading of patterns, lessons, and templates
+        self.lessons = load_lessons()
+        apply_lessons(logger, self.lessons)
         self.patterns = self._load_patterns()
-        self.templates = self._load_templates() + get_pattern_templates() + list(
-            get_lesson_templates().values()
+        lesson_descriptions = [lesson["description"] for lesson in self.lessons]
+        self.templates = (
+            lesson_descriptions
+            + self._load_templates()
+            + get_pattern_templates()
+            + list(get_lesson_templates().values())
         )
         self.cluster_vectorizer = None
         self.cluster_model = self._cluster_patterns()

--- a/tests/test_auto_generator.py
+++ b/tests/test_auto_generator.py
@@ -57,6 +57,19 @@ def test_lesson_templates_ranked(tmp_path: Path, monkeypatch) -> None:
     assert any("DatabaseFirstOperator" in t for t in ranked)
 
 
+def test_lessons_dataset_integrated(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    analytics_db, completion_db = create_test_dbs(tmp_path)
+    monkeypatch.setattr(
+        auto_generator,
+        "load_lessons",
+        lambda: [{"description": "Lesson template"}],
+    )
+    monkeypatch.setattr(auto_generator, "apply_lessons", lambda *a, **k: None)
+    gen = TemplateAutoGenerator(analytics_db, completion_db)
+    assert any("Lesson template" in t for t in gen.templates)
+
+
 def test_cluster_rep_no_dimension_error(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     analytics_db, completion_db = create_test_dbs(tmp_path)


### PR DESCRIPTION
## Summary
- load curated lessons dataset before template synthesis
- ensure validator checks for lessons dataset usage
- document lessons dataset integration and add regression test

## Testing
- `ruff check scripts/validation/lessons_learned_integration_validator.py template_engine/auto_generator.py tests/test_auto_generator.py`
- `pytest tests/test_auto_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_688d2193fd1c83318731c997456f5b22