### PR TITLE
feat: initialize wrapup session table in wlc manager

### DIFF
--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -74,6 +74,14 @@ def ensure_session_table(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def initialize_database(db_path: Path) -> None:
+    """Pre-run check to ensure required tables exist."""
+    if os.getenv("TEST_MODE"):
+        return
+    with get_connection(db_path) as conn:
+        ensure_session_table(conn)
+
+
 def setup_logging(verbose: bool) -> Path:
     """Configure enterprise logging to external backup root."""
     backup_root = CrossPlatformPathManager.get_backup_root()
@@ -241,6 +249,7 @@ def main(argv: list[str] | None = None) -> None:
     if os.getenv("TEST_MODE"):
         return
     args = parse_args(argv)
+    initialize_database(args.db_path)
     run_session(
         args.steps,
         args.db_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,14 @@ from zipfile import ZipFile
 
 import pytest
 
+# Enable test mode to prevent side effects such as database writes.
 os.environ.setdefault("TEST_MODE", "1")
+
+
+@pytest.fixture(autouse=True)
+def enforce_test_mode(monkeypatch):
+    """Ensure TEST_MODE is set for each test run."""
+    monkeypatch.setenv("TEST_MODE", "1")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- ensure `unified_wrapup_sessions` table exists before running WLC sessions
- skip session initialization when `TEST_MODE` is set to avoid DB side effects
- enforce `TEST_MODE` in test suite to prevent accidental writes

## Testing
- `ruff check scripts/wlc_session_manager.py tests/conftest.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py tests/test_wlc_session_manager.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py`


------
https://chatgpt.com/codex/tasks/task_e_688d707bc92083318f6e5c21ec744ccd