### PR TITLE
test: integrate placeholder audit in validation package

### DIFF
--- a/docs/testing_compliance.md
+++ b/docs/testing_compliance.md
@@ -1,0 +1,25 @@
+# Testing Compliance Procedures
+
+This guide summarizes the compliance-focused testing steps.
+
+1. **Run Tests**
+   - Execute the validation package tests and capture output:
+     ```bash
+     mkdir -p logs/compliance_monitoring
+     pytest tests/test_validation_package.py | tee logs/compliance_monitoring/pytest.log
+     ```
+   - Review `logs/compliance_monitoring/pytest.log` for any failures.
+
+2. **Placeholder Audit Integration**
+   - The test suite invokes `scripts.code_placeholder_audit` in simulation mode to ensure the placeholder audit module integrates with the validation framework.
+
+3. **Rollback Path Verification**
+   - Tests assert that rollback utilities exist at:
+     - `scripts/database/add_rollback_logs.py`
+     - `databases/migrations/add_rollback_logs.sql`
+
+4. **Linting**
+   - Validate style with Ruff:
+     ```bash
+     ruff tests/test_validation_package.py docs/testing_compliance.md
+     ```

--- a/tests/test_validation_package.py
+++ b/tests/test_validation_package.py
@@ -19,6 +19,7 @@ from validation.core.rules import (
 from validation.protocols.session import SessionProtocolValidator
 from validation.protocols.deployment import DeploymentValidator
 from validation.reporting.formatters import ValidationReportFormatter
+from scripts import code_placeholder_audit as placeholder_audit
 
 
 class MockValidator(BaseValidator):
@@ -418,3 +419,24 @@ class TestValidationReporting:
             with open(json_file) as f:
                 data = json.load(f)
             assert len(data["results"]) == 1
+
+
+class TestComplianceIntegration:
+    """Ensure compliance utilities integrate with validation package."""
+
+    def test_placeholder_audit_simulation(self, tmp_path):
+        """Run placeholder audit in simulation mode."""
+        sample = tmp_path / "sample.py"
+        sample.write_text("# TODO: fix\n")
+
+        assert placeholder_audit.main(workspace_path=str(tmp_path), simulate=True)
+
+    def test_rollback_paths_exist(self):
+        """Verify rollback utility paths exist."""
+        paths = [
+            Path("scripts/database/add_rollback_logs.py"),
+            Path("databases/migrations/add_rollback_logs.sql"),
+        ]
+
+        for p in paths:
+            assert p.exists(), f"Missing rollback path: {p}"


### PR DESCRIPTION
## Summary
- invoke `scripts.code_placeholder_audit` during validation tests and verify rollback utility paths
- document compliance-oriented testing workflow

## Testing
- `ruff check tests/test_validation_package.py`
- `pytest tests/test_validation_package.py` *(fails: ModuleNotFoundError: No module named 'tqdm')*


------
https://chatgpt.com/codex/tasks/task_e_688f289774fc8331a68288ced22fcbc4