### PR TITLE
fix: expose n_init parameter for KMeans clustering

### DIFF
--- a/quantum/algorithms/functional.py
+++ b/quantum/algorithms/functional.py
@@ -4,7 +4,7 @@ Refactored from original quantum_algorithms_functional.py with enhanced modulari
 """
 
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 from qiskit import QuantumCircuit
@@ -124,11 +124,13 @@ class QuantumFunctional(QuantumAlgorithmBase):
         runtime = time.perf_counter() - start_time
         return {"index": int(measured, 2), "time": runtime, "iterations": iterations}
 
-    def run_kmeans_clustering(self, samples: int = 100, clusters: int = 2) -> Dict[str, Any]:
+    def run_kmeans_clustering(
+        self, samples: int = 100, clusters: int = 2, n_init: Union[int, str] = 10
+    ) -> Dict[str, Any]:
         """Run ``KMeans`` clustering and return inertia and runtime."""
         features, _ = make_blobs(n_samples=samples, centers=clusters, random_state=42)
         start = time.perf_counter()
-        model = KMeans(n_clusters=clusters, n_init="auto", random_state=42)
+        model = KMeans(n_clusters=clusters, n_init=n_init, random_state=42)
         
         with tqdm(total=1, desc=f"{TEXT_INDICATORS['progress']} kmeans", leave=False) as bar:
             model.fit(features)

--- a/quantum_algorithms_functional.py
+++ b/quantum_algorithms_functional.py
@@ -5,12 +5,18 @@ quantum algorithms.  The implementations rely solely on the Qiskit simulator
 backends so they can be executed in a unit-test environment without requiring
 real quantum hardware.  These functions are intentionally lightweight and are
 meant for demonstration and testing purposes only.
+
+The :func:`run_kmeans_clustering` helper now exposes an ``n_init`` parameter
+with a numeric default of ``10`` rather than using ``"auto"``.  This maintains
+compatibility with older versions of scikit-learn that do not support the
+string value while still allowing callers to opt in to ``"auto"`` when running
+on newer releases.
 """
 
 from __future__ import annotations
 
 import time
-from typing import Iterable, List
+from typing import Iterable, List, Union
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit
@@ -85,11 +91,13 @@ def run_grover_search(data: List[int], target: int) -> dict:
     return {"index": int(measured, 2), "iterations": iterations}
 
 
-def run_kmeans_clustering(samples: int = 100, clusters: int = 2) -> dict:
+def run_kmeans_clustering(
+    samples: int = 100, clusters: int = 2, n_init: Union[int, str] = 10
+) -> dict:
     """Run KMeans clustering and return inertia and runtime."""
     features, _ = make_blobs(n_samples=samples, centers=clusters, random_state=42)
     start = time.perf_counter()
-    model = KMeans(n_clusters=clusters, n_init="auto", random_state=42)
+    model = KMeans(n_clusters=clusters, n_init=n_init, random_state=42)
     model.fit(features)
     runtime = time.perf_counter() - start
     return {"inertia": float(model.inertia_), "time": runtime}

--- a/scripts/utilities/quantum_algorithms_functional.py
+++ b/scripts/utilities/quantum_algorithms_functional.py
@@ -20,9 +20,9 @@ def run_grover_search(data, target):
     return QuantumFunctional().run_grover_search(data, target)
 
 
-def run_kmeans_clustering(samples=100, clusters=2):
+def run_kmeans_clustering(samples=100, clusters=2, n_init=10):
     """Run KMeans clustering and return metrics."""
-    return QuantumFunctional().run_kmeans_clustering(samples, clusters)
+    return QuantumFunctional().run_kmeans_clustering(samples, clusters, n_init)
 
 
 def run_simple_qnn():

--- a/tests/test_quantum_algorithms_functional.py
+++ b/tests/test_quantum_algorithms_functional.py
@@ -23,6 +23,20 @@ def test_run_kmeans_clustering_returns_inertia():
     assert metrics["inertia"] >= 0
 
 
+def test_run_kmeans_clustering_allows_custom_n_init():
+    metrics = run_kmeans_clustering(samples=20, clusters=2, n_init=1)
+    assert metrics["inertia"] >= 0
+
+
+def test_run_kmeans_clustering_supports_auto():
+    import sklearn
+
+    version = tuple(int(x) for x in sklearn.__version__.split(".")[:2])
+    if version >= (1, 4):
+        metrics = run_kmeans_clustering(samples=20, clusters=2, n_init="auto")
+        assert metrics["inertia"] >= 0
+
+
 def test_run_simple_qnn_accuracy_range():
     metrics = run_simple_qnn()
     assert 0.0 <= metrics["accuracy"] <= 1.0


### PR DESCRIPTION
## Summary
- allow optional `n_init` parameter in `run_kmeans_clustering` with integer default for broader scikit-learn support
- pass through `n_init` across functional wrappers
- test custom and version-specific `n_init` options

## Testing
- `ruff check quantum_algorithms_functional.py quantum/algorithms/functional.py scripts/utilities/quantum_algorithms_functional.py tests/test_quantum_algorithms_functional.py`
- `pytest tests/test_quantum_algorithms_functional.py tests/test_quantum_package.py`


------
https://chatgpt.com/codex/tasks/task_e_688d71204bbc8331a5e2c4a20a4fddb3