### PR TITLE
refactor: standardize dual validation workflow

### DIFF
--- a/docs/DUAL_COPILOT_PATTERN.md
+++ b/docs/DUAL_COPILOT_PATTERN.md
@@ -16,3 +16,9 @@ fails.
 
 Use `utils.validation_utils.run_dual_copilot_validation` to coordinate
 this flow in code.
+
+Recent orchestrators such as `scripts.enterprise_deployment_orchestrator`,
+`scripts.continuous_operation_orchestrator`, and
+`scripts.enterprise_validation_orchestrator` now delegate their primary and
+secondary checks through this helper, ensuring a unified validation workflow
+across the toolkit.

--- a/docs/PHASE5_TASKS_STARTED.md
+++ b/docs/PHASE5_TASKS_STARTED.md
@@ -76,8 +76,8 @@ These task stubs originate from the gap analysis report and have been formally s
 
 ## 18. Standardize Dual-Copilot Validation
 - **Statement Excerpt:** "Session Management Tie‑in: Link metrics to session lifecycle for full visibility" and "Comprehensive Tests" for validation.
-- **Status:** Started – orchestrator updates and dual validation test plan created.
-- **Progress:** [ ] 40% – dual-copilot validation now tested for failing primary paths.
+- **Status:** Completed – orchestrators now use `run_dual_copilot_validation` with comprehensive tests.
+- **Progress:** [x] 100% – dual-copilot validation standardized and covered by failing-order tests.
 
 ## 19. Clarify Quantum Placeholder Features
 - **Statement Excerpt:** "Audit Pass: Review whitepaper, README and guides; reconcile overstated claims (quantum features, test success)."
@@ -94,5 +94,5 @@ These task stubs originate from the gap analysis report and have been formally s
  - [ ] 7. Align Documentation with Implementation — 70% complete
 - [x] 12. Update Changelog and User Prompts — 100% complete
 - [ ] 17. Implement Anti-Recursion Guards — 50% complete
-- [ ] 18. Standardize Dual-Copilot Validation — 40% complete
+- [x] 18. Standardize Dual-Copilot Validation — 100% complete
  - [ ] 19. Clarify Quantum Placeholder Features — 80% complete

--- a/scripts/automation/strategic_implementation_orchestrator.py
+++ b/scripts/automation/strategic_implementation_orchestrator.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from tqdm import tqdm
+from utils.validation_utils import run_dual_copilot_validation
 
 # Enhanced Cognitive Processing Imports
 try:
@@ -801,8 +802,15 @@ def main():
         print(f"Report Location: {report_path}")
         print("=" * 80)
 
-        orchestrator.primary_validate()
-        orchestrator.secondary_validate()
+        def _primary_validation():
+            logger.info("🔍 PRIMARY VALIDATION")
+            return orchestrator.primary_validate()
+
+        def _secondary_validation():
+            logger.info("🔍 SECONDARY VALIDATION")
+            return orchestrator.secondary_validate()
+
+        run_dual_copilot_validation(_primary_validation, _secondary_validation)
 
         return implementation_results
 

--- a/scripts/enterprise_deployment_orchestrator.py
+++ b/scripts/enterprise_deployment_orchestrator.py
@@ -42,8 +42,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from enterprise_modules.compliance import validate_enterprise_operation
+from enterprise_modules import compliance
 from utils.cross_platform_paths import CrossPlatformPathManager
+from utils.validation_utils import run_dual_copilot_validation
 
 
 # 🚨 CRITICAL: Anti-recursion validation
@@ -133,7 +134,7 @@ class EnterpriseDeploymentOrchestrator:
 
     def __init__(self, workspace_path: Optional[str] = None):
         # Validate enterprise operation before initializing
-        validate_enterprise_operation()
+        compliance.validate_enterprise_operation()
 
         # 🚀 MANDATORY: Start time logging with enterprise formatting
         self.start_time = datetime.now()
@@ -195,8 +196,17 @@ class EnterpriseDeploymentOrchestrator:
     def execute_enterprise_deployment(self) -> Dict[str, Any]:
         """🚀 Execute comprehensive enterprise deployment"""
 
