### PR TITLE
fix: guard against missing pid in recursion enforcer

### DIFF
--- a/scripts/session/anti_recursion_enforcer.py
+++ b/scripts/session/anti_recursion_enforcer.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import logging
+import os
+import psutil
+
+class AntiRecursionEnforcer:
+    """Detect and handle recursive session execution."""
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def enforce_no_recursion(self, current_pid: int | None = None) -> None:
+        """Terminate the session if recursion is detected.
+
+        If ``current_pid`` is not found in the process table, a warning is
+        logged and the check is skipped to avoid crashes during integration
+        tests where the PID might be stale.
+        """
+        pid = current_pid or os.getpid()
+        if not psutil.pid_exists(pid):
+            self.logger.warning(
+                "PID %s not found in process table; skipping recursion enforcement",
+                pid,
+            )
+            return
+        if self._detect_recursion(pid):
+            self.logger.critical("Recursion detected in session %s. Aborting.", pid)
+            self._terminate_session(pid)
+
+    def _detect_recursion(self, pid: int) -> bool:
+        """Return ``True`` if another process shares the same command line."""
+        try:
+            cmdline = psutil.Process(pid).cmdline()
+        except psutil.Error:
+            return False
+        for proc in psutil.process_iter(["pid", "cmdline"]):
+            if proc.info["pid"] == pid:
+                continue
+            if proc.info.get("cmdline") == cmdline:
+                return True
+        return False
+
+    def _terminate_session(self, pid: int) -> None:
+        """Attempt to terminate the session associated with ``pid``."""
+        try:
+            psutil.Process(pid).terminate()
+        except psutil.Error as exc:  # pragma: no cover - best effort
+            self.logger.error("Failed to terminate session %s: %s", pid, exc)

--- a/tests/test_anti_recursion_enforcer.py
+++ b/tests/test_anti_recursion_enforcer.py
@@ -1,0 +1,11 @@
+import logging
+import psutil
+from scripts.session.anti_recursion_enforcer import AntiRecursionEnforcer
+
+
+def test_enforcer_skips_missing_pid(caplog):
+    enforcer = AntiRecursionEnforcer()
+    missing_pid = max(psutil.pids()) + 10000
+    with caplog.at_level(logging.WARNING):
+        enforcer.enforce_no_recursion(missing_pid)
+    assert f"PID {missing_pid} not found" in caplog.text

--- a/unified_monitoring_optimization_system.py
+++ b/unified_monitoring_optimization_system.py
@@ -19,7 +19,14 @@ from sklearn.ensemble import IsolationForest
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
-    from scripts.monitoring.unified_monitoring_optimization_system import EnterpriseUtility as _EnterpriseUtility  # noqa: F401
+    from scripts.monitoring.unified_monitoring_optimization_system import (
+        EnterpriseUtility as _EnterpriseUtility,  # noqa: F401
+        collect_metrics as _collect_metrics,  # noqa: F401
+    )
+else:
+    from scripts.monitoring.unified_monitoring_optimization_system import (
+        collect_metrics,
+    )
 
 WORKSPACE_ROOT = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
 DB_PATH = WORKSPACE_ROOT / "databases" / "analytics.db"
@@ -28,6 +35,7 @@ __all__ = [
     "push_metrics",
     "detect_anomalies",
     "QuantumInterface",
+    "collect_metrics",
 ]
 
 

--- a/unified_session_management_system.py
+++ b/unified_session_management_system.py
@@ -6,9 +6,6 @@ from contextlib import contextmanager
 from pathlib import Path
 import logging
 
-from scripts.utilities.unified_session_management_system import (
-    UnifiedSessionManagementSystem,
-)
 from utils.validation_utils import detect_zero_byte_files, anti_recursion_guard
 
 logger = logging.getLogger(__name__)
@@ -31,6 +28,16 @@ def ensure_no_zero_byte_files(root: str | Path):
     after = detect_zero_byte_files(root_path)
     if after:
         raise RuntimeError(f"Zero-byte files detected: {after}")
+
+
+def prevent_recursion(func):
+    """Decorator proxy for :func:`anti_recursion_guard`.
+
+    Exposes the anti-recursion guard to maintain backward compatibility
+    with modules expecting :func:`prevent_recursion` in this namespace.
+    """
+
+    return anti_recursion_guard(func)
 
 
 @anti_recursion_guard


### PR DESCRIPTION
## Summary
- add AntiRecursionEnforcer with check for missing PIDs in process table
- expose collect_metrics helper in unified monitoring optimization module
- restore prevent_recursion decorator shim in session management wrapper
- cover missing PID scenario with unit test

## Testing
- `ruff check scripts/session/anti_recursion_enforcer.py tests/test_anti_recursion_enforcer.py unified_monitoring_optimization_system.py unified_session_management_system.py`
- `pytest` *(fails: tests/dashboard/test_basic_entrypoint.py::test_html_views)*

------
https://chatgpt.com/codex/tasks/task_e_688ff4c943c08331a7b8c2390662b81f