### PR TITLE
feat: add composite compliance score and dashboard metrics

### DIFF
--- a/documentation/validation/compliance_metrics.md
+++ b/documentation/validation/compliance_metrics.md
@@ -1,0 +1,15 @@
+# Compliance Metrics
+
+The compliance report combines linting and test results into a single
+**composite compliance score** that ranges from 0 to 100.
+
+## Metric Formulas
+
+- **Lint Score** = `max(0, 100 - ruff_issues)`
+- **Test Score** = `(tests_passed / (tests_passed + tests_failed)) * 100` if any
+  tests were executed, otherwise `0`.
+- **Composite Compliance Score** = `(Lint Score + Test Score) / 2`
+
+The composite score is stored in `databases/analytics.db` alongside the raw
+metrics and is surfaced in the Enterprise Dashboard for visibility.
+

--- a/tests/test_validation_utils.py
+++ b/tests/test_validation_utils.py
@@ -1,6 +1,10 @@
 import pytest
 
-from utils.validation_utils import anti_recursion_guard, run_dual_copilot_validation
+from utils.validation_utils import (
+    anti_recursion_guard,
+    run_dual_copilot_validation,
+    calculate_composite_compliance_score,
+)
 
 
 def test_anti_recursion_guard_prevents_recursion():
@@ -45,3 +49,9 @@ def test_dual_copilot_runs_secondary_even_if_primary_fails():
 
     assert run_dual_copilot_validation(primary, secondary) is False
     assert order == ["primary", "secondary"]
+
+
+def test_calculate_composite_compliance_score_handles_metrics():
+    assert calculate_composite_compliance_score(0, 10, 0) == 100.0
+    assert calculate_composite_compliance_score(10, 8, 2) == 85.0
+    assert calculate_composite_compliance_score(5, 0, 0) == 47.5

--- a/utils/validation_utils.py
+++ b/utils/validation_utils.py
@@ -11,6 +11,18 @@ from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.lessons_learned_integrator import store_lesson
 
 
+def calculate_composite_compliance_score(
+    ruff_issues: int,
+    tests_passed: int,
+    tests_failed: int,
+) -> float:
+    """Return composite compliance score based on lint and test results."""
+    total_tests = tests_passed + tests_failed
+    test_score = (tests_passed / total_tests * 100) if total_tests else 0.0
+    lint_score = max(0.0, 100 - ruff_issues)
+    return round((lint_score + test_score) / 2, 2)
+
+
 def validate_workspace_integrity() -> Dict[str, Any]:
     """Validate workspace integrity and structure"""
     workspace = CrossPlatformPathManager.get_workspace_path()

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -87,6 +87,7 @@ def _fetch_metrics() -> Dict[str, Any]:
     metrics.setdefault("total_placeholders", 0)
     metrics.setdefault("lessons_integration_status", "UNKNOWN")
     metrics.setdefault("average_query_latency", 0.0)
+    metrics.setdefault("composite_score", 0.0)
     if ANALYTICS_DB.exists():
         with sqlite3.connect(ANALYTICS_DB) as conn:
             cur = conn.cursor()
@@ -95,6 +96,12 @@ def _fetch_metrics() -> Dict[str, Any]:
                 metrics["total_placeholders"] = cur.fetchone()[0]
                 metrics["lessons_integration_status"] = _get_lessons_integration_status(cur)
                 metrics["average_query_latency"] = _get_average_query_latency(cur)
+                cur.execute(
+                    "SELECT composite_score FROM code_quality_metrics ORDER BY id DESC LIMIT 1"
+                )
+                row = cur.fetchone()
+                if row and row[0] is not None:
+                    metrics["composite_score"] = row[0]
             except sqlite3.Error as exc:
                 logging.error("Metric fetch error: %s", exc)
     return metrics


### PR DESCRIPTION
## Summary
- calculate composite compliance score using lint and test results
- persist composite score and expose through enterprise dashboard
- document metric formulas and add tests

## Testing
- `ruff check validation/compliance_report_generator.py utils/validation_utils.py web_gui/scripts/flask_apps/enterprise_dashboard.py tests/test_validation_utils.py`
- `pytest tests/test_validation_utils.py tests/test_compliance_report_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_688f28f8d9c48331a1fc87798231587b