### PR TITLE
feat: enhance anti-recursion safeguards

### DIFF
--- a/docs/RECURSION_POLICY.md
+++ b/docs/RECURSION_POLICY.md
@@ -7,6 +7,7 @@ The workspace and backup directories must never contain one another, even throug
 - **Bidirectional checks**: both workspace and backup trees are scanned with symlink
   resolution to prevent indirect containment (e.g., a link in the backup root
   pointing back to the workspace).
+- **Detailed errors**: any violation raises a ``RuntimeError`` that reports the offending paths for quick diagnosis.
 - **Explicit validation**: importing the optimizer module performs no filesystem access. Call `validate_workspace()` or pass `validate_workspace=True` to `QuantumOptimizer` when you need these checks.
 
 Example:

--- a/quantum_optimizer.py
+++ b/quantum_optimizer.py
@@ -31,27 +31,45 @@ links.
 # --- Anti-Recursion Validation ---
 
 def chunk_anti_recursion_validation() -> bool:
-    """Validate workspace and backup paths for recursion issues."""
-    if not validate_no_recursive_folders():
-        raise RuntimeError("CRITICAL: Recursive violations prevent chunk execution")
-    if detect_c_temp_violations():
-        raise RuntimeError("CRITICAL: E:/temp/ violations prevent chunk execution")
+    """Run anti-recursion checks and surface offending paths."""
+
+    validate_no_recursive_folders()
+    offending = detect_c_temp_violations()
+    if offending:
+        raise RuntimeError(
+            f"CRITICAL: E:/temp/ violations prevent chunk execution: {offending}"
+        )
     return True
 
 
 def validate_workspace() -> bool:
     """Public entry point to trigger anti-recursion validation."""
+
     return chunk_anti_recursion_validation()
 
-def validate_no_recursive_folders() -> bool:
-    """Ensure workspace and backup directories do not recurse into each other.
+def validate_no_recursive_folders() -> None:
+    """Ensure workspace and backup directories are distinct and non-nesting.
 
