### PR TITLE
feat: add scheduled monitoring metrics push

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -19,3 +19,24 @@ to record optimization metrics:
 from scripts.monitoring.unified_monitoring_optimization_system import main as monitoring_main
 monitoring_main()
 ```
+
+## Scheduled Metrics Push
+
+`log_error_notifier.py` and `performance_tracker.py` can push metrics to
+`analytics.db` on a schedule. Each module exposes a helper that runs in a
+background thread and writes to the database at regular intervals:
+
+```python
+from pathlib import Path
+import threading
+
+from monitoring.log_error_notifier import schedule_log_monitoring
+from monitoring.performance_tracker import schedule_metrics_push
+
+stop = threading.Event()
+schedule_log_monitoring([Path("app.log")], interval=60, stop_event=stop)
+schedule_metrics_push(interval=60, stop_event=stop)
+```
+
+Call `stop.set()` to terminate the threads gracefully. Ensure
+`GH_COPILOT_WORKSPACE` is set so both helpers locate `analytics.db`.

--- a/monitoring/performance_tracker.py
+++ b/monitoring/performance_tracker.py
@@ -5,8 +5,9 @@ import builtins
 import logging
 import os
 import sqlite3
+import threading
 from pathlib import Path
-from time import perf_counter
+from time import perf_counter, sleep
 from typing import Dict, Iterable, Optional
 
 WORKSPACE_ROOT = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
@@ -24,6 +25,8 @@ __all__ = [
     "record_error",
     "ensure_table",
     "benchmark_queries",
+    "push_metrics",
+    "schedule_metrics_push",
     "RESPONSE_TIME_ALERT_MS",
     "ERROR_RATE_ALERT",
 ]
@@ -116,6 +119,50 @@ def benchmark_queries(queries: Iterable[str], db_path: Optional[Path] = None) ->
             duration = (perf_counter() - start) * 1000
             metrics = track_query_time(query, duration, db_path=path)
     return metrics
+
+
+def push_metrics(db_path: Optional[Path] = None) -> Dict[str, float]:
+    """Compute aggregate metrics and store them in ``analytics.db``."""
+
+    path = db_path or DB_PATH
+    with sqlite3.connect(path) as conn:
+        _ensure_table(conn)
+        metrics = _compute_metrics(conn)
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS performance_summary (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                avg_response_time_ms REAL,
+                error_rate REAL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO performance_summary (avg_response_time_ms, error_rate) VALUES (?, ?)",
+            (metrics["avg_response_time_ms"], metrics["error_rate"]),
+        )
+        conn.commit()
+    _update_dashboard(metrics)
+    return metrics
+
+
+def schedule_metrics_push(
+    interval: float, db_path: Optional[Path] = None, stop_event: Optional[threading.Event] = None
+) -> threading.Thread:
+    """Periodically push performance metrics to ``analytics.db``."""
+
+    def _loop() -> None:
+        while stop_event is None or not stop_event.is_set():
+            push_metrics(db_path=db_path)
+            if stop_event is None:
+                sleep(interval)
+            else:
+                stop_event.wait(interval)
+
+    thread = threading.Thread(target=_loop, daemon=True)
+    thread.start()
+    return thread
 
 
 builtins.benchmark_queries = benchmark_queries

--- a/tests/test_continuous_monitoring.py
+++ b/tests/test_continuous_monitoring.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Tests scheduled monitoring helpers."""
+
+import os
+import sqlite3
+import threading
+import time
+
+from monitoring.log_error_notifier import schedule_log_monitoring
+from monitoring.performance_tracker import (
+    schedule_metrics_push,
+    track_query_time,
+)
+
+
+def test_schedule_log_monitoring_records_notifications(tmp_path):
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    db = db_dir / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS log_errors (file TEXT, error TEXT, timestamp TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS log_notifications (errors_found INTEGER, timestamp TEXT)"
+        )
+    log_file = tmp_path / "app.log"
+    log_file.write_text("INFO ok\nERROR boom\n")
+    stop = threading.Event()
+    thread = schedule_log_monitoring([log_file], 0.1, db_path=db, stop_event=stop)
+    time.sleep(0.2)
+    stop.set()
+    thread.join(timeout=1)
+    with sqlite3.connect(db) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM log_notifications")
+        assert cur.fetchone()[0] > 0
+
+
+def test_schedule_metrics_push_inserts_summary(tmp_path):
+    db = tmp_path / "analytics.db"
+    track_query_time("q1", 10.0, db_path=db)
+    stop = threading.Event()
+    thread = schedule_metrics_push(0.1, db_path=db, stop_event=stop)
+    time.sleep(0.2)
+    stop.set()
+    thread.join(timeout=1)
+    with sqlite3.connect(db) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM performance_summary")
+        assert cur.fetchone()[0] > 0


### PR DESCRIPTION
## Summary
- add scheduler for log error monitoring to periodically push metrics
- push aggregated performance metrics and schedule recurring updates
- document scheduled monitoring setup and add regression tests

## Testing
- `ruff check monitoring/log_error_notifier.py monitoring/performance_tracker.py tests/test_continuous_monitoring.py`
- `pytest tests/test_log_error_notifier.py tests/test_performance_tracker.py tests/test_continuous_monitoring.py`


------
https://chatgpt.com/codex/tasks/task_e_688f38743be48331a400db6fef32d9e9