### PR TITLE
feat: implement algorithms for quantum stubs

### DIFF
--- a/tests/test_quantum_algorithm_library_expansion.py
+++ b/tests/test_quantum_algorithm_library_expansion.py
@@ -10,7 +10,10 @@ from quantum_algorithm_library_expansion import (
     demo_quantum_phase_estimation,
     demo_quantum_teleportation,
     quantum_cluster_representatives,
+    quantum_cluster_stub,
     quantum_similarity_score,
+    quantum_score_stub,
+    quantum_pattern_match_stub,
     QISKIT_AVAILABLE,
 )
 
@@ -60,9 +63,20 @@ def test_quantum_cluster_representatives():
     assert len(reps) == 2
 
 
+def test_quantum_cluster_stub():
+    labels = quantum_cluster_stub([0.0, 0.1, 0.9, 1.0])
+    assert len(labels) == 4
+    assert set(labels) == {0, 1}
+
+
 def test_quantum_similarity_score():
     score = quantum_similarity_score([1, 0], [0.5, 0.5])
     assert 0.0 <= score <= 1.0
+
+
+def test_quantum_score_stub():
+    score = quantum_score_stub([3, 4])
+    assert pytest.approx(score, rel=1e-5) == 2.5
 
 
 def test_quantum_text_score_fallback(monkeypatch):
@@ -96,3 +110,8 @@ def test_quantum_text_score_backend(monkeypatch):
     score = qalexp.quantum_text_score("abc", use_hardware=True)
     assert 0.0 <= score <= 1.0
     assert ("text_score", "qiskit") in events
+
+
+def test_quantum_pattern_match_stub():
+    assert quantum_pattern_match_stub([1, 2], [0, 1, 2, 3]) is True
+    assert quantum_pattern_match_stub([2, 1], [0, 1, 2, 3]) is False


### PR DESCRIPTION
## Summary
- replace placeholder implementations with real algorithms for clustering, scoring, and pattern matching
- expand tests covering the new quantum algorithm utilities

## Testing
- `ruff check quantum_algorithm_library_expansion.py tests/test_quantum_algorithm_library_expansion.py`
- `pytest tests/test_quantum_algorithm_library_expansion.py`


------
https://chatgpt.com/codex/tasks/task_e_688ecb9b4eb08331863bb65ed74adce6