### PR TITLE
feat: persist lessons across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 > Advanced AI integration features are fully integrated. They default to simulation mode unless real hardware is configured.
 
 ### 🎯 **Recent Milestones**
-- **Lessons Learned Integration:** sessions automatically apply lessons from `learning_monitor.db`
+- **Lessons Learned Integration:** sessions persist and reuse lessons from `learning_monitor.db`
 - **Database-First Architecture:** `databases/production.db` used as primary reference
 - **DUAL COPILOT Pattern:** primary/secondary validation framework available
 - **Dual Copilot Enforcement:** automation scripts now trigger secondary

--- a/docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md
+++ b/docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md
@@ -201,6 +201,9 @@ TEXT_INDICATORS = {
 - Extended the validator to audit all modules in `scripts/` and
   `template_engine/` for `utils.lessons_learned_integrator` hooks, logging any
   missing integrations for review.
+- Session modules now persist lessons to `learning_monitor.db`, and the
+  validator audits `session_*` utilities to ensure lessons are applied across
+  runs.
 
 ---
 

--- a/scripts/validation/lessons_learned_integration_validator.py
+++ b/scripts/validation/lessons_learned_integration_validator.py
@@ -443,6 +443,18 @@ class LessonsLearnedIntegrationValidator:
                     continue
                 if "lessons_learned_integrator" not in content:
                     missing_modules.append(path.relative_to(self.workspace_path).as_posix())
+
+        session_files = [p for p in self.workspace_path.glob("session_*\.py")]
+        for path in session_files:
+            try:
+                content = path.read_text(encoding="utf-8")
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                self.logger.warning(
+                    f"{TEXT_INDICATORS['warning']} Could not read {path}: {exc}"
+                )
+                continue
+            if "lessons_learned_integrator" not in content:
+                missing_modules.append(path.relative_to(self.workspace_path).as_posix())
         if missing_modules:
             self.logger.warning(
                 f"{TEXT_INDICATORS['warning']} Missing lessons learned hooks: {len(missing_modules)} modules"

--- a/tests/test_lessons_persistence.py
+++ b/tests/test_lessons_persistence.py
@@ -1,0 +1,21 @@
+from session_management_consolidation_executor import EnterpriseUtility
+from utils.lessons_learned_integrator import load_lessons
+
+
+def test_lessons_persist_across_sessions(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    (workspace / "databases").mkdir(parents=True)
+    backup_root = tmp_path / "backups"
+    backup_root.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    util = EnterpriseUtility(workspace_path=workspace)
+    assert util.loaded_lessons == []
+    assert util.execute_utility() is True
+
+    lessons = load_lessons(util.learning_db)
+    assert any("Session utility" in lesson["description"] for lesson in lessons)
+
+    util2 = EnterpriseUtility(workspace_path=workspace)
+    assert util2.loaded_lessons


### PR DESCRIPTION
## Summary
- load and apply lessons from learning_monitor.db in session management
- audit session modules for lessons integration
- document and test lesson persistence across sessions

## Testing
- `ruff check session_management_consolidation_executor.py scripts/validation/lessons_learned_integration_validator.py tests/test_lessons_persistence.py`
- `pytest` *(fails: tests/quantum/test_hardware_backend.py::test_init_backend_success)*

------
https://chatgpt.com/codex/tasks/task_e_688d8d9f201c8331a54825a07ba5fe78