### PR TITLE
feat: improve dual copilot validation failure handling

### DIFF
--- a/docs/DUAL_COPILOT_PATTERN.md
+++ b/docs/DUAL_COPILOT_PATTERN.md
@@ -1,0 +1,18 @@
+# Dual Copilot Pattern
+
+The **dual copilot** pattern provides an extra layer of assurance for
+critical operations. A primary action executes first and a secondary
+validator confirms the outcome. Both are executed even when the primary
+fails.
+
+## Validation Flow
+
+1. The primary validator runs and returns a boolean indicating success.
+   Any exception is captured and treated as a failure.
+2. The secondary validator runs regardless of the primary outcome.
+3. If either validator raises an exception, the errors are aggregated and
+   a `RuntimeError` is raised describing the failures.
+4. When both validators return `True`, the overall result is `True`.
+
+Use `utils.validation_utils.run_dual_copilot_validation` to coordinate
+this flow in code.

--- a/tests/test_dual_copilot_validation.py
+++ b/tests/test_dual_copilot_validation.py
@@ -1,0 +1,36 @@
+import pytest
+
+from utils.validation_utils import run_dual_copilot_validation
+
+
+def test_primary_exception_still_runs_secondary():
+    order = []
+
+    def primary() -> bool:
+        order.append("primary")
+        raise ValueError("boom")
+
+    def secondary() -> bool:
+        order.append("secondary")
+        return True
+
+    with pytest.raises(RuntimeError) as excinfo:
+        run_dual_copilot_validation(primary, secondary)
+
+    assert "Primary validation error" in str(excinfo.value)
+    assert order == ["primary", "secondary"]
+
+
+def test_both_exceptions_are_reported():
+    def primary() -> bool:
+        raise ValueError("p")
+
+    def secondary() -> bool:
+        raise ValueError("s")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        run_dual_copilot_validation(primary, secondary)
+
+    message = str(excinfo.value)
+    assert "Primary validation error" in message
+    assert "Secondary validation error" in message


### PR DESCRIPTION
## Summary
- enhance `run_dual_copilot_validation` to report primary/secondary errors after running both validators
- add tests covering exception scenarios in dual copilot validation
- document dual copilot validation flow

## Testing
- `ruff check utils/validation_utils.py tests/test_dual_copilot_validation.py tests/test_validation_utils.py`
- `pytest tests/test_dual_copilot_validation.py tests/test_validation_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f389b505483318f13ffe18d6d13ef