### PR TITLE
feat: add session-linked monitoring metrics

### DIFF
--- a/documentation/additional/monitoring/README.md
+++ b/documentation/additional/monitoring/README.md
@@ -1,0 +1,9 @@
+# Monitoring Guidelines
+
+This module provides runtime health metrics linked to session IDs.
+
+- Use `collect_metrics()` to gather CPU, memory, disk, and network data.
+- Each metrics record is associated with a session ID validated by
+  `UnifiedSessionManagementSystem`.
+- Metrics are stored in `analytics.db` within the `monitoring_metrics` table.
+- `quantum_hook()` is reserved for future quantum processing integrations.

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -7,6 +7,8 @@ from monitoring.health_monitor import (
     record_system_health,
     recent_average,
 )
+import scripts.monitoring.unified_monitoring_optimization_system as umos
+from unified_monitoring_optimization_system import collect_metrics
 
 
 def _prepare_db(tmp_path: Path) -> Path:
@@ -37,3 +39,33 @@ def test_recent_average_computes_values(tmp_path):
     avg = recent_average(2, db_path=db)
     assert round(avg["avg_cpu_percent"], 1) == 15.0
     assert round(avg["avg_memory_percent"], 1) == 25.0
+
+
+def test_collect_metrics_records_session(tmp_path, monkeypatch):
+    class DummySession:
+        def start_session(self) -> bool:
+            return True
+
+    monkeypatch.setattr(umos, "UnifiedSessionManagementSystem", lambda: DummySession())
+    monkeypatch.setattr(
+        umos,
+        "gather_metrics",
+        lambda: {
+            "cpu_percent": 1.0,
+            "memory_percent": 2.0,
+            "disk_percent": 3.0,
+            "net_bytes_sent": 4,
+            "net_bytes_recv": 5,
+        },
+    )
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+
+    result = collect_metrics()
+    assert result["session_id"]
+
+    with sqlite3.connect(tmp_path / "analytics.db") as conn:
+        row = conn.execute(
+            "SELECT session_id, cpu_percent FROM monitoring_metrics"
+        ).fetchone()
+    assert row[0] == result["session_id"]
+    assert row[1] == 1.0

--- a/unified_monitoring_optimization_system.py
+++ b/unified_monitoring_optimization_system.py
@@ -1,5 +1,9 @@
-"""Thin wrapper for :mod:`scripts.monitoring.unified_monitoring_optimization_system`."""
+"""Thin wrapper for unified monitoring utilities."""
 
-from scripts.monitoring.unified_monitoring_optimization_system import EnterpriseUtility
+from scripts.monitoring.unified_monitoring_optimization_system import (
+    EnterpriseUtility,
+    collect_metrics,
+    quantum_hook,
+)
 
-__all__ = ["EnterpriseUtility"]
+__all__ = ["EnterpriseUtility", "collect_metrics", "quantum_hook"]


### PR DESCRIPTION
## Summary
- extend monitoring system with `collect_metrics` storing metrics with session IDs and add placeholder `quantum_hook`
- document monitoring guidelines
- test `collect_metrics` session persistence

## Testing
- `ruff check scripts/monitoring/unified_monitoring_optimization_system.py unified_monitoring_optimization_system.py tests/test_health_monitor.py`
- `pytest tests/test_health_monitor.py tests/test_monitoring_optimization_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f288ff5308331a4e395ec5855c29f