### PR TITLE
test: replace lambda helpers with def functions

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5,7 +5,12 @@ import pytest
 
 from dashboard import compliance_metrics_updater as cmu
 
-cmu.validate_no_recursive_folders = lambda: None
+
+def no_recursive_folders() -> None:
+    return None
+
+
+cmu.validate_no_recursive_folders = no_recursive_folders
 from web_gui.scripts.flask_apps.enterprise_dashboard import app
 
 
@@ -27,9 +32,13 @@ def temp_db(tmp_path: Path) -> Path:
 
 def test_fetch_compliance_metrics(tmp_path: Path, temp_db: Path, monkeypatch):
     monkeypatch.setattr(cmu, "ANALYTICS_DB", temp_db)
-    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
-    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
-    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    
+    def noop(*a: object, **k: object) -> None:
+        return None
+
+    monkeypatch.setattr(cmu, "ensure_tables", noop)
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", no_recursive_folders)
+    monkeypatch.setattr(cmu, "validate_environment_root", noop)
     updater = cmu.ComplianceMetricsUpdater(tmp_path, test_mode=True)
     metrics = updater._fetch_compliance_metrics(test_mode=True)
     assert metrics["rollback_count"] == 1
@@ -38,10 +47,14 @@ def test_fetch_compliance_metrics(tmp_path: Path, temp_db: Path, monkeypatch):
 
 def test_metrics_stream(tmp_path: Path, temp_db: Path, monkeypatch):
     monkeypatch.setattr(cmu, "ANALYTICS_DB", temp_db)
-    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
-    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
-    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
-    monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
+    
+    def noop(*a: object, **k: object) -> None:
+        return None
+
+    monkeypatch.setattr(cmu, "ensure_tables", noop)
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", no_recursive_folders)
+    monkeypatch.setattr(cmu, "validate_environment_root", noop)
+    monkeypatch.setattr(cmu, "insert_event", noop)
     client = app.test_client()
     resp = client.get("/metrics_stream?once=1")
     assert resp.status_code == 200

--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3
 from dashboard import compliance_metrics_updater as cmu
 
-cmu.validate_no_recursive_folders = lambda: None
-cmu.validate_environment_root = lambda: None
+
+def no_recursive_folders() -> None:
+    return None
+
+
+def no_environment_root() -> None:
+    return None
+
+
+cmu.validate_no_recursive_folders = no_recursive_folders
+cmu.validate_environment_root = no_environment_root
 from web_gui.scripts.flask_apps.enterprise_dashboard import app
 
 

--- a/tests/test_dashboard_logging.py
+++ b/tests/test_dashboard_logging.py
@@ -4,17 +4,29 @@ from dashboard import compliance_metrics_updater as cmu
 def test_dashboard_update_logs_event(tmp_path, monkeypatch):
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     events = []
+    
+    def log_update_event(self, metrics, **k):  # noqa: ANN001, D401
+        events.append({"event": "dashboard_update"})
+
     monkeypatch.setattr(
         cmu.ComplianceMetricsUpdater,
         "_log_update_event",
-        lambda self, metrics, **k: events.append({"event": "dashboard_update"}),
+        log_update_event,
     )
     db_dir = tmp_path / "databases"
     db_dir.mkdir()
     (db_dir / "analytics.db").touch()
     dash = tmp_path / "dashboard"
     updater = cmu.ComplianceMetricsUpdater(dash, test_mode=True)
-    monkeypatch.setattr(updater, "_check_forbidden_operations", lambda: None)
-    updater._fetch_compliance_metrics = lambda **k: {}
+
+    def noop(*a, **k):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(updater, "_check_forbidden_operations", noop)
+
+    def fetch_metrics(**k):  # noqa: ANN001
+        return {}
+
+    updater._fetch_compliance_metrics = fetch_metrics
     updater.update()
     assert any(e.get("event") == "dashboard_update" for e in events)

--- a/tests/test_db_first_code_generator.py
+++ b/tests/test_db_first_code_generator.py
@@ -9,6 +9,10 @@ from template_engine.db_first_code_generator import DBFirstCodeGenerator
 from template_engine.learning_templates import get_lesson_templates
 
 
+def allow_operation(*args: object, **kwargs: object) -> bool:
+    return True
+
+
 def create_production_db(tmp_path: Path) -> Path:
     db = tmp_path / "production.db"
     with sqlite3.connect(db) as conn:
@@ -33,7 +37,7 @@ def create_production_db(tmp_path: Path) -> Path:
 
 def test_existing_pattern_loaded(tmp_path: Path) -> None:
     prod_db = create_production_db(tmp_path)
