### PR TITLE
fix: skip WLC session in test mode

### DIFF
--- a/tests/test_orchestrator_wlc_integration.py
+++ b/tests/test_orchestrator_wlc_integration.py
@@ -10,6 +10,7 @@ def test_main_triggers_wlc(monkeypatch):
         called["yes"] = True
 
     monkeypatch.setattr(uwo, "run_session", fake_run_session)
+    monkeypatch.setenv("TEST_MODE", "1")
 
     def fake_execute(self):
         return uwo.WrapUpResult(session_id="id", start_time=datetime.now(), status="COMPLETED")


### PR DESCRIPTION
## Summary
- short-circuit `run_session` when `TEST_MODE` is set to avoid side effects
- set `TEST_MODE` in orchestrator integration test to keep tests isolated

## Testing
- `ruff check scripts/wlc_session_manager.py tests/test_orchestrator_wlc_integration.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py tests/test_orchestrator_wlc_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d775753e0833191e55abcb29f6464