### PR TITLE
feat: log placeholder audits and expose dashboard view

### DIFF
--- a/dashboard/templates/audit_results.html
+++ b/dashboard/templates/audit_results.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Audit Results</title>
+  </head>
+  <body>
+    <h1>Audit Results</h1>
+    <ul>
+    {% for row in results %}
+      <li>{{ row.placeholder_type }}: {{ row.count }}</li>
+    {% endfor %}
+    </ul>
+  </body>
+</html>

--- a/docs/PLACEHOLDER_AUDIT_COMPLIANCE.md
+++ b/docs/PLACEHOLDER_AUDIT_COMPLIANCE.md
@@ -1,0 +1,18 @@
+# Placeholder Audit Compliance Guide
+
+This guide outlines the procedure for running the placeholder audit and verifying compliance.
+
+## Running the Audit
+
+1. Activate the project virtual environment.
+2. Execute `python -m scripts.code_placeholder_audit --workspace-path <path> --analytics-db databases/analytics.db --production-db databases/production.db --dashboard-dir dashboard/compliance`.
+3. The script scans for TODO, FIXME, and related markers. Findings are written to `analytics.db` and summarized under `dashboard/compliance`.
+
+## Reviewing Results
+
+- Query `analytics.db` for the `todo_fixme_tracking` table to view individual findings.
+- Open the enterprise dashboard and navigate to **Audit Results** to see aggregated counts by placeholder type.
+
+## Compliance
+
+Resolve open placeholders and re-run the audit until the dashboard reports zero findings and a compliant status.

--- a/tests/dashboard/test_audit_results_view.py
+++ b/tests/dashboard/test_audit_results_view.py
@@ -1,0 +1,32 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dashboard import enterprise_dashboard as ed
+
+
+@pytest.fixture()
+def app(tmp_path: Path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking (placeholder_type TEXT, status TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO todo_fixme_tracking VALUES ('TODO', 'open')"
+        )
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+    return ed.app
+
+
+def test_audit_results_json(app):
+    client = app.test_client()
+    data = client.get("/audit-results").get_json()
+    assert data == [{"placeholder_type": "TODO", "count": 1}]
+
+
+def test_audit_results_view(app):
+    client = app.test_client()
+    resp = client.get("/audit-results/view")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- log placeholder audit results to analytics.db and report insert counts
- surface audit results on enterprise dashboard with new HTML view
- document placeholder audit compliance procedure

## Testing
- `ruff check scripts/code_placeholder_audit.py dashboard/enterprise_dashboard.py tests/dashboard/test_audit_results_view.py`
- `pytest tests/dashboard/test_audit_results_view.py`
- `pytest tests/test_code_placeholder_audit_logger.py` *(fails: ImportError: cannot import name 'validate_enterprise_operation')*


------
https://chatgpt.com/codex/tasks/task_e_688f386c32008331824d1f86628ae17a