### PR TITLE
fix: handle naive datetimes in sync logger

### DIFF
--- a/scripts/database/cross_database_sync_logger.py
+++ b/scripts/database/cross_database_sync_logger.py
@@ -51,6 +51,8 @@ def log_sync_operation(
 
         initialize_database(db_path)
 
+    if start_time is not None and start_time.tzinfo is None:
+        start_time = start_time.replace(tzinfo=timezone.utc)
     start_dt = start_time or datetime.now(timezone.utc)
     end_dt = datetime.now(timezone.utc)
     duration = (end_dt - start_dt).total_seconds()

--- a/tests/test_cross_database_sync_logger.py
+++ b/tests/test_cross_database_sync_logger.py
@@ -24,3 +24,19 @@ def test_log_sync_operation(tmp_path: Path, monkeypatch) -> None:
     assert row[1] == "SUCCESS"
     assert row[2] == start.isoformat()
     assert row[3] > 0
+
+
+def test_log_sync_operation_accepts_naive_datetime(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "enterprise_modules.compliance.validate_enterprise_operation",
+        lambda: None,
+    )
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    db_path = tmp_path / "enterprise_assets.db"
+    start = datetime.utcnow()
+    log_sync_operation(db_path, "test_op", status="SUCCESS", start_time=start)
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT start_time FROM cross_database_sync_operations ORDER BY id DESC"
+        ).fetchone()
+    assert row[0] == start.replace(tzinfo=timezone.utc).isoformat()


### PR DESCRIPTION
## Summary
- ensure `log_sync_operation` normalizes naive datetimes to UTC
- add coverage for naive datetime logging

## Testing
- `ruff check scripts/database/cross_database_sync_logger.py tests/test_cross_database_sync_logger.py tests/test_documentation_manager.py`
- `pytest tests/test_cross_database_sync_logger.py tests/test_documentation_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d75fbe72c8331b888b2d5d0d5b020