### PR TITLE
test: configure fail-fast and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,7 +872,7 @@ bash setup.sh --with-optional
 source .venv/bin/activate
 
 # Run comprehensive test suite
-make test  # runs `pytest -q --disable-warnings --maxfail=10 --exitfirst tests`
+make test  # runs `pytest -q --disable-warnings tests` (defaults: --maxfail=10 --exitfirst)
 
 # Run linter
 ruff format .
@@ -887,10 +887,10 @@ python -m pytest tests/enterprise/ -v
 python scripts/validation/dual_copilot_pattern_tester.py
 ```
 
-Tests enforce a default 120 s timeout via `pytest-timeout` (configured in
-`pytest.ini` with `--maxfail=10 --timeout=120`). For modules that need more time,
-decorate slow tests with `@pytest.mark.timeout(<seconds>)` or split heavy tests
-into smaller pieces to keep the suite responsive.
+Tests enforce a default 120 s timeout via `pytest-timeout` (`timeout = 120` in
+`pytest.ini`) and fail fast with `--maxfail=10 --exitfirst`. For modules that
+need more time, decorate slow tests with `@pytest.mark.timeout(<seconds>)` or
+split heavy tests into smaller pieces to keep the suite responsive.
 
 ---
 

--- a/docs/REPOSITORY_GUIDELINES.md
+++ b/docs/REPOSITORY_GUIDELINES.md
@@ -144,10 +144,11 @@ make test   # Preferred test aggregator, combines unit and integration tests
 pytest -v   # Alternative for verbose test output
 ```
 
-The default configuration runs tests with `--maxfail=10 --exitfirst`,
-stopping the suite after the first failure. For tighter control over
-execution time, consider adding the `pytest-timeout` plugin to enforce
-per-test timeouts.
+The default configuration halts after the first failure
+(`--maxfail=10 --exitfirst`) and applies a 120 s per-test timeout via
+the `pytest-timeout` plugin (`timeout = 120` in `pytest.ini`). For tests
+needing more time, adjust the `timeout` value or decorate specific
+tests with `@pytest.mark.timeout(<seconds>)`.
 
 ### Lint Configuration
 The `.flake8` file at the repository root is the single source of lint rules.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 addopts = --maxfail=10 --exitfirst
+# Enforce per-test timeouts via pytest-timeout (seconds)
+timeout = 120
 norecursedirs = builds
 python_files = test_*.py
 markers =


### PR DESCRIPTION
## Summary
- enforce `--maxfail=10 --exitfirst` and a default 120s per-test timeout in `pytest.ini`
- document fail-fast and timeout settings in testing guide and README

## Testing
- `ruff check .`
- `pytest -q`
- `pytest tests/quantum/test_provider_fallback.py::test_executor_falls_back_without_ibm -q` *(fails: AttributeError: <module 'quantum.orchestration.executor' has no attribute 'HAS_IBM_PROVIDER'>)*

------
https://chatgpt.com/codex/tasks/task_e_688d7dc919b483319036c5fa0dcfefa5