### PR TITLE
feat: purge superseded templates after generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Full Validation Coverage:** ingestion, placeholder audits and migration scripts now run SecondaryCopilotValidator by default.
 - **Visual Processing Indicators:** progress bar utilities implemented
 - **Autonomous Systems:** early self-healing scripts included
+- **Integrated Legacy Cleanup:** script generation automatically purges superseded templates to keep workspaces current
 - **Disaster Recovery Orchestration:** scheduled backups and recovery
   execution coordinated through a new orchestrator with session and
   compliance hooks

--- a/scripts/utilities/unified_script_generation_system.py
+++ b/scripts/utilities/unified_script_generation_system.py
@@ -189,6 +189,11 @@ class EnterpriseUtility:
 
             self.logger.info(f"{TEXT_INDICATORS['success']} Generated template stored at {output_file}")
 
+            from unified_legacy_cleanup_system import UnifiedLegacyCleanupSystem
+
+            cleanup = UnifiedLegacyCleanupSystem(self.workspace_path)
+            cleanup.purge_superseded_scripts(generated_dir)
+
             validator = DualCopilotValidator()
             valid = validator.validate(ValidationResult(output_file=output_file, progress_complete=pbar.n == 100))
             secondary = SecondaryCopilotValidator(self.logger)

--- a/tests/test_unified_script_generation_system.py
+++ b/tests/test_unified_script_generation_system.py
@@ -28,3 +28,24 @@ def test_template_generation(mock_recognizer, _validate, tmp_path):
     assert generated_files, "Template file was not created"
     content = generated_files[0].read_text()
     assert "# Synthesized template" in content
+
+
+@patch(
+    "unified_legacy_cleanup_system.UnifiedLegacyCleanupSystem.purge_superseded_scripts"
+)
+@patch(
+    "scripts.utilities.unified_script_generation_system.SecondaryCopilotValidator.validate_corrections",
+    return_value=True,
+)
+@patch("scripts.utilities.unified_script_generation_system.PatternRecognizer")
+def test_generation_triggers_cleanup(mock_recognizer, _validate, mock_purge, tmp_path):
+    workspace = Path(tmp_path)
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+    source_db = Path(__file__).resolve().parents[1] / "databases" / "template_documentation.db"
+    shutil.copy(source_db, db_dir / "template_documentation.db")
+
+    utility = EnterpriseUtility(str(workspace))
+    assert utility.perform_utility_function() is True
+
+    mock_purge.assert_called_once_with(workspace / "generated_templates")


### PR DESCRIPTION
## Summary
- remove old generated templates with a new `purge_superseded_scripts` helper in the cleanup system
- invoke legacy cleanup after script generation to keep generated templates directory lean
- document cleanup integration and add tests verifying that generation triggers cleanup

## Testing
- `ruff check .` (fails: Remove unused import, Undefined name, Redefinition of unused `prevent_recursion` from line 19)
- `ruff check unified_legacy_cleanup_system.py scripts/utilities/unified_script_generation_system.py tests/test_unified_script_generation_system.py`
- `pytest tests/test_unified_script_generation_system.py tests/test_script_generation_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_688ff618ac68833193204dd5a83ac5a0