### PR TITLE
test: add QuantumSecureChannel round-trip tests

### DIFF
--- a/tests/quantum/test_secure_channel.py
+++ b/tests/quantum/test_secure_channel.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytest.importorskip("qiskit")
+pytest.importorskip("numpy")
+
+from quantum.integration import QuantumSecureChannel
+
+
+def test_round_trip_default_key():
+    channel = QuantumSecureChannel()
+    message = "hello quantum"
+    assert channel.transmit(message) == message
+
+
+def test_round_trip_custom_key():
+    channel = QuantumSecureChannel(key="custom")
+    message = "secret message"
+    assert channel.transmit(message) == message
+
+
+def test_round_trip_empty_payload():
+    channel = QuantumSecureChannel()
+    assert channel.transmit("") == ""


### PR DESCRIPTION
## Summary
- add tests validating QuantumSecureChannel message round trips including custom key and empty payload cases

## Testing
- `ruff check tests/quantum/test_secure_channel.py`
- `pytest tests/quantum/test_secure_channel.py -q` *(skipped: could not import 'qiskit')*

------
https://chatgpt.com/codex/tasks/task_e_688ea1fd20a08331a41c9f3dd7adc022