### PR TITLE
feat: add anomaly detection hooks and session metrics

### DIFF
--- a/docs/COMMUNICATION_STANDARDS.md
+++ b/docs/COMMUNICATION_STANDARDS.md
@@ -14,3 +14,9 @@ This project expects consistent logging and documentation conventions.
 ## Code Style
 - Follow existing snake_case function names and CamelCase classes.
 - Keep line length under 120 characters.
+
+## Monitoring
+- Capture runtime metrics with `unified_monitoring_optimization_system.push_metrics`.
+- Link metrics to `unified_wrapup_sessions` using the `session_id` parameter.
+- Use `detect_anomalies` to flag unusual metric patterns; escalate any anomalies.
+- Experimental quantum processing may be invoked via `QuantumInterface.analyze` for future integrations.

--- a/tests/test_unified_monitoring_optimization_system.py
+++ b/tests/test_unified_monitoring_optimization_system.py
@@ -1,0 +1,49 @@
+"""Tests for unified_monitoring_optimization_system utilities."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from unified_monitoring_optimization_system import (
+    detect_anomalies,
+    push_metrics,
+)
+
+
+def test_push_metrics_links_session(tmp_path: Path) -> None:
+    """Metrics should be associated with a session ID when provided."""
+
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE unified_wrapup_sessions (session_id TEXT PRIMARY KEY)"
+        )
+        conn.execute(
+            "INSERT INTO unified_wrapup_sessions (session_id) VALUES ('abc')"
+        )
+
+    push_metrics({"cpu": 1.0}, session_id="abc", db_path=db)
+
+    with sqlite3.connect(db) as conn:
+        row = conn.execute(
+            "SELECT session_id, metrics_json FROM monitoring_metrics"
+        ).fetchone()
+
+    assert row == ("abc", json.dumps({"cpu": 1.0}))
+
+
+def test_detect_anomalies_flags_outlier() -> None:
+    """An obvious outlier should be returned by the detector."""
+
+    history = [
+        {"cpu": 10.0, "mem": 20.0},
+        {"cpu": 12.0, "mem": 22.0},
+        {"cpu": 95.0, "mem": 99.0},
+    ]
+
+    anomalies = detect_anomalies(history, contamination=0.34)
+    assert history[-1] in anomalies
+    assert len(anomalies) == 1
+

--- a/unified_monitoring_optimization_system.py
+++ b/unified_monitoring_optimization_system.py
@@ -12,31 +12,61 @@ import json
 import os
 import sqlite3
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Iterable, List, Optional
 
-from scripts.monitoring.unified_monitoring_optimization_system import (
-    EnterpriseUtility,
-    collect_metrics,
-    quantum_hook,
-)
+from sklearn.ensemble import IsolationForest
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from scripts.monitoring.unified_monitoring_optimization_system import EnterpriseUtility as _EnterpriseUtility  # noqa: F401
 
 WORKSPACE_ROOT = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
-DB_PATH = WORKSPACE_ROOT / "analytics.db"
+DB_PATH = WORKSPACE_ROOT / "databases" / "analytics.db"
 
-__all__ = ["EnterpriseUtility", "push_metrics"]
+__all__ = [
+    "push_metrics",
+    "detect_anomalies",
+    "QuantumInterface",
+]
 
 
-def _ensure_table(conn: sqlite3.Connection, table: str) -> None:
-    """Create a simple table for pushed metrics if it does not exist."""
-    conn.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {table} (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-            metrics_json TEXT NOT NULL
+def _ensure_table(conn: sqlite3.Connection, table: str, with_session: bool) -> None:
+    """Create a table for pushed metrics if it does not exist.
+
+    Parameters
+    ----------
+    conn:
+        Open SQLite connection.
+    table:
+        Name of the metrics table.
+    with_session:
+        When ``True`` the table includes a ``session_id`` column linked to
+        ``unified_wrapup_sessions``.
+    """
+
+    if with_session:
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {table} (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                metrics_json TEXT NOT NULL,
+                FOREIGN KEY(session_id) REFERENCES unified_wrapup_sessions(session_id)
+            )
+            """
         )
-        """
-    )
+    else:
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {table} (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                metrics_json TEXT NOT NULL
+            )
+            """
+        )
 
 
 def push_metrics(
@@ -44,8 +74,13 @@ def push_metrics(
     *,
     table: str = "monitoring_metrics",
     db_path: Optional[Path] = None,
+    session_id: Optional[str] = None,
 ) -> None:
     """Store ``metrics`` in ``analytics.db``.
+
+    When ``session_id`` is provided the metrics row is linked to the
+    ``unified_wrapup_sessions`` table, enabling correlation with session
+    lifecycle data.
 
     Parameters
     ----------
@@ -56,13 +91,65 @@ def push_metrics(
     db_path:
         Optional path to the analytics database. If omitted the database in
         ``GH_COPILOT_WORKSPACE`` is used.
+    session_id:
+        Optional session identifier to associate metrics with a lifecycle
+        entry.
     """
 
     path = db_path or DB_PATH
     with sqlite3.connect(path) as conn:
-        _ensure_table(conn, table)
-        conn.execute(
-            f"INSERT INTO {table} (metrics_json) VALUES (?)",
-            (json.dumps(metrics),),
-        )
+        _ensure_table(conn, table, session_id is not None)
+        if session_id is None:
+            conn.execute(
+                f"INSERT INTO {table} (metrics_json) VALUES (?)",
+                (json.dumps(metrics),),
+            )
+        else:
+            conn.execute(
+                f"INSERT INTO {table} (session_id, metrics_json) VALUES (?, ?)",
+                (session_id, json.dumps(metrics)),
+            )
         conn.commit()
+
+
+def detect_anomalies(
+    history: Iterable[Dict[str, float]], *, contamination: float = 0.1
+) -> List[Dict[str, float]]:
+    """Identify anomalous metric entries using ``IsolationForest``.
+
+    Parameters
+    ----------
+    history:
+        Iterable of metric mappings ordered chronologically.
+    contamination:
+        Proportion of outliers in the data set.
+
+    Returns
+    -------
+    list of dict
+        Subset of ``history`` flagged as anomalies.
+    """
+
+    history_list = list(history)
+    if not history_list:
+        return []
+
+    keys = sorted(history_list[0])
+    data = [[m[k] for k in keys] for m in history_list]
+    model = IsolationForest(contamination=contamination, random_state=42)
+    preds = model.fit_predict(data)
+    return [m for m, pred in zip(history_list, preds) if pred == -1]
+
+
+class QuantumInterface:
+    """Placeholder interface for quantum metric processing."""
+
+    @staticmethod
+    def analyze(metrics: Dict[str, float]) -> None:
+        """Forward metrics to the quantum hook."""
+
+        from scripts.monitoring.unified_monitoring_optimization_system import (
+            quantum_hook as _quantum_hook,
+        )
+
+        _quantum_hook(metrics)


### PR DESCRIPTION
## Summary
- extend monitoring helper to link metrics with session lifecycle data in `databases/analytics.db`
- add `detect_anomalies` using IsolationForest and a placeholder `QuantumInterface`
- document monitoring guidelines in communication standards

## Testing
- `ruff check unified_monitoring_optimization_system.py tests/test_unified_monitoring_optimization_system.py`
- `pytest tests/test_unified_monitoring_optimization_system.py`


------
https://chatgpt.com/codex/tasks/task_e_688f350f5b588331b9dc297044e2e5a6