-        validate_enterprise_operation()
-        primary_validate()
+        compliance.validate_enterprise_operation()
+
+        def _primary_start():
+            logging.info("🔍 PRIMARY VALIDATION")
+            return primary_validate()
+
+        def _secondary_start():
+            logging.info("🔍 SECONDARY VALIDATION")
+            return self.secondary_validate()
+
+        run_dual_copilot_validation(_primary_start, _secondary_start)
 
         # 🚀 MANDATORY: Visual processing indicators
         logging.info(f"🚀 ENTERPRISE DEPLOYMENT STARTED: {self.session_id}")
@@ -275,12 +285,17 @@ class EnterpriseDeploymentOrchestrator:
         self._log_deployment_summary(deployment_results)
 
         # Dual Copilot validation steps
-        logging.info("🔍 PRIMARY VALIDATION")
-        primary_ok = self.primary_validate()
-        logging.info("🔍 SECONDARY VALIDATION")
-        secondary_ok = self.secondary_validate()
-        deployment_results["primary_validation"] = primary_ok
-        deployment_results["secondary_validation"] = secondary_ok
+        def _primary():
+            logging.info("🔍 PRIMARY VALIDATION")
+            return self.primary_validate()
+
+        def _secondary():
+            logging.info("🔍 SECONDARY VALIDATION")
+            return self.secondary_validate()
+
+        validation_passed = run_dual_copilot_validation(_primary, _secondary)
+        deployment_results["primary_validation"] = validation_passed
+        deployment_results["secondary_validation"] = validation_passed
 
         return deployment_results
 

--- a/scripts/enterprise_gh_copilot_deployment_orchestrator.py
+++ b/scripts/enterprise_gh_copilot_deployment_orchestrator.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from datetime import datetime
 
 from scripts.utilities.production_template_utils import generate_script_from_repository
+from utils.validation_utils import run_dual_copilot_validation
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {"start": "[START]", "success": "[SUCCESS]", "error": "[ERROR]", "info": "[INFO]"}
@@ -36,10 +37,18 @@ class EnterpriseUtility:
         try:
             # Utility implementation
             success = self.perform_utility_function()
-            self.primary_validate()
-            self.secondary_validate()
 
