### PR TITLE
feat: load production data and add quantum scoring

### DIFF
--- a/quantum/README.md
+++ b/quantum/README.md
@@ -56,15 +56,18 @@ fall back to local simulation, preserving existing behavior.
 
 ## Pattern Recognition
 
-- `ml_pattern_recognition.PatternRecognizer` – logistic regression based pattern recognizer using production datasets. Use
-  `ml_pattern_recognition.load_production_data` to load training data from
-  `databases/production.db` or a path supplied via the `ML_PATTERN_DATA_PATH`
-  environment variable.
+- `ml_pattern_recognition.PatternRecognizer` – logistic regression based pattern
+  recognizer using production datasets. Use
+  `load_production_data` to fetch samples from `databases/production.db`. The
+  ``evaluate`` method supports ``use_quantum=True`` to include a quantum
+  similarity score via
+  ``quantum_algorithm_library_expansion.quantum_similarity_score``.
 
 ### Configuration
 
-1. Prepare a dataset of newline-separated patterns.
-2. Set `ML_PATTERN_DATA_PATH` to the dataset location or place the file in
-   `databases/production_patterns.txt` and reference it via
-   `load_production_data`.
-3. Train the recognizer using `PatternRecognizer.learn` with the loaded data.
+1. Ensure `databases/production.db` contains entries in the
+   `solution_patterns` table.
+2. Load data with `load_production_data()` and train the recognizer using
+   `PatternRecognizer.train`.
+3. Optionally call `evaluate(..., use_quantum=True)` to compute a quantum
+   similarity score alongside accuracy.

--- a/quantum/ml_pattern_recognition.py
+++ b/quantum/ml_pattern_recognition.py
@@ -1,22 +1,52 @@
-"""Pattern recognition utilities using placeholder datasets."""
+"""Production-backed ML pattern recognition utilities.
 
+This module now loads sample training data directly from ``production.db`` and
+optionally computes quantum-aware evaluation metrics using
+``quantum_algorithm_library_expansion.quantum_similarity_score``.
+"""
+
+from pathlib import Path
 from typing import Tuple
 
 import numpy as np
-from sklearn.datasets import make_classification
+import sqlite3
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score
+from sklearn.preprocessing import LabelEncoder
 
 
-def load_placeholder_data(
-    n_samples: int = 100,
-    n_features: int = 4,
-    random_state: int = 42,
+def load_production_data(
+    db_path: Path | str = Path("databases/production.db"),
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Generate a simple classification dataset for demonstrations."""
-    X, y = make_classification(
-        n_samples=n_samples, n_features=n_features, random_state=random_state
-    )
+    """Load training data from the ``solution_patterns`` table.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the SQLite database. Defaults to ``databases/production.db``.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        Feature matrix ``X`` with columns ``effectiveness_score`` and
+        ``usage_count`` and label vector ``y`` with pattern categories.
+    """
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT effectiveness_score, usage_count, category FROM solution_patterns"
+        )
+        rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        raise ValueError("No data found in solution_patterns table")
+
+    X = np.array([[r[0], r[1]] for r in rows], dtype=float)
+    y = np.array([r[2] for r in rows])
     return X, y
 
 
@@ -42,7 +72,28 @@ class PatternRecognizer:
             raise RuntimeError("Model not trained")
         return self.model.predict(X)
 
-    def evaluate(self, X: np.ndarray, y: np.ndarray) -> float:
-        """Return accuracy score on provided data."""
+    def evaluate(self, X: np.ndarray, y: np.ndarray, *, use_quantum: bool = False) -> dict:
+        """Return evaluation metrics for provided data.
+
+        Parameters
+        ----------
+        X, y:
+            Dataset used for evaluation.
+        use_quantum:
+            When ``True`` a quantum similarity score is computed using
+            :func:`quantum_algorithm_library_expansion.quantum_similarity_score`.
+        """
+
         preds = self.predict(X)
-        return float(accuracy_score(y, preds))
+        result = {"accuracy": float(accuracy_score(y, preds))}
+
+        if use_quantum:
+            from quantum_algorithm_library_expansion import quantum_similarity_score
+
+            encoder = LabelEncoder()
+            encoder.fit(np.concatenate([preds, y]))
+            result["quantum_score"] = quantum_similarity_score(
+                encoder.transform(preds), encoder.transform(y)
+            )
+
+        return result

--- a/tests/quantum/test_ml_pattern_recognition.py
+++ b/tests/quantum/test_ml_pattern_recognition.py
@@ -1,9 +1,10 @@
-from quantum.ml_pattern_recognition import PatternRecognizer, load_placeholder_data
+from quantum.ml_pattern_recognition import PatternRecognizer, load_production_data
 
 
 def test_pattern_recognizer_trains_and_evaluates():
-    X, y = load_placeholder_data(n_samples=50, random_state=0)
+    X, y = load_production_data()
     recognizer = PatternRecognizer()
     recognizer.train(X, y)
-    acc = recognizer.evaluate(X, y)
-    assert 0.0 <= acc <= 1.0
+    metrics = recognizer.evaluate(X, y, use_quantum=True)
+    assert 0.0 <= metrics["accuracy"] <= 1.0
+    assert 0.0 <= metrics["quantum_score"] <= 1.0

--- a/tests/test_ml_pattern_recognition.py
+++ b/tests/test_ml_pattern_recognition.py
@@ -2,6 +2,10 @@
 
 from ml_pattern_recognition import PatternRecognizer
 from utils.lessons_learned_integrator import fetch_lessons_by_tag
+from quantum.ml_pattern_recognition import (
+    PatternRecognizer as QuantumPatternRecognizer,
+    load_production_data,
+)
 
 
 def test_pattern_recognizer_stores_lessons(tmp_path):
@@ -13,4 +17,13 @@ def test_pattern_recognizer_stores_lessons(tmp_path):
     assert predictions and predictions[0].startswith("cluster_")
     lessons = fetch_lessons_by_tag("pattern_recognition", db_path=db_path)
     assert lessons
+
+
+def test_quantum_recognizer_uses_production_data_and_quantum_score():
+    X, y = load_production_data()
+    recognizer = QuantumPatternRecognizer()
+    recognizer.train(X, y)
+    metrics = recognizer.evaluate(X, y, use_quantum=True)
+    assert 0.0 <= metrics["accuracy"] <= 1.0
+    assert 0.0 <= metrics["quantum_score"] <= 1.0
 


### PR DESCRIPTION
## Summary
- replace placeholder ML data generator with `load_production_data` reading `solution_patterns` from `production.db`
- add optional quantum similarity scoring to `PatternRecognizer.evaluate`
- cover production dataset and quantum path in pattern recognition tests and docs

## Testing
- `ruff check quantum/ml_pattern_recognition.py tests/test_ml_pattern_recognition.py tests/quantum/test_ml_pattern_recognition.py`
- `pytest tests/test_ml_pattern_recognition.py tests/quantum/test_ml_pattern_recognition.py`


------
https://chatgpt.com/codex/tasks/task_e_688ecb9bb5488331a427d0e3381d8403