### PR TITLE
feat: add VQE and phase estimation demos

### DIFF
--- a/quantum/README.md
+++ b/quantum/README.md
@@ -27,12 +27,27 @@ Hardware usage can also be toggled globally by setting the environment
 variable `QUANTUM_USE_HARDWARE` to `"1"`. Modules query this flag when no
 explicit option is provided.
 
+## IBM Quantum Access
+
+To run on real IBM Quantum hardware you need an access token from
+<https://quantum-computing.ibm.com>. Set the environment variable
+`QISKIT_IBM_TOKEN` before executing any demo modules:
+
+```
+export QISKIT_IBM_TOKEN="YOUR_API_TOKEN"
+```
+
+If the token or requested backend is unavailable the modules automatically
+fall back to local simulation, preserving existing behavior.
+
 ## Algorithms
 
 - `algorithms.expansion.QuantumLibraryExpansion` – Grover search demonstration.
 - `algorithms.teleportation.QuantumTeleportation` – teleports a qubit state using a Bell pair.
 - `algorithms.hardware_aware.HardwareAwareAlgorithm` – demonstrates automatic
   hardware selection via `qiskit-ibm-provider` with simulator fallback.
+- `algorithms.vqe_demo.run_vqe_demo` – prototype VQE ground state estimation.
+- `algorithms.phase_estimation_demo.run_phase_estimation_demo` – prototype phase estimation.
 
 ## Backend utilities
 

--- a/quantum/algorithms/__init__.py
+++ b/quantum/algorithms/__init__.py
@@ -7,6 +7,8 @@ from .expansion import QuantumLibraryExpansion
 from .functional import QuantumFunctional
 from .hardware_aware import HardwareAwareAlgorithm
 from .teleportation import QuantumTeleportation
