### PR TITLE
feat: integrate monitoring and recovery with session management

### DIFF
--- a/scripts/utilities/unified_session_management_system.py
+++ b/scripts/utilities/unified_session_management_system.py
@@ -15,6 +15,14 @@ from validation.core.validators import ValidationResult
 from pathlib import Path
 from datetime import datetime
 import logging
+import uuid
+
+from unified_monitoring_optimization_system import push_metrics
+from unified_disaster_recovery_system import (
+    UnifiedDisasterRecoverySystem,
+    log_backup_event,
+)
+from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {"start": "[START]", "success": "[SUCCESS]", "error": "[ERROR]", "info": "[INFO]"}
@@ -26,14 +34,47 @@ class UnifiedSessionManagementSystem:
     def __init__(self, workspace_root: str | None = None) -> None:
         self.workspace_root = get_workspace_path(workspace_root)
         from utils.validation_utils import validate_enterprise_environment
+
         validate_enterprise_environment()
         from session_protocol_validator import SessionProtocolValidator
+
         self.validator = SessionProtocolValidator(str(self.workspace_root))
         self.logger = logging.getLogger(self.__class__.__name__)
         from utils.lessons_learned_integrator import load_lessons, apply_lessons
+
         lessons = load_lessons()
         apply_lessons(self.logger, lessons)
+        self.session_id = uuid.uuid4().hex
+        self.analytics_db = self.workspace_root / "databases" / "analytics.db"
+        self.analytics_db.parent.mkdir(parents=True, exist_ok=True)
         self._session_active = False
+
+    # ------------------------------------------------------------------
+    # Integration helpers
+    # ------------------------------------------------------------------
+    def _record_metrics(self, **metrics: float) -> None:
+        """Push monitoring metrics to analytics.db."""
+        try:
+            push_metrics(metrics, db_path=self.analytics_db, session_id=self.session_id)
+        except Exception:
+            self.logger.exception("Failed to push session metrics")
+
+    def _trigger_backup(self, event: str) -> None:
+        """Log and schedule a backup event."""
+        try:
+            log_backup_event(event, {"session_id": self.session_id})
+            UnifiedDisasterRecoverySystem().schedule_backups()
+        except Exception:
+            self.logger.exception("Backup scheduling failed: %s", event)
+
+    def _rollback(self, message: str) -> None:
+        """Invoke correction logger and rollback subsystem."""
+        try:
+            clr = CorrectionLoggerRollback(self.analytics_db)
+            clr.log_violation(message)
+            clr.auto_rollback(self.workspace_root)
+        except Exception:
+            self.logger.exception("Rollback failed: %s", message)
 
     def _cleanup_zero_byte_files(self) -> list[Path]:
         from utils.validation_utils import detect_zero_byte_files
@@ -56,17 +97,26 @@ class UnifiedSessionManagementSystem:
 
         @anti_recursion_guard
         def _start() -> bool:
+            self._trigger_backup("pre_session")
             self.logger.info("%s Lifecycle start", TEXT_INDICATORS["start"])
             zero_files = self._cleanup_zero_byte_files()
             env_valid = validate_enterprise_environment()
             result = self.validator.validate_startup()
             success = env_valid and not zero_files and result.is_success
+            self._record_metrics(
+                zero_byte_files=float(len(zero_files)),
+                env_valid=float(env_valid),
+                validator_success=float(result.is_success),
+            )
             indicator = (
                 TEXT_INDICATORS["success"] if success else TEXT_INDICATORS["error"]
             )
             self.logger.info(
                 "%s Lifecycle start %s", indicator, "passed" if success else "failed"
             )
+            if not success:
+                self._rollback("Session startup validation failed")
+                self._trigger_backup("session_start_failure")
             return success
 
         success = _start()
@@ -83,20 +133,30 @@ class UnifiedSessionManagementSystem:
 
         @anti_recursion_guard
         def _end() -> bool:
+            self._trigger_backup("pre_session_end")
             self.logger.info("%s Lifecycle end", TEXT_INDICATORS["start"])
             zero_files = self._cleanup_zero_byte_files()
             env_valid = validate_enterprise_environment()
             result = self.validator.validate_session_cleanup()
             from utils.lessons_learned_integrator import store_lesson
+
             for lesson in collect_lessons(result):
                 store_lesson(**lesson)
             success = env_valid and not zero_files and result.is_success
+            self._record_metrics(
+                zero_byte_files=float(len(zero_files)),
+                env_valid=float(env_valid),
+                validator_success=float(result.is_success),
+            )
             indicator = (
                 TEXT_INDICATORS["success"] if success else TEXT_INDICATORS["error"]
             )
             self.logger.info(
                 "%s Lifecycle end %s", indicator, "passed" if success else "failed"
             )
+            if not success:
+                self._rollback("Session cleanup validation failed")
+                self._trigger_backup("session_end_failure")
             return success
 
         success = _end()

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -54,9 +54,69 @@ def test_lifecycle_logging(monkeypatch, tmp_path, caplog):
         "utils.validation_utils.validate_enterprise_environment", lambda: True
     )
     monkeypatch.setattr("utils.validation_utils.detect_zero_byte_files", lambda p: [])
