### PR TITLE
fix: decouple quantum compliance logging setup

### DIFF
--- a/tests/quantum/test_quantum_compliance_engine_logging.py
+++ b/tests/quantum/test_quantum_compliance_engine_logging.py
@@ -1,0 +1,22 @@
+import importlib
+import logging
+import sys
+
+
+def test_import_has_no_logging_side_effect(tmp_path):
+    """Importing the module should not alter existing logging handlers or level."""
+    root_logger = logging.getLogger()
+    handler = logging.FileHandler(tmp_path / "test.log")
+    root_logger.addHandler(handler)
+    original_handlers = root_logger.handlers.copy()
+    original_level = root_logger.level
+
+    module_name = "quantum.quantum_compliance_engine"
+    sys.modules.pop(module_name, None)
+    importlib.import_module(module_name)
+
+    assert root_logger.handlers == original_handlers
+    assert root_logger.level == original_level
+
+    root_logger.removeHandler(handler)
+    handler.close()


### PR DESCRIPTION
## Summary
- refactor quantum compliance engine to avoid configuring global logging at import
- add dedicated `setup_logging` and use module-level logger
- test that importing module leaves existing logging config untouched

## Testing
- `ruff check quantum/quantum_compliance_engine.py tests/quantum/test_quantum_compliance_engine_logging.py`
- `pytest tests/quantum/test_quantum_compliance_engine_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_688ec62092f88331ac02056ad73eb557