### PR TITLE
feat: add workflow enhancer compliance report support

### DIFF
--- a/template_engine/README.md
+++ b/template_engine/README.md
@@ -5,3 +5,7 @@ Lesson templates are returned by `get_lesson_templates()` in
 `learning_templates.py` and merged by `TemplateAutoGenerator` during
 initialization and ranking. To extend behavior, add new entries to the lesson
 store and they will influence template generation automatically.
+
+`TemplateWorkflowEnhancer` can generate in-memory compliance summaries via
+`generate_compliance_report`, combining clustering, pattern mining and
+compliance scoring for downstream analytics.

--- a/template_engine/workflow_enhancer.py
+++ b/template_engine/workflow_enhancer.py
@@ -119,6 +119,26 @@ class TemplateWorkflowEnhancer:
         logging.info(f"Average compliance score: {avg_score:.4f}")
         return avg_score
 
+    def generate_compliance_report(
+        self, templates: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Generate a compliance report for the provided templates.
+
+        Clusters templates, mines patterns, and calculates the average
+        compliance score. The resulting dictionary can be consumed by
+        analytics or dashboard modules for further processing.
+        """
+        clusters = self.cluster_templates(templates)
+        compliance_score = self.score_compliance(templates)
+        patterns = self.mine_patterns(templates)
+        report = {
+            "total_templates": len(templates),
+            "cluster_count": len(clusters),
+            "patterns_mined": patterns,
+            "average_compliance_score": compliance_score,
+        }
+        return report
+
     def generate_modular_report(
         self,
         templates: List[Dict[str, Any]],

--- a/tests/test_workflow_enhancer.py
+++ b/tests/test_workflow_enhancer.py
@@ -42,3 +42,17 @@ def test_pattern_mining(tmp_path, monkeypatch):
     templates = enhancer.fetch_templates()
     patterns = enhancer.mine_patterns(templates)
     assert "content" in patterns
+
+
+def test_generate_compliance_report(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setattr(workflow_enhancer, "validate_enterprise_operation", lambda *_a, **_k: True)
+    db = tmp_path / "prod.db"
+    _setup_db(db)
+    dashboard = tmp_path / "dash"
+    enhancer = TemplateWorkflowEnhancer(db, dashboard)
+    templates = enhancer.fetch_templates()
+    report = enhancer.generate_compliance_report(templates)
+    assert report["total_templates"] == 2
+    assert report["cluster_count"] >= 1
+    assert "average_compliance_score" in report


### PR DESCRIPTION
## Summary
- add `generate_compliance_report` helper for TemplateWorkflowEnhancer
- cover new report behavior with tests
- document compliance report capability in template engine README

## Testing
- `ruff check template_engine/workflow_enhancer.py tests/test_workflow_enhancer.py`
- `pytest tests/test_workflow_enhancer.py tests/test_workflow_enhancer_extended.py tests/test_workflow_enhancer_logging.py tests/test_workflow_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_688ffa9b183c833199943eeaa7b43e2f