### PR TITLE
feat: improve lessons integration metrics

### DIFF
--- a/docs/LESSONS_LEARNED_DATASET_INTEGRATION.md
+++ b/docs/LESSONS_LEARNED_DATASET_INTEGRATION.md
@@ -3,3 +3,12 @@
 The template generation pipeline now queries the curated `enhanced_lessons_learned` dataset before building templates. During `TemplateAutoGenerator` initialization, lessons are loaded from `databases/learning_monitor.db` and logged using the lessons integrator utilities. The lesson descriptions are combined with existing patterns and templates to guide synthesis.
 
 The validator at `scripts/validation/lessons_learned_integration_validator.py` includes a compliance check that ensures the dataset is present and non-empty, confirming that historical insights inform template generation.
+
+## Lessons Metrics
+
+Integration health is tracked in `databases/analytics.db` within the
+`integration_score_calculations` table. The `IntegrationScoreCalculator`
+stores the latest `integration_status` value, which the enterprise dashboard
+reads to report the lessons integration status. When the analytics database
+is empty or missing, the dashboard now reports `NO_DATA` or `PENDING`
+depending on whether lessons exist in `learning_monitor.db`.

--- a/scripts/analysis/integration_score_calculator.py
+++ b/scripts/analysis/integration_score_calculator.py
@@ -87,12 +87,14 @@ class IntegrationScoreCalculator:
 
         # Database and file paths
         self.production_db = self.workspace_path / "production.db"
+        self.analytics_db = self.workspace_path / "databases" / "analytics.db"
         self.reports_dir = self.workspace_path / "reports" / "integration_scores"
         self.logs_dir = self.workspace_path / "logs" / "integration_scores"
 
         # Ensure directories exist
         self.reports_dir.mkdir(parents=True, exist_ok=True)
         self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self.analytics_db.parent.mkdir(parents=True, exist_ok=True)
 
         # Initialize enterprise logging
         self._setup_enterprise_logging()
@@ -719,9 +721,9 @@ class IntegrationScoreCalculator:
         return recommendations
 
     def _update_score_calculation_database(self, result: IntegrationScoreResult) -> None:
-        """🗄️ Update database with score calculation results"""
+        """🗄️ Update analytics database with score calculation results"""
         try:
-            with sqlite3.connect(self.production_db) as conn:
+            with sqlite3.connect(self.analytics_db) as conn:
                 cursor = conn.cursor()
 
                 # Create integration score calculations table if not exists

--- a/tests/test_dashboard_placeholder_metrics.py
+++ b/tests/test_dashboard_placeholder_metrics.py
@@ -1,4 +1,15 @@
 def test_dashboard_metrics_after_audit(monkeypatch):
+    class DummyUpdater:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def _fetch_compliance_metrics(self, *args, **kwargs):
+            return {}
+
+    monkeypatch.setattr(
+        "dashboard.compliance_metrics_updater.ComplianceMetricsUpdater",
+        DummyUpdater,
+    )
     from web_gui.scripts.flask_apps import enterprise_dashboard as ed
 
     sample_metrics = {
@@ -23,3 +34,49 @@ def test_dashboard_metrics_after_audit(monkeypatch):
     assert data["metrics"]["total_placeholders"] == 1
     assert "rollback_count" in data["metrics"]
     assert "progress_status" in data["metrics"]
+
+
+def test_lessons_status_from_populated_db(tmp_path, monkeypatch):
+    import sqlite3
+
+    class DummyUpdater:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def _fetch_compliance_metrics(self, *args, **kwargs):
+            return {}
+
+    monkeypatch.setattr(
+        "dashboard.compliance_metrics_updater.ComplianceMetricsUpdater",
+        DummyUpdater,
+    )
+
+    from web_gui.scripts.flask_apps import enterprise_dashboard as ed
+    from dashboard import compliance_metrics_updater as cmu
+
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE integration_score_calculations (integration_status TEXT, timestamp TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO integration_score_calculations VALUES ('FULLY_INTEGRATED', '2024')"
+        )
+        conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT)")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (1, 'ok')")
+        conn.execute(
+            "CREATE TABLE performance_metrics (metric_name TEXT, metric_value REAL, metric_type TEXT, timestamp TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO performance_metrics VALUES ('query_latency', 1.0, 'ms', '2024')"
+        )
+
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+    monkeypatch.setattr(ed, "metrics_updater", cmu.ComplianceMetricsUpdater(tmp_path, test_mode=True))
+
+    metrics = ed._fetch_metrics()
+    assert metrics["lessons_integration_status"] == "FULLY_INTEGRATED"

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -41,16 +41,31 @@ metrics_updater = ComplianceMetricsUpdater(COMPLIANCE_DIR)
 
 
 def _get_lessons_integration_status(cur: sqlite3.Cursor) -> str:
-    """Return the latest lessons integration status from the database."""
+    """Return the latest lessons integration status from the database.
+
+    Provides descriptive fallbacks when the primary table is missing or empty."""
     try:
         cur.execute(
             "SELECT integration_status FROM integration_score_calculations ORDER BY timestamp DESC LIMIT 1"
         )
         row = cur.fetchone()
-        return row[0] if row and row[0] else "UNKNOWN"
+        if row and row[0]:
+            return row[0]
+        cur.execute("SELECT COUNT(*) FROM integration_score_calculations")
+        if cur.fetchone()[0] == 0:
+            logging.info("No integration score records found")
+            return "NO_DATA"
+    except sqlite3.OperationalError:
+        try:
+            cur.execute("SELECT COUNT(*) FROM enhanced_lessons_learned")
+            return "PENDING" if cur.fetchone()[0] else "NO_DATA"
+        except sqlite3.Error as exc:
+            logging.error("Lessons integration fallback error: %s", exc)
+            return "NO_DATA"
     except sqlite3.Error as exc:
         logging.error("Lessons integration fetch error: %s", exc)
-        return "UNKNOWN"
+        return "NO_DATA"
+    return "UNKNOWN"
 
 
 def _get_average_query_latency(cur: sqlite3.Cursor) -> float:


### PR DESCRIPTION
## Summary
- persist integration score results in analytics.db
- provide clearer dashboard status when integration records are missing
- document lessons integration metrics workflow

## Testing
- `ruff check scripts/analysis/integration_score_calculator.py web_gui/scripts/flask_apps/enterprise_dashboard.py tests/test_dashboard_placeholder_metrics.py`
- `pytest tests/test_dashboard_placeholder_metrics.py tests/dashboard/test_additional_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_688ecb9caf408331aba159c1f81dcac1