### PR TITLE
feat: validate lessons learned defaults

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - gh_COPILOT Enterprise Toolkit
 
+## [4.1.4] - 2025-07-27
+### Added
+- Script `ensure_enhanced_lessons_learned_table.py` validates defaults and creates
+  `enhanced_lessons_learned` in `production.db` when missing.
+
 ## [4.1.3] - 2025-07-27
 ### Added
 - Dual Copilot integration verified across core modules, enabling redundant validation for critical workflows.

--- a/tests/test_ensure_enhanced_lessons_learned_table.py
+++ b/tests/test_ensure_enhanced_lessons_learned_table.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import shutil
 import sqlite3
 
+import pytest
+
 from scripts.ensure_enhanced_lessons_learned_table import (
     ensure_enhanced_lessons_learned_table,
     TABLE_NAME,
@@ -40,4 +42,31 @@ def test_table_created_when_missing(tmp_path):
         ref_sql = cur.fetchone()[0]
 
     assert prod_sql == ref_sql
+
+
+def test_default_mismatch_raises(tmp_path):
+    prod_src = Path("databases/production.db")
+    ref_src = Path("databases/learning_monitor.db")
+
+    prod_db = tmp_path / "production.db"
+    ref_db = tmp_path / "learning_monitor.db"
+    shutil.copy(prod_src, prod_db)
+    shutil.copy(ref_src, ref_db)
+
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+        conn.execute(
+            """
+            CREATE TABLE enhanced_lessons_learned (
+                description TEXT DEFAULT 'test',
+                source TEXT DEFAULT 'test',
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                validation_status TEXT DEFAULT 'pending',
+                tags TEXT DEFAULT '["mismatch"]'
+            )
+            """
+        )
+
+    with pytest.raises(RuntimeError):
+        ensure_enhanced_lessons_learned_table(prod_db, ref_db)
 


### PR DESCRIPTION
## Summary
- ensure `enhanced_lessons_learned` table exists in production using reference schema and validate default values
- cover default validation with targeted tests
- record migration in release notes

## Testing
- `ruff check scripts/ensure_enhanced_lessons_learned_table.py tests/test_ensure_enhanced_lessons_learned_table.py`
- `pytest tests/test_ensure_enhanced_lessons_learned_table.py`


------
https://chatgpt.com/codex/tasks/task_e_688d2ec888d88331a228936b9f544f10