### PR TITLE
fix: guard log event row id

### DIFF
--- a/tests/quantum/test_backend_provider_config.py
+++ b/tests/quantum/test_backend_provider_config.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 from quantum.utils import backend_provider

--- a/tests/quantum/test_quantum_compliance_engine_ml.py
+++ b/tests/quantum/test_quantum_compliance_engine_ml.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from quantum.quantum_compliance_engine import QuantumComplianceEngine
 
 

--- a/tests/template_engine/test_lesson_template_merge.py
+++ b/tests/template_engine/test_lesson_template_merge.py
@@ -13,7 +13,8 @@ def test_lesson_template_merge(tmp_path, monkeypatch):
     monkeypatch.setattr(ag, "quantum_text_score", lambda text: 0.0)
     monkeypatch.setattr(ag, "quantum_similarity_score", lambda a, b: 0.0)
     monkeypatch.setattr(ag, "quantum_cluster_score", lambda m: 0.0)
-    lesson_func = lambda: {"l": "lesson snippet"}
+    def lesson_func():
+        return {"l": "lesson snippet"}
     monkeypatch.setattr(lt, "get_lesson_templates", lesson_func)
     monkeypatch.setattr(ag, "get_lesson_templates", lesson_func)
     gen = ag.TemplateAutoGenerator(analytics_db=tmp_path / "a.db", completion_db=tmp_path / "c.db")

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -360,6 +360,7 @@ def _log_event(
 
     test_result = _can_create_analytics_db(db_path)
     start_ts = time.time()
+    row_id = -1
     with tqdm(total=1, desc="log", unit="evt", leave=False) as bar:
         if test_result:
             ensure_tables(db_path, [table], test_mode=test_mode)


### PR DESCRIPTION
## Summary
- prevent `UnboundLocalError` when analytics DB cannot be created by initializing `row_id`
- clean up test utilities to satisfy lint (convert lambda to function, drop unused imports)

## Testing
- `pytest tests/template_engine/test_lesson_template_merge.py tests/quantum/test_backend_provider_config.py tests/quantum/test_quantum_compliance_engine_ml.py tests/test_dual_copilot_coverage.py tests/test_log_utils.py`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_688d2dfe65ec8331af17c3a01b3271cb