-            if success:
+            def _primary():
+                self.logger.info("[INFO] PRIMARY VALIDATION")
+                return self.primary_validate()
+
+            def _secondary():
+                self.logger.info("[INFO] SECONDARY VALIDATION")
+                return self.secondary_validate()
+
+            validation_passed = run_dual_copilot_validation(_primary, _secondary)
+
+            if success and validation_passed:
                 duration = (datetime.now() - start_time).total_seconds()
                 self.logger.info(f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s")
                 return True

--- a/scripts/enterprise_validation_orchestrator.py
+++ b/scripts/enterprise_validation_orchestrator.py
@@ -60,7 +60,8 @@ from typing import Any, Dict, List, Optional
 import psutil
 from tqdm import tqdm
 
-from enterprise_modules.compliance import validate_enterprise_operation
+from enterprise_modules import compliance
+from utils.validation_utils import run_dual_copilot_validation
 
 # Configure comprehensive logging
 logging.basicConfig(
@@ -203,8 +204,17 @@ class EnterpriseValidationOrchestrator:
 
     def __init__(self, workspace_path: Optional[str] = None, config: Optional[ValidationConfiguration] = None):
         """Initialize Enterprise Validation Orchestrator with comprehensive capabilities"""
-        validate_enterprise_operation()
-        primary_validate()
+        compliance.validate_enterprise_operation()
+
+        def _primary_start():
+            logger.info("🔍 PRIMARY VALIDATION")
+            return primary_validate()
+
+        def _secondary_start():
+            logger.info("🔍 SECONDARY VALIDATION")
+            return self.secondary_validate()
+
+        run_dual_copilot_validation(_primary_start, _secondary_start)
         # CRITICAL: Anti-recursion validation
         self.validate_workspace_integrity()
 
@@ -682,12 +692,17 @@ class EnterpriseValidationOrchestrator:
         logger.info("=" * 80)
 
         # Dual Copilot validation
-        logger.info("🔍 PRIMARY VALIDATION")
-        primary_ok = self.primary_validate()
-        logger.info("🔍 SECONDARY VALIDATION")
-        secondary_ok = self.secondary_validate()
-        self.validation_metrics.primary_valid = primary_ok
-        self.validation_metrics.secondary_valid = secondary_ok
+        def _primary():
+            logger.info("🔍 PRIMARY VALIDATION")
+            return self.primary_validate()
+
+        def _secondary():
+            logger.info("🔍 SECONDARY VALIDATION")
+            return self.secondary_validate()
+
+        validation_passed = run_dual_copilot_validation(_primary, _secondary)
+        self.validation_metrics.primary_valid = validation_passed
+        self.validation_metrics.secondary_valid = validation_passed
 
         return self.validation_metrics
 

--- a/scripts/regenerated/integrated_deployment_orchestrator.py
+++ b/scripts/regenerated/integrated_deployment_orchestrator.py
@@ -18,6 +18,7 @@ from utils.cross_platform_paths import CrossPlatformPathManager
 from datetime import datetime
 
 from scripts.utilities.production_template_utils import generate_script_from_repository
+from utils.validation_utils import run_dual_copilot_validation
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {"start": "[START]", "success": "[SUCCESS]", "error": "[ERROR]", "info": "[INFO]"}
@@ -39,10 +40,18 @@ class EnterpriseUtility:
         try:
             # Utility implementation
             success = self.perform_utility_function()
-            self.primary_validate()
-            self.secondary_validate()
 
-            if success:
+            def _primary():
+                self.logger.info("[INFO] PRIMARY VALIDATION")
+                return self.primary_validate()
+
+            def _secondary():
+                self.logger.info("[INFO] SECONDARY VALIDATION")
+                return self.secondary_validate()
+
+            validation_passed = run_dual_copilot_validation(_primary, _secondary)
+
+            if success and validation_passed:
                 duration = (datetime.now() - start_time).total_seconds()
                 self.logger.info(f"{TEXT_INDICATORS['success']} Utility completed in {duration:.1f}s")
                 return True

--- a/tests/test_dual_copilot_validation.py
+++ b/tests/test_dual_copilot_validation.py
@@ -21,11 +21,15 @@ def test_primary_exception_still_runs_secondary():
     assert order == ["primary", "secondary"]
 
 
-def test_both_exceptions_are_reported():
+def test_both_exceptions_are_reported_with_order():
+    order = []
+
     def primary() -> bool:
+        order.append("primary")
         raise ValueError("p")
 
     def secondary() -> bool:
+        order.append("secondary")
         raise ValueError("s")
 
     with pytest.raises(RuntimeError) as excinfo:
@@ -34,3 +38,20 @@ def test_both_exceptions_are_reported():
     message = str(excinfo.value)
     assert "Primary validation error" in message
     assert "Secondary validation error" in message
+    assert order == ["primary", "secondary"]
+
+
+def test_both_validations_return_false_ordered():
+    order = []
+
+    def primary() -> bool:
+        order.append("primary")
+        return False
+
+    def secondary() -> bool:
+        order.append("secondary")
+        return False
+
+    result = run_dual_copilot_validation(primary, secondary)
+    assert result is False
+    assert order == ["primary", "secondary"]


### PR DESCRIPTION
## Summary
- refactor orchestrators and utilities to run primary and secondary checks via `run_dual_copilot_validation`
- test dual validator failure ordering and false-return cases
- document unified dual-copilot validation workflow and mark Phase 5 task complete

## Testing
- `ruff check scripts/automation/strategic_implementation_orchestrator.py scripts/continuous_operation_orchestrator.py scripts/database/complete_consolidation_orchestrator.py scripts/enterprise_deployment_orchestrator.py scripts/enterprise_gh_copilot_deployment_orchestrator.py scripts/enterprise_validation_orchestrator.py scripts/regenerated/integrated_deployment_orchestrator.py tests/test_dual_copilot_validation.py`
- `pytest tests/test_dual_copilot_validation.py tests/test_dual_copilot_coverage.py tests/test_orchestrator_validation_calls.py`

------
https://chatgpt.com/codex/tasks/task_e_688ff151a4e08331bfb448c3b1879dc6