### PR TITLE
feat: enhance IBM hardware setup and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,20 @@ python scripts/automation/quantum_integration_orchestrator.py --hardware --backe
 
 Set `QISKIT_IBM_TOKEN` to your IBM Quantum API token for hardware execution. If the provider cannot be initialized the orchestrator automatically falls back to simulation.
 
+Persist your token and verify connectivity with the helper script:
+
+```bash
+python -m quantum.cli.token_setup --token YOUR_TOKEN --save --use-hardware
+```
+
+Run a simple circuit on hardware to confirm access:
+
+```bash
+python scripts/quantum/run_hardware_demo.py --hardware --backend ibm_oslo
+```
+
+If hardware is requested but misconfigured these commands raise a clear error instead of silently falling back to the simulator.
+
 ### Run Template Matcher
 ```bash
 echo "def foo(): pass" | python scripts/template_matcher.py

--- a/quantum/README.md
+++ b/quantum/README.md
@@ -46,12 +46,16 @@ To run on real IBM Quantum hardware you need an access token from
 
 ```
 export QISKIT_IBM_TOKEN="YOUR_API_TOKEN"
-# or
-python -m quantum.cli.token_setup --token YOUR_API_TOKEN --use-hardware
+# or persist the token and verify hardware access
+python -m quantum.cli.token_setup --token YOUR_API_TOKEN --save --use-hardware
 ```
 
-If the token or requested backend is unavailable the modules automatically
-fall back to local simulation, preserving existing behavior.
+Run ``scripts/quantum/run_hardware_demo.py --hardware`` to execute a simple
+quantum circuit. If the provider or token is misconfigured the utilities raise a
+``RuntimeError`` instead of silently falling back to simulation.
+
+If a hardware backend is unavailable the modules automatically fall back to
+local simulation.
 
 ## Algorithms
 

--- a/scripts/quantum/run_hardware_demo.py
+++ b/scripts/quantum/run_hardware_demo.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python3
 """Run a simple circuit on IBM Quantum hardware if available."""
 
+import argparse
+
 from qiskit import QuantumCircuit
 
 from quantum.ibm_backend import init_ibm_backend
 
 
 def main() -> None:
-    backend, use_hardware = init_ibm_backend()
+    parser = argparse.ArgumentParser(description="Run a demo circuit")
+    parser.add_argument("--hardware", action="store_true", help="Require hardware backend")
+    parser.add_argument("--backend", help="Specific backend name to use")
+    args = parser.parse_args()
+
+    backend, use_hardware = init_ibm_backend(
+        backend_name=args.backend,
+        enforce_hardware=args.hardware,
+    )
     qc = QuantumCircuit(1, 1)
     qc.h(0)
     qc.measure(0, 0)

--- a/tests/quantum/test_hardware_backend.py
+++ b/tests/quantum/test_hardware_backend.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from quantum.ibm_backend import init_ibm_backend
 
 
@@ -33,3 +35,15 @@ def test_init_backend_no_token(monkeypatch):
     result, use_hw = init_ibm_backend()
     assert result is simulator
     assert use_hw is False
+
+
+def test_enforce_hardware_without_token(monkeypatch):
+    monkeypatch.delenv("QISKIT_IBM_TOKEN", raising=False)
+    def _stub_get_backend_simulator(name):
+        return object()
+
+    monkeypatch.setattr(
+        "quantum.ibm_backend.Aer", MagicMock(get_backend=_stub_get_backend_simulator)
+    )
+    with pytest.raises(RuntimeError):
+        init_ibm_backend(enforce_hardware=True)

--- a/tests/quantum/test_ibm_backend_integration.py
+++ b/tests/quantum/test_ibm_backend_integration.py
@@ -1,7 +1,10 @@
+import os
 import pytest
 
 import importlib.util
 from pathlib import Path
+
+os.environ["QISKIT_IBM_TOKEN"] = "TOKEN"
 
 
 def _load_ibm_backend():
@@ -17,7 +20,6 @@ def _load_ibm_backend():
 @pytest.mark.hardware
 def test_backend_initializes_with_real_provider(monkeypatch):
     """Verify provider initialization with token using a mock provider."""
-    monkeypatch.setenv("QISKIT_IBM_TOKEN", "TOKEN")
     monkeypatch.delenv("IBM_BACKEND", raising=False)
     ibm_backend = _load_ibm_backend()
 
@@ -35,6 +37,6 @@ def test_backend_initializes_with_real_provider(monkeypatch):
 
     monkeypatch.setattr(ibm_backend, "IBMProvider", DummyProvider)
     monkeypatch.setattr(ibm_backend, "Aer", DummyAer)
-    backend, use_hw = ibm_backend.init_ibm_backend()
+    backend, use_hw = ibm_backend.init_ibm_backend(enforce_hardware=True)
     assert backend == "backend"
     assert use_hw is True

--- a/tests/quantum/test_token_setup.py
+++ b/tests/quantum/test_token_setup.py
@@ -1,0 +1,25 @@
+import sys
+
+import json
+
+from quantum.cli import token_setup
+
+
+def test_token_setup_writes_config(tmp_path, monkeypatch):
+    cfg = tmp_path / "qiskit.json"
+    monkeypatch.setattr(token_setup, "CONFIG_PATH", cfg)
+
+    captured = {}
+
+    def fake_init_ibm_backend(token=None, backend_name=None, enforce_hardware=False):
+        captured["token"] = token
+        return object(), True
+
+    monkeypatch.setattr(token_setup, "init_ibm_backend", fake_init_ibm_backend)
+    monkeypatch.setenv("IBM_BACKEND", "ibmq_qasm_simulator")
+    monkeypatch.setattr(sys, "argv", ["token_setup", "--token", "ABC", "--save", "--use-hardware"])
+    token_setup.main()
+
+    assert json.loads(cfg.read_text())["QISKIT_IBM_TOKEN"] == "ABC"
+    assert cfg.stat().st_mode & 0o777 == 0o600
+    assert captured["token"] == "ABC"


### PR DESCRIPTION
## Summary
- raise clear errors when IBM hardware is requested but credentials or provider are missing
- add token setup utility to store `QISKIT_IBM_TOKEN` and validate connectivity
- document IBM Quantum setup, and include hardware demo and tests

## Testing
- `ruff check quantum/ibm_backend.py quantum/cli/token_setup.py scripts/quantum/run_hardware_demo.py tests/quantum/test_hardware_backend.py tests/quantum/test_ibm_backend_integration.py tests/quantum/test_token_setup.py`
- `pytest tests/quantum/test_ibm_backend_integration.py tests/quantum/test_hardware_backend.py tests/quantum/test_token_setup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ddeb62df08331a7aa7d0cae481069