### PR TITLE
fix: ignore safe directories in recursion validation

### DIFF
--- a/tests/test_auto_generator.py
+++ b/tests/test_auto_generator.py
@@ -278,3 +278,10 @@ def test_lessons_applied_during_generation(tmp_path: Path, monkeypatch) -> None:
 
     assert applied["called"]
     assert any("integrate tests" in t for t in gen.templates)
+
+
+def test_validate_no_recursive_folders_ignores_venv(tmp_path: Path, monkeypatch) -> None:
+    """Virtual environments may contain backup-like paths that should be ignored."""
+    (tmp_path / ".venv/lib/python/backupsearch").mkdir(parents=True)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    auto_generator.validate_no_recursive_folders()  # Should not raise


### PR DESCRIPTION
## Summary
- avoid false positives in `validate_no_recursive_folders` by skipping `.venv` and `tmp` directories and restricting triggers to real temp/backup folders
- add regression test ensuring virtual environment folders are ignored

## Testing
- `pytest tests/test_quantum_template_generator.py -q`
- `pytest tests/test_auto_generator.py::test_validate_no_recursive_folders_ignores_venv -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff9a4435c8331b8c00c0742a07770