-    db_first_code_generator.validate_enterprise_operation = lambda *args, **kwargs: True
+    db_first_code_generator.validate_enterprise_operation = allow_operation
     gen = DBFirstCodeGenerator(
         prod_db,
         tmp_path / "documentation.db",
@@ -46,7 +50,7 @@ def test_existing_pattern_loaded(tmp_path: Path) -> None:
 
 def test_missing_pattern_triggers_database_lookup(tmp_path: Path, monkeypatch) -> None:
     prod_db = create_production_db(tmp_path)
-    db_first_code_generator.validate_enterprise_operation = lambda *args, **kwargs: True
+    db_first_code_generator.validate_enterprise_operation = allow_operation
     gen = DBFirstCodeGenerator(
         prod_db,
         tmp_path / "documentation.db",
@@ -70,7 +74,7 @@ def test_similarity_ranking_selects_best(tmp_path: Path, monkeypatch) -> None:
         conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
         conn.execute("INSERT INTO code_templates (template_code) VALUES ('foo')")
         conn.execute("INSERT INTO code_templates (template_code) VALUES ('bar')")
-    db_first_code_generator.validate_enterprise_operation = lambda *a, **k: True
+    db_first_code_generator.validate_enterprise_operation = allow_operation
     gen = DBFirstCodeGenerator(
         prod_db,
         tmp_path / "documentation.db",
@@ -88,7 +92,7 @@ def test_similarity_ranking_selects_best(tmp_path: Path, monkeypatch) -> None:
 
 def test_generate_logs_event(tmp_path: Path, monkeypatch) -> None:
     prod_db = create_production_db(tmp_path)
-    db_first_code_generator.validate_enterprise_operation = lambda *a, **k: True
+    db_first_code_generator.validate_enterprise_operation = allow_operation
     gen = DBFirstCodeGenerator(
         prod_db,
         tmp_path / "documentation.db",
@@ -107,7 +111,7 @@ def test_generate_logs_event(tmp_path: Path, monkeypatch) -> None:
 
 def test_selects_lesson_template(tmp_path: Path) -> None:
     prod_db = tmp_path / "prod.db"
-    db_first_code_generator.validate_enterprise_operation = lambda *a, **k: True
+    db_first_code_generator.validate_enterprise_operation = allow_operation
     gen = DBFirstCodeGenerator(
         prod_db,
         tmp_path / "documentation.db",

--- a/tests/test_db_first_codegen_analytics.py
+++ b/tests/test_db_first_codegen_analytics.py
@@ -7,8 +7,17 @@ from template_engine.db_first_code_generator import DBFirstCodeGenerator
 from template_engine import auto_generator
 import template_engine.db_first_code_generator as dbgen
 
-auto_generator.validate_no_recursive_folders = lambda: None
-dbgen.validate_enterprise_operation = lambda *a, **k: None
+
+def no_recursive_folders() -> None:
+    return None
+
+
+def noop_operation(*args: object, **kwargs: object) -> None:
+    return None
+
+
+auto_generator.validate_no_recursive_folders = no_recursive_folders
+dbgen.validate_enterprise_operation = noop_operation
 
 
 def test_auto_generation_logs_event(tmp_path: Path) -> None:
@@ -20,7 +29,11 @@ def test_auto_generation_logs_event(tmp_path: Path) -> None:
 
     os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
-    dbgen._log_event = lambda *a, **k: None
+
+    def log_event(*a: object, **k: object) -> None:
+        return None
+
+    dbgen._log_event = log_event
     gen = DBFirstCodeGenerator(prod_db, doc_db, tpl_db, analytics)
     result = gen.generate("TestObjective")
     assert "Auto-generated template" in result
@@ -58,7 +71,11 @@ def test_generate_integration_ready_code(tmp_path: Path) -> None:
     dbgen._log_event = fake_log
 
     gen = DBFirstCodeGenerator(prod_db, doc_db, tpl_db, analytics)
-    gen.select_best_template = lambda *_: "print('{{NAME}}')"
+
+    def select_template(*_: object) -> str:
+        return "print('{{NAME}}')"
+
+    gen.select_best_template = select_template
     path = gen.generate_integration_ready_code("Obj")
     assert path.exists()
     assert path.read_text() == "print('World')"
@@ -92,7 +109,11 @@ def test_integration_ready_updates_tracking(tmp_path: Path) -> None:
     dbgen._log_event = fake_log
 
     gen = DBFirstCodeGenerator(prod_db, doc_db, tpl_db, analytics)
-    gen.select_best_template = lambda *_: "print('{{NAME}}')"
+
+    def select_template(*_: object) -> str:
+        return "print('{{NAME}}')"
+
+    gen.select_best_template = select_template
     path = gen.generate_integration_ready_code("Obj")
     assert path.exists()
 
@@ -129,8 +150,16 @@ def test_integration_ready_rollback_on_failure(tmp_path: Path, monkeypatch) -> N
             conn.commit()
 
     monkeypatch.setattr(dbgen, "_log_event", fake_log)
-    monkeypatch.setattr(dbgen.DBFirstCodeGenerator, "generate", lambda self, *_: "print('{{NAME}}')")
-    monkeypatch.setattr(Path, "write_text", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("fail")))
+
+    def generate(self, *_: object) -> str:
+        return "print('{{NAME}}')"
+
+    monkeypatch.setattr(dbgen.DBFirstCodeGenerator, "generate", generate)
+
+    def write_text(*a: object, **k: object) -> None:
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(Path, "write_text", write_text)
 
     gen = DBFirstCodeGenerator(prod_db, doc_db, tpl_db, analytics)
     with pytest.raises(RuntimeError):
@@ -168,11 +197,24 @@ def test_integration_ready_runs_validator(tmp_path: Path, monkeypatch) -> None:
         conn.execute("CREATE TABLE template_placeholders (placeholder_name TEXT, default_value TEXT)")
         conn.execute("INSERT INTO template_placeholders VALUES ('{{NAME}}', 'World')")
 
-    dummy = type(
-        "D", (), {"called": False, "validate_corrections": lambda self, files: setattr(self, "called", True) or True}
-    )()
-    monkeypatch.setattr(dbgen, "SecondaryCopilotValidator", lambda: dummy)
+    class D:
+        called = False
+
+        def validate_corrections(self, files: object) -> bool:  # noqa: ANN001
+            self.called = True
+            return True
+
+    dummy = D()
+
+    def secondary_copilot_validator() -> D:
+        return dummy
+
+    monkeypatch.setattr(dbgen, "SecondaryCopilotValidator", secondary_copilot_validator)
     gen = DBFirstCodeGenerator(prod_db, doc_db, tpl_db, analytics)
-    gen.select_best_template = lambda *_: "print('{{NAME}}')"
+
+    def select_template(*_: object) -> str:
+        return "print('{{NAME}}')"
+
+    gen.select_best_template = select_template
     gen.generate_integration_ready_code("Obj")
     assert dummy.called

--- a/tests/test_docs_metrics.py
+++ b/tests/test_docs_metrics.py
@@ -48,10 +48,13 @@ def test_docs_metrics_validator_wrapper(tmp_path, monkeypatch):
     db_path = _setup_db(tmp_path)
     from scripts import docs_metrics_validator
 
+    def validate(path: Path) -> bool:
+        return path == db_path
+
     monkeypatch.setattr(
         docs_metrics_validator,
         "validate",
-        lambda path: path == db_path,
+        validate,
     )
 
     result = docs_metrics_validator.main(["--db-path", str(db_path)])
@@ -61,7 +64,11 @@ def test_docs_metrics_validator_wrapper(tmp_path, monkeypatch):
 def test_docs_metrics_validator_as_script(tmp_path, monkeypatch):
     db_path = _setup_db(tmp_path)
     module = types.ModuleType("validate_docs_metrics")
-    module.validate = lambda path: path == db_path
+
+    def validate(path: Path) -> bool:
+        return path == db_path
+
+    module.validate = validate
     module.DB_PATH = Path("dummy")
     monkeypatch.setitem(sys.modules, "validate_docs_metrics", module)
     script = Path(__file__).resolve().parents[1] / "scripts" / "docs_metrics_validator.py"
@@ -75,7 +82,11 @@ def test_docs_metrics_validator_as_script(tmp_path, monkeypatch):
 def test_docs_metrics_validator_module(tmp_path, monkeypatch):
     db_path = _setup_db(tmp_path)
     module = types.ModuleType("scripts.validate_docs_metrics")
-    module.validate = lambda path: path == db_path
+
+    def validate(path: Path) -> bool:
+        return path == db_path
+
+    module.validate = validate
     module.DB_PATH = Path("dummy")
     module.WHITEPAPER_PATH = tmp_path / "whitepaper.md"
     module.WHITEPAPER_PATH.write_text("templates: 0")

--- a/tests/test_documentation_manager_validator.py
+++ b/tests/test_documentation_manager_validator.py
@@ -8,7 +8,12 @@ from archive.consolidated_scripts.enterprise_database_driven_documentation_manag
 )
 from template_engine import auto_generator
 
-auto_generator.validate_no_recursive_folders = lambda: None
+
+def no_recursive_folders() -> None:
+    return None
+
+
+auto_generator.validate_no_recursive_folders = no_recursive_folders
 
 
 def test_documentation_validator(tmp_path: Path) -> None:
@@ -40,5 +45,9 @@ def test_documentation_validator(tmp_path: Path) -> None:
     import archive.consolidated_scripts.enterprise_database_driven_documentation_manager as mod
 
     mod_obj = manager
-    setattr(mod, "DocumentationManager", lambda: mod_obj)
+
+    def documentation_manager_factory() -> DocumentationManager:
+        return mod_obj
+
+    setattr(mod, "DocumentationManager", documentation_manager_factory)
     assert dual_validate()


### PR DESCRIPTION
## Summary
- refactor tests to use def-based helpers instead of lambda assignments
- improve readability for documentation manager and dashboard-related tests

## Testing
- `ruff check tests/test_documentation_manager_validator.py tests/test_dashboard_endpoints.py tests/test_db_first_code_generator.py tests/test_db_first_codegen_analytics.py tests/test_docs_metrics.py tests/test_dashboard.py tests/test_dashboard_logging.py`
- `pytest tests/test_documentation_manager_validator.py tests/test_dashboard_endpoints.py tests/test_db_first_code_generator.py tests/test_db_first_codegen_analytics.py tests/test_docs_metrics.py tests/test_dashboard.py tests/test_dashboard_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_688d7076c26483319fab565c37eaaba7