### PR TITLE
feat: ensure lessons table creation and workspace path

### DIFF
--- a/docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md
+++ b/docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md
@@ -195,6 +195,8 @@ TEXT_INDICATORS = {
   Windows path. The validator now writes logs cross-platform and excludes
   virtual environment and version-control directories from anti-recursion
   checks.
+- Added environment-aware database path and automatic table creation helper in
+  `utils/lessons_learned_integrator.py` to ensure database-first compliance.
 
 ---
 

--- a/tests/template_engine/test_lesson_driven_updates.py
+++ b/tests/template_engine/test_lesson_driven_updates.py
@@ -1,6 +1,7 @@
 import sqlite3
 
 import template_engine.auto_generator as ag
+from utils.lessons_learned_integrator import ensure_lessons_table
 
 
 def test_lessons_from_db_update_templates(tmp_path, monkeypatch):
@@ -9,10 +10,8 @@ def test_lessons_from_db_update_templates(tmp_path, monkeypatch):
     db_dir = tmp_path / "databases"
     db_dir.mkdir()
     db = db_dir / "learning_monitor.db"
+    ensure_lessons_table(db)
     with sqlite3.connect(db) as conn:
-        conn.execute(
-            "CREATE TABLE enhanced_lessons_learned (description TEXT, source TEXT, timestamp TEXT, validation_status TEXT, tags TEXT)"
-        )
         conn.execute(
             "INSERT INTO enhanced_lessons_learned VALUES (?,?,?,?,?)",
             ("Prefer dataclasses", "test", "2024", "validated", "style"),

--- a/tests/template_engine/test_lessons_learned.py
+++ b/tests/template_engine/test_lessons_learned.py
@@ -1,33 +1,17 @@
 import logging
-import sqlite3
-from pathlib import Path
 
 from utils.lessons_learned_integrator import (
-    store_lesson,
-    load_lessons,
-    fetch_lessons_by_tag,
     apply_lessons,
+    ensure_lessons_table,
+    fetch_lessons_by_tag,
+    load_lessons,
+    store_lesson,
 )
 
 
-def _init_db(path: Path) -> Path:
-    with sqlite3.connect(path) as conn:
-        conn.execute(
-            """
-            CREATE TABLE enhanced_lessons_learned (
-                description TEXT,
-                source TEXT,
-                timestamp TEXT,
-                validation_status TEXT,
-                tags TEXT
-            )
-            """
-        )
-    return path
-
-
 def test_store_retrieve_apply(tmp_path, caplog):
-    db = _init_db(tmp_path / "lessons.db")
+    db = tmp_path / "lessons.db"
+    ensure_lessons_table(db)
     store_lesson(
         "use mock DB",
         source="unit",

--- a/tests/test_auto_generator.py
+++ b/tests/test_auto_generator.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from template_engine.auto_generator import TemplateAutoGenerator
 import template_engine.auto_generator as auto_generator
+from utils.lessons_learned_integrator import ensure_lessons_table
 
 os.environ.setdefault("GH_COPILOT_DISABLE_VALIDATION", "1")
 
@@ -246,18 +247,8 @@ def test_lessons_applied_during_generation(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     analytics_db, completion_db = create_test_dbs(tmp_path)
     learning_db = tmp_path / "learning_monitor.db"
+    ensure_lessons_table(learning_db)
     with sqlite3.connect(learning_db) as conn:
-        conn.execute(
-            """
-            CREATE TABLE enhanced_lessons_learned (
-                description TEXT,
-                source TEXT,
-                timestamp TEXT,
-                validation_status TEXT,
-                tags TEXT
-            )
-            """
-        )
         conn.execute(
             "INSERT INTO enhanced_lessons_learned VALUES (?,?,?,?,?)",
             (

--- a/tests/test_lessons_learned_integrator.py
+++ b/tests/test_lessons_learned_integrator.py
@@ -1,31 +1,18 @@
 import sqlite3
-from pathlib import Path
+from pathlib import Path  # noqa: F401
 
 from utils.lessons_learned_integrator import (
+    ensure_lessons_table,
+    fetch_lessons_by_tag,
     load_lessons,
     store_lesson,
     store_lessons,
-    fetch_lessons_by_tag,
 )
-
-def _create_table(db: Path) -> None:
-    with sqlite3.connect(db) as conn:
-        conn.execute(
-            """
-            CREATE TABLE enhanced_lessons_learned (
-                description TEXT,
-                source TEXT,
-                timestamp TEXT,
-                validation_status TEXT,
-                tags TEXT
-            )
-            """
-        )
 
 
 def test_load_lessons(tmp_path):
     db = tmp_path / "lessons.db"
-    _create_table(db)
+    ensure_lessons_table(db)
     store_lesson(
         "Use temp dirs",
         source="tests",
@@ -40,7 +27,7 @@ def test_load_lessons(tmp_path):
 
 def test_store_lesson_and_fetch_by_tag(tmp_path):
     db = tmp_path / "lessons.db"
-    _create_table(db)
+    ensure_lessons_table(db)
     store_lesson(
         "Add more docs",
         source="review",
@@ -55,7 +42,7 @@ def test_store_lesson_and_fetch_by_tag(tmp_path):
 
 def test_store_lessons_batch(tmp_path):
     db = tmp_path / "lessons.db"
-    _create_table(db)
+    ensure_lessons_table(db)
     lessons = [
         {
             "description": "Use context managers",

--- a/tests/test_lessons_storage.py
+++ b/tests/test_lessons_storage.py
@@ -9,34 +9,21 @@ single inserts, batch inserts, and tag-based filtering.
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
+from pathlib import Path  # noqa: F401
 
 from utils.lessons_learned_integrator import (
+    ensure_lessons_table,
     fetch_lessons_by_tag,
     store_lesson,
     store_lessons,
 )
 
 
-def _create_table(db_path: Path) -> None:
-    """Create the ``enhanced_lessons_learned`` table in ``db_path``."""
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            """
-            CREATE TABLE enhanced_lessons_learned (
-                description TEXT,
-                source TEXT,
-                timestamp TEXT,
-                validation_status TEXT,
-                tags TEXT
-            )
-            """
-        )
 
 
 def test_store_lesson_inserts_row(tmp_path: Path) -> None:
     db = tmp_path / "lessons.db"
-    _create_table(db)
+    ensure_lessons_table(db)
     store_lesson(
         "Document edge cases",
         source="review",
@@ -60,7 +47,7 @@ def test_store_lesson_inserts_row(tmp_path: Path) -> None:
 
 def test_store_lessons_batch_inserts_rows(tmp_path: Path) -> None:
     db = tmp_path / "lessons.db"
-    _create_table(db)
+    ensure_lessons_table(db)
     lessons = [
         {
             "description": "Use context managers",
@@ -86,7 +73,7 @@ def test_store_lessons_batch_inserts_rows(tmp_path: Path) -> None:
 
 def test_fetch_lessons_by_tag_filters(tmp_path: Path) -> None:
     db = tmp_path / "lessons.db"
-    _create_table(db)
+    ensure_lessons_table(db)
     store_lesson(
         "Tag filtering works",
         source="tests",

--- a/tests/test_session_db_tools.py
+++ b/tests/test_session_db_tools.py
@@ -1,27 +1,12 @@
 import sqlite3
-from pathlib import Path
 
 from session_db_tools import record_lesson
-
-
-def _create_table(db: Path) -> None:
-    with sqlite3.connect(db) as conn:
-        conn.execute(
-            """
-            CREATE TABLE enhanced_lessons_learned (
-                description TEXT,
-                source TEXT,
-                timestamp TEXT,
-                validation_status TEXT,
-                tags TEXT
-            )
-            """
-        )
+from utils.lessons_learned_integrator import ensure_lessons_table
 
 
 def test_record_lesson_success(tmp_path):
     db = tmp_path / "lessons.db"
-    _create_table(db)
+    ensure_lessons_table(db)
     result = record_lesson(
         db,
         "Ensure backups",
@@ -44,9 +29,9 @@ def test_record_lesson_success(tmp_path):
     )
 
 
-def test_record_lesson_failure(tmp_path):
+def test_record_lesson_creates_table(tmp_path):
     db = tmp_path / "lessons.db"
-    # Table is not created to trigger failure
+    # Table not pre-created; store_lesson should create it automatically
     result = record_lesson(
         db,
         "Missing table",
@@ -55,4 +40,4 @@ def test_record_lesson_failure(tmp_path):
         validation_status="validated",
         tags="testing",
     )
-    assert result is False
+    assert result is True


### PR DESCRIPTION
## Summary
- derive lessons-learned database path from `GH_COPILOT_WORKSPACE`
- add helper to auto-create `enhanced_lessons_learned` table
- adjust tests and docs for new helper

## Testing
- `ruff check utils/lessons_learned_integrator.py tests/test_lessons_learned_integrator.py tests/test_lessons_storage.py tests/template_engine/test_lessons_learned.py tests/template_engine/test_lesson_driven_updates.py tests/test_session_db_tools.py tests/test_auto_generator.py`
- `pytest tests/test_lessons_learned_integrator.py tests/test_lessons_storage.py tests/template_engine/test_lessons_learned.py tests/template_engine/test_lesson_driven_updates.py tests/test_session_db_tools.py tests/test_auto_generator.py tests/test_ensure_enhanced_lessons_learned_table.py`
- `python -m scripts.validation.lessons_learned_integration_validator`


------
https://chatgpt.com/codex/tasks/task_e_688d75fd6f9c8331b94232093bd1a872