### PR TITLE
feat: add IBM Quantum hardware configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. All core modules are implemented. Quantum functionality runs in simulation mode by default but supports real hardware when `qiskit-ibm-provider` is configured.
 
 > **Note**
-> Qiskit-based operations run in **simulation mode** unless hardware access is configured. Install `qiskit-ibm-provider` and set the optional `QISKIT_IBM_TOKEN` environment variable to use real IBM Quantum backends. When `IBM_BACKEND` is unset the system automatically selects an available backend. Use the `--hardware` flag in `quantum_integration_orchestrator.py` or `--use-hardware` in `quantum/cli/executor_cli.py` to enforce hardware execution.
+> Qiskit-based operations run in **simulation mode** unless hardware access is configured. Install `qiskit-ibm-provider` and supply an IBM Quantum token via the `QISKIT_IBM_TOKEN` environment variable or the `--token` flag. Select a backend with `IBM_BACKEND` or `--backend`. Use the `--hardware` flag in `quantum_integration_orchestrator.py` or `--use-hardware` in `quantum/cli/executor_cli.py` to enforce hardware execution.
 > **Phase 5 AI**
 > Advanced AI integration features are fully integrated. They default to simulation mode unless real hardware is configured.
 
@@ -1059,8 +1059,8 @@ Set these variables in your `.env` file or shell before running scripts:
 - `OPENAI_API_KEY` – enables optional OpenAI features.
 - `FLASK_SECRET_KEY` – Flask dashboard secret.
 - `FLASK_RUN_PORT` – dashboard port (default `5000`).
-- `QISKIT_IBM_TOKEN` – optional IBM Quantum token.
-- `IBM_BACKEND` – optional IBM Quantum backend name (default `ibmq_qasm_simulator`).
+- `QISKIT_IBM_TOKEN` – optional IBM Quantum token (or use `--token`).
+- `IBM_BACKEND` – optional IBM Quantum backend name (default `ibmq_qasm_simulator`, or use `--backend`).
 - `LOG_WEBSOCKET_ENABLED` – set to `1` to stream logs.
 - `CLW_MAX_LINE_LENGTH` – max line length for the `clw` wrapper (default `1550`).
 

--- a/docs/quantum/HARDWARE_SETUP.md
+++ b/docs/quantum/HARDWARE_SETUP.md
@@ -1,0 +1,17 @@
+# Quantum Hardware Configuration
+
+The quantum modules operate in simulation mode by default. To execute on IBM
+Quantum hardware:
+
+1. Install the optional `qiskit-ibm-provider` dependency.
+2. Supply your IBM Quantum API token using the `QISKIT_IBM_TOKEN` environment
+   variable or the `--token` flag of `quantum/cli/executor_cli.py`.
+3. Select a backend with the `IBM_BACKEND` environment variable or the
+   `--backend` CLI flag. When unspecified, the system auto-selects an available
+   backend.
+4. Pass `--use-hardware` to the CLI (or equivalent flags in other tools) to
+   request hardware execution.
+
+If hardware initialization fails for any reason, the executor transparently
+falls back to the local Qiskit simulator.
+

--- a/docs/quantum/INDEX.md
+++ b/docs/quantum/INDEX.md
@@ -37,6 +37,10 @@ This documentation suite provides comprehensive information about the quantum op
    - Step-by-step module creation
    - CLI integration instructions
    - Testing and validation checklist
+7. **[Hardware Setup](HARDWARE_SETUP.md)**
+   - Token and backend configuration
+   - Hardware execution flags
+   - Simulator fallback behavior
 
 ### Quick Start
 For immediate implementation, start with the Integration Guide and follow the deployment checklist.
@@ -51,7 +55,7 @@ For immediate implementation, start with the Integration Guide and follow the de
 -### Generated Information
 **Documentation Version**: 1.2
 **Generated**: 2025-07-10T10:28:01.243876
