### PR TITLE
feat: add quantum placeholder modules

### DIFF
--- a/docs/QUANTUM_PLACEHOLDERS.md
+++ b/docs/QUANTUM_PLACEHOLDERS.md
@@ -1,0 +1,20 @@
+# Quantum Placeholder Modules
+
+The `scripts/quantum_placeholders` package provides importable stubs for
+future quantum integrations. They reference the planned features outlined
+in the [technical whitepaper](COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md)
+around line 587 and later. These modules are **not** used in production
+but exist to reserve package structure for upcoming development.
+
+## Status
+- Modules return inputs unchanged and do not perform quantum operations.
+- Maintainers can expand these stubs with real algorithms when hardware
+  integration becomes available.
+
+## Roadmap
+1. Implement quantum optimization engine hooks.
+2. Integrate hardware or simulator backends.
+3. Expose results to analytics dashboards.
+
+This document tracks the placeholder status and will be updated as the
+quantum roadmap progresses.

--- a/scripts/quantum_placeholders/__init__.py
+++ b/scripts/quantum_placeholders/__init__.py
@@ -1,0 +1,8 @@
+"""Placeholder modules for future quantum features.
+
+These modules are stubs referencing planned quantum capabilities
+outlined in the whitepaper. They are excluded from production paths
+and serve only as importable placeholders for future work.
+"""
+
+__all__ = ["quantum_placeholder_algorithm"]

--- a/scripts/quantum_placeholders/quantum_placeholder_algorithm.py
+++ b/scripts/quantum_placeholders/quantum_placeholder_algorithm.py
@@ -1,0 +1,23 @@
+"""Quantum placeholder module.
+
+This file references the roadmap described in
+`docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md` line 587+
+where full quantum optimization engines are planned.
+
+TODO: Implement real quantum algorithm integration as detailed in the whitepaper.
+"""
+
+from __future__ import annotations
+
+
+def simulate_quantum_process(data: list[int]) -> list[int]:
+    """Return data unchanged as a placeholder simulation.
+
+    Args:
+        data: Sample integer list.
+
+    Returns:
+        The same list, representing a simulated quantum pass.
+    """
+
+    return data

--- a/tests/test_quantum_placeholders_import.py
+++ b/tests/test_quantum_placeholders_import.py
@@ -1,0 +1,8 @@
+"""Tests for quantum placeholder modules."""
+
+from scripts.quantum_placeholders import quantum_placeholder_algorithm
+
+
+def test_simulate_quantum_process_round_trip():
+    data = [1, 2, 3]
+    assert quantum_placeholder_algorithm.simulate_quantum_process(data) == data


### PR DESCRIPTION
## Summary
- add `scripts/quantum_placeholders` package with basic stub and helper
- document roadmap for future quantum integrations
- cover placeholder module with unit test

## Testing
- `ruff check scripts/quantum_placeholders tests/test_quantum_placeholders_import.py`
- `pytest tests/test_quantum_placeholders_import.py`


------
https://chatgpt.com/codex/tasks/task_e_688eca7e4ad48331919d496098b0677d