+from .vqe_demo import run_vqe_demo
+from .phase_estimation_demo import run_phase_estimation_demo
 
 __all__ = [
     'QuantumAlgorithmBase',
@@ -16,4 +18,6 @@ __all__ = [
     'HardwareAwareAlgorithm',
     'QuantumLibraryExpansion',
     'QuantumTeleportation',
+    'run_vqe_demo',
+    'run_phase_estimation_demo',
 ]

--- a/quantum/algorithms/phase_estimation_demo.py
+++ b/quantum/algorithms/phase_estimation_demo.py
@@ -1,0 +1,55 @@
+"""Prototype Quantum Phase Estimation demo with simulator fallback."""
+
+from __future__ import annotations
+
+from math import pi
+
+from quantum.utils.backend_provider import get_backend
+
+try:  # pragma: no cover - optional dependency
+    from qiskit import QuantumCircuit, transpile
+    from qiskit.circuit.library import QFT
+    from qiskit.primitives import Sampler
+except Exception:  # pragma: no cover - qiskit may be missing
+    QuantumCircuit = transpile = QFT = Sampler = None
+
+
+def run_phase_estimation_demo(use_hardware: bool = False) -> str | None:
+    """Estimate the phase of a ``T`` gate applied to ``|1\rangle``.
+
+    Builds a small phase estimation circuit with three evaluation qubits. When
+    ``use_hardware`` is True the function attempts to run on an IBM Quantum
+    backend and falls back to the local Aer simulator if hardware is
+    unavailable.
+
+    Returns:
+        The most frequent phase bitstring (length three) or ``None`` if Qiskit
+        is unavailable.
+    """
+
+    if QuantumCircuit is None:
+        return None
+
+    backend = get_backend(use_hardware=True) if use_hardware else None
+
+    qc = QuantumCircuit(4, 3)
+    qc.h(range(3))
+    qc.x(3)  # prepare eigenstate |1>
+    for k in range(3):
+        qc.cp(pi / 4 * (2 ** k), k, 3)
+    qc.append(QFT(3, inverse=True), range(3))
+    qc.measure(range(3), range(3))
+
+    if backend is not None:
+        transpiled = transpile(qc, backend)
+        job = backend.run(transpiled, shots=1024)
+        counts = job.result().get_counts()
+    else:
+        sampler = Sampler(options={"shots": 1024})
+        quasi = sampler.run(qc).result().quasi_dists[0]
+        counts = {format(int(k), "03b"): int(v * 1024) for k, v in quasi.items()}
+    return max(counts, key=counts.get)
+
+
+__all__ = ["run_phase_estimation_demo"]
+

--- a/quantum/algorithms/vqe_demo.py
+++ b/quantum/algorithms/vqe_demo.py
@@ -1,0 +1,39 @@
+"""Prototype Variational Quantum Eigensolver demo with simulator fallback."""
+
+from __future__ import annotations
+
+from quantum.utils.backend_provider import get_backend
+
+try:  # pragma: no cover - optional dependency
+    from qiskit.circuit import QuantumCircuit
+    from qiskit.primitives import BackendEstimator, Estimator
+    from qiskit.quantum_info import SparsePauliOp
+    from scipy.optimize import minimize
+except Exception:  # pragma: no cover - qiskit may be missing
+    QuantumCircuit = BackendEstimator = Estimator = SparsePauliOp = minimize = None
+
+
+def run_vqe_demo(use_hardware: bool = False) -> float | None:
+    """Estimate ground state energy of a single-qubit ``Z`` operator."""
+
+    if QuantumCircuit is None:
+        return None
+
+    backend = get_backend(use_hardware=True) if use_hardware else None
+    hamiltonian = SparsePauliOp.from_list([("Z", 1.0)])
+
+    def energy(theta):
+        circuit = QuantumCircuit(1)
+        circuit.ry(theta[0], 0)
+        if backend is not None and BackendEstimator is not None:
+            estimator = BackendEstimator(backend=backend, options={"shots": 1024})
+        else:
+            estimator = Estimator()
+        return estimator.run(circuit, hamiltonian).result().values[0]
+
+    result = minimize(lambda x: energy(x), x0=[0.0], method="COBYLA")
+    return float(result.fun)
+
+
+__all__ = ["run_vqe_demo"]
+

--- a/quantum/utils/backend_provider.py
+++ b/quantum/utils/backend_provider.py
@@ -8,7 +8,19 @@ import os
 try:  # pragma: no cover - optional dependency
     from qiskit import Aer
 except Exception:  # pragma: no cover - qiskit may be missing
-    Aer = None
+    try:  # fallback to BasicAer if available
+        from qiskit.providers.basicaer import QasmSimulator
+
+        class _AerShim:  # pragma: no cover - simple shim
+            @staticmethod
+            def get_backend(name: str):
+                if name == "qasm_simulator":
+                    return QasmSimulator()
+                raise ValueError("Backend not available")
+
+        Aer = _AerShim()
+    except Exception:
+        Aer = None
 
 try:  # pragma: no cover - optional dependency
     from qiskit_ibm_provider import IBMProvider

--- a/tests/quantum/test_vqe_phase_estimation_demo.py
+++ b/tests/quantum/test_vqe_phase_estimation_demo.py
@@ -1,0 +1,27 @@
+"""Tests for VQE and phase estimation demos with hardware fallback."""
+
+import pytest
+
+from quantum.algorithms import phase_estimation_demo, vqe_demo
+from quantum.utils import backend_provider
+
+
+class _FailingProvider:
+    def __init__(self, *args, **kwargs):  # pragma: no cover - dummy
+        raise RuntimeError("no provider")
+
+
+def test_vqe_demo_falls_back(monkeypatch):
+    monkeypatch.setattr(backend_provider, "IBMProvider", _FailingProvider)
+    sim = vqe_demo.run_vqe_demo(use_hardware=False)
+    fallback = vqe_demo.run_vqe_demo(use_hardware=True)
+    assert sim is not None and pytest.approx(sim, rel=1e-6) == fallback
+
+
+def test_phase_estimation_demo_falls_back(monkeypatch):
+    monkeypatch.setattr(backend_provider, "IBMProvider", _FailingProvider)
+    sim = phase_estimation_demo.run_phase_estimation_demo(use_hardware=False)
+    fallback = phase_estimation_demo.run_phase_estimation_demo(use_hardware=True)
+    assert sim == fallback
+    assert sim in {"001", "100"}  # bit order may vary
+


### PR DESCRIPTION
## Summary
- prototype VQE and quantum phase estimation demos with simulator fallback
- expose demos in quantum algorithms and document IBM Quantum token setup
- add tests ensuring hardware requests gracefully fall back to simulation

## Testing
- `ruff check quantum/algorithms/vqe_demo.py quantum/algorithms/phase_estimation_demo.py quantum/utils/backend_provider.py tests/quantum/test_vqe_phase_estimation_demo.py`
- `pytest tests/quantum/test_vqe_phase_estimation_demo.py -q`
- `pytest tests/quantum/test_backend_provider.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d219745c08331aa75894fefb933b6