### PR TITLE
feat: add quantum data pipeline and advanced algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Correction History:** cleanup and fix events recorded in `analytics.db:correction_history`
 - **Analytics Migrations:** run `add_code_audit_log.sql`, `add_correction_history.sql`, `add_code_audit_history.sql`, `add_violation_logs.sql`, and `add_rollback_logs.sql` (use `sqlite3` manually if `analytics.db` shipped without the tables) or use the initializer. The `correction_history` table tracks file corrections with `user_id`, session ID, action, timestamp, and optional details. The new `code_audit_history` table records each audit entry along with the responsible user and timestamp.
 
-- **Quantum Utilities:** see [quantum/README.md](quantum/README.md) for optimizer and search helpers. `quantum_optimizer.run_quantum_routine` now exposes annealing, superposition search and entanglement correction. Routines use Qiskit simulators by default and accept `use_hardware=True` to attempt IBM Quantum execution.
+- **Quantum Utilities:** see [quantum/README.md](quantum/README.md) for optimizer and search helpers. New data pipelines combine Grover search, VQE and database joins with automatic fallback to simulation when hardware is unavailable.
 - **Phase 6 Quantum Demo:** `scripts/automation/quantum_integration_orchestrator.py` now supports
   advanced algorithms and quantum-enhanced database processing, using hardware
   backends when `QISKIT_IBM_TOKEN` is available.

--- a/documentation/ROADMAP.md
+++ b/documentation/ROADMAP.md
@@ -6,7 +6,7 @@ Milestones guide development toward advanced capabilities.
 - ML pattern recognition framework `[status: planned]`
 - Autonomous systems expansion `[status: planned]`
 - Compliance automation and stricter checks `[status: planned]`
-- Advanced quantum feature set `[status: planned]`
+ - Advanced quantum feature set `[status: in progress]`
 
 ## CI Reporting
 The CI workflow runs `ruff`, `pytest --cov`, and

--- a/quantum/README.md
+++ b/quantum/README.md
@@ -17,6 +17,12 @@ gh_COPILOT toolkit.
 - `quantum.quantum_database_search` – lightweight helpers for SQL, NoSQL and
   hybrid search. All queries are logged to `analytics.db` for compliance.
 
+## Data Pipelines
+- `quantum.quantum_data_pipeline.QuantumDataPipeline` – orchestrates database
+  joins and advanced algorithms (Grover search and VQE). Pipelines attempt to
+  use IBM Quantum hardware when available and otherwise fall back to the local
+  simulator.
+
 These modules default to simulation mode but can use real IBM Quantum hardware
 when `qiskit-ibm-provider` is installed and `QISKIT_IBM_TOKEN` is configured.
 Use the `--hardware` flag in `quantum_integration_orchestrator.py` to enable

--- a/quantum/__init__.py
+++ b/quantum/__init__.py
@@ -11,6 +11,7 @@ from .quantum_database_search import (
     quantum_search_sql,
     quantum_search_nosql,
     quantum_search_hybrid,
+    quantum_join_sql,
 )
 from .optimizers.quantum_optimizer import QuantumOptimizer
 from .hybrid_database_processor import QuantumDatabaseProcessor
@@ -24,6 +25,8 @@ from .algorithms.expansion import QuantumLibraryExpansion
 from .orchestration.registry import QuantumAlgorithmRegistry, get_global_registry
 from .orchestration.executor import QuantumExecutor
 from .quantum_integration_orchestrator import QuantumIntegrationOrchestrator
+from .quantum_data_pipeline import QuantumDataPipeline
+from .quantum_algorithm_library_expansion import advanced_grover_search, advanced_vqe
 
 import logging
 
@@ -44,4 +47,8 @@ __all__ = [
     "QuantumDatabaseProcessor",
     "NextGenerationAI",
     "QuantumOptimizer",
+    "QuantumDataPipeline",
+    "quantum_join_sql",
+    "advanced_grover_search",
+    "advanced_vqe",
 ]

