### PR TITLE
feat: add hardware hooks and pattern recognition module

### DIFF
--- a/quantum/README.md
+++ b/quantum/README.md
@@ -52,3 +52,8 @@ fall back to local simulation, preserving existing behavior.
 ## Backend utilities
 
 - `utils.backend_provider.get_backend` – loads IBM Quantum backends and falls back to `Aer` simulators when hardware is unavailable.
+
+## Pattern Recognition
+
+- `ml_pattern_recognition.PatternRecognizer` – logistic regression based pattern recognizer using placeholder datasets. Use
+  `load_placeholder_data` to generate sample data for experiments.

--- a/quantum/ml_pattern_recognition.py
+++ b/quantum/ml_pattern_recognition.py
@@ -1,0 +1,48 @@
+"""Pattern recognition utilities using placeholder datasets."""
+
+from typing import Tuple
+
+import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+
+
+def load_placeholder_data(
+    n_samples: int = 100,
+    n_features: int = 4,
+    random_state: int = 42,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Generate a simple classification dataset for demonstrations."""
+    X, y = make_classification(
+        n_samples=n_samples, n_features=n_features, random_state=random_state
+    )
+    return X, y
+
+
+class PatternRecognizer:
+    """Trainable pattern recognizer with logistic regression backend."""
+
+    def __init__(self) -> None:
+        self.model = LogisticRegression()
+        self.trained = False
+
+    def train(self, X: np.ndarray, y: np.ndarray) -> None:
+        """Fit the model on data."""
+        self.model.fit(X, y)
+        self.trained = True
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        """Predict labels for ``X``.
+
+        Raises:
+            RuntimeError: If called before training.
+        """
+        if not self.trained:
+            raise RuntimeError("Model not trained")
+        return self.model.predict(X)
+
+    def evaluate(self, X: np.ndarray, y: np.ndarray) -> float:
+        """Return accuracy score on provided data."""
+        preds = self.predict(X)
+        return float(accuracy_score(y, preds))

--- a/quantum/optimizers/quantum_optimizer.py
+++ b/quantum/optimizers/quantum_optimizer.py
@@ -149,11 +149,23 @@ class QuantumOptimizer:
 
         Args:
             x0: Initial guess for variables (if required by method).
+            backend_name: Optional IBM backend name when requesting hardware.
+            token: Optional IBM Quantum API token.
             kwargs: Additional arguments passed to optimizer.
 
         Returns:
             Dictionary containing result, metrics, and full history.
         """
+        backend_name = kwargs.pop("backend_name", "ibmq_qasm_simulator")
+        token = kwargs.pop("token", None)
+        if self.use_hardware and self.backend is None:
+            try:
+                self.configure_backend(
+                    backend_name=backend_name, use_hardware=True, token=token
+                )
+            except Exception:
+                self.use_hardware = False
+
         self.log_event("optimization_start", {"method": self.method, "bounds": self.variable_bounds})
         start_time = datetime.utcnow()
         result = None

--- a/tests/quantum/test_ml_pattern_recognition.py
+++ b/tests/quantum/test_ml_pattern_recognition.py
@@ -1,0 +1,9 @@
+from quantum.ml_pattern_recognition import PatternRecognizer, load_placeholder_data
+
+
+def test_pattern_recognizer_trains_and_evaluates():
+    X, y = load_placeholder_data(n_samples=50, random_state=0)
+    recognizer = PatternRecognizer()
+    recognizer.train(X, y)
+    acc = recognizer.evaluate(X, y)
+    assert 0.0 <= acc <= 1.0

--- a/tests/test_quantum_optimizer_fallback.py
+++ b/tests/test_quantum_optimizer_fallback.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from quantum.optimizers.quantum_optimizer import QuantumOptimizer
+from quantum.optimizers import quantum_optimizer as qo
+
+
+def test_run_falls_back_when_hardware_unavailable(monkeypatch):
+    monkeypatch.setattr(qo, "IBMProvider", None)
+
+    def obj(x: np.ndarray) -> float:
+        return float(np.sum(x**2))
+
+    opt = QuantumOptimizer(obj, [(-1, 1)], method="simulated_annealing", use_hardware=True)
+    summary = opt.run(x0=np.array([0.0]), max_iter=5)
+    assert "best_result" in summary["result"]
+    assert opt.use_hardware is False


### PR DESCRIPTION
## Summary
- enable automatic IBM Quantum backend configuration with graceful fallback
- introduce logistic-regression pattern recognizer with placeholder dataset helper
- test quantum optimizer fallback and pattern recognition training

## Testing
- `ruff check quantum/optimizers/quantum_optimizer.py quantum/ml_pattern_recognition.py tests/test_quantum_optimizer_fallback.py tests/quantum/test_ml_pattern_recognition.py`
- `pytest tests/test_quantum_optimizer.py tests/test_quantum_optimizer_fallback.py tests/quantum/test_optimizer_backend.py tests/quantum/test_provider_fallback.py tests/quantum/test_ml_pattern_recognition.py`

------
https://chatgpt.com/codex/tasks/task_e_688d41667908833199bdabb1f3720a3d