### PR TITLE
feat: add template clustering utility

### DIFF
--- a/template_engine/pattern_mining_engine.py
+++ b/template_engine/pattern_mining_engine.py
@@ -26,6 +26,7 @@ from tqdm import tqdm
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.cluster import KMeans
 from sklearn.metrics import silhouette_score
+import numpy as np
 
 from .template_synchronizer import _log_audit_real
 from utils.log_utils import _log_event
@@ -105,6 +106,30 @@ def extract_patterns(templates: List[str]) -> List[str]:
         for i in range(len(words) - 2):
             patterns.add(" ".join(words[i : i + 3]))
     return list(patterns)
+
+
+def cluster_templates(features: List[List[float]], n_clusters: int = 5) -> List[int]:
+    """Cluster templates based on numeric features using KMeans.
+
+    Parameters
+    ----------
+    features: List[List[float]]
+        Feature vectors representing templates.
+    n_clusters: int, optional
+        Desired number of clusters, default is 5.
+
+    Returns
+    -------
+    List[int]
+        Cluster label for each feature vector. Returns an empty list when
+        ``features`` is empty.
+    """
+    if not features:
+        return []
+    data = np.array(features)
+    k = min(len(data), n_clusters)
+    model = KMeans(n_clusters=k, n_init="auto", random_state=0)
+    return model.fit_predict(data).tolist()
 
 
 def _log_patterns(patterns: List[str], analytics_db: Path) -> None:
@@ -350,6 +375,7 @@ def validate_mining(expected_count: int, analytics_db: Path = DEFAULT_ANALYTICS_
 
 __all__ = [
     "extract_patterns",
+    "cluster_templates",
     "mine_patterns",
     "get_clusters",
     "get_cluster_metrics",

--- a/tests/test_pattern_mining_engine.py
+++ b/tests/test_pattern_mining_engine.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import template_engine.pattern_mining_engine as pme
 from template_engine.pattern_mining_engine import (
     extract_patterns,
+    cluster_templates,
     mine_patterns,
     get_clusters,
     validate_mining,
@@ -28,6 +29,12 @@ def test_extract_patterns():
     end_time = datetime.now()
     duration = (end_time - start_time).total_seconds()
     print(f"TEST COMPLETED: test_extract_patterns in {duration:.2f}s")
+
+
+def test_cluster_templates_basic():
+    features = [[1.0, 0.0], [0.0, 1.0]]
+    labels = cluster_templates(features, n_clusters=2)
+    assert sorted(set(labels)) == [0, 1]
 
 
 def test_mine_patterns(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add `cluster_templates` helper to pattern mining engine for KMeans clustering of feature vectors
- expose clustering helper and cover with unit test

## Testing
- `ruff check template_engine/pattern_mining_engine.py tests/test_pattern_mining_engine.py`
- `pytest tests/test_pattern_mining_engine.py::test_cluster_templates_basic -q`


------
https://chatgpt.com/codex/tasks/task_e_688ffa2c874883318053c4be05135a14