### PR TITLE
feat: add task stubs overview

### DIFF
--- a/docs/task_stubs.md
+++ b/docs/task_stubs.md
@@ -1,0 +1,29 @@
+# Task Stubs Overview
+
+The project tracks twenty upcoming efforts. Each entry
+summarizes design intent, planned development, testing,
+documentation, and planning notes. These stubs are
+lightweight references for future implementation.
+
+| Task | Design | Development | Testing | Documentation | Planning |
+| --- | --- | --- | --- | --- | --- |
+| UnifiedDisasterRecoverySystem | Autonomous backups and restore workflow | Backup scheduler, restore executor, compliance logger | Unit tests for backup creation and restore integrity | Usage guides for DR system | Establish baseline DR capabilities |
+| FlaskDashboard | Flask app powered by analytics.db | Templates for compliance trends and rollback logs | Manual QA for layout and data updates | README updates covering web UI setup | Provide initial dashboard |
+| DatabaseSynchronizationEngine | Real time sync across databases | Conflict resolution and logging | Integration tests for data consistency | Failure modes and recovery steps | Keep datasets in sync |
+| MonitoringOptimization | ML enhanced monitoring with quantum hooks | Link metrics to session lifecycle | Validate metric calculations and alerts | Monitoring guidelines and metrics reference | Expand observability |
+| SessionManagementEnhancements | Zero byte detection and anti recursion | Lifecycle enforcement logging states | Unit tests for validation rules | Revised session protocol docs | Strengthen session integrity |
+| ScriptGenerationCleanup | Template intelligence via clustering | Pattern library and legacy asset cleanup | Tests for pattern matching and cleanup | Template generation and cleanup guides | Improve script generator |
+| DocumentationAlignment | Audit whitepaper, README, guides | Regenerate metrics using docs scripts | Validator confirms accuracy | Changelog and guides current | Ensure docs match implementation |
+| TestingComplianceChecks | Full pytest suite and compliance scoring | Placeholder audit integration | Run audits and verify rollback paths | Testing procedures documented | Maintain high coverage |
+| TimelineRiskMitigationPlan | Week by week rollout | Structured module milestones | Review integration points weekly | Planning artifacts for stakeholders | Reduce delivery risk |
+| SuccessCriteriaRiskMitigation | Quantitative and qualitative goals | Stakeholder signoff workflows | Coverage enforcement and latency checks | Risk controls and mitigation notes | Define success metrics |
+| CorrectionLoggingDashboardIntegration | Structured logs on dashboard | Invoke CorrectionLoggerRollback in critical ops | Validate log entries and rollbacks | Compliance and rollback flow docs | Unify correction logging |
+| PlaceholderAuditComplianceScripts | Audit results stored in analytics.db | Dual copilot orchestrator runs audits | Verify audit outputs | Audit procedure guide | Track placeholders and compliance |
+| ChangelogUserPrompts | Update changelog and prompts | Align prompts with session management rules | Secondary copilot validation | Updated user guides | Communicate new capabilities |
+| EnterprisePilotPreparation | Integrate modules with dual copilot | Deploy to staging and collect feedback | Run full tests and fix failures | Pilot results documented | Prepare for enterprise rollout |
+| GovernanceStandards | docs/GOVERNANCE_STANDARDS.md | Reference standards in README/contributing | CI checks for governance | Governance standards document | Establish organizational rules |
+| ContinuousMonitoringSetup | Metrics pushed to analytics.db | Alerts for threshold breaches | Validate monitoring endpoints | Monitoring endpoints explained | Enable live insight |
+| BackupValidationChecks | Verify external backup root | Tests for backup path logic | Ensure no backups inside workspace | Environment setup docs | Prevent recursive backups |
+| AntiRecursionGuards | Decorator tracking active sessions | Apply to risk modules | Recursion prevention tests | Developer guide usage | Avoid nested execution |
+| DualCopilotValidationStandardization | Audit scripts for secondary validation | Orchestrator coordinates modules | Verify orchestrator triggers | Dual copilot flow documented | Standardize validation pattern |
+| QuantumPlaceholderFeatures | Placeholder modules under scripts/quantum_placeholders | Exclude from production path | Importability tests | Quantum roadmap and placeholder status | Clarify future quantum features |