+    monkeypatch.setattr(usms, "push_metrics", lambda *a, **k: None)
+    monkeypatch.setattr(usms, "log_backup_event", lambda *a, **k: None)
+    monkeypatch.setattr(
+        usms,
+        "UnifiedDisasterRecoverySystem",
+        lambda: SimpleNamespace(schedule_backups=lambda: None),
+    )
     system = usms.UnifiedSessionManagementSystem(workspace_root=str(tmp_path))
     with caplog.at_level(logging.INFO):
         system.start_session()
         system.end_session()
     assert any("Lifecycle start" in r.getMessage() for r in caplog.records)
     assert any("Lifecycle end" in r.getMessage() for r in caplog.records)
+
+
+def test_metrics_and_recovery(monkeypatch, tmp_path):
+    import scripts.utilities.unified_session_management_system as usms
+
+    class FailingValidator(DummyValidator):
+        def validate_startup(self):  # type: ignore[override]
+            return SimpleNamespace(is_success=False, errors=["e"], warnings=[])
+
+    monkeypatch.setattr(
+        "session_protocol_validator.SessionProtocolValidator", lambda *a, **k: FailingValidator()
+    )
+    monkeypatch.setattr(
+        "utils.validation_utils.validate_enterprise_environment", lambda: True
+    )
+    monkeypatch.setattr("utils.validation_utils.detect_zero_byte_files", lambda p: [])
+
+    metrics: dict[str, float] = {}
+    monkeypatch.setattr(usms, "push_metrics", lambda m, *, db_path=None, session_id=None: metrics.update(m))
+    events: list[str] = []
+
+    def fake_log_backup_event(event, details=None):
+        events.append(event)
+
+    monkeypatch.setattr(usms, "log_backup_event", fake_log_backup_event)
+
+    class FakeDRS:
+        def schedule_backups(self):
+            events.append("scheduled")
+
+    monkeypatch.setattr(usms, "UnifiedDisasterRecoverySystem", FakeDRS)
+
+    class FakeCLR:
+        def __init__(self, analytics_db):
+            pass
+
+        def log_violation(self, message: str) -> None:  # pragma: no cover - simple record
+            events.append("violation")
+
+        def auto_rollback(self, target, backup_path=None) -> None:  # pragma: no cover
+            events.append("rollback")
+
+    monkeypatch.setattr(
+        "scripts.correction_logger_and_rollback.CorrectionLoggerRollback", FakeCLR
+    )
+    monkeypatch.setattr(usms, "CorrectionLoggerRollback", FakeCLR)
+
+    system = usms.UnifiedSessionManagementSystem(workspace_root=str(tmp_path))
+    assert not system.start_session()
+    assert "session_start_failure" in events
+    assert "rollback" in events
+    assert metrics["validator_success"] == 0.0
+    assert metrics["zero_byte_files"] == 0.0

--- a/tests/test_session_protocol_validator.py
+++ b/tests/test_session_protocol_validator.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from types import SimpleNamespace
+
 from scripts.utilities.unified_session_management_system import (
     UnifiedSessionManagementSystem,
 )
@@ -16,10 +18,14 @@ def test_startup_detects_zero_byte(tmp_path, monkeypatch):
 
 def test_unified_session_start_fails_with_zero_byte(tmp_path, monkeypatch):
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
     zero_file = tmp_path / "b.py"
     zero_file.write_text("")
+    import scripts.utilities.unified_session_management_system as usms
+    monkeypatch.setattr(usms, "UnifiedDisasterRecoverySystem", lambda: SimpleNamespace(schedule_backups=lambda: None))
+    monkeypatch.setattr(usms, "log_backup_event", lambda *a, **k: None)
     mgr = UnifiedSessionManagementSystem()
-    assert not mgr.start_session().is_success
+    assert not mgr.start_session()
 
 
 def test_unicode_workspace_path(tmp_path, monkeypatch):
@@ -41,6 +47,10 @@ def test_comprehensive_validation_fails(monkeypatch):
 
 def test_unified_session_end_detects_zero_byte(tmp_path, monkeypatch):
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
+    import scripts.utilities.unified_session_management_system as usms
+    monkeypatch.setattr(usms, "UnifiedDisasterRecoverySystem", lambda: SimpleNamespace(schedule_backups=lambda: None))
+    monkeypatch.setattr(usms, "log_backup_event", lambda *a, **k: None)
     mgr = UnifiedSessionManagementSystem()
     mgr.start_session()
     zero_file = tmp_path / "end.py"


### PR DESCRIPTION
## Summary
- integrate unified session management with monitoring metrics and disaster recovery hooks
- log recovery attempts through correction logger and rollback subsystem
- add regression tests for metrics, rollback, and validator expectations

## Testing
- `ruff check scripts/utilities/unified_session_management_system.py tests/test_session_management.py tests/test_session_protocol_validator.py`
- `pytest tests/test_session_management.py tests/test_session_protocol_validator.py`
- `pytest` *(fails: ImportError cannot import name 'collect_metrics' from 'unified_monitoring_optimization_system' in tests/test_health_monitor.py)*

------
https://chatgpt.com/codex/tasks/task_e_688ff4c943c08331a7b8c2390662b81f