### PR TITLE
feat: implement qaoa and vqe algorithms

### DIFF
--- a/tests/test_quantum_optimizer.py
+++ b/tests/test_quantum_optimizer.py
@@ -34,3 +34,27 @@ def test_set_backend_hardware(monkeypatch):
     opt.set_backend(None, use_hardware=True)
     assert opt.use_hardware is True
     assert opt.backend is backend
+
+
+def test_qaoa_runs_with_progress():
+    pytest.importorskip("qiskit_algorithms")
+    def obj(x):
+        return float(np.sum(x))
+
+    optimizer = QuantumOptimizer(obj, [(0, 1)], method="qaoa")
+    summary = optimizer.run(n_qubits=1, reps=1, max_iter=2)
+    events = [e["event"] for e in summary["history"]]
+    assert "qaoa_complete" in events
+    assert any(e == "qaoa_progress" for e in events)
+
+
+def test_vqe_runs_with_progress():
+    pytest.importorskip("qiskit_algorithms")
+    def obj(x):
+        return float(np.sum(x))
+
+    optimizer = QuantumOptimizer(obj, [(0, 1)], method="vqe")
+    summary = optimizer.run(n_qubits=1, reps=1, max_iter=2)
+    events = [e["event"] for e in summary["history"]]
+    assert "vqe_complete" in events
+    assert any(e == "vqe_progress" for e in events)


### PR DESCRIPTION
## Summary
- replace QAOA and VQE stubs with Qiskit algorithm implementations
- log progress and implement backend fallback
- add tests for QAOA and VQE routines

## Testing
- `ruff check quantum/optimizers/quantum_optimizer.py tests/test_quantum_optimizer.py`
- `pytest tests/test_quantum_optimizer.py`


------
https://chatgpt.com/codex/tasks/task_e_688ec61e74f88331ab8f93b2b8ef7264