### PR TITLE
feat: enhance compliance metrics calculation

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -123,9 +123,8 @@ class ComplianceMetricsUpdater:
                 open_ph = metrics["open_placeholders"]
                 resolved_ph = metrics["resolved_placeholders"]
                 denominator = resolved_ph + open_ph
-                metrics["compliance_score"] = (
-                    resolved_ph / denominator if denominator else 1.0
-                )
+                base_score = resolved_ph / denominator if denominator else 1.0
+                metrics["compliance_score"] = base_score
 
                 # Placeholder type breakdown
                 try:
@@ -164,6 +163,8 @@ class ComplianceMetricsUpdater:
                 else:
                     metrics["recent_rollbacks"] = []
                     metrics["rollback_count"] = 0
+                penalty = 0.1 * metrics["violation_count"] + 0.05 * metrics["rollback_count"]
+                metrics["compliance_score"] = max(0.0, min(1.0, base_score - penalty))
             except Exception as e:
                 logging.error(f"Error fetching metrics: {e}")
         total_ph = metrics["resolved_placeholders"] + metrics["open_placeholders"]

--- a/docs/COMPLIANCE_METRICS.md
+++ b/docs/COMPLIANCE_METRICS.md
@@ -1,0 +1,27 @@
+# Compliance Metrics
+
+This document describes how compliance scores are calculated for the dashboard.
+
+## Compliance Score
+
+The compliance score measures progress resolving placeholders while
+accounting for outstanding issues. It is computed as:
+
+```
+base = resolved_placeholders / (resolved_placeholders + open_placeholders)
+penalty = 0.10 * violation_count + 0.05 * rollback_count
+score = max(0, min(1, base - penalty))
+```
+
+The score ranges from 0 to 1 and decreases when violations or rollbacks
+occur. A missing denominator defaults the base score to 1.0.
+
+## Trend and Latency
+
+The updater records recent compliance scores in `correction_logs`.
+The dashboard shows these as the `compliance_trend` to visualize
+improvement over time.
+
+Average query latency is derived from entries in the
+`performance_metrics` table with `metric_name='query_latency'` and
+reported alongside compliance metrics.

--- a/tests/test_compliance_metrics.py
+++ b/tests/test_compliance_metrics.py
@@ -1,0 +1,69 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dashboard import compliance_metrics_updater as cmu
+
+
+@pytest.fixture()
+def analytics_db(tmp_path: Path, monkeypatch) -> Path:
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking (placeholder_type TEXT, status TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO todo_fixme_tracking VALUES (?, ?)",
+            [("TODO", "open"), ("FIXME", "resolved"), ("TODO", "resolved")],
+        )
+        conn.execute(
+            "CREATE TABLE correction_logs (event TEXT, score REAL, timestamp TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO correction_logs VALUES ('update', ?, ?)",
+            [(0.3, "2024-01-01"), (0.6, "2024-01-02")],
+        )
+        conn.execute(
+            "CREATE TABLE violation_logs (details TEXT, timestamp TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO violation_logs VALUES ('v1', '2024-01-03')"
+        )
+        conn.execute(
+            "CREATE TABLE rollback_logs (target TEXT, backup TEXT, timestamp TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO rollback_logs VALUES ('file', 'bak', '2024-01-03')"
+        )
+        conn.execute(
+            "CREATE TABLE performance_metrics (metric_name TEXT, metric_value REAL)"
+        )
+        conn.executemany(
+            "INSERT INTO performance_metrics VALUES ('query_latency', ?)",
+            [(10.0,), (20.0,)],
+        )
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "ANALYTICS_DB", db)
+    return db
+
+
+def test_score_trend_and_formula(analytics_db: Path, tmp_path: Path):
+    updater = cmu.ComplianceMetricsUpdater(tmp_path, test_mode=True)
+    metrics = updater._fetch_compliance_metrics(test_mode=True)
+    assert metrics["compliance_trend"] == [0.3, 0.6]
+    expected = max(0.0, min(1.0, (2 / 3) - 0.1 - 0.05))
+    assert metrics["compliance_score"] == pytest.approx(expected, rel=1e-3)
+
+
+def test_latency_metric(analytics_db: Path):
+    with sqlite3.connect(analytics_db) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT AVG(metric_value) FROM performance_metrics WHERE metric_name='query_latency'"
+        )
+        avg = cur.fetchone()[0]
+    assert avg == pytest.approx(15.0)


### PR DESCRIPTION
## Summary
- refine compliance score with penalties for violations and rollbacks
- document compliance metric formulas
- add tests for compliance trend and query latency calculations

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/test_compliance_metrics.py`
- `pytest -p no:conftest tests/test_compliance_metrics.py` *(fails: ImportError: cannot import name 'validate_enterprise_operation' from partially initialized module 'enterprise_modules.compliance')*


------
https://chatgpt.com/codex/tasks/task_e_688f38a0dd8c8331a783a11dde32b200