### PR TITLE
test: use temp database fixture for wlc session manager tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def unified_wrapup_session_db(tmp_path):
-    """Provide a temporary database with unified_wrapup_sessions table."""
-    db_file = tmp_path / "production.db"
+@pytest.fixture(scope="session")
+def unified_wrapup_session_db(tmp_path_factory):
+    """Provide a temporary database with the unified_wrapup_sessions table."""
+    db_dir = tmp_path_factory.mktemp("wrapup_db")
+    db_file = db_dir / "production.db"
     with sqlite3.connect(db_file) as conn:
         wsm.ensure_session_table(conn)
     return db_file

--- a/tests/test_wlc_session_manager.py
+++ b/tests/test_wlc_session_manager.py
@@ -1,5 +1,3 @@
-import sqlite3
-
 import pytest
 
 import scripts.wlc_session_manager as wsm
@@ -37,10 +35,10 @@ def test_main_skips_side_effects_with_test_mode(unified_wrapup_session_db, tmp_p
         "UnifiedWrapUpOrchestrator",
         lambda workspace_path=None: orch,
     )
-    with sqlite3.connect(unified_wrapup_session_db) as conn:
+    with wsm.get_connection(unified_wrapup_session_db) as conn:
         before = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
     wsm.main([])
-    with sqlite3.connect(unified_wrapup_session_db) as conn:
+    with wsm.get_connection(unified_wrapup_session_db) as conn:
         after = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
     assert after == before
     assert not dummy.called
@@ -71,10 +69,10 @@ def test_orchestrator_called(unified_wrapup_session_db, tmp_path, monkeypatch):
     dummy = DummyValidator()
     monkeypatch.setattr(wsm, "SecondaryCopilotValidator", lambda: dummy)
 
-    with sqlite3.connect(unified_wrapup_session_db) as conn:
+    with wsm.get_connection(unified_wrapup_session_db) as conn:
         before = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
     wsm.main([])
-    with sqlite3.connect(unified_wrapup_session_db) as conn:
+    with wsm.get_connection(unified_wrapup_session_db) as conn:
         after = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
 
     assert after == before
@@ -97,10 +95,10 @@ def test_session_error_skipped_in_test_mode(unified_wrapup_session_db, tmp_path,
 
     monkeypatch.setattr(wsm, "UnifiedWrapUpOrchestrator", lambda workspace_path=None: FailingOrchestrator())
 
-    with sqlite3.connect(unified_wrapup_session_db) as conn:
+    with wsm.get_connection(unified_wrapup_session_db) as conn:
         before = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
     wsm.main([])
-    with sqlite3.connect(unified_wrapup_session_db) as conn:
+    with wsm.get_connection(unified_wrapup_session_db) as conn:
         after = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
 
     assert after == before


### PR DESCRIPTION
## Summary
- create session-scoped fixture for a temporary database used by WLC session tests
- refactor WLC session manager tests to rely on the temp DB fixture instead of copying production data

## Testing
- `ruff check tests/test_wlc_session_manager.py tests/conftest.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py`


------
https://chatgpt.com/codex/tasks/task_e_688d7dc3ebc48331b0259a0f9fc24bee