### PR TITLE
fix: short-circuit session manager in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Ensure the development environment is correctly configured **before** making any
 
   * **GH\_COPILOT\_WORKSPACE** – Absolute path to the repository’s root workspace. This should point to the project root (in the Codex container it defaults to `/app`, but set it explicitly). Many scripts use this to locate files and databases.
   * **GH\_COPILOT\_BACKUP\_ROOT** – Path to an **external** backup directory (must be outside the workspace). This enforces anti-recursion: backups **must not** be stored under the project root. If not set, the toolkit defaults to a temp directory (e.g. `/tmp/<user>/gh_COPILOT_Backups` on Linux). It’s recommended to set this to a dedicated folder.
+  * **TEST_MODE** – Set to "1" in test environments to disable side effects (e.g., database writes) in scripts like `scripts/wlc_session_manager.py`.
   * *Optional variables:* **WORKSPACE\_ROOT** (alias for `GH_COPILOT_WORKSPACE`), **FLASK\_SECRET\_KEY** (for the optional Flask web UI, default `'your_secret_key'` – replace in production), **FLASK\_RUN\_PORT** (Flask dev server port, default 5000), **CONFIG\_PATH** (path to a custom config file if not using the default `config/enterprise.json`), **WEB\_DASHBOARD\_ENABLED** (`"1"` or `"0"` to toggle logging of performance metrics with `[DASHBOARD]` tags). Configure these as needed if using those features.
 * After installing dependencies and setting variables, **run the test suite** (see [Testing and Validation](#testing-and-validation)) to verify the environment is correctly set up.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
+
+os.environ.setdefault("TEST_MODE", "1")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 logger = logging.getLogger(__name__)

--- a/tests/test_wlc_session_manager_cli.py
+++ b/tests/test_wlc_session_manager_cli.py
@@ -79,7 +79,7 @@ def test_cli_invalid_env(tmp_path):
     env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     env["PYTHONPATH"] = str(Path.cwd())
     env.pop("GH_COPILOT_BACKUP_ROOT", None)
-    env["TEST_MODE"] = "1"
+    env.pop("TEST_MODE", None)
     # Missing GH_COPILOT_BACKUP_ROOT
     result = subprocess.run(
         [


### PR DESCRIPTION
## Summary
- avoid side effects in `wlc_session_manager.run_session` when `TEST_MODE` is set
- set `TEST_MODE=1` in tests and document the variable in AGENTS guide
- adjust session manager tests and CLI tests for new `TEST_MODE` behavior

## Testing
- `ruff check scripts/wlc_session_manager.py tests/conftest.py tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py`


------
https://chatgpt.com/codex/tasks/task_e_688d68c3745c8331ad582c9be83a6d03