### PR TITLE
fix: base compliance score on resolved and open placeholders

### DIFF
--- a/dashboard/compliance/metrics.json
+++ b/dashboard/compliance/metrics.json
@@ -1,7 +1,9 @@
 {
   "metrics": {
     "placeholder_removal": 14,
-    "compliance_score": 0.88,
+    "open_placeholders": 2,
+    "resolved_placeholders": 14,
+    "compliance_score": 0.875,
     "violation_count": 5,
     "rollback_count": 1,
     "auto_removal_count": 0,

--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -122,9 +122,10 @@ class ComplianceMetricsUpdater:
 
                 open_ph = metrics["open_placeholders"]
                 resolved_ph = metrics["resolved_placeholders"]
-                total_ph = resolved_ph + open_ph
                 metrics["compliance_score"] = (
-                    resolved_ph / total_ph if total_ph else 1.0
+                    resolved_ph / (resolved_ph + open_ph)
+                    if (resolved_ph + open_ph) > 0
+                    else 1.0
                 )
 
                 # Placeholder type breakdown

--- a/tests/test_compliance_metrics_updater.py
+++ b/tests/test_compliance_metrics_updater.py
@@ -64,7 +64,8 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch, simulate, test_mode):
         return
     data = json.loads(metrics_file.read_text())
     assert data["metrics"]["placeholder_removal"] == 1
-    assert data["metrics"]["compliance_score"] == 0.5
+    expected_score = 1 / (1 + 1)
+    assert data["metrics"]["compliance_score"] == expected_score
     assert data["metrics"]["violation_count"] == 1
     assert data["metrics"]["rollback_count"] == 1
     assert data["metrics"]["progress_status"] == "issues_pending"


### PR DESCRIPTION
## Summary
- compute compliance score using resolved/(resolved + open)
- update tests for new compliance score calculation
- regenerate dashboard metrics with open/resolved counts

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/test_compliance_metrics_updater.py`
- `pytest tests/test_compliance_metrics_updater.py`


------
https://chatgpt.com/codex/tasks/task_e_688d2dffda208331890ff50a588bb300