### PR TITLE
feat: add compliance correction logging

### DIFF
--- a/docs/AUDITING_WORKFLOW.md
+++ b/docs/AUDITING_WORKFLOW.md
@@ -12,5 +12,11 @@ This project includes an automated placeholder audit to keep the codebase compli
    `compliance_score` based on remaining open placeholders. Run it to refresh the
    dashboard after each audit.
 
+The `DatabaseComplianceChecker` now corrects common issues automatically. Its
+`correct_file` routine removes placeholder markers (such as `TODO` or
+`PLACEHOLDER` comments), trims trailing whitespace, ensures files end with a
+newline, and records the outcome to `analytics.db`. If a file cannot be
+corrected, the failure and error message are logged for further review.
+
 These scripts follow the repository's dual‑copilot and database‑first protocols. Ensure
 that the virtual environment is active and tests pass before committing changes.

--- a/tests/db_tools/test_compliance_corrections.py
+++ b/tests/db_tools/test_compliance_corrections.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import tempfile
+from db_tools.operations.compliance import DatabaseComplianceChecker
+
+
+def test_correct_file_removes_placeholders_and_logs():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "databases").mkdir()
+        checker = DatabaseComplianceChecker(workspace_path=str(workspace))
+        file_path = workspace / "sample.py"
+        file_path.write_text("# TODO: fix me\nprint('hi')  \n", encoding="utf-8")
+
+        result = checker.apply_corrections([str(file_path)])
+        assert str(file_path) in result
+        content = file_path.read_text(encoding="utf-8")
+        assert "TODO" not in content
+        assert content.endswith("\n")
+
+        rows = checker.db_connection.execute_query("SELECT success, error_message FROM corrections")
+        assert rows and rows[0]["success"] == 1
+        assert "removed" in rows[0]["error_message"]
+
+
+def test_correct_file_failure_logged():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "databases").mkdir()
+        checker = DatabaseComplianceChecker(workspace_path=str(workspace))
+        missing_file = workspace / "missing.py"
+
+        result = checker.apply_corrections([str(missing_file)])
+        assert str(missing_file) not in result
+        rows = checker.db_connection.execute_query("SELECT success, error_message FROM corrections")
+        assert rows and rows[0]["success"] == 0
+        assert rows[0]["error_message"]


### PR DESCRIPTION
## Summary
- enhance `DatabaseComplianceChecker` to auto-fix common placeholders and formatting issues
- log compliance correction results to `analytics.db`
- document updated compliance workflow and add tests for corrections and failures

## Testing
- `ruff check db_tools/operations/compliance.py tests/db_tools/test_compliance_corrections.py`
- `pytest tests/db_tools/test_compliance_corrections.py`

------
https://chatgpt.com/codex/tasks/task_e_688d7df00eac8331bc8927d85ac98d91