### PR TITLE
docs: add asset ingestion overview

### DIFF
--- a/docs/ASSET_INGESTION.md
+++ b/docs/ASSET_INGESTION.md
@@ -1,0 +1,20 @@
+# Asset Ingestion (Docs & Templates)
+
+## Distinct Abilities & Functionalities
+- Automates parsing, validation, and cataloging of Markdown documentation and code/template assets into the persistent `enterprise_assets.db` store.
+- Computes SHA256 or MD5 hashes to guarantee content uniqueness, skipping duplicates and generating a detailed ingestion log for each operation.
+- Supports recursive directory traversal, extension and pattern-based file selection, and robust error handling for malformed or partial assets.
+- Ingestion events link to analytics pipelines for real-time monitoring of coverage and asset health.
+- All ingested assets are indexed by metadata—filename, content hash, ingest timestamp, asset type, and lineage—which downstream modules use for template mining, pattern clustering, and compliance reporting.
+- The ingestion process is highly extensible, supporting new document formats, selective inclusion/exclusion filters, and scheduled batch jobs tied to session management.
+
+## Key Scripts / Files
+- `scripts/database/documentation_ingestor.py` — Automates Markdown document detection, deduplication, hashing, and ingestion.
+- `scripts/database/template_asset_ingestor.py` — Specialized for code/template file ingestion; computes hashes, checks for existing assets, and supports asset type tagging.
+- `scripts/autonomous_setup_and_audit.py` — Supports scheduled ingestion runs, startup audits, and hooks for compliance checks. Integrates with session and analytics modules.
+- `scripts/database/asset_ingestion_schema.sql` — Defines schema for asset metadata, including unique content hashes and ingest event tracking.
+
+## Potential Combinations & New Capabilities
+- Integrate with the pattern mining engine and Unified Script Generation System to provide a continuously expanding, deduplicated template library for adaptive code synthesis.
+- Feed ingestion results and analytics into dashboards, supporting ingestion success/failure metrics, trend analysis, and anomaly detection on asset coverage.
+- Automate scheduled and event-driven ingestion runs via integration with the Unified Session Management System, enabling proactive updates and health audits for all enterprise documentation and code templates.


### PR DESCRIPTION
## Summary
- document asset ingestion subsystem covering hashing, deduplication, and analytics integration

## Testing
- `ruff check scripts/database/documentation_ingestor.py scripts/database/template_asset_ingestor.py scripts/autonomous_setup_and_audit.py`
- `pytest` *(fails: cannot import name 'collect_metrics' from 'unified_monitoring_optimization_system')*


------
https://chatgpt.com/codex/tasks/task_e_688ff77dac0c833194e9c573746fa0ab