### PR TITLE
docs: add governance standards and checks

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,14 @@
+name: governance
+
+on: [push, pull_request]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate governance docs
+        run: |
+          test -f docs/GOVERNANCE_STANDARDS.md
+          test -f docs/REPOSITORY_GUIDELINES.md
+          grep -q "GOVERNANCE_STANDARDS.md" README.md

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 > Tests: run `pytest` before committing. Current repository tests report multiple failures.
 > Lint: run `ruff check .` before committing.
 > Quantum modules operate in placeholder simulation modes; compliance auditing is still in progress. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) for details.
-> Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules.
+> Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards.
 
 ---
 

--- a/docs/GOVERNANCE_STANDARDS.md
+++ b/docs/GOVERNANCE_STANDARDS.md
@@ -1,13 +1,21 @@
 # Governance Standards
 
-This document outlines the organizational rules for contributions to gh_COPILOT.
+This document defines organizational rules and coding standards for the gh_COPILOT
+project. All contributors must comply with these policies to maintain a secure and
+collaborative codebase.
 
 ## Core Principles
 - **Transparency:** Record significant decisions and changes within the repository.
 - **Compliance:** Follow licensing requirements and project policies.
 - **Review:** Every change undergoes peer review through pull requests.
 
+## Coding Standards
+- Adhere to PEP 8 style guidelines with a 120-character line limit.
+- Use `snake_case` for functions and variables and `CamelCase` for classes.
+- Include type hints and docstrings for public functions.
+- Run `ruff` and `pytest` before submitting a pull request.
+
 ## Contributor Expectations
 - Run `bash setup.sh`, activate the virtual environment, and execute `ruff` and `pytest` before committing.
-- Reference these standards in proposals and pull requests.
+- Reference these standards and the [Repository Guidelines](REPOSITORY_GUIDELINES.md) in proposals and pull requests.
 - Respect the dual-copilot validation and database-first principles.

--- a/docs/REPOSITORY_GUIDELINES.md
+++ b/docs/REPOSITORY_GUIDELINES.md
@@ -3,7 +3,7 @@
 
 ## OBJECTIVE
 
-This file defines the standard operating procedures (SOPs) for contributing to the **gh_COPILOT** project, maintaining repository health, and ensuring compliance with enterprise and team guidelines.
+This file defines the standard operating procedures (SOPs) for contributing to the **gh_COPILOT** project, maintaining repository health, and ensuring compliance with enterprise and team guidelines. Review the [Governance Standards](GOVERNANCE_STANDARDS.md) for overarching policies and coding conventions.
 
 ## AGENTS RESPONSIBILITY
 


### PR DESCRIPTION
## Summary
- expand governance standards with coding conventions and contributor expectations
- cross-link repository guidelines and reference governance in README
- add governance CI workflow ensuring docs and references exist

## Testing
- `ruff check .` *(fails: F821 Undefined name `ensure_no_zero_byte_files` and other errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_688f3872063c83318b5939c53638ccb9