### PR TITLE
feat: integrate compliance metrics updater

### DIFF
--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -34,6 +34,7 @@ from template_engine.template_placeholder_remover import remove_unused_placehold
 from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
 from secondary_copilot_validator import SecondaryCopilotValidator
 from utils.log_utils import log_message
+from dashboard.compliance_metrics_updater import ComplianceMetricsUpdater
 
 # Visual processing indicator constants
 TEXT = {
@@ -585,6 +586,13 @@ def main(
         update_dashboard(len(results), dashboard, analytics, summary_path)
     else:
         log_message(__name__, "[TEST MODE] Dashboard update skipped")
+    # Combine with Compliance Metrics Updater for real-time metrics
+    try:
+        updater = ComplianceMetricsUpdater(dashboard, test_mode=simulate)
+        updater.update(simulate=simulate)
+        updater.validate_update()
+    except Exception as exc:  # pragma: no cover - updater errors
+        log_message(__name__, f"{TEXT['error']} compliance update failed: {exc}", level=logging.ERROR)
     elapsed = time.time() - start_time
     log_message(__name__, f"{TEXT['info']} audit completed in {elapsed:.2f}s")
 

--- a/tests/test_placeholder_audit_compliance_integration.py
+++ b/tests/test_placeholder_audit_compliance_integration.py
@@ -1,0 +1,36 @@
+import importlib
+
+
+def test_audit_triggers_compliance_metrics(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "mod.py").write_text("pass  # TODO\n", encoding="utf-8")
+    analytics = tmp_path / "analytics.db"
+    dash = tmp_path / "dashboard"
+
+    calls = []
+
+    class StubUpdater:
+        def __init__(self, dashboard_dir, test_mode=False):
+            self.dashboard_dir = dashboard_dir
+            self.test_mode = test_mode
+
+        def update(self, simulate=False):
+            calls.append(simulate)
+
+        def validate_update(self):
+            return True
+
+    module = importlib.import_module("scripts.code_placeholder_audit")
+    monkeypatch.setattr(module, "ComplianceMetricsUpdater", StubUpdater)
+
+    module.main(
+        workspace_path=str(ws),
+        analytics_db=str(analytics),
+        dashboard_dir=str(dash),
+        simulate=True,
+    )
+
+    assert calls == [True]


### PR DESCRIPTION
## Summary
- combine placeholder audit with dashboard compliance metrics updater
- test compliance updater integration during placeholder audits

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/test_placeholder_audit_compliance_integration.py`
- `pytest tests/test_placeholder_audit.py tests/test_placeholder_audit_compliance_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_688ff80160fc833196d646d950b47a58