### PR TITLE
feat: persist and recall session lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ python -m scripts.analysis.lessons_learned_gap_analyzer --lesson "use temp dirs"
 
 Lessons are written to `learning_monitor.db` and automatically applied in future sessions.
 
+### End-to-End Lessons Flow
+1. `scripts/wlc_session_manager.py` loads prior lessons at startup and logs them for transparency.
+2. The same session persists new wrap-up lessons back into `learning_monitor.db`.
+3. `scripts/analysis/lessons_learned_gap_analyzer.py` records remediation actions as lessons, closing detected gaps for future runs.
+
 ### OpenAI Connector
 The repository provides `github_integration/openai_connector.py` for OpenAI API
 calls using the `OpenAIClient` helper in

--- a/docs/LESSONS_LEARNED_DATASET_INTEGRATION.md
+++ b/docs/LESSONS_LEARNED_DATASET_INTEGRATION.md
@@ -3,3 +3,5 @@
 The template generation pipeline now queries the curated `enhanced_lessons_learned` dataset before building templates. During `TemplateAutoGenerator` initialization, lessons are loaded from `databases/learning_monitor.db` and logged using the lessons integrator utilities. The lesson descriptions are combined with existing patterns and templates to guide synthesis.
 
 The validator at `scripts/validation/lessons_learned_integration_validator.py` includes a compliance check that ensures the dataset is present and non-empty, confirming that historical insights inform template generation.
+
+`scripts/wlc_session_manager.py` now loads these stored lessons at the start of each session and logs their application. After a wrap-up, new lessons are persisted back into the same database. In addition, `scripts/analysis/lessons_learned_gap_analyzer.py` writes remediation actions for any detected gaps, ensuring continuous improvement across runs.

--- a/scripts/analysis/lessons_learned_gap_analyzer.py
+++ b/scripts/analysis/lessons_learned_gap_analyzer.py
@@ -23,7 +23,7 @@ from template_engine.learning_templates import (
     get_lesson_templates,
     get_dataset_sources,
 )
-from utils.lessons_learned_integrator import store_lesson
+from utils.lessons_learned_integrator import persist_new_lessons, store_lesson
 
 
 # 🚨 CRITICAL: Anti-recursion workspace validation
@@ -308,6 +308,7 @@ class LessonsLearnedGapAnalyzer:
         # Update database and generate reports
         self._update_gap_analysis_database(analysis_result)
         self._generate_gap_analysis_reports(analysis_result)
+        self._auto_resolve_gaps(gaps_found)
 
         return analysis_result
 
@@ -710,6 +711,26 @@ class LessonsLearnedGapAnalyzer:
             json.dump(report_data, f, indent=2, ensure_ascii=False)
 
         self.logger.info(f"📊 Gap analysis report generated: {json_report_path}")
+
+    def _auto_resolve_gaps(self, gaps: List[LessonsLearnedGap]) -> None:
+        """Create remediation lessons for detected gaps and persist them."""
+
+        lessons = []
+        now = datetime.utcnow().isoformat()
+        for gap in gaps:
+            for action in gap.remediation_actions:
+                lessons.append(
+                    {
+                        "description": action,
+                        "source": f"gap:{gap.gap_id}",
+                        "timestamp": now,
+                        "validation_status": "pending",
+                        "tags": gap.category,
+                    }
+                )
+        if lessons:
+            persist_new_lessons(lessons)
+            self.logger.info("📝 Stored %d remediation lessons", len(lessons))
 
     def _check_timeout(self) -> None:
         """⏱️ Check for timeout conditions"""

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -39,7 +39,11 @@ from tqdm import tqdm
 from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.validation_utils import validate_enterprise_environment
-from utils.lessons_learned_integrator import store_lesson
+from utils.lessons_learned_integrator import (
+    apply_lessons,
+    persist_new_lessons,
+    retrieve_prior_lessons,
+)
 
 try:
     from scripts.orchestrators.unified_wrapup_orchestrator import (
@@ -172,6 +176,9 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
     setup_logging(verbose)
     logging.info("WLC session starting")
 
+    existing_lessons = retrieve_prior_lessons()
+    apply_lessons(logging.getLogger(__name__), existing_lessons)
+
     global UnifiedWrapUpOrchestrator
     if UnifiedWrapUpOrchestrator is None:
         from scripts.orchestrators.unified_wrapup_orchestrator import (
@@ -206,12 +213,16 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
             raise
 
         finalize_session_entry(conn, entry_id, compliance_score)
-        store_lesson(
-            description=f"WLC session completed with score {compliance_score:.2f}",
-            source="wlc_session_manager",
-            timestamp=datetime.now(UTC).isoformat(),
-            validation_status="validated",
-            tags="wlc",
+        persist_new_lessons(
+            [
+                {
+                    "description": f"WLC session completed with score {compliance_score:.2f}",
+                    "source": "wlc_session_manager",
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "validation_status": "validated",
+                    "tags": "wlc",
+                }
+            ]
         )
 
         if run_orchestrator:

--- a/tests/test_wlc_lesson_persistence.py
+++ b/tests/test_wlc_lesson_persistence.py
@@ -1,0 +1,50 @@
+"""Verify WLC sessions persist lessons and load them on subsequent runs."""
+
+from __future__ import annotations
+
+import logging
+
+
+class DummyOrchestrator:
+    """Minimal orchestrator stub returning a perfect score."""
+
+    def __init__(self, workspace_path: str) -> None:  # pragma: no cover - simple init
+        self.workspace_path = workspace_path
+
+    def execute_unified_wrapup(self):  # pragma: no cover - simple return
+        class Result:
+            compliance_score = 100
+
+        return Result()
+
+
+def test_lessons_persist_and_load(tmp_path, monkeypatch, caplog):
+    workspace = tmp_path / "workspace"
+    backup = tmp_path / "backup"
+    workspace.mkdir()
+    backup.mkdir()
+    (workspace / "databases").mkdir()
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup))
+    monkeypatch.delenv("TEST_MODE", raising=False)
+
+    from scripts import wlc_session_manager
+    monkeypatch.setattr(
+        wlc_session_manager, "UnifiedWrapUpOrchestrator", DummyOrchestrator
+    )
+    from scripts.wlc_session_manager import run_session
+    from utils.lessons_learned_integrator import load_lessons
+
+    prod_db = workspace / "databases" / "production.db"
+    lessons_db = workspace / "databases" / "learning_monitor.db"
+
+    caplog.set_level(logging.INFO, logger="scripts.wlc_session_manager")
+
+    run_session(steps=0, db_path=prod_db, verbose=False)
+    lessons = load_lessons(lessons_db)
+    assert lessons, "first run persisted a lesson"
+
+    caplog.clear()
+    run_session(steps=0, db_path=prod_db, verbose=False)
+    assert any("Lesson applied" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- load and apply prior session lessons at startup and persist new wrap-ups
- gap analyzer records remediation actions back into learning_monitor.db
- document and test end-to-end lesson lifecycle

## Testing
- `ruff check utils/lessons_learned_integrator.py scripts/wlc_session_manager.py scripts/analysis/lessons_learned_gap_analyzer.py tests/test_wlc_lesson_persistence.py`
- `pytest tests/test_lessons_learned_integrator.py tests/test_wlc_lesson_persistence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ddea7e0dc8331989f007fbe08463e