### PR TITLE
feat: enforce external backup root in disaster recovery

### DIFF
--- a/docs/PHASE5_TASKS_STARTED.md
+++ b/docs/PHASE5_TASKS_STARTED.md
@@ -64,7 +64,7 @@ These task stubs originate from the gap analysis report and have been formally s
 
 ## 16. Implement Backup Validation Checks
 - **Statement Excerpt:** "Integrity Checks: Implement zero‑byte detection, wrap‑up validation and anti‑recursion safeguards" applied to backup paths.
-- **Status:** Started – external backup validation and path enforcement scripted.
+- **Status:** Implemented – disaster recovery now enforces external backup roots and aborts when misconfigured.
 
 ## 17. Implement Anti-Recursion Guards
 - **Statement Excerpt:** "Integrity Checks: Implement zero‑byte detection, wrap‑up validation and anti‑recursion safeguards."

--- a/documentation/BACKUP_COMPLIANCE_GUIDE.md
+++ b/documentation/BACKUP_COMPLIANCE_GUIDE.md
@@ -17,7 +17,7 @@ export GH_COPILOT_BACKUP_ROOT="/external/backup/location"
 - Unix/Linux: /temp/gh_COPILOT_Backups
 
 Validation
-The system automatically validates that backup locations are external to the workspace and will raise errors if internal backup attempts are detected.
+The system automatically validates that backup locations are external to the workspace and will raise errors if internal backup attempts are detected. The `UnifiedDisasterRecoverySystem` refuses to run when `GH_COPILOT_BACKUP_ROOT` points inside the workspace.
 
 Usage
 ```python

--- a/scripts/utilities/unified_disaster_recovery_system.py
+++ b/scripts/utilities/unified_disaster_recovery_system.py
@@ -30,7 +30,18 @@ class UnifiedDisasterRecoverySystem:
     def perform_recovery(self) -> bool:
         """Restore files from ``GH_COPILOT_BACKUP_ROOT``."""
         start_time = datetime.now()
-        backup_root = Path(os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups"))
+        backup_root = Path(os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups")).resolve()
+        workspace = self.workspace_path.resolve()
+
+        if workspace in backup_root.parents or backup_root == workspace:
+            self.logger.error(
+                "%s Backup root %s resides within workspace %s",
+                TEXT_INDICATORS["error"],
+                backup_root,
+                workspace,
+            )
+            return False
+
         source = backup_root / "production_backup"
         restore_dir = self.workspace_path / "restored"
         restore_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_disaster_recovery_backup_validation.py
+++ b/tests/test_disaster_recovery_backup_validation.py
@@ -1,0 +1,14 @@
+from unified_disaster_recovery_system import UnifiedDisasterRecoverySystem
+
+
+def test_recovery_rejects_internal_backup(tmp_path, monkeypatch, caplog):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    internal_backup = workspace / "backup"
+    internal_backup.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(internal_backup))
+    system = UnifiedDisasterRecoverySystem(str(workspace))
+    with caplog.at_level("ERROR"):
+        assert not system.perform_recovery()
+        assert "resides within workspace" in caplog.text

--- a/tmp/test_artifacts.zip
+++ b/tmp/test_artifacts.zip
@@ -1,3 +1,2 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1aecd5a2256def2f57b3b67be0fb7cd43383e7b40d9f5c95763db59edda67d66
-size 1108941
+oid sha256:d6818adcf67b631d9b7b99b5141ee2ab313ea4fe9e19734b51468c051283589e
+size 504


### PR DESCRIPTION
## Summary
- ensure UnifiedDisasterRecoverySystem aborts if GH_COPILOT_BACKUP_ROOT is inside the workspace
- document external-backup requirement and mark backup validation task as implemented
- add tests covering misconfigured backup paths

## Testing
- `ruff check scripts/utilities/unified_disaster_recovery_system.py tests/test_disaster_recovery_backup_validation.py`
- `pytest tests/test_disaster_recovery_backup_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688eca7e4ad48331919d496098b0677d