### PR TITLE
feat: add lessons integration and latency metrics

### DIFF
--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -6,8 +6,8 @@
         function updateMetrics(data){
             document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
             document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
-            document.getElementById('lessons_integration_status').textContent = data.lessons_integration_status;
-            document.getElementById('average_query_latency').textContent = data.average_query_latency.toFixed(3);
+            document.getElementById('lessons_integration_status').textContent = data.lessons_integration_status || 'UNKNOWN';
+            document.getElementById('average_query_latency').textContent = (data.average_query_latency ?? 0).toFixed(3);
             document.getElementById('rollback_count').textContent = data.rollback_count || 0;
             document.getElementById('progress_status').textContent = data.progress_status || 'unknown';
             const pb = document.getElementById('placeholder_breakdown');

--- a/tests/dashboard/test_additional_metrics.py
+++ b/tests/dashboard/test_additional_metrics.py
@@ -80,3 +80,12 @@ def test_additional_metrics_present(test_app):
     assert metrics["lessons_integration_status"] == "FULLY_INTEGRATED"
     assert metrics["average_query_latency"] == pytest.approx(12.5)
 
+
+def test_metrics_endpoint_additional_metrics(test_app):
+    client = test_app.test_client()
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    metrics = resp.get_json()
+    assert metrics["lessons_integration_status"] == "FULLY_INTEGRATED"
+    assert metrics["average_query_latency"] == pytest.approx(12.5)
+


### PR DESCRIPTION
## Summary
- factor out helpers to fetch lessons integration status and average query latency
- show lessons integration status and query latency in dashboard template with fallbacks
- test metrics endpoint for lessons integration status and query latency

## Testing
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py tests/dashboard/test_additional_metrics.py`
- `pytest tests/dashboard/test_additional_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_688d2e09c1908331a0cc39390e02517b