### PR TITLE
feat: add optional setup flags and migration automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,15 @@ cp .env.example .env
 # 2. Set the external backup directory and run the setup script
 export GH_COPILOT_BACKUP_ROOT=/path/to/external/backups
 bash setup.sh            # installs core dependencies
-# Or include test and optional extras
-GH_COPILOT_BACKUP_ROOT=/path/to/external/backups bash setup.sh --with-optional
+# Include extras as needed
+GH_COPILOT_BACKUP_ROOT=/path/to/external/backups bash setup.sh --with-test
+GH_COPILOT_BACKUP_ROOT=/path/to/external/backups bash setup.sh --with-a
+GH_COPILOT_BACKUP_ROOT=/path/to/external/backups bash setup.sh --with-quantum
+# Use `--with-all` to install all optional groups at once.
 # Always run this script before executing tests or automation tasks.
-# The script installs `requirements.txt` by default and, when `--with-optional`
-# is supplied, also installs `requirements-a.txt`, `requirements-test.txt`, and
-# `requirements-quantum.txt` when present. Database migrations are triggered
-# automatically if any `.db` files exist.
+# The script installs `requirements.txt` by default. Optional flags install
+# their corresponding requirements files when present. Database migrations run
+# automatically without manual intervention.
 # If package installation fails due to network restrictions,
 # update the environment to permit outbound connections to PyPI.
 
@@ -141,18 +143,8 @@ credentials.
 python scripts/database/unified_database_initializer.py
 
 # Add analytics tables (setup runs migrations automatically when databases exist)
+# Migrations are applied automatically during `setup.sh`
 python scripts/database/add_code_audit_log.py
-# If `analytics.db` is missing required tables, run the SQL migrations manually
-sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
-sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
-sqlite3 databases/analytics.db < databases/migrations/add_code_audit_history.sql
-sqlite3 databases/analytics.db < databases/migrations/add_violation_logs.sql
-sqlite3 databases/analytics.db < databases/migrations/add_rollback_logs.sql
-sqlite3 databases/analytics.db < databases/migrations/create_todo_fixme_tracking.sql
-sqlite3 databases/analytics.db < databases/migrations/extend_todo_fixme_tracking.sql
-# Verify creation
-sqlite3 databases/analytics.db ".schema code_audit_log"
-sqlite3 databases/analytics.db ".schema code_audit_history"
 python scripts/database/size_compliance_checker.py
 
 # 3b. Synchronize databases
@@ -468,21 +460,8 @@ The previously referenced `optimization_metrics.db` is deprecated and no longer
 included in the repository.
 
 ### Analytics Database Test Protocol
-You must never create or modify the `analytics.db` file automatically. Use the commands below for manual migrations.
-To create or migrate the file manually, run:
-
-```bash
-sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
-sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
-sqlite3 databases/analytics.db < databases/migrations/add_code_audit_history.sql
-sqlite3 databases/analytics.db < databases/migrations/add_violation_logs.sql
-sqlite3 databases/analytics.db < databases/migrations/add_rollback_logs.sql
-sqlite3 databases/analytics.db < databases/migrations/create_todo_fixme_tracking.sql
-sqlite3 databases/analytics.db < databases/migrations/extend_todo_fixme_tracking.sql
-```
-
-Automated tests perform these migrations in-memory with progress bars and DUAL
-COPILOT validation, leaving the on-disk database untouched.
+The setup script now applies all SQL migrations automatically. Manual
+invocations of `sqlite3` are no longer required for routine development.
 
 ### **Database-First Workflow**
 1. **Connect Safely:** Use `get_validated_production_db_connection()` from

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
-"""Bootstrap environment and ensure test requirements are installed."""
+"""Bootstrap environment and optional test requirements."""
 
 from __future__ import annotations
 
+import argparse
+import logging
 import shutil
 import sqlite3
 import subprocess
 import sys
 from pathlib import Path
 from typing import Iterable
-import logging
 
 from . import run_migrations
 
@@ -86,10 +87,19 @@ def verify_migrations() -> None:
     print("Migrations verified")
 
 
