### PR TITLE
feat: apply anti-recursion guard to scripts and expand tests

### DIFF
--- a/docs/RECURSION_POLICY.md
+++ b/docs/RECURSION_POLICY.md
@@ -28,3 +28,20 @@ validate_workspace()
 # 2. backup root linking back to workspace
 (bk / 'ws_link').symlink_to(ws)
 ```
+
+## Developer Usage
+
+Use the `anti_recursion_guard` decorator from `utils.validation_utils` to prevent
+scripts from invoking themselves recursively. Decorate any entry points that
+perform filesystem operations or manage archives:
+
+```python
+from utils.validation_utils import anti_recursion_guard
+
+@anti_recursion_guard
+def archive_backups() -> Path:
+    ...
+```
+
+This guard creates a transient lock file so that re-entrant calls raise a
+`RuntimeError` instead of causing recursive behaviour.

--- a/scripts/backup_archiver.py
+++ b/scripts/backup_archiver.py
@@ -12,8 +12,10 @@ import py7zr
 
 from enterprise_modules.compliance import validate_enterprise_operation
 from utils.cross_platform_paths import CrossPlatformPathManager
+from utils.validation_utils import anti_recursion_guard
 
 
+@anti_recursion_guard
 def archive_backups() -> Path:
     """Compress backup files and store the archive under ``archive/``."""
 

--- a/scripts/validation/semantic_search_reference_validator.py
+++ b/scripts/validation/semantic_search_reference_validator.py
@@ -9,6 +9,7 @@ import time
 from datetime import datetime
 from tqdm import tqdm
 import logging
+from utils.validation_utils import anti_recursion_guard
 
 # === ENTERPRISE LOGGING SETUP ===
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -16,6 +17,7 @@ logger = logging.getLogger("SemanticSearchValidator")
 
 
 # === ANTI-RECURSION & COMPLIANCE VALIDATION ===
+@anti_recursion_guard
 def validate_no_recursive_folders():
     """
     Scan workspace for forbidden recursive folders (backup/temp) and log violations.

--- a/tests/test_anti_recursion_guard.py
+++ b/tests/test_anti_recursion_guard.py
@@ -1,0 +1,93 @@
+import threading
+import time
+import importlib
+import sys
+import types
+
+import py7zr
+import pytest
+
+from utils.validation_utils import anti_recursion_guard
+import utils.validation_utils as validation_utils_module
+from scripts.validation.semantic_search_reference_validator import (
+    validate_no_recursive_folders,
+)
+
+
+def test_guard_prevents_direct_recursion():
+    calls = []
+
+    @anti_recursion_guard
+    def recurse(n: int) -> int:
+        calls.append(n)
+        if n > 0:
+            recurse(n - 1)
+        return len(calls)
+
+    with pytest.raises(RuntimeError):
+        recurse(1)
+
+
+def test_guard_via_multiple_import_paths():
+    @anti_recursion_guard
+    def first():
+        second()
+
+    @validation_utils_module.anti_recursion_guard
+    def second():
+        first()
+
+    with pytest.raises(RuntimeError):
+        first()
+
+
+def test_guard_applied_to_backup_archiver(monkeypatch, tmp_path):
+    dummy_compliance = types.ModuleType("enterprise_modules.compliance")
+    dummy_compliance.validate_enterprise_operation = lambda path: True
+    sys.modules["enterprise_modules.compliance"] = dummy_compliance
+    backup_archiver = importlib.import_module("scripts.backup_archiver")
+    archive_backups = backup_archiver.archive_backups
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    backup_root = tmp_path / "backups"
+    backup_root.mkdir()
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    class Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            time.sleep(0.2)
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def write(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(py7zr, "SevenZipFile", Dummy)
+
+    t = threading.Thread(target=archive_backups)
+    t.start()
+    time.sleep(0.05)
+    with pytest.raises(RuntimeError):
+        archive_backups()
+    t.join()
+
+
+def test_guard_applied_to_semantic_validator(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    def slow_walk(path):
+        time.sleep(0.2)
+        return []
+
+    monkeypatch.setattr("scripts.validation.semantic_search_reference_validator.os.walk", slow_walk)
+
+    t = threading.Thread(target=validate_no_recursive_folders)
+    t.start()
+    time.sleep(0.05)
+    with pytest.raises(RuntimeError):
+        validate_no_recursive_folders()
+    t.join()


### PR DESCRIPTION
## Summary
- guard backup_archiver.archive_backups and semantic validator's `validate_no_recursive_folders` with `anti_recursion_guard`
- add comprehensive anti-recursion tests covering multiple import paths and script usage
- document decorator usage in recursion policy

## Testing
- `ruff check scripts/backup_archiver.py scripts/validation/semantic_search_reference_validator.py tests/test_anti_recursion_guard.py`
- `pyright scripts/backup_archiver.py scripts/validation/semantic_search_reference_validator.py tests/test_anti_recursion_guard.py`
- `pytest tests/test_anti_recursion_guard.py`

------
https://chatgpt.com/codex/tasks/task_e_688f3879bf448331a90e3117fde39717