-    The validator resolves symlinks and inspects both trees to catch cases
-    where one root is nested within the other or reachable through symlinks.
+    Walks both roots, resolving symlinks and comparing inodes so that no
+    subdirectory can link back to either root.
     """
 
     workspace = CrossPlatformPathManager.get_workspace_path().resolve()
     backup_root = CrossPlatformPathManager.get_backup_root().resolve()
+
+    if workspace == backup_root:
+        raise RuntimeError(f"Workspace and backup root are identical: {workspace}")
+    if workspace in backup_root.parents:
+        raise RuntimeError(
+            f"Backup root {backup_root} cannot reside within workspace {workspace}"
+        )
+    if backup_root in workspace.parents:
+        raise RuntimeError(
+            f"Workspace {workspace} cannot reside within backup root {backup_root}"
+        )
+
+    workspace_inode = workspace.stat().st_ino
+    backup_inode = backup_root.stat().st_ino
 
     def is_nested(child: Path, parent: Path) -> bool:
         try:
@@ -60,31 +78,34 @@ def validate_no_recursive_folders() -> bool:
         except ValueError:
             return False
 
-    if workspace == backup_root or is_nested(workspace, backup_root) or is_nested(backup_root, workspace):
-        return False
-
     for base, target in ((workspace, backup_root), (backup_root, workspace)):
         for root, dirs, _ in os.walk(base, followlinks=True):
             for d in dirs:
                 path = Path(root) / d
                 try:
                     resolved = path.resolve()
+                    inode = resolved.stat().st_ino
                 except OSError:
                     continue
-                if resolved == workspace or resolved == backup_root:
-                    return False
+                if inode in {workspace_inode, backup_inode} or resolved in {
+                    workspace,
+                    backup_root,
+                }:
+                    raise RuntimeError(f"Subdirectory {path} links back to {resolved}")
                 if is_nested(resolved, target):
-                    return False
-    return True
+                    raise RuntimeError(
+                        f"Subdirectory {path} nests within {target}: {resolved}"
+                    )
 
-def detect_c_temp_violations() -> bool:
+def detect_c_temp_violations() -> Optional[str]:
     forbidden = ["E:/temp/", "E:\\temp\\"]
     workspace = str(CrossPlatformPathManager.get_workspace_path())
     backup_root = str(CrossPlatformPathManager.get_backup_root())
-    for forbidden_path in forbidden:
-        if workspace.startswith(forbidden_path) or backup_root.startswith(forbidden_path):
-            return True
-    return False
+    for path in (workspace, backup_root):
+        for forbidden_path in forbidden:
+            if path.startswith(forbidden_path):
+                return path
+    return None
 
 
 

--- a/tests/test_anti_recursion.py
+++ b/tests/test_anti_recursion.py
@@ -1,10 +1,30 @@
 import importlib
+import importlib.util
 import os
 import sys
+import types
+from pathlib import Path
 
 import pytest
 
-from quantum.optimizers.quantum_optimizer import validate_workspace
+# Create minimal "quantum" package to satisfy absolute imports without loading heavy dependencies
+_quantum_pkg = types.ModuleType("quantum")
+sys.modules.setdefault("quantum", _quantum_pkg)
+_ibm_spec = importlib.util.spec_from_file_location(
+    "quantum.ibm_backend", Path(__file__).resolve().parents[1] / "quantum/ibm_backend.py"
+)
+_ibm = importlib.util.module_from_spec(_ibm_spec)
+_ibm_spec.loader.exec_module(_ibm)  # type: ignore[assignment]
+sys.modules["quantum.ibm_backend"] = _ibm
+_quantum_pkg.ibm_backend = _ibm
+
+_spec = importlib.util.spec_from_file_location(
+    "quantum.optimizers.quantum_optimizer",
+    Path(__file__).resolve().parents[1] / "quantum/optimizers/quantum_optimizer.py",
+)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)  # type: ignore[assignment]
+validate_workspace = _module.validate_workspace
 
 
 def _prepare_env(tmp_path, monkeypatch):
@@ -27,8 +47,9 @@ def test_validate_workspace_same_path(tmp_path, monkeypatch):
     ws.mkdir()
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(ws))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as exc:
         validate_workspace()
+    assert str(ws) in str(exc.value)
 
 
 def test_validate_workspace_nested(tmp_path, monkeypatch):
@@ -38,19 +59,45 @@ def test_validate_workspace_nested(tmp_path, monkeypatch):
     bk.mkdir()
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(ws))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(bk))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as exc:
         validate_workspace()
+    msg = str(exc.value)
+    assert str(ws) in msg and str(bk) in msg
 
 
 def test_validate_workspace_symlink(tmp_path, monkeypatch):
     ws, bk = _prepare_env(tmp_path, monkeypatch)
     (ws / "link").symlink_to(bk)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as exc:
         validate_workspace()
+    msg = str(exc.value)
+    assert "link" in msg and str(bk) in msg
+
+
+def test_validate_workspace_symlink_to_workspace(tmp_path, monkeypatch):
+    ws, bk = _prepare_env(tmp_path, monkeypatch)
+    loop = ws / "loop"
+    loop.symlink_to(ws)
+    with pytest.raises(RuntimeError) as exc:
+        validate_workspace()
+    msg = str(exc.value)
+    assert "loop" in msg and str(ws) in msg
+    loop.unlink()
+
+
+def test_validate_backup_symlink_to_workspace(tmp_path, monkeypatch):
+    ws, bk = _prepare_env(tmp_path, monkeypatch)
+    loop = bk / "loop"
+    loop.symlink_to(ws)
+    with pytest.raises(RuntimeError) as exc:
+        validate_workspace()
+    msg = str(exc.value)
+    assert str(loop) in msg and str(ws) in msg
+    loop.unlink()
 
 
 def test_import_no_filesystem(monkeypatch, tmp_path):
-    ws, bk = _prepare_env(tmp_path, monkeypatch)
+    _prepare_env(tmp_path, monkeypatch)
     called = False
 
     def fake_walk(*args, **kwargs):
@@ -59,6 +106,10 @@ def test_import_no_filesystem(monkeypatch, tmp_path):
         raise AssertionError("os.walk should not be called during import")
 
     monkeypatch.setattr(os, "walk", fake_walk)
-    sys.modules.pop("quantum.optimizers.quantum_optimizer", None)
-    importlib.import_module("quantum.optimizers.quantum_optimizer")
+    spec = importlib.util.spec_from_file_location(
+        "quantum_optimizer_import",
+        Path(__file__).resolve().parents[1] / "quantum/optimizers/quantum_optimizer.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[assignment]
     assert called is False


### PR DESCRIPTION
## Summary
- enforce explicit workspace/backup separation with inode-based recursion checks
- add tests for valid and invalid directory links
- document detailed error reporting in recursion policy

## Testing
- `ruff check tests/test_anti_recursion.py quantum/optimizers/quantum_optimizer.py quantum_optimizer.py`
- `pytest tests/test_anti_recursion.py`

------
https://chatgpt.com/codex/tasks/task_e_688d7df136988331b115e61f50b99e9a