### PR TITLE
feat: add template clustering and cleanup routines

### DIFF
--- a/docs/USING_AUTONOMOUS_FILE_MANAGER.md
+++ b/docs/USING_AUTONOMOUS_FILE_MANAGER.md
@@ -13,3 +13,16 @@ from scripts.file_management.autonomous_file_manager import AutonomousFileManage
 manager = AutonomousFileManager(Path('databases/production.db'))
 manager.organize_files(Path('workspace'))
 ```
+
+## Workflow Integration
+
+1. Generate templates using the unified script generation utility. The
+   utility now classifies templates by clustering placeholder counts
+   (KMeans) and records the mapping in ``cluster_output.json``.
+2. Regenerate or create new templates with ``CompleteTemplateGenerator``.
+   When template metadata becomes stale, call
+   ``cleanup_legacy_assets()`` to purge records older than your
+   retention window.
+3. After generation and cleanup, run ``AutonomousFileManager`` as shown
+   above to organize files in the workspace based on the latest
+   database state.

--- a/scripts/utilities/unified_script_generation_system.py
+++ b/scripts/utilities/unified_script_generation_system.py
@@ -26,7 +26,11 @@ from tqdm import tqdm
 from secondary_copilot_validator import SecondaryCopilotValidator
 from utils.visual_progress import start_indicator, progress_bar, end_indicator
 from ml_pattern_recognition import PatternRecognizer
-from unified_session_management_system import prevent_recursion
+try:
+    from unified_session_management_system import prevent_recursion
+except Exception:  # pragma: no cover - fallback if session system unavailable
+    def prevent_recursion(func):
+        return func
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {"start": "[START]", "success": "[SUCCESS]", "error": "[ERROR]", "info": "[INFO]"}
@@ -187,6 +191,11 @@ class EnterpriseUtility:
                 self.logger.error(f"{TEXT_INDICATORS['error']} Validation failed")
                 end_indicator("Script Generation Utility", start_time)
                 return False
+
+            # Cluster all generated templates for classification
+            generated_templates = list(generated_dir.glob("*.txt"))
+            if generated_templates:
+                self.cluster_templates(generated_templates, n_clusters=3)
 
             end_indicator("Script Generation Utility", start_time)
             return True

--- a/tests/test_script_generation_cleanup.py
+++ b/tests/test_script_generation_cleanup.py
@@ -1,0 +1,52 @@
+import json
+import sqlite3
+from datetime import datetime, timedelta
+
+from complete_template_generator import CompleteTemplateGenerator
+from unified_script_generation_system import EnterpriseUtility
+
+
+def test_cluster_templates(tmp_path):
+    t1 = tmp_path / "one.txt"
+    t2 = tmp_path / "two.txt"
+    t1.write_text("{a}{b}")
+    t2.write_text("{a}")
+    util = EnterpriseUtility(workspace_path=str(tmp_path))
+    clusters = util.cluster_templates([t1, t2], n_clusters=2)
+    assert len(clusters) == 2
+    cluster_file = tmp_path / "cluster_output.json"
+    assert cluster_file.exists()
+    data = json.loads(cluster_file.read_text())
+    assert sum(len(v) for v in data.values()) == 2
+
+
+def test_cleanup_legacy_assets(tmp_path):
+    db = tmp_path / "prod.db"
+    gen = CompleteTemplateGenerator(production_db=db)
+    old = (datetime.utcnow() - timedelta(days=40)).isoformat()
+    new = datetime.utcnow().isoformat()
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "INSERT INTO template_generation_stats (cluster_id, template_length, generated_at) VALUES (1, 10, ?)",
+            (old,),
+        )
+        conn.execute(
+            "INSERT INTO template_generation_stats (cluster_id, template_length, generated_at) VALUES (1, 10, ?)",
+            (new,),
+        )
+        conn.execute(
+            "INSERT INTO generated_templates (template_id, template_content, generated_at) VALUES ('old', 'x', ?)",
+            (old,),
+        )
+        conn.execute(
+            "INSERT INTO generated_templates (template_id, template_content, generated_at) VALUES ('new', 'y', ?)",
+            (new,),
+        )
+        conn.commit()
+    removed = gen.cleanup_legacy_assets(retention_days=30)
+    with sqlite3.connect(db) as conn:
+        stats = conn.execute("SELECT COUNT(*) FROM template_generation_stats").fetchone()[0]
+        generated = conn.execute("SELECT COUNT(*) FROM generated_templates").fetchone()[0]
+    assert removed == 2
+    assert stats == 1
+    assert generated == 1


### PR DESCRIPTION
## Summary
- integrate KMeans clustering into script generation workflow
- add legacy asset cleanup to template generator
- document file manager workflow for generation/cleanup

## Testing
- `ruff check scripts/utilities/unified_script_generation_system.py scripts/utilities/complete_template_generator.py tests/test_script_generation_cleanup.py`
- `pytest tests/test_script_generation_cleanup.py -q`
- `python scripts/wlc_session_manager.py` *(fails: validate_enterprise_operation KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688f3860b068833191902147107a7caa