### PR TITLE
test: add unified_wrapup_session_db fixture for WLC session manager tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
+import sqlite3
+import scripts.wlc_session_manager as wsm
 
 # Enable test mode to prevent side effects such as database writes.
 os.environ.setdefault("TEST_MODE", "1")
@@ -20,6 +22,15 @@ def enforce_test_mode(monkeypatch):
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def unified_wrapup_session_db(tmp_path):
+    """Provide a temporary database with unified_wrapup_sessions table."""
+    db_file = tmp_path / "production.db"
+    with sqlite3.connect(db_file) as conn:
+        wsm.ensure_session_table(conn)
+    return db_file
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_wlc_session_manager_cli.py
+++ b/tests/test_wlc_session_manager_cli.py
@@ -2,23 +2,15 @@
 # > Generated: 2025-07-24 06:42 | Author: mbaetiong
 
 import os
-import shutil
 import sqlite3
 import subprocess
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "wlc_session_manager.py"
-DEFAULT_DB = Path("databases/production.db")
 
 
-def copy_db_to_tmp(tmp_path):
-    temp_db = tmp_path / "production.db"
-    shutil.copy(DEFAULT_DB, temp_db)
-    return temp_db
-
-
-def test_cli_execution(tmp_path):
-    temp_db = copy_db_to_tmp(tmp_path)
+def test_cli_execution(unified_wrapup_session_db, tmp_path):
+    temp_db = unified_wrapup_session_db
     env = os.environ.copy()
     env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     env["GH_COPILOT_BACKUP_ROOT"] = str(tmp_path / "backups")
@@ -47,8 +39,8 @@ def test_cli_execution(tmp_path):
     assert count == before
 
 
-def test_cli_orchestrate(tmp_path):
-    temp_db = copy_db_to_tmp(tmp_path)
+def test_cli_orchestrate(unified_wrapup_session_db, tmp_path):
+    temp_db = unified_wrapup_session_db
     env = os.environ.copy()
     env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     env["GH_COPILOT_BACKUP_ROOT"] = str(tmp_path / "backups")
@@ -73,8 +65,8 @@ def test_cli_orchestrate(tmp_path):
     assert result.returncode == 0
 
 
-def test_cli_invalid_env(tmp_path):
-    temp_db = copy_db_to_tmp(tmp_path)
+def test_cli_invalid_env(unified_wrapup_session_db, tmp_path):
+    temp_db = unified_wrapup_session_db
     env = os.environ.copy()
     env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     env["PYTHONPATH"] = str(Path.cwd())

--- a/tests/test_wlc_session_manager_importpath.py
+++ b/tests/test_wlc_session_manager_importpath.py
@@ -1,15 +1,12 @@
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "wlc_session_manager.py"
-DEFAULT_DB = Path("databases/production.db")
 
 
-def test_cli_import_path(tmp_path):
-    temp_db = tmp_path / "production.db"
-    shutil.copy(DEFAULT_DB, temp_db)
+def test_cli_import_path(unified_wrapup_session_db, tmp_path):
+    temp_db = unified_wrapup_session_db
     env = os.environ.copy()
     env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     env["GH_COPILOT_BACKUP_ROOT"] = str(tmp_path / "backups")


### PR DESCRIPTION
## Summary
- add `unified_wrapup_session_db` fixture to pre-create `unified_wrapup_sessions` table
- use new fixture in WLC session manager tests and CLI variants

## Testing
- `ruff check tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py tests/conftest.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py`


------
https://chatgpt.com/codex/tasks/task_e_688d771468008331bba9d2647853cc03