### PR TITLE
docs: clarify testing baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 **Status:** Active development with incremental improvements
 
-> Tests: run `pytest` (currently one failing quantum test).
-> Lint: run `ruff check .` (one redefinition warning).
+> Tests: run `pytest` before committing.
+> Lint: run `ruff check .` before committing.
 > Quantum modules operate in placeholder simulation modes; compliance auditing is still in progress.
 
 ---


### PR DESCRIPTION
## Summary
- clarify README status lines with generic instructions for running tests and lints before commits

## Testing
- `ruff check .` *(fails: unused imports, syntax errors in misc modules)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_688ea1f9cc0483318601ae3b0c7c2590