### PR TITLE
fix: migrate log directories to artifacts

### DIFF
--- a/archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py
+++ b/archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 from template_engine.auto_generator import TemplateAutoGenerator, calculate_etc
 from utils.log_utils import DEFAULT_ANALYTICS_DB, _log_event
 
-RENDER_LOG_DIR = Path("logs/template_rendering")
+RENDER_LOG_DIR = Path("artifacts/logs/template_rendering")
 LOG_FILE = RENDER_LOG_DIR / "documentation_render.log"
 ANALYTICS_DB = DEFAULT_ANALYTICS_DB
 

--- a/deployment/deployment_package_20250710_183234/scripts/enterprise_database_driven_documentation_manager.py
+++ b/deployment/deployment_package_20250710_183234/scripts/enterprise_database_driven_documentation_manager.py
@@ -14,7 +14,6 @@ import logging
 import sys
 from datetime import datetime
 from pathlib import Path
-from tqdm import tqdm
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {
@@ -25,7 +24,7 @@ TEXT_INDICATORS = {
     'info': '[INFO]'
 }
 
-RENDER_LOG_DIR = Path("logs") / "template_rendering"
+RENDER_LOG_DIR = Path("artifacts/logs") / "template_rendering"
 
 
 class EnterpriseDatabaseProcessor:

--- a/quantum/quantum_compliance_engine.py
+++ b/quantum/quantum_compliance_engine.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 import logging
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Optional
 
 from tqdm import tqdm
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -26,7 +26,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from .utils.backend_provider import get_backend
 
 try:
-    from qiskit import QuantumCircuit, execute, Aer  # type: ignore
+    from qiskit import QuantumCircuit, execute  # type: ignore
 
     QISKIT_AVAILABLE = True
 except ImportError:
@@ -34,7 +34,7 @@ except ImportError:
 
 # Enterprise logging setup
 WORKSPACE_ROOT = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
-LOGS_DIR = WORKSPACE_ROOT / "logs" / "quantum_compliance"
+LOGS_DIR = WORKSPACE_ROOT / "artifacts" / "logs" / "quantum_compliance"
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"quantum_compliance_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 

--- a/scripts/analysis/file_movement_assessment_report.py
+++ b/scripts/analysis/file_movement_assessment_report.py
@@ -13,8 +13,8 @@ from tqdm import tqdm
 import logging
 
 # Configure logging to route to logs folder
-logs_folder = Path("logs")
-logs_folder.mkdir(exist_ok=True)
+logs_folder = Path("artifacts/logs")
+logs_folder.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(
     filename=logs_folder / f"file_assessment_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log",
     level=logging.INFO,
@@ -37,7 +37,7 @@ class FileMovementAssessment:
 
         # Define correct folder structure
         self.target_folders = {
-            "logs": self.workspace_root / "logs",
+            "logs": self.workspace_root / "artifacts" / "logs",
             "reports": self.workspace_root / "reports",
             "results": self.workspace_root / "results",
             "documentation": self.workspace_root / "documentation",

--- a/scripts/analysis/systematic_flake8_error_analysis_corrector.py
+++ b/scripts/analysis/systematic_flake8_error_analysis_corrector.py
@@ -31,8 +31,8 @@ from tqdm import tqdm
 import subprocess
 
 # Configure logging
-LOG_DIR = Path("logs")
-LOG_DIR.mkdir(exist_ok=True)
+LOG_DIR = Path("artifacts/logs")
+LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",

--- a/scripts/enterprise_deployment_orchestrator.py
+++ b/scripts/enterprise_deployment_orchestrator.py
@@ -140,14 +140,14 @@ class EnterpriseDeploymentOrchestrator:
         self.session_id = f"DEPLOY_{self.start_time.strftime('%Y%m%d_%H%M%S')}"
 
         # Setup enterprise logging
-        log_dir = Path("logs")
-        log_dir.mkdir(exist_ok=True)
+        log_dir = Path("artifacts/logs")
+        log_dir.mkdir(parents=True, exist_ok=True)
 
         logging.basicConfig(
             level=logging.INFO,
             format="%(asctime)s - %(levelname)s - %(message)s",
             handlers=[
-                logging.FileHandler(f"logs/enterprise_deployment_{self.session_id}.log"),
+                logging.FileHandler(f"artifacts/logs/enterprise_deployment_{self.session_id}.log"),
                 logging.StreamHandler(),
             ],
         )

--- a/scripts/maintenance/quarantine_zero_byte_logs.py
+++ b/scripts/maintenance/quarantine_zero_byte_logs.py
@@ -14,7 +14,7 @@ import logging
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     quarantine_dir = Path("_ZERO_BYTE_QUARANTINE")
-    moved = quarantine_zero_byte_files(Path("logs"), quarantine_dir)
+    moved = quarantine_zero_byte_files(Path("artifacts/logs"), quarantine_dir)
     logging.info("Moved %s zero-byte log file(s) to %s", moved, quarantine_dir)
 
 

--- a/scripts/utilities/configuration_path_updater.py
+++ b/scripts/utilities/configuration_path_updater.py
@@ -15,8 +15,8 @@ from tqdm import tqdm
 import logging
 
 # Configure logging to route to logs folder
-logs_folder = Path("logs")
-logs_folder.mkdir(exist_ok=True)
+logs_folder = Path("artifacts/logs")
+logs_folder.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(
     filename=logs_folder / f"config_path_updates_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log",
     level=logging.INFO,

--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -81,7 +81,7 @@ except ImportError:  # pragma: no cover - optional dependency
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
 DEFAULT_COMPLETION_DB = Path("databases/template_completion.db")
 
-LOGS_DIR = Path("logs/template_rendering")
+LOGS_DIR = Path("artifacts/logs/template_rendering")
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"auto_generator_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 

--- a/template_engine/db_first_code_generator.py
+++ b/template_engine/db_first_code_generator.py
@@ -57,7 +57,7 @@ except ImportError:  # pragma: no cover - optional dependency
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
 DEFAULT_COMPLETION_DB = Path("databases/template_completion.db")
 
-LOGS_DIR = Path("logs/template_rendering")
+LOGS_DIR = Path("artifacts/logs/template_rendering")
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"auto_generator_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 

--- a/template_engine/objective_similarity_scorer.py
+++ b/template_engine/objective_similarity_scorer.py
@@ -28,7 +28,7 @@ from quantum_algorithm_library_expansion import quantum_text_score
 
 DEFAULT_PRODUCTION_DB = Path("databases/production.db")
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
-LOGS_DIR = Path("logs/template_rendering")
+LOGS_DIR = Path("artifacts/logs/template_rendering")
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"objective_similarity_scorer_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 

--- a/template_engine/pattern_mining_engine.py
+++ b/template_engine/pattern_mining_engine.py
@@ -32,7 +32,7 @@ from utils.log_utils import _log_event
 
 DEFAULT_PRODUCTION_DB = Path("databases/production.db")
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
-LOGS_DIR = Path("logs/template_rendering")
+LOGS_DIR = Path("artifacts/logs/template_rendering")
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"pattern_mining_engine_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 

--- a/template_engine/template_placeholder_remover.py
+++ b/template_engine/template_placeholder_remover.py
@@ -26,7 +26,7 @@ import shutil
 
 DEFAULT_PRODUCTION_DB = Path("databases/production.db")
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
-LOGS_DIR = Path("logs/template_rendering")
+LOGS_DIR = Path("artifacts/logs/template_rendering")
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"template_placeholder_remover_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 

--- a/validation/compliance_report_generator.py
+++ b/validation/compliance_report_generator.py
@@ -14,7 +14,7 @@ from typing import Dict, Any
 from tqdm import tqdm
 
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
-LOGS_DIR = Path("logs/template_rendering")
+LOGS_DIR = Path("artifacts/logs/template_rendering")
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOGS_DIR / f"compliance_report_generator_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -32,7 +32,7 @@ COMPLIANCE_DIR = Path(os.getenv("COMPLIANCE_DIR", workspace_root / "dashboard" /
 TEMPLATES = Path(__file__).resolve().parents[2] / "templates"
 app = Flask(__name__, template_folder=str(TEMPLATES))
 app.secret_key = get_secret("FLASK_SECRET_KEY", "dev_key")
-LOG_FILE = Path("logs/dashboard") / "dashboard.log"
+LOG_FILE = Path("artifacts/logs/dashboard") / "dashboard.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler(LOG_FILE), logging.StreamHandler()])
 


### PR DESCRIPTION
## Summary
- redirect quantum compliance engine logs to `artifacts/logs/quantum_compliance`
- move compliance report generator and related modules to `artifacts/logs`
- migrate remaining scripts and template engines from `logs/` to `artifacts/logs/`

## Testing
- `ruff check quantum/quantum_compliance_engine.py validation/compliance_report_generator.py web_gui/scripts/flask_apps/enterprise_dashboard.py template_engine/pattern_mining_engine.py template_engine/objective_similarity_scorer.py template_engine/auto_generator.py template_engine/db_first_code_generator.py template_engine/template_placeholder_remover.py scripts/enterprise_deployment_orchestrator.py scripts/maintenance/quarantine_zero_byte_logs.py scripts/utilities/configuration_path_updater.py scripts/analysis/systematic_flake8_error_analysis_corrector.py scripts/analysis/file_movement_assessment_report.py deployment/deployment_package_20250710_183234/scripts/enterprise_database_driven_documentation_manager.py archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_688ea1f7392883318c57270688da0e20