### PR TITLE
feat: enhance disaster recovery modules and tests

### DIFF
--- a/documentation/BACKUP_COMPLIANCE_GUIDE.md
+++ b/documentation/BACKUP_COMPLIANCE_GUIDE.md
@@ -20,9 +20,21 @@ Validation
 The system automatically validates that backup locations are external to the workspace and will raise errors if internal backup attempts are detected. The `UnifiedDisasterRecoverySystem` refuses to run when `GH_COPILOT_BACKUP_ROOT` points inside the workspace.
 
 Usage
+
+### Scheduling Backups
 ```python
-from scripts.database.complete_consolidation_orchestrator import create_external_backup
-backup_path = create_external_backup(source_file, "my_backup")
+from unified_disaster_recovery_system import UnifiedDisasterRecoverySystem
+
+system = UnifiedDisasterRecoverySystem()
+backup_path = system.schedule_backups()
+```
+
+### Restoring a Backup
+```python
+from unified_disaster_recovery_system import UnifiedDisasterRecoverySystem
+
+system = UnifiedDisasterRecoverySystem()
+system.restore_backup(backup_path)
 ```
 
 ### Disaster Recovery
@@ -34,6 +46,8 @@ system = UnifiedDisasterRecoverySystem()
 system.perform_recovery()
 ```
 The utility copies data from `$GH_COPILOT_BACKUP_ROOT/production_backup` into a `restored/` directory and logs `[START]` and `[SUCCESS]` indicators. Recovery aborts if the backup root is inside the workspace.
+
+Both scheduling and restore operations record compliance events through the built-in `ComplianceLogger` for auditing.
 
 ### Appendix: Using `validate_enterprise_operation()`
 Before any script performs file changes, call:

--- a/scripts/utilities/unified_disaster_recovery_system.py
+++ b/scripts/utilities/unified_disaster_recovery_system.py
@@ -14,7 +14,13 @@ from typing import Optional
 from unified_disaster_recovery_system import log_backup_event
 from utils import log_utils as enterprise_logging
 
-__all__ = ["UnifiedDisasterRecoverySystem", "main"]
+__all__ = [
+    "ComplianceLogger",
+    "BackupScheduler",
+    "RestoreExecutor",
+    "UnifiedDisasterRecoverySystem",
+    "main",
+]
 
 TEXT_INDICATORS = {
     "start": "[START]",
@@ -24,12 +30,99 @@ TEXT_INDICATORS = {
 }
 
 
+class ComplianceLogger:
+    """Record compliance events for disaster recovery operations."""
+
+    def log(self, event: str, **details: str) -> None:
+        payload = {"module": "disaster_recovery", "event": event, **details}
+        enterprise_logging.log_event(payload)
+        log_backup_event(event, details)
+
+
+class BackupScheduler:
+    """Handle creation of scheduled backup files."""
+
+    def __init__(self, workspace_path: Path, logger: ComplianceLogger) -> None:
+        self.workspace_path = workspace_path
+        self.compliance_logger = logger
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def schedule(self) -> Path:
+        backup_root = Path(
+            os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups")
+        ).resolve()
+        workspace = self.workspace_path.resolve()
+
+        if workspace in backup_root.parents or backup_root == workspace:
+            msg = f"Backup root {backup_root} resides within workspace {workspace}"
+            self.logger.error("%s %s", TEXT_INDICATORS["error"], msg)
+            raise ValueError(msg)
+
+        backup_root.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        backup_file = backup_root / f"scheduled_backup_{timestamp}.bak"
+        backup_file.write_text("scheduled backup", encoding="utf-8")
+        hash_file = backup_file.with_suffix(backup_file.suffix + ".sha256")
+        hash_file.write_text(
+            hashlib.sha256(backup_file.read_bytes()).hexdigest(), encoding="utf-8"
+        )
+        self.compliance_logger.log("backup_scheduled", path=str(backup_file))
+        return backup_file
+
+
+class RestoreExecutor:
+    """Restore individual backups with integrity checks."""
+
+    def __init__(self, workspace_path: Path, logger: ComplianceLogger) -> None:
+        self.workspace_path = workspace_path
+        self.compliance_logger = logger
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def restore(self, path: str | Path) -> bool:
+        backup_file = Path(path)
+        hash_file = backup_file.with_suffix(backup_file.suffix + ".sha256")
+
+        if not backup_file.exists() or not hash_file.exists():
+            self.logger.error(
+                "%s Missing backup or checksum for %s",
+                TEXT_INDICATORS["error"],
+                backup_file,
+            )
+            self.compliance_logger.log(
+                "restore_failed", path=str(backup_file), reason="missing"
+            )
+            return False
+
+        digest = hashlib.sha256(backup_file.read_bytes()).hexdigest()
+        expected = hash_file.read_text().strip()
+        if digest != expected:
+            self.logger.error(
+                "%s Hash mismatch for %s", TEXT_INDICATORS["error"], backup_file
+            )
+            self.compliance_logger.log(
+                "restore_failed", path=str(backup_file), reason="hash_mismatch"
+            )
+            return False
+
+        destination = self.workspace_path / backup_file.name
+        shutil.copy2(backup_file, destination)
+        self.compliance_logger.log("restore_success", path=str(backup_file))
+        return True
+
+
 class UnifiedDisasterRecoverySystem:
     """Perform simple disaster recovery from backups."""
 
     def __init__(self, workspace_path: Optional[str] = None) -> None:
-        self.workspace_path = Path(workspace_path or os.getenv("GH_COPILOT_WORKSPACE", "."))
+        self.workspace_path = Path(
+            workspace_path or os.getenv("GH_COPILOT_WORKSPACE", ".")
+        )
         self.logger = logging.getLogger(self.__class__.__name__)
+        self.compliance_logger = ComplianceLogger()
+        self.scheduler = BackupScheduler(self.workspace_path, self.compliance_logger)
+        self.restore_executor = RestoreExecutor(
+            self.workspace_path, self.compliance_logger
+        )
 
     def perform_recovery(self) -> bool:
         """Restore files from ``GH_COPILOT_BACKUP_ROOT``."""
@@ -70,71 +163,11 @@ class UnifiedDisasterRecoverySystem:
 
     def schedule_backups(self) -> Path:
         """Create a timestamped backup in ``GH_COPILOT_BACKUP_ROOT``."""
-        backup_root = Path(os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups")).resolve()
-        workspace = self.workspace_path.resolve()
-
-        if workspace in backup_root.parents or backup_root == workspace:
-            msg = f"Backup root {backup_root} resides within workspace {workspace}"
-            self.logger.error("%s %s", TEXT_INDICATORS["error"], msg)
-            raise ValueError(msg)
-
-        backup_root.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-        backup_file = backup_root / f"scheduled_backup_{timestamp}.bak"
-        backup_file.write_text("scheduled backup", encoding="utf-8")
-        hash_file = backup_file.with_suffix(backup_file.suffix + ".sha256")
-        hash_file.write_text(hashlib.sha256(backup_file.read_bytes()).hexdigest(), encoding="utf-8")
-        log_backup_event("backup_scheduled", {"path": str(backup_file)})
-        return backup_file
+        return self.scheduler.schedule()
 
     def restore_backup(self, path: str | Path) -> bool:
         """Restore a single backup file with integrity verification."""
-        backup_file = Path(path)
-        hash_file = backup_file.with_suffix(backup_file.suffix + ".sha256")
-
-        if not backup_file.exists() or not hash_file.exists():
-            self.logger.error(
-                "%s Missing backup or checksum for %s", TEXT_INDICATORS["error"], backup_file
-            )
-            enterprise_logging.log_event(
-                {
-                    "module": "disaster_recovery",
-                    "event": "restore_failed",
-                    "path": str(backup_file),
-                    "reason": "missing",
-                }
-            )
-            log_backup_event("restore_failed", {"path": str(backup_file), "reason": "missing"})
-            return False
-
-        digest = hashlib.sha256(backup_file.read_bytes()).hexdigest()
-        expected = hash_file.read_text().strip()
-        if digest != expected:
-            self.logger.error(
-                "%s Hash mismatch for %s", TEXT_INDICATORS["error"], backup_file
-            )
-            enterprise_logging.log_event(
-                {
-                    "module": "disaster_recovery",
-                    "event": "restore_failed",
-                    "path": str(backup_file),
-                    "reason": "hash_mismatch",
-                }
-            )
-            log_backup_event("restore_failed", {"path": str(backup_file), "reason": "hash_mismatch"})
-            return False
-
-        destination = self.workspace_path / backup_file.name
-        shutil.copy2(backup_file, destination)
-        enterprise_logging.log_event(
-            {
-                "module": "disaster_recovery",
-                "event": "restore_success",
-                "path": str(backup_file),
-            }
-        )
-        log_backup_event("restore_success", {"path": str(backup_file)})
-        return True
+        return self.restore_executor.restore(path)
 
 
 def main() -> int:

--- a/tests/test_disaster_recovery_backup_validation.py
+++ b/tests/test_disaster_recovery_backup_validation.py
@@ -1,4 +1,5 @@
 from unified_disaster_recovery_system import UnifiedDisasterRecoverySystem
+import hashlib
 
 
 def test_recovery_rejects_internal_backup(tmp_path, monkeypatch, caplog):
@@ -12,3 +13,19 @@ def test_recovery_rejects_internal_backup(tmp_path, monkeypatch, caplog):
     with caplog.at_level("ERROR"):
         assert not system.perform_recovery()
         assert "resides within workspace" in caplog.text
+
+
+def test_schedule_backup_creates_checksum(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = tmp_path / "backup"
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+    system = UnifiedDisasterRecoverySystem(str(workspace))
+
+    backup_file = system.schedule_backups()
+    assert backup_file.exists()
+    hash_file = backup_file.with_suffix(backup_file.suffix + ".sha256")
+    assert hash_file.exists()
+    digest = hashlib.sha256(backup_file.read_bytes()).hexdigest()
+    assert hash_file.read_text().strip() == digest

--- a/tests/test_disaster_recovery_restore.py
+++ b/tests/test_disaster_recovery_restore.py
@@ -58,3 +58,20 @@ def test_restore_backup_hash_mismatch(tmp_path, monkeypatch):
     system = UnifiedDisasterRecoverySystem(str(workspace))
     assert not system.restore_backup(backup_file)
     assert any(evt["event"] == "restore_failed" for evt in events)
+
+
+def test_restore_backup_missing_checksum(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = tmp_path / "backup"
+    backup_root.mkdir()
+    backup_file = backup_root / "data.txt"
+    backup_file.write_text("data", encoding="utf-8")
+
+    events = []
+    monkeypatch.setattr(util_module.enterprise_logging, "log_event", lambda e: events.append(e))
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    system = UnifiedDisasterRecoverySystem(str(workspace))
+    assert not system.restore_backup(backup_file)
+    assert any(evt["event"] == "restore_failed" for evt in events)

--- a/unified_disaster_recovery_system.py
+++ b/unified_disaster_recovery_system.py
@@ -32,6 +32,9 @@ def log_backup_event(event: str, details: Optional[Dict[str, Any]] = None) -> No
 
 
 from scripts.utilities.unified_disaster_recovery_system import (  # noqa: E402
+    BackupScheduler,
+    ComplianceLogger,
+    RestoreExecutor,
     UnifiedDisasterRecoverySystem as _UnifiedDisasterRecoverySystem,
 )
 
@@ -46,5 +49,12 @@ def schedule_backups() -> None:
 # Re-export class for public consumers
 UnifiedDisasterRecoverySystem = _UnifiedDisasterRecoverySystem
 
-__all__ = ["UnifiedDisasterRecoverySystem", "schedule_backups", "log_backup_event"]
+__all__ = [
+    "UnifiedDisasterRecoverySystem",
+    "BackupScheduler",
+    "RestoreExecutor",
+    "ComplianceLogger",
+    "schedule_backups",
+    "log_backup_event",
+]
 


### PR DESCRIPTION
## Summary
- add dedicated ComplianceLogger, BackupScheduler, and RestoreExecutor modules
- expand disaster recovery tests for backup scheduling and restore integrity
- document backup scheduling and restore usage

## Testing
- `ruff check scripts/utilities/unified_disaster_recovery_system.py tests/test_disaster_recovery_backup_validation.py tests/test_disaster_recovery_restore.py`
- `pytest tests/test_disaster_recovery_backup_validation.py tests/test_disaster_recovery_restore.py`


------
https://chatgpt.com/codex/tasks/task_e_688f3506bd14833194cdb2ea3e3639d7