--- a/quantum/quantum_data_pipeline.py
+++ b/quantum/quantum_data_pipeline.py
@@ -1,0 +1,50 @@
+"""Quantum-accelerated data pipeline utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+
+from .quantum_algorithm_library_expansion import advanced_grover_search, advanced_vqe
+from .quantum_database_search import DEFAULT_DB_PATH, quantum_join_sql
+
+
+class QuantumDataPipeline:
+    """Simple pipeline combining database joins and algorithm execution."""
+
+    def __init__(self, *, use_hardware: bool = False, backend_name: str | None = None) -> None:
+        self.use_hardware = use_hardware
+        self.backend_name = backend_name
+
+    def run(self, db_path: str | Path | None = None) -> Dict[str, Any]:
+        """Execute the pipeline against ``db_path`` and return results."""
+
+        db = Path(db_path) if db_path else DEFAULT_DB_PATH
+        join_results = quantum_join_sql(
+            "a",
+            "b",
+            "l.id = r.id",
+            db_path=db,
+            use_hardware=self.use_hardware,
+            backend_name=self.backend_name,
+        )
+        grover_result = advanced_grover_search(
+            target=1,
+            n_qubits=2,
+            use_hardware=self.use_hardware,
+            backend_name=self.backend_name,
+        )
+        hamiltonian = np.array([[1, 0], [0, -1]], dtype=float)
+        vqe_result = advanced_vqe(
+            hamiltonian,
+            steps=10,
+            use_hardware=self.use_hardware,
+            backend_name=self.backend_name,
+        )
+        return {"join": join_results, "grover": grover_result, "vqe": vqe_result}
+
+
+__all__ = ["QuantumDataPipeline"]
+

--- a/quantum/quantum_integration_orchestrator.py
+++ b/quantum/quantum_integration_orchestrator.py
@@ -13,6 +13,7 @@ from .orchestration.executor import QuantumExecutor
 from .orchestration.registry import get_global_registry
 from .hybrid_database_processor import QuantumDatabaseProcessor
 from .next_generation_ai import NextGenerationAI
+from .quantum_data_pipeline import QuantumDataPipeline
 
 
 class QuantumIntegrationOrchestrator:
@@ -76,6 +77,20 @@ class QuantumIntegrationOrchestrator:
     def execution_summary(self) -> Dict[str, Any]:
         """Return aggregated statistics from the executor."""
         return self.executor.get_execution_summary()
+
+    def run_data_pipeline(
+        self,
+        db_path: str | None = None,
+        *,
+        use_hardware: bool | None = None,
+    ) -> Dict[str, Any]:
+        """Execute the quantum-accelerated data pipeline."""
+
+        pipeline = QuantumDataPipeline(
+            use_hardware=use_hardware if use_hardware is not None else self.executor.use_hardware,
+            backend_name=self.executor.backend_name,
+        )
+        return pipeline.run(db_path=db_path)
 
 
 __all__ = ["QuantumIntegrationOrchestrator"]

--- a/tests/quantum/test_quantum_data_pipeline.py
+++ b/tests/quantum/test_quantum_data_pipeline.py
@@ -1,0 +1,50 @@
+import sqlite3
+
+import numpy as np
+import pytest
+
+from quantum import (
+    QuantumIntegrationOrchestrator,
+    advanced_grover_search,
+    advanced_vqe,
+    quantum_join_sql,
+)
+
+
+def _setup_db(path):
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE a(id INTEGER PRIMARY KEY, v INTEGER)")
+        conn.execute("CREATE TABLE b(id INTEGER PRIMARY KEY, v INTEGER)")
+        conn.executemany("INSERT INTO a(id, v) VALUES (?, ?)", [(1, 10), (2, 20)])
+        conn.executemany("INSERT INTO b(id, v) VALUES (?, ?)", [(1, 100), (3, 300)])
+        conn.commit()
+
+
+def test_advanced_grover_search_fallback():
+    assert advanced_grover_search(1, n_qubits=2) == 1
+    assert advanced_grover_search(1, n_qubits=2, use_hardware=True) == 1
+
+
+def test_advanced_vqe_fallback():
+    h = np.array([[1, 0], [0, -1]], dtype=float)
+    sim = advanced_vqe(h, steps=5)
+    hw = advanced_vqe(h, steps=5, use_hardware=True)
+    assert pytest.approx(sim["energy"], rel=1e-6) == hw["energy"]
+
+
+def test_quantum_join_sql(tmp_path):
+    db = tmp_path / "test.db"
+    _setup_db(db)
+    rows = quantum_join_sql("a", "b", "l.id = r.id", db_path=db)
+    assert rows == [{"id": 1, "left_v": 10, "right_v": 100}]
+
+
+def test_quantum_data_pipeline(tmp_path):
+    db = tmp_path / "pipeline.db"
+    _setup_db(db)
+    orchestrator = QuantumIntegrationOrchestrator(use_hardware=True)
+    result = orchestrator.run_data_pipeline(db_path=db)
+    assert result["join"] == [{"id": 1, "left_v": 10, "right_v": 100}]
+    assert result["grover"] == 1
+    assert "energy" in result["vqe"]
+


### PR DESCRIPTION
## Summary
- extend quantum algorithm library with hardware-aware Grover search and VQE routines
- add quantum SQL join helper and orchestrated data pipeline with graceful hardware fallback
- document new quantum capabilities and mark roadmap progress

## Testing
- `ruff check quantum tests/quantum/test_quantum_data_pipeline.py`
- `pytest tests/quantum/test_quantum_data_pipeline.py tests/quantum/test_quantum_integration_orchestrator.py tests/test_quantum_database_search.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688dc0f253688331a882916f4487ce0f