### PR TITLE
feat: integrate compliance updates into placeholder remover

### DIFF
--- a/tests/template_engine/test_placeholder_removal_and_ranking.py
+++ b/tests/template_engine/test_placeholder_removal_and_ranking.py
@@ -97,7 +97,9 @@ def test_generate_integration_ready_code_removes_placeholders(tmp_path, monkeypa
         "template_engine.template_placeholder_remover.validate_no_recursive_folders",
         lambda: None,
     )
-    (workspace / "logs" / "template_rendering").mkdir(parents=True, exist_ok=True)
+    (workspace / "artifacts" / "logs" / "template_rendering").mkdir(
+        parents=True, exist_ok=True
+    )
     monkeypatch.chdir(workspace)
     path = gen.generate_integration_ready_code("demo")
     assert "{{UNKNOWN}}" not in path.read_text()

--- a/tests/test_template_placeholder_remover.py
+++ b/tests/test_template_placeholder_remover.py
@@ -3,6 +3,7 @@ import sqlite3
 from datetime import datetime
 from pathlib import Path
 
+import template_engine.template_placeholder_remover as tpr
 from template_engine.template_placeholder_remover import (
     remove_unused_placeholders,
     validate_removals,
@@ -63,3 +64,53 @@ def test_no_placeholders_returns_same(tmp_path: Path) -> None:
     result = remove_unused_placeholders(code, prod, analytics, timeout_minutes=1)
     assert result == code
     assert validate_removals(0, analytics)
+
+
+def test_updates_and_generation(tmp_path: Path, monkeypatch) -> None:
+    prod = tmp_path / "production.db"
+    analytics = tmp_path / "analytics.db"
+    with sqlite3.connect(prod) as conn:
+        conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
+        conn.execute("INSERT INTO code_templates VALUES (1, 'print(\"{{MISSING}}\")')")
+        conn.execute("CREATE TABLE template_placeholders (placeholder_name TEXT)")
+    with sqlite3.connect(analytics) as conn:
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking (file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, timestamp TEXT, resolved INTEGER, resolved_timestamp TEXT, status TEXT, removal_id INTEGER)"
+        )
+
+    called = {"dashboard": False, "utility": False}
+
+    class DummyUpdater:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def update(self, simulate: bool = False) -> None:
+            called["dashboard"] = True
+
+        def validate_update(self) -> None:
+            pass
+
+    class DummyUtility:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def execute_utility(self) -> bool:
+            called["utility"] = True
+            return True
+
+    monkeypatch.setattr(tpr, "ComplianceMetricsUpdater", DummyUpdater)
+    monkeypatch.setattr(tpr, "EnterpriseUtility", DummyUtility)
+
+    code = "print(\"{{MISSING}}\")"
+    remove_unused_placeholders(
+        code,
+        prod,
+        analytics,
+        timeout_minutes=1,
+        update_compliance=True,
+        auto_remediate=True,
+        workspace_path=tmp_path,
+        dashboard_dir=tmp_path,
+    )
+    assert called["dashboard"]
+    assert called["utility"]


### PR DESCRIPTION
## Summary
- extend template placeholder removal to update compliance metrics and trigger unified script generation for auto-remediation
- adjust placeholder remover tests to cover compliance dashboard and script generation hooks
- fix placeholder-removal ranking test path for new log location

## Testing
- `pytest tests/test_template_placeholder_remover.py tests/template_engine/test_placeholder_removal_and_ranking.py`
- `ruff check template_engine/template_placeholder_remover.py tests/test_template_placeholder_remover.py tests/template_engine/test_placeholder_removal_and_ranking.py`


------
https://chatgpt.com/codex/tasks/task_e_688ff80160fc833196d646d950b47a58