### PR TITLE
test: enforce global pytest timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,11 @@ python -m pytest tests/enterprise/ -v
 python scripts/validation/dual_copilot_pattern_tester.py
 ```
 
+Tests enforce a default 120 s timeout via `pytest-timeout` (configured in
+`pytest.ini` with `--maxfail=10 --timeout=120`). For modules that need more time,
+decorate slow tests with `@pytest.mark.timeout(<seconds>)` or split heavy tests
+into smaller pieces to keep the suite responsive.
+
 ---
 
 ## 📊 PERFORMANCE METRICS

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = --maxfail=10 --timeout=120
 norecursedirs = builds
 python_files = test_*.py
 markers =

--- a/tests/test_quantum_optimizer.py
+++ b/tests/test_quantum_optimizer.py
@@ -3,6 +3,8 @@ import pytest
 
 from quantum.optimizers.quantum_optimizer import QuantumOptimizer
 
+pytestmark = pytest.mark.timeout(60)
+
 
 def test_simulated_annealing_runs():
     def obj(x):


### PR DESCRIPTION
## Summary
- configure pytest with `--maxfail=10 --timeout=120`
- document timeout guidance for contributors
- mark quantum optimizer tests with explicit 60s timeout

## Testing
- `ruff check tests/test_quantum_optimizer.py`
- `pytest tests/test_quantum_optimizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7080b4d88331880170efc67b4010