### PR TITLE
feat: enforce lesson coverage and dataset sourcing

### DIFF
--- a/template_engine/learning_templates.py
+++ b/template_engine/learning_templates.py
@@ -56,17 +56,16 @@ class SelfHealingSystem:
 def get_dataset_sources(workspace_path: str | None = None) -> List[Path]:
     """Return database paths ordered by priority.
 
-    The first entry is always ``production.db`` to satisfy the database-first
-    mandate. Additional databases may be used as fallbacks when present.
+    ``production.db`` is always first to satisfy the database-first mandate.
+    Additional ``*.db`` files located in the workspace ``databases``
+    directory are appended in alphabetical order.
     """
 
     workspace = Path(workspace_path or os.getenv("GH_COPILOT_WORKSPACE", str(Path.cwd())))
     db_dir = workspace / "databases"
-    return [
-        db_dir / "production.db",
-        db_dir / "template_completion.db",
-        db_dir / "enterprise_assets.db",
-    ]
+    production = db_dir / "production.db"
+    others = sorted(p for p in db_dir.glob("*.db") if p.name != "production.db")
+    return [production, *others]
 
 
 def get_lesson_templates() -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- centralize dataset discovery to prefer `production.db`
- verify gap analyzer covers all lesson templates
- test lesson application during template generation

## Testing
- `ruff check template_engine/learning_templates.py scripts/analysis/lessons_learned_gap_analyzer.py tests/test_lessons_learned_gap_analyzer.py tests/test_auto_generator.py`
- `pytest tests/test_lessons_learned_gap_analyzer.py tests/test_auto_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_688d2e032068833197b590eb40f5d9ef