### PR TITLE
feat: add single-file placeholder scan helper

### DIFF
--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -316,6 +316,49 @@ def update_dashboard(
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
+# Scan a single file for placeholder patterns
+def scan_file_for_placeholders(file_path: Path, patterns: List[str] | None = None) -> List[Dict]:
+    """Return placeholder findings for ``file_path``.
+
+    Parameters
+    ----------
+    file_path:
+        File to scan for placeholder tokens.
+    patterns:
+        Optional list of regex patterns. Defaults to :data:`DEFAULT_PATTERNS`.
+
+    Returns
+    -------
+    List[Dict]
+        A list of findings with ``file``, ``line``, ``pattern`` and ``context``
+        keys. Errors reading the file are logged and yield an empty list.
+    """
+
+    patterns = patterns or DEFAULT_PATTERNS
+    try:
+        lines = file_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except Exception as exc:  # pragma: no cover - read errors are logged
+        log_message(
+            __name__,
+            f"{TEXT['error']} Could not read {file_path}: {exc}",
+            level=logging.ERROR,
+        )
+        return []
+    results: List[Dict] = []
+    for idx, line in enumerate(lines, 1):
+        for pat in patterns:
+            if re.search(pat, line):
+                results.append(
+                    {
+                        "file": str(file_path),
+                        "line": idx,
+                        "pattern": pat,
+                        "context": line.strip()[:200],
+                    }
+                )
+    return results
+
+
 # Scan files for patterns with timeout and visual indicators
 def scan_files(workspace: Path, patterns: List[str], timeout: Optional[float] = None) -> List[Dict]:
     """Scan files for given patterns with optional timeout and progress bar."""

--- a/tests/test_code_placeholder_audit_utils.py
+++ b/tests/test_code_placeholder_audit_utils.py
@@ -6,6 +6,7 @@ from scripts.code_placeholder_audit import (
     fetch_db_placeholders,
     log_findings,
     update_dashboard,
+    scan_file_for_placeholders,
 )
 
 
@@ -35,3 +36,12 @@ def test_log_findings_and_update_dashboard(tmp_path: Path) -> None:
     assert summary["progress_status"] in {"issues_pending", "complete"}
     assert summary["compliance_status"] == "non_compliant"
     assert summary["placeholder_counts"] == {"TODO": 1, "FIXME": 1}
+
+
+def test_scan_file_for_placeholders(tmp_path: Path) -> None:
+    target = tmp_path / "demo.py"
+    target.write_text("def x():\n    pass  # TODO something\n")
+    findings = scan_file_for_placeholders(target)
+    patterns = {f["pattern"] for f in findings}
+    assert "TODO" in patterns
+    assert "pass\\b" in patterns


### PR DESCRIPTION
## Summary
- add `scan_file_for_placeholders` for targeted placeholder audits
- exercise new helper with unit test covering TODO and `pass` tokens

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/test_code_placeholder_audit_utils.py`
- `pytest tests/test_code_placeholder_audit_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_688ff80160fc833196d646d950b47a58