### PR TITLE
feat: add explicit workspace validation entry point

### DIFF
--- a/docs/RECURSION_POLICY.md
+++ b/docs/RECURSION_POLICY.md
@@ -3,13 +3,13 @@
 The workspace and backup directories must never contain one another, even through symlinks.
 
 - **No nested workspaces**: the backup root cannot reside inside the workspace and vice versa.
-- **Symlink awareness**: symlinks pointing to the workspace or backup directories are treated as violations.
-- **Validation**: call `quantum_optimizer.validate_workspace()` or pass `validate_workspace=True` to `QuantumOptimizer` to enforce these checks.
+- **Symlink awareness**: symlinks pointing to the workspace or backup directories are treated as violations. Validation walks the workspace and resolves inodes to catch loops.
+- **Explicit validation**: importing the optimizer module performs no filesystem access. Call `validate_workspace()` or pass `validate_workspace=True` to `QuantumOptimizer` when you need these checks.
 
 Example:
 ```python
 from pathlib import Path
-from quantum_optimizer import validate_workspace
+from quantum.optimizers.quantum_optimizer import validate_workspace
 
 # Ensures `/data/workspace` and `/backups` are not recursive
 Path('/data/workspace').mkdir(exist_ok=True)

--- a/quantum/optimizers/quantum_optimizer.py
+++ b/quantum/optimizers/quantum_optimizer.py
@@ -22,39 +22,72 @@ except Exception:  # pragma: no cover - provider optional
 
 # --- Anti-Recursion Validation ---
 
-def chunk_anti_recursion_validation():
-    """CRITICAL: Validate workspace before chunk execution"""
-    if not validate_no_recursive_folders():
-        raise RuntimeError("CRITICAL: Recursive violations prevent chunk execution")
-    if detect_c_temp_violations():
-        raise RuntimeError("CRITICAL: E:/temp/ violations prevent chunk execution")
+def chunk_anti_recursion_validation() -> bool:
+    """Run all anti-recursion checks.
+
+    Returns ``True`` when the workspace and backup paths are safe.
+    Raises ``RuntimeError`` with details on failure.
+    """
+
+    validate_no_recursive_folders()
+    offending = detect_c_temp_violations()
+    if offending:
+        raise RuntimeError(f"CRITICAL: E:/temp/ violations prevent chunk execution: {offending}")
     return True
 
-def validate_no_recursive_folders():
-    # Placeholder: Implement workspace root and backup root recursion checks
-    workspace = CrossPlatformPathManager.get_workspace_path()
-    backup_root = CrossPlatformPathManager.get_backup_root()
-    real_workspace = workspace.resolve()
-    real_backup = backup_root.resolve()
-    if real_workspace == real_backup:
-        return False
-    for root, dirs, files in os.walk(workspace):
+
+def validate_workspace() -> bool:
+    """Public entry point to trigger anti-recursion validation."""
+
+    return chunk_anti_recursion_validation()
+
+
+def validate_no_recursive_folders() -> None:
+    """Ensure workspace and backup directories are distinct and not nested.
+
+    Traverses the workspace to detect subdirectories that resolve back to either
+    root, preventing symlink-based recursion.
+    """
+
+    workspace = CrossPlatformPathManager.get_workspace_path().resolve()
+    backup_root = CrossPlatformPathManager.get_backup_root().resolve()
+
+    if workspace == backup_root:
+        raise RuntimeError(f"Workspace and backup root are identical: {workspace}")
+    if workspace in backup_root.parents:
+        raise RuntimeError(
+            f"Backup root {backup_root} cannot reside within workspace {workspace}"
+        )
+    if backup_root in workspace.parents:
+        raise RuntimeError(
+            f"Workspace {workspace} cannot reside within backup root {backup_root}"
+        )
+
+    workspace_inode = workspace.stat().st_ino
+    backup_inode = backup_root.stat().st_ino
+
+    for root, dirs, _ in os.walk(workspace, followlinks=True):
         for d in dirs:
-            dpath = os.path.realpath(os.path.join(root, d))
-            if dpath == real_workspace or dpath == real_backup:
-                return False
-    return True
+            path = os.path.join(root, d)
+            real = os.path.realpath(path)
+            try:
+                inode = os.stat(real).st_ino
+            except FileNotFoundError:
+                continue
+            if inode in {workspace_inode, backup_inode}:
+                raise RuntimeError(f"Subdirectory {path} links back to {real}")
 
-def detect_c_temp_violations():
+
+def detect_c_temp_violations() -> Optional[str]:
     forbidden = ["E:/temp/", "E:\\temp\\"]
     workspace = str(CrossPlatformPathManager.get_workspace_path())
     backup_root = str(CrossPlatformPathManager.get_backup_root())
     for forbidden_path in forbidden:
-        if workspace.startswith(forbidden_path) or backup_root.startswith(forbidden_path):
-            return True
-    return False
-
-chunk_anti_recursion_validation()
+        if workspace.startswith(forbidden_path):
+            return workspace
+        if backup_root.startswith(forbidden_path):
+            return backup_root
+    return None
 
 # --- Quantum Optimizer Class ---
 
@@ -77,6 +110,7 @@ class QuantumOptimizer:
         options: Optional[Dict[str, Any]] = None,
         backend: Any = None,
         use_hardware: bool = False,
+        validate_workspace: bool = False,
     ):
         """Initialize optimizer."""
         self.objective_function = objective_function
@@ -87,6 +121,8 @@ class QuantumOptimizer:
         self.metrics: Dict[str, Any] = {}
         self.backend = backend
         self.use_hardware = use_hardware
+        if validate_workspace:
+            chunk_anti_recursion_validation()
         self._validate_init()
 
     def set_backend(self, backend: Any, use_hardware: bool = False) -> None:

--- a/tests/test_anti_recursion.py
+++ b/tests/test_anti_recursion.py
@@ -1,0 +1,64 @@
+import importlib
+import os
+import sys
+
+import pytest
+
+from quantum.optimizers.quantum_optimizer import validate_workspace
+
+
+def _prepare_env(tmp_path, monkeypatch):
+    ws = tmp_path / "ws"
+    bk = tmp_path / "bk"
+    ws.mkdir()
+    bk.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
+    return ws, bk
+
+
+def test_validate_workspace_valid(tmp_path, monkeypatch):
+    _prepare_env(tmp_path, monkeypatch)
+    assert validate_workspace() is True
+
+
+def test_validate_workspace_same_path(tmp_path, monkeypatch):
+    ws = tmp_path / "same"
+    ws.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(ws))
+    with pytest.raises(RuntimeError):
+        validate_workspace()
+
+
+def test_validate_workspace_nested(tmp_path, monkeypatch):
+    ws = tmp_path / "ws"
+    bk = ws / "bk"
+    ws.mkdir()
+    bk.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
+    with pytest.raises(RuntimeError):
+        validate_workspace()
+
+
+def test_validate_workspace_symlink(tmp_path, monkeypatch):
+    ws, bk = _prepare_env(tmp_path, monkeypatch)
+    (ws / "link").symlink_to(bk)
+    with pytest.raises(RuntimeError):
+        validate_workspace()
+
+
+def test_import_no_filesystem(monkeypatch, tmp_path):
+    ws, bk = _prepare_env(tmp_path, monkeypatch)
+    called = False
+
+    def fake_walk(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("os.walk should not be called during import")
+
+    monkeypatch.setattr(os, "walk", fake_walk)
+    sys.modules.pop("quantum.optimizers.quantum_optimizer", None)
+    importlib.import_module("quantum.optimizers.quantum_optimizer")
+    assert called is False


### PR DESCRIPTION
## Summary
- move anti-recursion checks behind new `validate_workspace` function and optional `QuantumOptimizer` init flag
- guard against nested or symlinked paths when validating workspace vs backup root
- document and test enhanced anti-recursion behavior

## Testing
- `ruff check quantum/optimizers/quantum_optimizer.py tests/test_anti_recursion.py`
- `pytest` *(fails: missing tables, recursive folder detection, etc.)*
- `pytest tests/test_anti_recursion.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d69630dd48331b2dcc23689949ba5