- **Total Documents**: 6
+ **Total Documents**: 7
  **Status**: Enterprise Review Ready
 
 ### Newly Added Algorithms (v1.1)

--- a/quantum/cli/executor_cli.py
+++ b/quantum/cli/executor_cli.py
@@ -7,14 +7,31 @@ from quantum.orchestration.executor import QuantumExecutor
 def main() -> None:
     parser = argparse.ArgumentParser(description="Quantum Executor CLI")
     parser.add_argument("--use-hardware", action="store_true", help="Use IBM Quantum hardware")
-    parser.add_argument("--backend", default=os.getenv("IBM_BACKEND", "ibmq_qasm_simulator"), help="Backend name")
+    parser.add_argument(
+        "--backend",
+        default=os.getenv("IBM_BACKEND", "ibmq_qasm_simulator"),
+        help="Backend name",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.getenv("QISKIT_IBM_TOKEN"),
+        help="IBM Quantum API token",
+    )
     args = parser.parse_args()
 
-    if args.use_hardware and not os.getenv("QISKIT_IBM_TOKEN"):
-        parser.error("--use-hardware requires QISKIT_IBM_TOKEN to be set")
+    if args.token:
+        os.environ["QISKIT_IBM_TOKEN"] = args.token
+    if args.backend:
+        os.environ["IBM_BACKEND"] = args.backend
 
-    executor = QuantumExecutor(use_hardware=args.use_hardware, backend_name=args.backend)
-    print(f"Backend: {getattr(executor.backend, 'name', 'none')}")
+    executor = QuantumExecutor(
+        use_hardware=args.use_hardware, backend_name=args.backend
+    )
+    if args.use_hardware and not executor.use_hardware:
+        print("Hardware backend requested but unavailable; using simulator")
+    print(
+        f"Backend: {getattr(executor.backend, 'name', 'none')} (hardware={executor.use_hardware})"
+    )
 
 
 if __name__ == "__main__":

--- a/quantum/ibm_backend.py
+++ b/quantum/ibm_backend.py
@@ -28,6 +28,8 @@ def _load_token_from_config() -> str | None:
 
 
 def init_ibm_backend(
+    token: str | None = None,
+    backend_name: str | None = None,
     token_env: str = "QISKIT_IBM_TOKEN",
     backend_env: str = "IBM_BACKEND",
 ) -> Tuple[Any, bool]:
