### PR TITLE
test: replace lambda assignments with named stubs

### DIFF
--- a/tests/quantum/test_hardware_backend.py
+++ b/tests/quantum/test_hardware_backend.py
@@ -9,8 +9,11 @@ def test_init_backend_success(monkeypatch):
     provider.return_value.get_backend.return_value = backend
     monkeypatch.setenv("QISKIT_IBM_TOKEN", "token")
     monkeypatch.setattr("quantum.ibm_backend.IBMProvider", provider)
+    def _stub_get_backend_backend(name):
+        return backend
+
     monkeypatch.setattr(
-        "quantum.ibm_backend.Aer", MagicMock(get_backend=lambda name: backend)
+        "quantum.ibm_backend.Aer", MagicMock(get_backend=_stub_get_backend_backend)
     )
     result, use_hw = init_ibm_backend()
     assert result is backend
@@ -20,8 +23,11 @@ def test_init_backend_success(monkeypatch):
 def test_init_backend_no_token(monkeypatch):
     simulator = object()
     monkeypatch.delenv("QISKIT_IBM_TOKEN", raising=False)
+    def _stub_get_backend_simulator(name):
+        return simulator
+
     monkeypatch.setattr(
-        "quantum.ibm_backend.Aer", MagicMock(get_backend=lambda name: simulator)
+        "quantum.ibm_backend.Aer", MagicMock(get_backend=_stub_get_backend_simulator)
     )
     result, use_hw = init_ibm_backend()
     assert result is simulator

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6,11 +6,11 @@ import pytest
 from dashboard import compliance_metrics_updater as cmu
 
 
-def no_recursive_folders() -> None:
+def _stub_no_recursive_folders() -> None:
     return None
 
 
-cmu.validate_no_recursive_folders = no_recursive_folders
+cmu.validate_no_recursive_folders = _stub_no_recursive_folders
 from web_gui.scripts.flask_apps.enterprise_dashboard import app
 
 
@@ -37,7 +37,7 @@ def test_fetch_compliance_metrics(tmp_path: Path, temp_db: Path, monkeypatch):
         return None
 
     monkeypatch.setattr(cmu, "ensure_tables", noop)
-    monkeypatch.setattr(cmu, "validate_no_recursive_folders", no_recursive_folders)
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", _stub_no_recursive_folders)
     monkeypatch.setattr(cmu, "validate_environment_root", noop)
     updater = cmu.ComplianceMetricsUpdater(tmp_path, test_mode=True)
     metrics = updater._fetch_compliance_metrics(test_mode=True)
@@ -52,7 +52,7 @@ def test_metrics_stream(tmp_path: Path, temp_db: Path, monkeypatch):
         return None
 
     monkeypatch.setattr(cmu, "ensure_tables", noop)
-    monkeypatch.setattr(cmu, "validate_no_recursive_folders", no_recursive_folders)
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", _stub_no_recursive_folders)
     monkeypatch.setattr(cmu, "validate_environment_root", noop)
     monkeypatch.setattr(cmu, "insert_event", noop)
     client = app.test_client()

--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -2,16 +2,16 @@
 from dashboard import compliance_metrics_updater as cmu
 
 
-def no_recursive_folders() -> None:
+def _stub_no_recursive_folders() -> None:
     return None
 
 
-def no_environment_root() -> None:
+def _stub_no_environment_root() -> None:
     return None
 
 
-cmu.validate_no_recursive_folders = no_recursive_folders
-cmu.validate_environment_root = no_environment_root
+cmu.validate_no_recursive_folders = _stub_no_recursive_folders
+cmu.validate_environment_root = _stub_no_environment_root
 from web_gui.scripts.flask_apps.enterprise_dashboard import app
 
 


### PR DESCRIPTION
## Summary
- replace inline lambda assignments in dashboard tests with named helper functions
- swap MagicMock lambdas for helper functions in quantum hardware backend tests

## Testing
- `ruff check tests/test_dashboard_endpoints.py tests/test_dashboard.py tests/quantum/test_hardware_backend.py`
- `pytest tests/test_dashboard_endpoints.py tests/test_dashboard.py tests/quantum/test_hardware_backend.py`


------
https://chatgpt.com/codex/tasks/task_e_688d7dc3582c8331b7918f4b50268753