### PR TITLE
test: add placeholder audit and rollback checks

### DIFF
--- a/docs/testing_compliance.md
+++ b/docs/testing_compliance.md
@@ -1,0 +1,35 @@
+## Compliance Testing Procedures
+
+This project uses `pytest` and `ruff` to validate changes and enforce code quality.
+
+### Running Tests
+
+```bash
+pytest tests/test_validation_package.py tests/compliance_test_suite.py \
+ 2>&1 | tee logs/compliance_monitoring/pytest.log
+```
+
+The test run writes its output to `logs/compliance_monitoring/pytest.log` so any
+failures can be reviewed after execution.
+
+### Placeholder Audit
+
+The compliance test suite invokes the placeholder audit module in simulation
+mode. To run it directly:
+
+```bash
+python -m scripts.code_placeholder_audit --simulate \
+  --workspace-path "$(pwd)" --analytics-db databases/analytics.db \
+  --production-db databases/production.db --dashboard-dir dashboard/compliance
+```
+
+### Linting
+
+Run `ruff` on modified files before committing:
+
+```bash
+ruff tests/test_validation_package.py tests/compliance_test_suite.py
+```
+
+These steps help ensure the repository remains in a compliant state.
+

--- a/tests/compliance_test_suite.py
+++ b/tests/compliance_test_suite.py
@@ -66,6 +66,7 @@ def run_compliance_tests(tmp_path: Path) -> Dict[str, Any]:
         ("DBFirstCodeGenerator", test_db_first_code_generator),
         ("PatternClusteringSync", test_pattern_clustering_sync),
         ("CorrectionLoggerRollback", test_correction_logger_and_rollback),
+        ("PlaceholderAudit", test_placeholder_audit_module),
         ("QuantumComplianceEngine", test_quantum_compliance_engine),
     ]
     total_steps = len(test_cases)
@@ -142,6 +143,19 @@ def test_correction_logger_and_rollback(tmp_path: Path) -> None:
     log.log_change(test_file, "test rationale", compliance_score=1.0, rollback_reference=None)
     rollback_success = log.auto_rollback(test_file, None)
     assert rollback_success is True
+
+
+def test_placeholder_audit_module(tmp_path: Path) -> None:
+    import scripts.code_placeholder_audit as placeholder_audit
+
+    result = placeholder_audit.main(
+        workspace_path=str(tmp_path),
+        analytics_db=str(tmp_path / "analytics.db"),
+        production_db=str(tmp_path / "production.db"),
+        dashboard_dir=str(tmp_path / "dashboard"),
+        simulate=True,
+    )
+    assert isinstance(result, bool)
 
 
 def test_quantum_compliance_engine(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- integrate placeholder audit into compliance test suite
- verify rollback paths in validation package tests
- document compliance testing workflow

## Testing
- `pytest tests/test_validation_package.py`
- `GH_COPILOT_WORKSPACE=$(mktemp -d) pytest tests/compliance_test_suite.py`
- `ruff check tests/test_validation_package.py tests/compliance_test_suite.py`


------
https://chatgpt.com/codex/tasks/task_e_688f289774fc8331a68288ced22fcbc4