### PR TITLE
fix: skip WLC session when TEST_MODE is enabled

### DIFF
--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -164,7 +164,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: bool = False) -> None:
-    if os.getenv("TEST_MODE"):
+    if os.getenv("TEST_MODE") == "1":
+        logging.debug("TEST_MODE=1; skipping run_session")
         return  # Skip side effects during tests
     if not validate_environment():
         raise EnvironmentError("Required environment variables are not set or paths invalid")
@@ -238,7 +239,8 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
 
 
 def main(argv: list[str] | None = None) -> None:
-    if os.getenv("TEST_MODE"):
+    if os.getenv("TEST_MODE") == "1":
+        logging.debug("TEST_MODE=1; exiting early")
         return
     args = parse_args(argv)
     initialize_database(args.db_path)
@@ -251,6 +253,6 @@ def main(argv: list[str] | None = None) -> None:
 
 
 if __name__ == "__main__":
-    if os.getenv("TEST_MODE"):
+    if os.getenv("TEST_MODE") == "1":
         sys.exit(0)
     main()

--- a/tests/test_wlc_session_manager_cli.py
+++ b/tests/test_wlc_session_manager_cli.py
@@ -14,9 +14,8 @@ def test_cli_execution(unified_wrapup_session_db, tmp_path):
     env = os.environ.copy()
     env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     env["GH_COPILOT_BACKUP_ROOT"] = str(tmp_path / "backups")
-    env["TEST_MODE"] = "1"
+    env["TEST_MODE"] = "1"  # ensure early exit during tests
     env["PYTHONPATH"] = str(Path.cwd())
-    env["TEST_MODE"] = "1"
     with sqlite3.connect(temp_db) as conn:
         before = conn.execute("SELECT COUNT(*) FROM unified_wrapup_sessions").fetchone()[0]
 
@@ -44,9 +43,8 @@ def test_cli_orchestrate(unified_wrapup_session_db, tmp_path):
     env = os.environ.copy()
     env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     env["GH_COPILOT_BACKUP_ROOT"] = str(tmp_path / "backups")
-    env["TEST_MODE"] = "1"
+    env["TEST_MODE"] = "1"  # ensure early exit during tests
     env["PYTHONPATH"] = str(Path.cwd())
-    env["TEST_MODE"] = "1"
 
     result = subprocess.run(
         [

--- a/tests/test_wlc_session_manager_importpath.py
+++ b/tests/test_wlc_session_manager_importpath.py
@@ -10,7 +10,7 @@ def test_cli_import_path(unified_wrapup_session_db, tmp_path):
     env = os.environ.copy()
     env["GH_COPILOT_WORKSPACE"] = str(tmp_path)
     env["GH_COPILOT_BACKUP_ROOT"] = str(tmp_path / "backups")
-    env["TEST_MODE"] = "1"
+    env["TEST_MODE"] = "1"  # ensure early exit during tests
     result = subprocess.run(
         [
             "python",


### PR DESCRIPTION
## Summary
- skip `run_session` and `main` when `TEST_MODE=1`
- set `TEST_MODE` in WLC session CLI tests to avoid side effects

## Testing
- `ruff check scripts/wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py`
- `pytest tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py tests/test_orchestrator_wlc_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_688d7dc6ac708331a201de4e123f823e