### PR TITLE
ci: run pytest with fail-fast and timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           mkdir -p artifacts
-          coverage run -m pytest -q tests tests/documentation tests/quantum --junitxml=artifacts/test-results.xml
+          coverage run -m pytest -q --disable-warnings --maxfail=10 --exitfirst tests tests/documentation tests/quantum --junitxml=artifacts/test-results.xml
           coverage xml -o artifacts/coverage.xml
 
       - name: Upload artifacts
@@ -124,7 +124,7 @@ jobs:
             -e GH_COPILOT_BACKUP_ROOT=/tmp/backups \
             -e FLASK_SECRET_KEY=$FLASK_SECRET_KEY \
             -v ${{ github.workspace }}/artifacts:/app/artifacts \
-            gh_copilot coverage run -m pytest -q tests --junitxml=/app/artifacts/test-results.xml
+            gh_copilot coverage run -m pytest -q --disable-warnings --maxfail=10 --exitfirst tests --junitxml=/app/artifacts/test-results.xml
           docker run --rm \
             -e GH_COPILOT_BACKUP_ROOT=/tmp/backups \
             -e FLASK_SECRET_KEY=$FLASK_SECRET_KEY \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint:
 	ruff check . --exit-zero
 
 test: setup lint
-	pytest tests
+        pytest -q --disable-warnings --maxfail=10 --exitfirst tests
 
 clean-logs:
         bash scripts/clean_zero_logs.sh logs

--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ source .venv/bin/activate
 pip install -r requirements-test.txt
 
 # Run comprehensive test suite
-make test  # runs `pytest tests`
+make test  # runs `pytest -q --disable-warnings --maxfail=10 --exitfirst tests`
 
 # Run linter
 ruff format .

--- a/docs/COMMUNICATION_EXCELLENCE_GUIDE.md
+++ b/docs/COMMUNICATION_EXCELLENCE_GUIDE.md
@@ -5,7 +5,7 @@ This guide summarizes how to communicate changes effectively in the gh_COPILOT p
 ## Commit Message Conventions
 - Use **Conventional Commits** prefixes (`feat:`, `fix:`, `docs:`, `chore:`, etc.).
 - Keep messages concise and explain the reason for the change.
-- Run `ruff check .` and `pytest -q` before committing to ensure code quality.
+- Run `ruff check .` and `pytest -q --disable-warnings --maxfail=10 --exitfirst` before committing to ensure code quality.
 
 ## Recent Validation
 The most recent linting run showed no issues using `ruff`. Automated tests

--- a/docs/phase1_prompts.md
+++ b/docs/phase1_prompts.md
@@ -14,7 +14,7 @@ This file contains suggested GitHub issues and workflow snippets generated from 
 
 3. **Add CI for lint and tests**
    - *Title*: Introduce GitHub Actions workflow for `ruff` and `pytest`
-   - *Body*: "Automate style and test checks. Workflow should install dependencies via `setup.sh`, set required environment variables, then run `ruff check .` and `pytest -q`."
+   - *Body*: "Automate style and test checks. Workflow should install dependencies via `setup.sh`, set required environment variables, then run `ruff check .` and `pytest -q --disable-warnings --maxfail=10 --exitfirst`."
 
 4. **Document ingestion process**
    - *Title*: Document safe usage of ingestion scripts
@@ -39,5 +39,5 @@ jobs:
         run: |
           source .venv/bin/activate
           ruff check .
-          pytest -q
+          pytest -q --disable-warnings --maxfail=10 --exitfirst
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 norecursedirs = builds
 python_files = test_*.py
+addopts = -q --disable-warnings --maxfail=10 --exitfirst
+timeout = 30

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 requests
 pytest
+pytest-timeout
 psutil
 tqdm
 numpy


### PR DESCRIPTION
## Summary
- run pytest with `-q --disable-warnings --maxfail=10 --exitfirst`
- enforce global 30s test timeout via pytest-timeout
- document new test command in README and guides

## Testing
- `ruff check .` *(fails: scripts/wlc_session_manager.py:79:5 F811)*
- `pytest` *(fails: tests/quantum/test_scoring.py::test_quantum_text_score_qiskit - AssertionError: assert 'simulated' == 'qiskit')*
- `pytest --timeout=1 tmp/test_hang.py` *(fails: Timeout (>1.0s) from pytest-timeout)*


------
https://chatgpt.com/codex/tasks/task_e_688d68c509688331b1907da703e7e556