### PR TITLE
feat: add template clustering and cleanup

### DIFF
--- a/documentation/additional/user_guides/quick_start_guide.md
+++ b/documentation/additional/user_guides/quick_start_guide.md
@@ -129,6 +129,19 @@ recommendations = platform.get_environment_recommendations("production")
 print(recommendations)
 ```
 
+### Template Clustering and Cleanup
+```python
+import os
+from pathlib import Path
+from scripts.utilities.unified_script_generation_system import EnterpriseUtility
+from scripts.cleanup import cleanup_legacy_assets
+
+utility = EnterpriseUtility(workspace_path=os.getenv("GH_COPILOT_WORKSPACE", "/path/to/workspace"))
+clusters = utility.cluster_templates(list((utility.workspace_path / "generated_templates").glob("*.txt")))
+# Remove stale templates from the smallest cluster in dry-run mode
+cleanup_legacy_assets(utility.workspace_path / "cluster_output.json", dry_run=True)
+```
+
 ## Best Practices
 
 ### 1. Naming Conventions

--- a/scripts/cleanup.py
+++ b/scripts/cleanup.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Legacy asset cleanup based on template clusters."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def cleanup_legacy_assets(cluster_file: Path, dry_run: bool = True) -> list[Path]:
+    """Remove legacy assets referenced in cluster outputs.
+
+    Parameters
+    ----------
+    cluster_file:
+        Path to a JSON file produced by ``cluster_templates``.
+    dry_run:
+        If True, no files are deleted.
+
+    Returns
+    -------
+    list[Path]
+        List of removed file paths.
+    """
+    if not cluster_file.exists():
+        logger.info("No cluster output found; nothing to clean")
+        return []
+    data = json.loads(cluster_file.read_text(encoding="utf-8"))
+    legacy_paths = [Path(p) for p in data.get("0", [])]
+    removed: list[Path] = []
+    cutoff = datetime.now() - timedelta(days=30)
+    for path in legacy_paths:
+        if path.exists() and path.stat().st_mtime < cutoff.timestamp():
+            logger.info(f"Removing legacy asset: {path}")
+            if not dry_run:
+                path.unlink()
+            removed.append(path)
+    return removed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Cleanup legacy assets using clusters")
+    parser.add_argument("--clusters", type=Path, default=Path("cluster_output.json"))
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    cleanup_legacy_assets(args.clusters, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/utilities/unified_script_generation_system.py
+++ b/scripts/utilities/unified_script_generation_system.py
@@ -14,11 +14,14 @@ import sys
 import logging
 import re
 import sqlite3
+import json
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
 
 from dataclasses import dataclass
+import numpy as np
+from sklearn.cluster import KMeans
 from tqdm import tqdm
 from secondary_copilot_validator import SecondaryCopilotValidator
 from utils.visual_progress import start_indicator, progress_bar, end_indicator
@@ -73,6 +76,54 @@ class EnterpriseUtility:
             self.logger.error(f"{TEXT_INDICATORS['error']} Utility error: {e}")
             end_indicator("Script Generation Utility", start_time)
             return False
+
+    def cluster_templates(self, template_paths: list[Path], n_clusters: int = 2) -> dict[int, list[Path]]:
+        """Cluster templates based on placeholder counts.
+
+        Parameters
+        ----------
+        template_paths:
+            List of paths to template files.
+        n_clusters:
+            Desired number of clusters. Adjusted if fewer templates exist.
+
+        Returns
+        -------
+        dict[int, list[Path]]
+            Mapping of cluster label to template paths. Results are also
+            written to ``cluster_output.json`` in the workspace.
+        """
+
+        features: list[list[int]] = []
+        valid_paths: list[Path] = []
+        for path in template_paths:
+            if not path.exists():
+                continue
+            text = path.read_text(encoding="utf-8")
+            placeholders = re.findall(r"{(.*?)}", text)
+            features.append([len(placeholders)])
+            valid_paths.append(path)
+
+        if not features:
+            return {}
+
+        matrix = np.array(features)
+        n_clusters = min(n_clusters, len(features))
+        kmeans = KMeans(n_clusters=n_clusters, random_state=42)
+        labels = kmeans.fit_predict(matrix)
+        clusters: dict[int, list[Path]] = {i: [] for i in range(n_clusters)}
+        for label, path in zip(labels, valid_paths):
+            clusters[int(label)].append(path)
+
+        cluster_file = self.workspace_path / "cluster_output.json"
+        cluster_file.write_text(
+            json.dumps({k: [str(p) for p in v] for k, v in clusters.items()}, indent=2),
+            encoding="utf-8",
+        )
+        self.logger.info(
+            f"{TEXT_INDICATORS['info']} Cluster output written to {cluster_file}"
+        )
+        return clusters
 
     def perform_utility_function(self) -> bool:
         """Generate a template using patterns from ``template_documentation.db``.

--- a/tests/test_workflow_enhancer.py
+++ b/tests/test_workflow_enhancer.py
@@ -30,3 +30,15 @@ def test_workflow_enhancer_basic(tmp_path, monkeypatch):
     assert len(clusters) == 2
     score = enhancer.score_compliance(templates)
     assert score > 0
+
+
+def test_pattern_mining(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setattr(workflow_enhancer, "validate_enterprise_operation", lambda *_a, **_k: True)
+    db = tmp_path / "prod.db"
+    _setup_db(db)
+    dashboard = tmp_path / "dash"
+    enhancer = TemplateWorkflowEnhancer(db, dashboard)
+    templates = enhancer.fetch_templates()
+    patterns = enhancer.mine_patterns(templates)
+    assert "content" in patterns


### PR DESCRIPTION
## Summary
- implement KMeans-based template clustering in `EnterpriseUtility`
- add cluster-driven legacy asset cleanup script
- test pattern mining and document clustering workflow

## Testing
- `ruff check scripts/utilities/unified_script_generation_system.py scripts/cleanup.py tests/test_workflow_enhancer.py`
- `pytest tests/test_workflow_enhancer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f2891d7cc8331b76e206d8b7b8161