### PR TITLE
docs: add success criteria guidelines

### DIFF
--- a/docs/success_criteria.md
+++ b/docs/success_criteria.md
@@ -1,0 +1,14 @@
+# Success Criteria
+
+## Quantitative Goals
+- Code coverage must remain above **95%**.
+- Compliance score should be **0.9** or higher.
+
+## Stakeholder Sign-off Workflow
+Stakeholders sign off only after validation steps in [`validation/protocols`](../validation/protocols)
+confirm regulatory and process compliance.
+
+## Latency and Failure Handling
+- Latency checks ensure each validation completes in under one minute.
+- Any run exceeding the threshold triggers a retry and logs the failure for review.
+- Persistent failures escalate to the compliance team for resolution.


### PR DESCRIPTION
## Summary
- document success metrics for coverage and compliance
- note stakeholder sign-off via `validation/protocols`
- outline latency checks and escalation paths

## Testing
- `ruff check docs/success_criteria.md --exit-zero` *(syntax errors reported for Markdown content)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_688f289d6ebc8331babdc8dd62d04ec8