### PR TITLE
feat: add legacy cleanup logging utilities

### DIFF
--- a/scripts/database/add_legacy_cleanup_log.py
+++ b/scripts/database/add_legacy_cleanup_log.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from tqdm import tqdm
+
+from .size_compliance_checker import check_database_sizes
+from utils.log_utils import _log_event
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS legacy_cleanup_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file TEXT NOT NULL,
+    action TEXT NOT NULL,
+    reason TEXT,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_legacy_cleanup_log_timestamp
+    ON legacy_cleanup_log(timestamp);
+"""
+
+
+
+def add_table(db_path: Path) -> None:
+    """Create ``legacy_cleanup_log`` table in ``db_path``."""
+    start_time = datetime.now()
+    logger.info("[START] add_table for %s", db_path)
+    logger.info("Process ID: %s", os.getpid())
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path, timeout=5) as conn, tqdm(total=1, desc="create-table", unit="step") as bar:
+        conn.executescript(SCHEMA_SQL)
+        conn.commit()
+        bar.update(1)
+    logger.info("legacy_cleanup_log ensured in %s", db_path)
+    check_database_sizes(db_path.parent)
+    _log_event({"event": "legacy_cleanup_log_ready", "db": str(db_path)})
+
+    elapsed = datetime.now() - start_time
+    logger.info("[SUCCESS] Completed in %s", str(elapsed))
+
+
+
+def ensure_legacy_cleanup_log(db_path: Path) -> None:
+    """Ensure ``legacy_cleanup_log`` table exists."""
+    add_table(db_path)
+
+
+
+def log_cleanup_event(file_path: str, action: str, reason: str, *, db_path: Path) -> None:
+    """Record a cleanup event to ``legacy_cleanup_log``."""
+    entry = {
+        "file": file_path,
+        "action": action,
+        "reason": reason,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    _log_event(entry, table="legacy_cleanup_log", db_path=db_path)
+
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    db_path = root / "databases" / "analytics.db"
+    start = datetime.now()
+    add_table(db_path)
+    etc = start + timedelta(seconds=1)
+    logger.info(
+        "Migration completed at %s | ETC was %s",
+        datetime.utcnow().isoformat(),
+        etc.strftime("%Y-%m-%d %H:%M:%S"),
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    logging.basicConfig(level=logging.INFO)
+    main()
+
+__all__ = ["add_table", "ensure_legacy_cleanup_log", "log_cleanup_event"]

--- a/scripts/database/legacy_cleanup_schema.sql
+++ b/scripts/database/legacy_cleanup_schema.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS legacy_cleanup_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file TEXT NOT NULL,
+    action TEXT NOT NULL,
+    reason TEXT,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_legacy_cleanup_log_timestamp
+    ON legacy_cleanup_log(timestamp);

--- a/scripts/unified_legacy_cleanup_wrapper.py
+++ b/scripts/unified_legacy_cleanup_wrapper.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Wrapper for scheduling Unified Legacy Cleanup System runs.
+
+This script provides a thin CLI around :class:`unified_legacy_cleanup_system.UnifiedLegacyCleanupSystem`
+so it can be invoked by schedulers or shell scripts. It supports optional
+workspace selection and dry-run mode.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from unified_legacy_cleanup_system import UnifiedLegacyCleanupSystem
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Unified Legacy Cleanup Wrapper")
+    parser.add_argument("--workspace", type=Path, default=None, help="Workspace root to scan")
+    parser.add_argument("--dry-run", action="store_true", help="Perform cleanup without changing files")
+    return parser.parse_args(args)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = parse_args(argv)
+    system = UnifiedLegacyCleanupSystem(ns.workspace)
+    system.run_cleanup(dry_run=ns.dry_run)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_legacy_cleanup_log.py
+++ b/tests/test_legacy_cleanup_log.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sqlite3
+
+from scripts.database.add_legacy_cleanup_log import (
+    ensure_legacy_cleanup_log,
+    log_cleanup_event,
+)
+
+
+def test_log_cleanup_event(tmp_path: Path, monkeypatch) -> None:
+    db = tmp_path / "databases" / "analytics.db"
+    ensure_legacy_cleanup_log(db)
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "0")
+    log_cleanup_event("demo.py", action="archived", reason="test", db_path=db)
+    with sqlite3.connect(db) as conn:
+        row = conn.execute(
+            "SELECT file, action, reason FROM legacy_cleanup_log"
+        ).fetchone()
+    assert row == ("demo.py", "archived", "test")

--- a/unified_legacy_cleanup_system.py
+++ b/unified_legacy_cleanup_system.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import logging
+import os
+import shutil
+import sqlite3
 from pathlib import Path
 from typing import List, Optional
 
@@ -10,6 +13,11 @@ from scripts.unified_legacy_cleanup_system import (
 )
 from scripts.database.add_violation_logs import ensure_violation_logs
 from scripts.database.add_rollback_logs import ensure_rollback_logs
+from scripts.database.add_legacy_cleanup_log import (
+    ensure_legacy_cleanup_log,
+    log_cleanup_event,
+)
+from unified_disaster_recovery_system import UnifiedDisasterRecoverySystem
 from secondary_copilot_validator import SecondaryCopilotValidator
 from utils.log_utils import _log_event
 
@@ -25,6 +33,7 @@ class UnifiedLegacyCleanupSystem(_BaseCleanup):
         super().__init__(workspace_path)
         ensure_violation_logs(self.analytics_db)
         ensure_rollback_logs(self.analytics_db)
+        ensure_legacy_cleanup_log(self.analytics_db)
         self.validator = SecondaryCopilotValidator()
 
     def archive_script(self, script: Path, dry_run: bool = False) -> bool:
@@ -40,6 +49,12 @@ class UnifiedLegacyCleanupSystem(_BaseCleanup):
         archived = self.config.workspace_path / "archive" / "legacy" / script.name
         result = super().archive_script(script, dry_run=dry_run)
         if result:
+            log_cleanup_event(
+                str(script),
+                action="archived",
+                reason="legacy script archived",
+                db_path=self.analytics_db,
+            )
             _log_event(
                 {"target": str(script), "backup": str(archived)},
                 table="rollback_logs",
@@ -54,6 +69,64 @@ class UnifiedLegacyCleanupSystem(_BaseCleanup):
             table="violation_logs",
             db_path=self.analytics_db,
         )
+        log_cleanup_event(
+            "workspace",
+            action="optimized",
+            reason="workspace optimization complete",
+            db_path=self.analytics_db,
+        )
+
+    def run_cleanup(self, dry_run: bool = False) -> bool:
+        """Run cleanup and return ``True`` on success."""
+        with sqlite3.connect(self.analytics_db) as conn:
+            conn.execute("CREATE TABLE IF NOT EXISTS event_log (event TEXT)")
+            conn.commit()
+        try:
+            _log_event({"event": "legacy_cleanup_start"}, db_path=self.analytics_db)
+            removed_any = False
+            pattern = "*deprecated*.py"
+            for file in self.config.workspace_path.glob(pattern):
+                if not file.is_file():
+                    continue
+                backup_root = Path(os.environ.get("GH_COPILOT_BACKUP_ROOT", "/tmp")) / "legacy_cleanup"
+                backup_root.mkdir(parents=True, exist_ok=True)
+                backup = backup_root / file.name
+                shutil.copy2(file, backup)
+                file.unlink()
+                removed_any = True
+                try:
+                    _log_event(
+                        {"event": "removed_file", "path": str(file)},
+                        db_path=self.analytics_db,
+                    )
+                except Exception:
+                    pass
+                log_cleanup_event(
+                    str(file),
+                    action="removed",
+                    reason="deprecated",
+                    db_path=self.analytics_db,
+                )
+            _log_event(
+                {"event": "legacy_cleanup_complete", "count": int(removed_any)},
+                db_path=self.analytics_db,
+            )
+            log_cleanup_event(
+                "run_cleanup",
+                action="completed",
+                reason="cleanup executed",
+                db_path=self.analytics_db,
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - safety net
+            UnifiedDisasterRecoverySystem().perform_recovery()
+            log_cleanup_event(
+                "run_cleanup",
+                action="failed",
+                reason=str(exc),
+                db_path=self.analytics_db,
+            )
+            return False
 
 
 __all__ = ["UnifiedLegacyCleanupSystem", "main"]


### PR DESCRIPTION
## Summary
- add helper to record legacy cleanup events and schema
- wrap cleanup system for shell scheduling
- enhance cleanup system with logging and deprecated file removal

## Testing
- `ruff check scripts/database/add_legacy_cleanup_log.py unified_legacy_cleanup_system.py scripts/unified_legacy_cleanup_wrapper.py tests/test_legacy_cleanup_log.py`
- `pytest tests/test_legacy_cleanup_log.py tests/test_unified_legacy_cleanup_system.py tests/test_unified_legacy_cleanup_system_root.py`

------
https://chatgpt.com/codex/tasks/task_e_688ff618ac68833193204dd5a83ac5a0