### PR TITLE
feat: add secondary validation for quantum modules

### DIFF
--- a/quantum/integration/secure_channel.py
+++ b/quantum/integration/secure_channel.py
@@ -1,15 +1,23 @@
 """Integration utilities for quantum-encrypted communication."""
 
 from quantum.algorithms import QuantumEncryptedCommunication
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 
 class QuantumSecureChannel:
     """High-level interface for quantum-encrypted message exchange."""
 
-    def __init__(self, key: str | None = None):
+    def __init__(
+        self,
+        key: str | None = None,
+        validator: SecondaryCopilotValidator | None = None,
+    ):
         self.engine = QuantumEncryptedCommunication(key)
+        self.validator = validator or SecondaryCopilotValidator()
 
     def transmit(self, payload: str) -> str:
         """Encrypt and immediately decrypt the payload to simulate a secure channel."""
         encrypted = self.engine.encrypt_message(payload)
-        return self.engine.decrypt_message(encrypted)
+        decrypted = self.engine.decrypt_message(encrypted)
+        self.validator.validate_corrections([decrypted])
+        return decrypted

--- a/tests/test_quantum_compliance_engine.py
+++ b/tests/test_quantum_compliance_engine.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import sys
+from importlib import util
+from types import ModuleType, SimpleNamespace
+
+# Stub minimal sklearn dependency to avoid heavy install
+sklearn = ModuleType("sklearn")
+feature_extraction = ModuleType("sklearn.feature_extraction")
+text = ModuleType("sklearn.feature_extraction.text")
+
+
+class DummyVectorizer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def fit_transform(self, texts):
+        return SimpleNamespace(toarray=lambda: [[0.0]])
+
+    def get_feature_names_out(self):
+        return ["dummy"]
+
+
+text.TfidfVectorizer = DummyVectorizer
+feature_extraction.text = text
+sklearn.feature_extraction = feature_extraction
+sys.modules["sklearn"] = sklearn
+sys.modules["sklearn.feature_extraction"] = feature_extraction
+sys.modules["sklearn.feature_extraction.text"] = text
+
+quantum_pkg = ModuleType("quantum")
+quantum_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "quantum")]
+sys.modules["quantum"] = quantum_pkg
+
+utils_pkg = ModuleType("quantum.utils")
+backend_provider = ModuleType("quantum.utils.backend_provider")
+
+
+def get_backend(*args, **kwargs):
+    return None
+
+
+backend_provider.get_backend = get_backend
+utils_pkg.backend_provider = backend_provider
+sys.modules["quantum.utils"] = utils_pkg
+sys.modules["quantum.utils.backend_provider"] = backend_provider
+
+spec = util.spec_from_file_location(
+    "quantum.quantum_compliance_engine",
+    Path(__file__).resolve().parents[1] / "quantum" / "quantum_compliance_engine.py",
+)
+qce = util.module_from_spec(spec)
+sys.modules[spec.name] = qce
+spec.loader.exec_module(qce)
+
+
+def test_secondary_validator_invoked(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("quantum compliance")
+
+    called = {"files": None}
+
+    def dummy_validate(self, files):
+        called["files"] = files
+        return True
+
+    monkeypatch.setattr(
+        qce.SecondaryCopilotValidator,
+        "validate_corrections",
+        dummy_validate,
+    )
+
+    monkeypatch.setattr(qce, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(qce, "validate_environment_root", lambda: None)
+
+    engine = qce.QuantumComplianceEngine(tmp_path)
+    score = engine.score(target, ["quantum"])
+
+    assert called["files"] == [f"{score:.4f}"]

--- a/tests/test_secure_channel.py
+++ b/tests/test_secure_channel.py
@@ -1,0 +1,53 @@
+import sys
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+
+quantum_pkg = ModuleType("quantum")
+quantum_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "quantum")]
+sys.modules["quantum"] = quantum_pkg
+
+algorithms_pkg = ModuleType("quantum.algorithms")
+
+
+class DummyQEC:
+    def __init__(self, key=None):
+        self.key = key or "k"
+
+    def encrypt_message(self, payload: str) -> str:
+        return payload[::-1]
+
+    def decrypt_message(self, encrypted: str) -> str:
+        return encrypted[::-1]
+
+
+algorithms_pkg.QuantumEncryptedCommunication = DummyQEC
+sys.modules["quantum.algorithms"] = algorithms_pkg
+
+spec = util.spec_from_file_location(
+    "quantum.integration.secure_channel",
+    Path(__file__).resolve().parents[1] / "quantum" / "integration" / "secure_channel.py",
+)
+qs = util.module_from_spec(spec)
+sys.modules[spec.name] = qs
+spec.loader.exec_module(qs)
+
+
+def test_transmit_uses_secondary_validator(monkeypatch) -> None:
+    called = {"files": None}
+
+    def dummy_validate(self, files):
+        called["files"] = files
+        return True
+
+    monkeypatch.setattr(
+        qs.SecondaryCopilotValidator,
+        "validate_corrections",
+        dummy_validate,
+    )
+
+    channel = qs.QuantumSecureChannel()
+    result = channel.transmit("hello")
+
+    assert result == "hello"
+    assert called["files"] == ["hello"]


### PR DESCRIPTION
## Summary
- integrate `SecondaryCopilotValidator` into `QuantumComplianceEngine` for score verification
- add validator check to `QuantumSecureChannel` decrypted payload
- test dual validation in compliance engine and secure channel

## Testing
- `ruff check quantum/quantum_compliance_engine.py quantum/integration/secure_channel.py tests/test_quantum_compliance_engine.py tests/test_secure_channel.py`
- `pytest tests/test_quantum_compliance_engine.py tests/test_secure_channel.py`


------
https://chatgpt.com/codex/tasks/task_e_688ea1fc7db883319dca712c5238f540