### PR TITLE
feat: add quantum integration orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Analytics Migrations:** run `add_code_audit_log.sql`, `add_correction_history.sql`, `add_code_audit_history.sql`, `add_violation_logs.sql`, and `add_rollback_logs.sql` (use `sqlite3` manually if `analytics.db` shipped without the tables) or use the initializer. The `correction_history` table tracks file corrections with `user_id`, session ID, action, timestamp, and optional details. The new `code_audit_history` table records each audit entry along with the responsible user and timestamp.
 
 - **Quantum Utilities:** see [quantum/README.md](quantum/README.md) for
-  optimizer and search helpers. These modules default to simulation mode unless `QISKIT_IBM_TOKEN` is configured.
-- **Phase 6 Quantum Demo:** `quantum_integration_orchestrator.py` runs a quantum database search example and uses hardware backends when `QISKIT_IBM_TOKEN` is available.
+  optimizer and search helpers. The new `quantum.quantum_integration_orchestrator`
+  module coordinates algorithm execution and automatically falls back to
+  simulation when hardware access isn't configured.
+- **Phase 6 Quantum Demo:** `quantum_integration_orchestrator.py` runs a quantum
+  database search example and uses hardware backends when `QISKIT_IBM_TOKEN` is
+  available.
 
 ### 🏆 **Enterprise Achievements**
  - ✅ **Script Validation**: 1,679 scripts synchronized

--- a/docs/quantum_integration_plan.md
+++ b/docs/quantum_integration_plan.md
@@ -1,0 +1,11 @@
+# Quantum Integration Plan
+
+## Module Architecture
+- **QuantumAlgorithmRegistry**: central registry for available algorithms.
+- **QuantumExecutor**: manages backend selection and executes registered algorithms.
+- **QuantumIntegrationOrchestrator**: high level interface that coordinates algorithm execution using the registry and executor.
+
+## Simulation Fallback
+- Attempts to use IBM Quantum hardware when `QISKIT_IBM_TOKEN` is configured.
+- Falls back to `qasm_simulator` from `qiskit` when hardware access is unavailable.
+- Maintains identical interfaces for hardware and simulation to ensure consistent behavior.

--- a/quantum/__init__.py
+++ b/quantum/__init__.py
@@ -21,6 +21,7 @@ from .algorithms.functional import QuantumFunctional
 from .algorithms.expansion import QuantumLibraryExpansion
 from .orchestration.registry import QuantumAlgorithmRegistry, get_global_registry
 from .orchestration.executor import QuantumExecutor
+from .quantum_integration_orchestrator import QuantumIntegrationOrchestrator
 
 import logging
 
@@ -37,5 +38,6 @@ __all__ = [
     "QuantumAlgorithmRegistry",
     "get_global_registry",
     "QuantumExecutor",
+    "QuantumIntegrationOrchestrator",
     "QuantumOptimizer",
 ]

--- a/quantum/quantum_integration_orchestrator.py
+++ b/quantum/quantum_integration_orchestrator.py
@@ -1,0 +1,54 @@
+"""High-level orchestration for quantum algorithm execution.
+
+Provides a simple interface that coordinates the algorithm registry and
+executor. When quantum hardware is unavailable, the underlying executor
+falls back to the local `qasm_simulator` so callers can rely on a
+consistent API.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .orchestration.executor import QuantumExecutor
+from .orchestration.registry import get_global_registry
+
+
+class QuantumIntegrationOrchestrator:
+    """Coordinate execution of registered quantum algorithms."""
+
+    def __init__(
+        self,
+        *,
+        use_hardware: bool = False,
+        backend_name: Optional[str] = None,
+        max_workers: int = 4,
+    ) -> None:
+        self.executor = QuantumExecutor(
+            max_workers=max_workers,
+            use_hardware=use_hardware,
+            backend_name=backend_name,
+        )
+        self.registry = get_global_registry()
+
+    def run_algorithm(self, name: str, **kwargs: Any) -> Dict[str, Any]:
+        """Execute a single algorithm by name."""
+        return self.executor.execute_algorithm(name, **kwargs)
+
+    def run_plan(
+        self, algorithm_configs: List[Dict[str, Any]], *, parallel: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Execute multiple algorithms sequentially or in parallel."""
+        if parallel:
+            return self.executor.execute_algorithms_parallel(algorithm_configs)
+        return self.executor.execute_algorithms_sequential(algorithm_configs)
+
+    def available_algorithms(self) -> List[str]:
+        """List algorithms registered with the global registry."""
+        return self.registry.list_algorithms()
+
+    def execution_summary(self) -> Dict[str, Any]:
+        """Return aggregated statistics from the executor."""
+        return self.executor.get_execution_summary()
+
+
+__all__ = ["QuantumIntegrationOrchestrator"]

--- a/tests/quantum/test_quantum_integration_orchestrator.py
+++ b/tests/quantum/test_quantum_integration_orchestrator.py
@@ -1,0 +1,9 @@
+from quantum.quantum_integration_orchestrator import QuantumIntegrationOrchestrator
+
+
+def test_orchestrator_simulation_fallback(monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "1")
+    orchestrator = QuantumIntegrationOrchestrator(use_hardware=False)
+    results = orchestrator.run_plan([{"algorithm": "expansion"}])
+    assert results[0]["success"] is True
+    assert orchestrator.executor.use_hardware is False


### PR DESCRIPTION
## Summary
- document quantum integration architecture and simulation fallback
- introduce `QuantumIntegrationOrchestrator` for coordinated algorithm execution
- cover orchestrator with tests and document usage

## Testing
- `ruff check .`
- `pytest tests/quantum/test_quantum_integration_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_688d75fb5c0c8331950b87c924a7320b