### PR TITLE
test: ensure placeholder removal events table exists

### DIFF
--- a/tests/template_engine/test_placeholder_removal_and_ranking.py
+++ b/tests/template_engine/test_placeholder_removal_and_ranking.py
@@ -7,6 +7,22 @@ def test_remove_unused_placeholders_logs_event(tmp_path, monkeypatch):
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     prod_db = tmp_path / "prod.db"
     analytics_db = tmp_path / "databases" / "analytics.db"
+    analytics_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS placeholder_removal_events (
+                event TEXT,
+                placeholder TEXT,
+                removal_id INTEGER,
+                removed INTEGER,
+                timestamp TEXT,
+                level TEXT,
+                module TEXT
+            )
+            """
+        )
+        conn.commit()
     with sqlite3.connect(prod_db) as conn:
         conn.execute(
             "CREATE TABLE template_placeholders (placeholder_name TEXT, default_value TEXT)"


### PR DESCRIPTION
## Summary
- ensure placeholder removal events table exists during template tests

## Testing
- `ruff check tests/template_engine/test_placeholder_removal_and_ranking.py`
- `PYTHONWARNINGS=ignore pytest test_placeholder_removal_and_ranking.py::test_remove_unused_placeholders_logs_event -q`


------
https://chatgpt.com/codex/tasks/task_e_688d68c285048331b23afb695309f85d