### PR TITLE
fix: default to cwd when workspace env missing

### DIFF
--- a/tests/test_compliance_report_generator.py
+++ b/tests/test_compliance_report_generator.py
@@ -1,10 +1,16 @@
 from pathlib import Path
 import json
 import sqlite3
-from validation.compliance_report_generator import generate_compliance_report
+import pytest
+
+from validation.compliance_report_generator import (
+    generate_compliance_report,
+    validate_no_recursive_folders,
+)
 
 
-def test_generate_compliance_report(tmp_path: Path) -> None:
+def test_generate_compliance_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     ruff_file = tmp_path / "ruff.txt"
     ruff_file.write_text("file.py:1:1 F401 unused\n", encoding="utf-8")
     pytest_file = tmp_path / "pytest.json"
@@ -18,3 +24,11 @@ def test_generate_compliance_report(tmp_path: Path) -> None:
         cur = conn.execute("SELECT COUNT(*) FROM code_quality_metrics")
         assert cur.fetchone()[0] == 1
     assert summary["ruff"]["issues"] == 1
+
+
+def test_validate_no_recursive_folders_uses_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("GH_COPILOT_WORKSPACE", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "my_backup").mkdir()
+    with pytest.raises(RuntimeError):
+        validate_no_recursive_folders()

--- a/validation/compliance_report_generator.py
+++ b/validation/compliance_report_generator.py
@@ -26,7 +26,7 @@ logging.basicConfig(
 
 
 def validate_no_recursive_folders() -> None:
-    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", "e:/gh_COPILOT"))
+    workspace_root = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
     forbidden_patterns = ["*backup*", "*_backup_*", "backups", "*temp*"]
     for pattern in forbidden_patterns:
         for folder in workspace_root.rglob(pattern):


### PR DESCRIPTION
## Summary
- fall back to current directory when `GH_COPILOT_WORKSPACE` is undefined
- test that recursive-folder validation uses `Path.cwd()` if no workspace env is set

## Testing
- `ruff check validation/compliance_report_generator.py tests/test_compliance_report_generator.py`
- `pytest tests/test_compliance_report_generator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ea1f7326883318633cb388f0615cc