--- a/enterprise_modules/__init__.py
+++ b/enterprise_modules/__init__.py
@@ -4,8 +4,9 @@ Modular architecture utilities extracted from strategic implementation
 
 Available modules:
 - utility_utils: Common utility functions (19 scripts, 285 lines saved)
-- file_utils: File operation utilities (4 scripts, 90 lines saved) 
+- file_utils: File operation utilities (4 scripts, 90 lines saved)
 - database_utils: Database operation utilities (4 scripts, 60 lines saved)
+- task_stubs: Planning placeholders for upcoming enterprise features
 
 Total Impact: 435 lines saved across 27 scripts
 """

--- a/enterprise_modules/task_stubs.py
+++ b/enterprise_modules/task_stubs.py
@@ -1,0 +1,188 @@
+"""Task stubs for upcoming enterprise modules.
+
+Each `TaskStub` records high level design, development,
+testing, documentation, and planning notes for features
+that are slated for future implementation.  The stubs
+serve as placeholders so downstream systems can reference
+emerging work without requiring full functionality yet.
+"""
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class TaskStub:
+    """Simple container describing a planned task."""
+
+    name: str
+    design: str
+    development: str
+    testing: str
+    documentation: str
+    planning: str
+
+
+TASK_STUBS: List[TaskStub] = [
+    TaskStub(
+        name="UnifiedDisasterRecoverySystem",
+        design="Autonomous backups, restore workflow, and compliance logging",
+        development="Backup scheduler, restore executor, compliance logger hooked into production.db",
+        testing="Unit tests for backup creation, restore integrity, and error handling",
+        documentation="Usage guides for the disaster recovery system",
+        planning="Establish baseline DR capabilities",
+    ),
+    TaskStub(
+        name="FlaskDashboard",
+        design="Flask app scaffolding powered by analytics.db",
+        development="Templates showing compliance trends and rollback logs with admin endpoints",
+        testing="Manual QA for layout and data updates",
+        documentation="README updates covering web UI setup",
+        planning="Provide initial dashboard for operators",
+    ),
+    TaskStub(
+        name="DatabaseSynchronizationEngine",
+        design="Real time synchronization across production.db and analytics.db",
+        development="Conflict resolution and logging for >25 databases",
+        testing="Integration tests ensuring data consistency",
+        documentation="Failure modes and recovery steps",
+        planning="Keep enterprise datasets in sync",
+    ),
+    TaskStub(
+        name="MonitoringOptimization",
+        design="ML enhanced monitoring with placeholder quantum hooks",
+        development="Link metrics to session lifecycle",
+        testing="Validate metric calculations and alert triggers",
+        documentation="Monitoring guidelines and metrics reference",
+        planning="Expand observability across systems",
+    ),
+    TaskStub(
+        name="SessionManagementEnhancements",
+        design="Zero byte detection and anti recursion safeguards",
+        development="Lifecycle enforcement logging start/end states",
+        testing="Unit tests for new validation rules",
+        documentation="Revised session protocol documentation",
+        planning="Strengthen session integrity",
+    ),
+    TaskStub(
+        name="ScriptGenerationCleanup",
+        design="Template intelligence via clustering and automated cleanup",
+        development="Pattern library and legacy asset removal",
+        testing="Cover pattern matching and cleanup routines",
+        documentation="Template generation and cleanup guides",
+        planning="Improve script generator quality",
+    ),
+    TaskStub(
+        name="DocumentationAlignment",
+        design="Audit pass over whitepaper, README, and guides",
+        development="Regenerate metrics using docs scripts",
+        testing="Validator confirms documentation accuracy",
+        documentation="Changelog and guides kept current",
+        planning="Ensure docs reflect implementation",
+    ),
+    TaskStub(
+        name="TestingComplianceChecks",
+        design="Full pytest suite and compliance score tracking",
+        development="Placeholder audit integration",
+        testing="Run audits and ensure CorrectionLoggerRollback paths meet targets",
+        documentation="Testing procedures for new modules",
+        planning="Maintain high test coverage",
+    ),
+    TaskStub(
+        name="TimelineRiskMitigationPlan",
+        design="Week by week rollout from design to pilot",
+        development="Structured milestones for modules",
+        testing="Integration points reviewed each week",
+        documentation="Planning artifacts for stakeholders",
+        planning="Reduce delivery risk",
+    ),
+    TaskStub(
+        name="SuccessCriteriaRiskMitigation",
+        design="Quantitative goals for coverage, compliance, and latency",
+        development="Qualitative goals and stakeholder signoff",
+        testing="Coverage enforcement and dashboard latency checks",
+        documentation="Risk controls and mitigation notes",
+        planning="Define success metrics",
+    ),
+    TaskStub(
+        name="CorrectionLoggingDashboardIntegration",
+        design="Structured logs surfaced on dashboard",
+        development="CorrectionLoggerRollback invoked by critical ops",
+        testing="Log entries and rollback behavior validated",
+        documentation="Compliance and rollback flow",
+        planning="Unify correction logging",
+    ),
+    TaskStub(
+        name="PlaceholderAuditComplianceScripts",
+        design="Audit script storing results in analytics.db",
+        development="Dual copilot orchestrator runs audits post session",
+        testing="Verify audit outputs",
+        documentation="Audit procedure guide",
+        planning="Track placeholder counts and compliance trends",
+    ),
+    TaskStub(
+        name="ChangelogUserPrompts",
+        design="Append changelog entries and revise user prompts",
+        development="Consistency with session management rules",
+        testing="Prompts validated by secondary copilot",
+        documentation="Updated user guides",
+        planning="Communicate new capabilities",
+    ),
+    TaskStub(
+        name="EnterprisePilotPreparation",
+        design="Integrate modules and dual copilot workflows",
+        development="Deploy to staging and collect feedback",
+        testing="Run full tests and fix failures",
+        documentation="Pilot results and module adjustments",
+        planning="Prepare for enterprise rollout",
+    ),
+    TaskStub(
+        name="GovernanceStandards",
+        design="Create docs/GOVERNANCE_STANDARDS.md",
+        development="Reference standards in README and contributing",
+        testing="CI checks verifying governance requirements",
+        documentation="Governance standards document",
+        planning="Establish organizational rules",
+    ),
+    TaskStub(
+        name="ContinuousMonitoringSetup",
+        design="Metrics pushed to analytics.db with dashboard widgets",
+        development="Alerts for threshold breaches",
+        testing="Monitoring endpoint validation",
+        documentation="Monitoring endpoints explained",
+        planning="Enable live operational insight",
+    ),
+    TaskStub(
+        name="BackupValidationChecks",
+        design="DR system verifies external backup root",
+        development="Tests validating backup path logic",
+        testing="Ensure backups do not run inside workspace",
+        documentation="Environment setup emphasizing external backups",
+        planning="Prevent recursive backups",
+    ),
+    TaskStub(
+        name="AntiRecursionGuards",
+        design="Decorator tracking active sessions via lock files",
+        development="Apply to risk modules",
+        testing="Recursion prevention tests",
+        documentation="Developer guide usage",
+        planning="Avoid nested session execution",
+    ),
+    TaskStub(
+        name="DualCopilotValidationStandardization",
+        design="Audit scripts for secondary validation coverage",
+        development="Orchestrator coordinates new modules",
+        testing="Verify orchestrator triggers",
+        documentation="Dual copilot flow",
+        planning="Standardize validation pattern",
+    ),
+    TaskStub(
+        name="QuantumPlaceholderFeatures",
+        design="Placeholder modules under scripts/quantum_placeholders/",
+        development="Ensure excluded from production path",
+        testing="Importability tests",
+        documentation="Quantum roadmap and placeholder status",
+        planning="Clarify future quantum features",
+    ),
+]
+
+__all__ = ["TaskStub", "TASK_STUBS"]

--- a/tests/test_task_stubs.py
+++ b/tests/test_task_stubs.py
@@ -1,0 +1,15 @@
+from enterprise_modules.task_stubs import TASK_STUBS
+
+
+def test_task_stub_count():
+    assert len(TASK_STUBS) == 20
+
+
+def test_task_stub_fields():
+    for stub in TASK_STUBS:
+        assert stub.name
+        assert stub.design
+        assert stub.development
+        assert stub.testing
+        assert stub.documentation
+        assert stub.planning


### PR DESCRIPTION
## Summary
- add TaskStub dataclass and enumerate 20 upcoming tasks
- document task stubs for design, development, testing, docs, and planning
- include unit test validating stub coverage

## Testing
- `ruff check enterprise_modules/task_stubs.py enterprise_modules/__init__.py tests/test_task_stubs.py`
- `pytest tests/test_task_stubs.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_688eca7e4ad48331919d496098b0677d