### PR TITLE
feat: deduplicate assets during ingestion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [4.1.19] - 2025-08-09
+- Enforced content-hash deduplication for documentation and template ingestion.
+
 ## [4.1.18] - 2025-08-08
 - Documented disaster recovery enforcement and verified restore procedures.
 - Clarified simulation-only behavior of quantum placeholders.

--- a/docs/DATABASE_FIRST_USAGE_GUIDE.md
+++ b/docs/DATABASE_FIRST_USAGE_GUIDE.md
@@ -170,7 +170,8 @@ audit the results and perform a rollback if necessary. Commands assume
    ```
 
    These commands record ingestion events in `analytics.db` and log progress to
-   `dashboard/compliance/metrics.json`.
+   `dashboard/compliance/metrics.json`. Duplicate files are skipped based on
+   their content hash.
 
 3. **Validate Ingested Assets**
 

--- a/docs/USER_PROMPTS.md
+++ b/docs/USER_PROMPTS.md
@@ -31,6 +31,7 @@ Expected output:
 [INGEST] 20 docs loaded
 [INGEST] 15 templates loaded
 ```
+Duplicate files are skipped automatically based on their content hash.
 Troubleshooting:
 - *0 files found*: confirm Markdown files exist under `docs/` and `prompts/`.
 

--- a/scripts/database/asset_ingestion_schema.sql
+++ b/scripts/database/asset_ingestion_schema.sql
@@ -1,0 +1,25 @@
+-- Schema for asset ingestion tables
+
+CREATE TABLE IF NOT EXISTS documentation_assets (
+    id INTEGER PRIMARY KEY,
+    doc_path TEXT NOT NULL,
+    content_hash TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL,
+    modified_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS template_assets (
+    id INTEGER PRIMARY KEY,
+    template_path TEXT NOT NULL,
+    content_hash TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pattern_assets (
+    id INTEGER PRIMARY KEY,
+    pattern TEXT NOT NULL,
+    usage_count INTEGER DEFAULT 0,
+    lesson_name TEXT,
+    created_at TEXT NOT NULL
+);
+

--- a/scripts/database/documentation_ingestor.py
+++ b/scripts/database/documentation_ingestor.py
@@ -76,6 +76,13 @@ def ingest_documentation(
             conn.close()
             initialize_database(db_path)
             conn = sqlite3.connect(db_path)
+        existing_hashes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT content_hash FROM documentation_assets"
+            )
+        }
+
         with conn, tqdm(total=len(files), desc="Docs", unit="file") as bar:
             for path in files:
                 if timeout_seconds and (datetime.now(timezone.utc) - start_time).total_seconds() > timeout_seconds:
@@ -91,6 +98,11 @@ def ingest_documentation(
 
                 content = path.read_text(encoding="utf-8")
                 digest = hashlib.sha256(content.encode()).hexdigest()
+                if digest in existing_hashes:
+                    logger.info("Skipping duplicate content: %s", path)
+                    bar.update(1)
+                    continue
+                existing_hashes.add(digest)
                 modified_at = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
                 conn.execute(
                     (

--- a/scripts/database/template_asset_ingestor.py
+++ b/scripts/database/template_asset_ingestor.py
@@ -70,6 +70,13 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
             conn.close()
             initialize_database(db_path)
             conn = sqlite3.connect(db_path)
+        existing_hashes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT content_hash FROM template_assets"
+            )
+        }
+
         with conn, tqdm(total=len(files), desc="Templates", unit="file") as bar:
             for path in files:
                 rel_path = str(path.relative_to(workspace))
@@ -78,6 +85,11 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
                     continue
                 content = path.read_text(encoding="utf-8")
                 digest = hashlib.sha256(content.encode()).hexdigest()
+                if digest in existing_hashes:
+                    logger.info("Skipping duplicate content: %s", path)
+                    bar.update(1)
+                    continue
+                existing_hashes.add(digest)
                 conn.execute(
                     ("INSERT INTO template_assets (template_path, content_hash, created_at) VALUES (?, ?, ?)"),
                     (

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -48,7 +48,7 @@ TABLES: dict[str, str] = {
         "CREATE TABLE IF NOT EXISTS documentation_assets ("
         "id INTEGER PRIMARY KEY,"
         "doc_path TEXT NOT NULL,"
-        "content_hash TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL UNIQUE,"
         "created_at TEXT NOT NULL,"
         "modified_at TEXT NOT NULL"
         ")"
@@ -57,7 +57,7 @@ TABLES: dict[str, str] = {
         "CREATE TABLE IF NOT EXISTS template_assets ("
         "id INTEGER PRIMARY KEY,"
         "template_path TEXT NOT NULL,"
-        "content_hash TEXT NOT NULL,"
+        "content_hash TEXT NOT NULL UNIQUE,"
         "created_at TEXT NOT NULL"
         ")"
     ),

--- a/tests/test_template_asset_ingestor.py
+++ b/tests/test_template_asset_ingestor.py
@@ -29,3 +29,20 @@ def test_ingest_templates(tmp_path: Path) -> None:
     assert t_count == 1
     assert p_count == 1 + expected_lessons
     assert lesson_count == expected_lessons
+
+
+def test_duplicate_template_skipped(tmp_path: Path) -> None:
+    workspace = tmp_path
+    os.environ["GH_COPILOT_WORKSPACE"] = str(workspace)
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+    db_path = db_dir / "enterprise_assets.db"
+    initialize_database(db_path)
+    templates_dir = workspace / "prompts"
+    templates_dir.mkdir()
+    (templates_dir / "a.md").write_text("Sample template")
+    (templates_dir / "b.md").write_text("Sample template")
+    ingest_templates(workspace, templates_dir)
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM template_assets").fetchone()[0]
+    assert count == 1


### PR DESCRIPTION
## Summary
- skip duplicate markdown files and templates by content hash during ingestion
- enforce unique hashes in enterprise asset tables and provide SQL schema
- document ingestion dedupe behavior and add regression tests

## Testing
- `ruff check scripts/database/documentation_ingestor.py scripts/database/template_asset_ingestor.py scripts/database/unified_database_initializer.py tests/test_documentation_ingestor.py tests/test_template_asset_ingestor.py`
- `pytest tests/test_documentation_ingestor.py tests/test_template_asset_ingestor.py > /tmp/pytest.log && tail -n 50 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688ff77dac0c833194e9c573746fa0ab