### PR TITLE
test: cover WebGUIIntegrationSystem start

### DIFF
--- a/tests/test_web_gui_integration_system_start.py
+++ b/tests/test_web_gui_integration_system_start.py
@@ -1,0 +1,24 @@
+def test_start_invokes_integrator_and_app_run(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    from scripts.utilities import web_gui_integration_system as module
+
+    system = module.WebGUIIntegrationSystem()
+    called = {"register": False, "initialize": False, "port": None}
+
+    def fake_register(app):
+        assert app is module.app
+        called["register"] = True
+
+    def fake_initialize():
+        called["initialize"] = True
+
+    def fake_run(*, port, **kwargs):
+        called["port"] = port
+
+    monkeypatch.setattr(system.integrator, "register_endpoints", fake_register)
+    monkeypatch.setattr(system.integrator, "initialize", fake_initialize)
+    monkeypatch.setattr(module.app, "run", fake_run)
+
+    system.start(port=1234)
+
+    assert called == {"register": True, "initialize": True, "port": 1234}


### PR DESCRIPTION
## Summary
- test WebGUIIntegrationSystem.start to ensure endpoints register and Flask app runs

## Testing
- `ruff check tests/test_web_gui_integration_system_start.py`
- `pyright tests/test_web_gui_integration_system_start.py`
- `GH_COPILOT_WORKSPACE=$(mktemp -d) GH_COPILOT_BACKUP_ROOT=$(mktemp -d) pytest tests/test_web_gui_integration_system_start.py tests/test_web_gui_disaster_modules.py tests/test_web_gui_integrator_registration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff668d0648331ba07521663abf7f7