@@ -35,10 +37,11 @@ def init_ibm_backend(
 
     Returns a tuple ``(backend, use_hardware)``. If hardware initialization
     fails or dependencies are missing, a simulator backend is returned with
-    ``use_hardware`` set to ``False``.
+    ``use_hardware`` set to ``False``. Optional ``token`` and ``backend_name``
+    parameters override environment variables for configuration.
     """
-    token = os.getenv(token_env) or _load_token_from_config()
-    backend_name = os.getenv(backend_env)
+    token = token or os.getenv(token_env) or _load_token_from_config()
+    backend_name = backend_name or os.getenv(backend_env)
 
     if IBMProvider is None or Aer is None:
         warnings.warn(

--- a/quantum/orchestration/executor.py
+++ b/quantum/orchestration/executor.py
@@ -49,7 +49,9 @@ class QuantumExecutor:
             self.logger.warning("IBM provider unavailable; using simulator")
             self.use_hardware = False
         if self.use_hardware:
-            backend, success = init_ibm_backend()
+            backend, success = init_ibm_backend(
+                token=env_token, backend_name=self.backend_name
+            )
             self.backend = backend
             self.use_hardware = success
         elif QISKIT_AVAILABLE:
@@ -62,7 +64,9 @@ class QuantumExecutor:
             if QISKIT_AVAILABLE:
                 return Aer.get_backend("qasm_simulator")
             return None
-        backend, success = init_ibm_backend()
+        backend, success = init_ibm_backend(
+            token=os.getenv("QISKIT_IBM_TOKEN"), backend_name=backend_name
+        )
         self.use_hardware = success
         if success:
             return backend

--- a/tests/quantum/test_executor_cli.py
+++ b/tests/quantum/test_executor_cli.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+from quantum.cli import executor_cli
+
+
+class DummyExecutor:
+    def __init__(self, use_hardware: bool, backend_name: str):
+        self.init_args = {"use_hardware": use_hardware, "backend_name": backend_name}
+        self.backend = type("B", (), {"name": backend_name})()
+        # Simulate hardware availability based on flag
+        self.use_hardware = use_hardware
+
+
+def test_cli_parses_token_and_backend(monkeypatch, capsys):
+    called = {}
+
+    def fake_executor(**kwargs):
+        called.update(kwargs)
+        return DummyExecutor(**kwargs)
+
+    monkeypatch.setattr(executor_cli, "QuantumExecutor", fake_executor)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", "--use-hardware", "--token", "TEST", "--backend", "ibm_test"],
+    )
+
+    executor_cli.main()
+    out = capsys.readouterr().out
+    assert "ibm_test" in out
+    assert called == {"use_hardware": True, "backend_name": "ibm_test"}
+    assert os.getenv("QISKIT_IBM_TOKEN") == "TEST"
+
+
+def test_cli_fallback_without_token(monkeypatch, capsys):
+    def fake_executor(**kwargs):
+        # Hardware request but mark unavailable
+        exec_ = DummyExecutor(**kwargs)
+        exec_.use_hardware = False
+        return exec_
+
+    monkeypatch.delenv("QISKIT_IBM_TOKEN", raising=False)
+    monkeypatch.setattr(executor_cli, "QuantumExecutor", fake_executor)
+    monkeypatch.setattr(sys, "argv", ["prog", "--use-hardware"])
+
+    executor_cli.main()
+    out = capsys.readouterr().out
+    assert "using simulator" in out
+    assert "hardware=False" in out

--- a/tests/quantum/test_executor_hardware.py
+++ b/tests/quantum/test_executor_hardware.py
@@ -41,14 +41,18 @@ class MockProvider:
 
 def test_missing_token_fallback(monkeypatch):
     monkeypatch.delenv("QISKIT_IBM_TOKEN", raising=False)
-    monkeypatch.setattr(qexec, "init_ibm_backend", lambda: (MockBackend(), False))
+    monkeypatch.setattr(
+        qexec, "init_ibm_backend", lambda *_, **__: (MockBackend(), False)
+    )
     exec_ = QuantumExecutor(use_hardware=True, backend_name="mock")
     assert exec_.use_hardware is False
 
 
 def test_hardware_execution(monkeypatch):
     backend = MockBackend()
-    monkeypatch.setattr(qexec, "init_ibm_backend", lambda: (backend, True))
+    monkeypatch.setattr(
+        qexec, "init_ibm_backend", lambda *_, **__: (backend, True)
+    )
     exec_ = QuantumExecutor(use_hardware=True, backend_name="mock")
     result = exec_.execute_algorithm("dummy_test")
     assert result["success"]


### PR DESCRIPTION
## Summary
- support token and backend flags in Quantum executor CLI
- enable token/backend overrides in IBM backend initialization and executor
- document and test hardware configuration with simulator fallback

## Testing
- `ruff check quantum/cli/executor_cli.py quantum/ibm_backend.py quantum/orchestration/executor.py tests/quantum/test_executor_cli.py tests/quantum/test_executor_hardware.py tests/quantum/test_ibm_backend_integration.py`
- `pytest tests/quantum/test_executor_cli.py tests/quantum/test_executor_hardware.py tests/quantum/test_backend_selection.py tests/quantum/test_backend_provider.py tests/quantum/test_provider_fallback.py tests/quantum/test_ibm_backend_integration.py tests/quantum/test_hardware_backend.py`


------
https://chatgpt.com/codex/tasks/task_e_688d8da62c808331b15b08f13aeccb2c