### PR TITLE
Add placeholder audit test and coverage config

### DIFF
--- a/docs/TESTING_AND_COMPLIANCE.md
+++ b/docs/TESTING_AND_COMPLIANCE.md
@@ -1,0 +1,29 @@
+# Testing and Compliance
+
+This project uses `pytest` for automated testing and `pytest-cov` for coverage
+reporting. To run the test suite with coverage enabled:
+
+```
+pytest
+```
+
+Individual tests can be executed with:
+
+```
+pytest path/to/test_file.py
+```
+
+Linting is provided by `ruff`:
+
+```
+ruff check <paths>
+```
+
+Placeholder audits can be simulated via:
+
+```
+python scripts/code_placeholder_audit.py --simulate
+```
+
+All outputs should be reviewed to ensure that no placeholders remain and that
+coverage metrics are captured.

--- a/misc/tests/test_base64_zip_transformer.py
+++ b/misc/tests/test_base64_zip_transformer.py
@@ -1,13 +1,19 @@
 """Regression tests for the Base64 ZIP transformer."""
 
 from __future__ import annotations
+
 import io
 import zipfile
 from pathlib import Path
 
+import pytest
+
+# Skip tests if PyQt6 is unavailable
+pytest.importorskip("PyQt6")
 
 # Make legacy module importable
 import sys
+
 sys.path.append(str(Path(__file__).resolve().parents[1] / "legacy"))
 from Base64ZipTransformer import DecodeWorker, EncodeWorker  # noqa: E402
 

--- a/misc/tests/test_zip_transformer.py
+++ b/misc/tests/test_zip_transformer.py
@@ -6,6 +6,9 @@ import sys
 import zipfile
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("PyQt6")
 from PyQt6.QtCore import QCoreApplication
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "legacy"))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --maxfail=10 --exitfirst
+addopts = --maxfail=10 --exitfirst --cov=. --cov-report=term
 # Enforce per-test timeouts via pytest-timeout (seconds)
 timeout = 120
 norecursedirs = builds

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 requests
 pytest
+pytest-cov
 pytest-timeout
 psutil
 tqdm

--- a/tests/test_placeholder_audit_integration.py
+++ b/tests/test_placeholder_audit_integration.py
@@ -1,0 +1,30 @@
+"""Basic integration test for the placeholder audit script."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import os
+
+import pytest
+
+audit_module = pytest.importorskip("scripts.code_placeholder_audit")
+main = audit_module.main
+
+
+def test_placeholder_audit_clean_workspace(tmp_path):
+    """The audit should succeed when no placeholders are present."""
+
+    os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+
+    test_file: Path = tmp_path / "clean.py"
+    test_file.write_text("print('hi')\n", encoding="utf-8")
+
+    assert main(
+        workspace_path=str(tmp_path),
+        analytics_db=str(tmp_path / "analytics.db"),
+        production_db=str(tmp_path / "production.db"),
+        dashboard_dir=str(tmp_path / "dashboard"),
+        simulate=True,
+    )
+


### PR DESCRIPTION
## Summary
- skip PyQt-dependent tests when PyQt6 is missing
- add basic placeholder audit integration test and enable coverage reporting
- document testing and linting workflows

## Testing
- `ruff check misc/tests/test_base64_zip_transformer.py misc/tests/test_zip_transformer.py tests/test_placeholder_audit_integration.py`
- `pytest tests/test_placeholder_audit_integration.py misc/tests/test_base64_zip_transformer.py misc/tests/test_zip_transformer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3864ac948331a61d0f5424c0b9c9