-def main() -> None:
-    """Bootstrap environment and install test requirements."""
+def main(argv: list[str] | None = None) -> None:
+    """Bootstrap environment and optionally install test requirements."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--install-tests",
+        action="store_true",
+        help="install requirements-test.txt",
+    )
+    args = parser.parse_args(argv)
+
     ensure_env()
-    install_test_requirements()
+    if args.install_tests:
+        install_test_requirements()
     verify_migrations()
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-WITH_OPTIONAL=0
+WITH_A=0
+WITH_TEST=0
+WITH_QUANTUM=0
 for arg in "$@"; do
     case "$arg" in
-        --with-optional) WITH_OPTIONAL=1 ;;
-        *) echo "Usage: $0 [--with-optional]" >&2; exit 1 ;;
+        --with-a) WITH_A=1 ;;
+        --with-test) WITH_TEST=1 ;;
+        --with-quantum) WITH_QUANTUM=1 ;;
+        --with-optional|--with-all)
+            WITH_A=1
+            WITH_TEST=1
+            WITH_QUANTUM=1
+            ;;
+        *)
+            echo "Usage: $0 [--with-a] [--with-test] [--with-quantum] [--with-all]" >&2
+            exit 1
+            ;;
     esac
 done
 
@@ -21,21 +33,25 @@ pip install --upgrade pip >/tmp/setup_install.log
 
 pip install -r "$WORKSPACE/requirements.txt" >>/tmp/setup_install.log
 
-if [ "$WITH_OPTIONAL" -eq 1 ]; then
-    for req in "$WORKSPACE/requirements-a.txt" \
-               "$WORKSPACE/requirements-test.txt" \
-               "$WORKSPACE/requirements-quantum.txt"; do
-        if [ -f "$req" ]; then
-            pip install -r "$req" >>/tmp/setup_install.log
-        fi
-    done
+if [ "$WITH_A" -eq 1 ] && [ -f "$WORKSPACE/requirements-a.txt" ]; then
+    pip install -r "$WORKSPACE/requirements-a.txt" >>/tmp/setup_install.log
 fi
 
-python -m scripts.setup_environment >>/tmp/setup_install.log
-
-if find "$WORKSPACE/databases" -maxdepth 1 -name '*.db' | grep -q .; then
-    python scripts/run_migrations.py >>/tmp/setup_install.log
+if [ "$WITH_TEST" -eq 1 ] && [ -f "$WORKSPACE/requirements-test.txt" ]; then
+    pip install -r "$WORKSPACE/requirements-test.txt" >>/tmp/setup_install.log
 fi
+
+if [ "$WITH_QUANTUM" -eq 1 ] && [ -f "$WORKSPACE/requirements-quantum.txt" ]; then
+    pip install -r "$WORKSPACE/requirements-quantum.txt" >>/tmp/setup_install.log
+fi
+
+if [ "$WITH_TEST" -eq 1 ]; then
+    python -m scripts.setup_environment --install-tests >>/tmp/setup_install.log
+else
+    python -m scripts.setup_environment >>/tmp/setup_install.log
+fi
+
+python scripts/run_migrations.py >>/tmp/setup_install.log
 
 # install clw line wrapper if missing
 if [ ! -x /usr/local/bin/clw ]; then

--- a/tests/test_setup_smoke.py
+++ b/tests/test_setup_smoke.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_setup_sh_installs_optional_and_runs_migrations(tmp_path):
+    """Smoke test for setup.sh optional flag and migrations."""
+    env = os.environ.copy()
+    env["GH_COPILOT_BACKUP_ROOT"] = str(tmp_path / "backups")
+
+    log_file = Path("logs/migrations.log")
+    before = log_file.stat().st_mtime if log_file.exists() else 0.0
+
+    subprocess.run(["bash", "setup.sh", "--with-test"], check=True, env=env)
+
+    assert log_file.exists() and log_file.stat().st_mtime >= before


### PR DESCRIPTION
## Summary
- allow fine-grained optional dependency installation in `setup.sh`
- run database migrations automatically during setup
- document new setup flags and automated migrations; remove manual SQL steps
- add smoke test verifying setup script and migrations when optional flag is used

## Testing
- `ruff check scripts/setup_environment.py tests/test_setup_smoke.py`
- `pytest tests/test_setup_smoke.py`
- `pytest` *(fails: ImportError: No module named 'unified_legacy_cleanup_system' in tests/test_legacy_cleanup_system.py)*

------
https://chatgpt.com/codex/tasks/task_e_688ddeb1ceb88331b68a904c1b712715