### PR TITLE
feat: add compliance metrics dashboard templates

### DIFF
--- a/web_gui/documentation/README.md
+++ b/web_gui/documentation/README.md
@@ -63,6 +63,13 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
    - Backup: http://localhost:5000/backup
    - Migration: http://localhost:5000/migration
 
+5. **Metrics & Compliance Endpoints**:
+   - Metrics JSON: http://localhost:5000/metrics
+   - Compliance data (metrics + rollback logs): http://localhost:5000/compliance
+   - HTML Metrics Table: http://localhost:5000/metrics_table
+
+   These routes read from `databases/analytics.db`. Ensure this database exists before starting the dashboard.
+
 5. **API Endpoints**:
    - Health Check: http://localhost:5000/api/health
    - Scripts Data: http://localhost:5000/api/scripts

--- a/web_gui/templates/dashboard.html
+++ b/web_gui/templates/dashboard.html
@@ -3,18 +3,30 @@
 <h1>Compliance Dashboard</h1>
 <div id="progress">Loading...</div>
 <div>
-    <strong>Placeholder Removals:</strong> <span id="placeholder_removal">0</span><br>
-    <strong>Open Placeholders:</strong> <span id="open_placeholders">0</span><br>
-    <strong>Compliance Score:</strong> <span id="compliance_score">0.000</span><br>
+    <strong>Placeholder Removals:</strong> <span id="placeholder_removal">{{ metrics.placeholder_removal or 0 }}</span><br>
+    <strong>Open Placeholders:</strong> <span id="open_placeholders">{{ metrics.open_placeholders or 0 }}</span><br>
+    <strong>Compliance Score:</strong> <span id="compliance_score">{{ '%.3f'|format(metrics.compliance_score or 0) }}</span><br>
     <h3>Placeholder Types</h3>
     <ul id="placeholder_breakdown"></ul>
     <h3>Compliance Trend</h3>
-    <span id="compliance_trend"></span>
+    <span id="compliance_trend">
+        {% for score in metrics.compliance_trend or [] %}
+            {{ score }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+    </span>
 </div>
 <h2>Violations</h2>
-<ul id="violations"></ul>
+<ul id="violations">
+    {% for v in (alerts.violations if alerts is defined else []) %}
+        <li>{{ v.timestamp }} - {{ v.details }}</li>
+    {% endfor %}
+</ul>
 <h2>Rollbacks</h2>
-<ul id="rollbacks"></ul>
+<ul id="rollbacks">
+    {% for rb in (alerts.rollbacks if alerts is defined else []) %}
+        <li>{{ rb.timestamp }} - {{ rb.target }}{% if rb.backup %} ({{ rb.backup }}){% endif %}</li>
+    {% endfor %}
+</ul>
 <p><a href="/dashboard/compliance">Compliance Metrics</a></p>
 <script>
 function updateMetrics(data){

--- a/web_gui/templates/metrics_table.html
+++ b/web_gui/templates/metrics_table.html
@@ -3,7 +3,23 @@
 <table border="1">
     <tr><th>Metric</th><th>Value</th></tr>
     {% for key, value in metrics.items() %}
-    <tr><td>{{ key }}</td><td>{{ value }}</td></tr>
+        {% if key not in ['compliance_trend', 'recent_rollbacks'] %}
+        <tr><td>{{ key }}</td><td>{{ value }}</td></tr>
+        {% endif %}
     {% endfor %}
 </table>
+
+<h2>Compliance Trend</h2>
+<ul>
+    {% for score in metrics.compliance_trend or [] %}
+    <li>{{ score }}</li>
+    {% endfor %}
+</ul>
+
+<h2>Rollback Logs</h2>
+<ul>
+    {% for rb in metrics.recent_rollbacks or [] %}
+    <li>{{ rb.timestamp }} - {{ rb.target }}{% if rb.backup %} ({{ rb.backup }}){% endif %}</li>
+    {% endfor %}
+</ul>
 


### PR DESCRIPTION
## Summary
- fetch rollback logs from analytics.db for compliance reports
- render compliance trend and rollback history in dashboard and metrics table templates
- document metrics endpoints and analytics database requirement

## Testing
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py`
- `pytest tests/test_dashboard_endpoints.py tests/test_web_gui_templates.py`


------
https://chatgpt.com/codex/tasks/task_e_688f288bcda48331b2ee75513c79944f