### PR TITLE
feat: improve quantum optimizer validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 ![Learning Patterns](https://img.shields.io/badge/Learning_Patterns-ongoing-yellow)
 ![DUAL COPILOT](https://img.shields.io/badge/DUAL_COPILOT-Pattern_Validated-orange)
 ![Database First](https://img.shields.io/badge/Database_First-Architecture_Complete-purple)
-![Tests](https://img.shields.io/badge/Tests-passing-brightgreen)
-![Ruff](https://img.shields.io/badge/Ruff-passing-blue)
+<!-- CI badges for tests and lint will appear when workflows are configured -->
 
 **Status:** Active development with incremental improvements
+
+> Current test and lint status should be verified locally using `pytest` and `ruff`.
+> Quantum modules operate in placeholder simulation modes pending full compliance integration.
 
 ---
 

--- a/docs/RECURSION_POLICY.md
+++ b/docs/RECURSION_POLICY.md
@@ -1,0 +1,18 @@
+# Recursion Policy
+
+The workspace and backup directories must never contain one another, even through symlinks.
+
+- **No nested workspaces**: the backup root cannot reside inside the workspace and vice versa.
+- **Symlink awareness**: symlinks pointing to the workspace or backup directories are treated as violations.
+- **Validation**: call `quantum_optimizer.validate_workspace()` or pass `validate_workspace=True` to `QuantumOptimizer` to enforce these checks.
+
+Example:
+```python
+from pathlib import Path
+from quantum_optimizer import validate_workspace
+
+# Ensures `/data/workspace` and `/backups` are not recursive
+Path('/data/workspace').mkdir(exist_ok=True)
+Path('/backups').mkdir(exist_ok=True)
+validate_workspace()
+```

--- a/tests/test_quantum_optimizer_import.py
+++ b/tests/test_quantum_optimizer_import.py
@@ -1,0 +1,14 @@
+import importlib
+import sys
+from unittest import mock
+
+
+def test_import_no_validation(monkeypatch):
+    if "quantum_optimizer" in sys.modules:
+        del sys.modules["quantum_optimizer"]
+    with mock.patch(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        side_effect=RuntimeError("called"),
+    ):
+        module = importlib.import_module("quantum_optimizer")
+    assert module is not None

--- a/tests/test_quantum_optimizer_modes.py
+++ b/tests/test_quantum_optimizer_modes.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+import quantum_optimizer as qo
+
+
+def objective(x: np.ndarray) -> float:
+    return float(np.sum((x - 1) ** 2))
+
+
+def test_simulated_annealing():
+    opt = qo.QuantumOptimizer(objective, [(-2, 2), (-2, 2)], method="simulated_annealing")
+    summary = opt.run(max_iter=5)
+    assert "best_result" in summary["result"]
+
+
+def test_basin_hopping():
+    opt = qo.QuantumOptimizer(objective, [(-2, 2)], method="basin_hopping")
+    summary = opt.run(x0=np.array([0.0]), niter=5)
+    assert "best_result" in summary["result"]
+
+
+@pytest.mark.skipif(not qo.QISKIT_AVAILABLE, reason="Qiskit not installed")
+def test_qaoa():
+    opt = qo.QuantumOptimizer(objective, [(-2, 2)], method="qaoa")
+    summary = opt.run(n_qubits=2)
+    assert "statevector" in summary["result"]
+
+
+@pytest.mark.skipif(not qo.QISKIT_AVAILABLE, reason="Qiskit not installed")
+def test_vqe():
+    opt = qo.QuantumOptimizer(objective, [(-2, 2)], method="vqe")
+    summary = opt.run(n_qubits=2)
+    assert "statevector" in summary["result"]

--- a/tests/test_validate_no_recursive_folders.py
+++ b/tests/test_validate_no_recursive_folders.py
@@ -1,0 +1,33 @@
+from unittest import mock
+import quantum_optimizer as qo
+
+
+def test_validate_no_recursive_folders_normal(tmp_path):
+    ws = tmp_path / "ws"
+    bk = tmp_path / "bk"
+    ws.mkdir()
+    bk.mkdir()
+    with mock.patch("quantum_optimizer.CrossPlatformPathManager.get_workspace_path", return_value=ws), \
+         mock.patch("quantum_optimizer.CrossPlatformPathManager.get_backup_root", return_value=bk):
+        assert qo.validate_no_recursive_folders()
+
+
+def test_validate_no_recursive_folders_nested(tmp_path):
+    ws = tmp_path / "ws"
+    bk = ws / "bk"
+    ws.mkdir()
+    bk.mkdir()
+    with mock.patch("quantum_optimizer.CrossPlatformPathManager.get_workspace_path", return_value=ws), \
+         mock.patch("quantum_optimizer.CrossPlatformPathManager.get_backup_root", return_value=bk):
+        assert qo.validate_no_recursive_folders() is False
+
+
+def test_validate_no_recursive_folders_symlink(tmp_path):
+    ws = tmp_path / "ws"
+    bk = tmp_path / "bk"
+    ws.mkdir()
+    bk.mkdir()
+    (ws / "bk_link").symlink_to(bk)
+    with mock.patch("quantum_optimizer.CrossPlatformPathManager.get_workspace_path", return_value=ws), \
+         mock.patch("quantum_optimizer.CrossPlatformPathManager.get_backup_root", return_value=bk):
+        assert qo.validate_no_recursive_folders() is False


### PR DESCRIPTION
## Summary
- remove import-time recursion validation and expose `validate_workspace` API
- enhance recursion checks with symlink and nesting detection
- add comprehensive optimizer mode and recursion tests; document recursion policy

## Testing
- `ruff check quantum_optimizer.py tests/test_quantum_optimizer_modes.py tests/test_validate_no_recursive_folders.py tests/test_quantum_optimizer_import.py`
- `pytest tests/test_quantum_optimizer_modes.py tests/test_validate_no_recursive_folders.py tests/test_quantum_optimizer_import.py tests/test_quantum_optimizer.py tests/test_quantum_optimizer_fallback.py tests/test_quantum_optimizer_wrapper.py tests/quantum/test_optimizer_backend.py tests/quantum/test_modules_simulation.py`


------
https://chatgpt.com/codex/tasks/task_e_688d6489a560833184db3516232efbd3