### PR TITLE
docs: add CI badges and testing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 ![Learning Patterns](https://img.shields.io/badge/Learning_Patterns-ongoing-yellow)
 ![DUAL COPILOT](https://img.shields.io/badge/DUAL_COPILOT-Pattern_Validated-orange)
 ![Database First](https://img.shields.io/badge/Database_First-Architecture_Complete-purple)
-<!-- CI badges for tests and lint will appear when workflows are configured -->
+[![CI](https://github.com/gh-COPILOT/gh_COPILOT/actions/workflows/ci.yml/badge.svg)](https://github.com/gh-COPILOT/gh_COPILOT/actions/workflows/ci.yml)
+[![Compliance](https://github.com/gh-COPILOT/gh_COPILOT/actions/workflows/compliance-audit.yml/badge.svg)](https://github.com/gh-COPILOT/gh_COPILOT/actions/workflows/compliance-audit.yml)
 
 **Status:** Active development with incremental improvements
 
-> Current test and lint status should be verified locally using `pytest` and `ruff`.
-> Quantum modules operate in placeholder simulation modes pending full compliance integration.
+> Tests: run `pytest` (currently one failing quantum test).
+> Lint: run `ruff check .` (one redefinition warning).
+> Quantum modules operate in placeholder simulation modes; compliance auditing is still in progress.
 
 ---
 


### PR DESCRIPTION
## Summary
- document dynamic CI and compliance badges
- note failing tests/lint and how to run `pytest` and `ruff`

## Testing
- `pytest tests/quantum/test_scoring.py::test_quantum_text_score_qiskit -q`
- `ruff check scripts/wlc_session_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688d6cb42d508331981d431f5404b895