### PR TITLE
feat: interrupt streaming when stop event set

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -289,7 +289,10 @@ class ComplianceMetricsUpdater:
             metrics["suggestion"] = self._cognitive_compliance_suggestion(metrics)
             yield metrics
             count += 1
-            time.sleep(interval)
+            if stop_event:
+                stop_event.wait(interval)
+            else:
+                time.sleep(interval)
 
     def _update_dashboard(self, metrics: Dict[str, Any]) -> None:
         """Update dashboard/compliance with metrics."""

--- a/tests/test_compliance_metrics_scheduler.py
+++ b/tests/test_compliance_metrics_scheduler.py
@@ -1,6 +1,7 @@
 import sqlite3
 import logging
 import threading
+import time
 import pytest
 from dashboard import compliance_metrics_updater as cmu
 
@@ -99,3 +100,41 @@ def test_stream_metrics_stop_event(tmp_path, monkeypatch):
     stop.set()
     with pytest.raises(StopIteration):
         next(gen)
+
+
+def test_stream_metrics_stop_event_during_wait(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    analytics_db = db_dir / "analytics.db"
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute("CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT)")
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES (1, 'resolved')")
+        conn.execute("CREATE TABLE correction_logs (compliance_score REAL)")
+        conn.execute("INSERT INTO correction_logs VALUES (1.0)")
+
+    monkeypatch.setattr(cmu, "ANALYTICS_DB", analytics_db)
+    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    monkeypatch.setattr(cmu, "validate_enterprise_operation", lambda *a, **k: None)
+
+    dash = tmp_path / "dashboard"
+    updater = cmu.ComplianceMetricsUpdater(dash)
+    stop = threading.Event()
+    gen = updater.stream_metrics(interval=1, stop_event=stop)
+
+    results = []
+
+    def consume() -> None:
+        for m in gen:
+            results.append(m)
+
+    t = threading.Thread(target=consume)
+    t.start()
+    time.sleep(0.1)
+    stop.set()
+    t.join(0.5)
+    assert not t.is_alive()
+    assert results


### PR DESCRIPTION
## Summary
- allow compliance metric streaming to break promptly when a stop event is set
- test streaming loop interruption during wait

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/test_compliance_metrics_scheduler.py`
- `pytest tests/test_compliance_metrics_scheduler.py tests/dashboard/test_live_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff89eeeec8331aacf797e45ad5010