### PR TITLE
feat: add database reconciliation, monitoring, and backup utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Disaster Recovery Orchestration:** scheduled backups and recovery
   execution coordinated through a new orchestrator with session and
   compliance hooks
+- **Cross-Database Reconciliation:** new `cross_database_reconciler.py` heals
+  drift across `production.db`, `analytics.db` and related stores.
+- **Event Rate Monitoring:** `database_event_monitor.py` aggregates metrics in
+  `analytics.db` and alerts on anomalous activity.
+- **Point-in-Time Snapshots:** `point_in_time_backup.py` provides timestamped
+  SQLite backups with restore support.
 - **Placeholder Auditing:** detection script logs findings to `analytics.db:code_audit_log`
 - **Disaster Recovery Validation:** `UnifiedDisasterRecoverySystem` verifies external backup roots and restores files from `production_backup`
 - **Correction History:** cleanup and fix events recorded in `analytics.db:correction_history`

--- a/scripts/database/cross_database_reconciler.py
+++ b/scripts/database/cross_database_reconciler.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Database reconciliation utilities.
+
+This module scans multiple SQLite databases for drift in the
+``cross_database_sync_operations`` table and attempts simple healing by
+copying missing rows.  It logs reconciliation operations using
+``cross_database_sync_logger.log_sync_operation`` and emits warnings for
+schema mismatches.
+
+The script is intentionally lightweight – it performs a best-effort copy
+without guaranteeing full transactional consistency, but it provides a
+foundation for future enhancements such as detailed diffing and
+rollback support.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+from enterprise_modules.compliance import validate_enterprise_operation
+from utils.logging_utils import log_enterprise_operation, setup_enterprise_logging
+
+from .cross_database_sync_logger import log_sync_operation
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DBState:
+    path: Path
+    rows: List[Tuple]
+
+
+def _fetch_operations(conn: sqlite3.Connection) -> List[Tuple]:
+    cur = conn.execute(
+        "SELECT operation, status, start_time, duration, timestamp FROM cross_database_sync_operations"
+    )
+    return [tuple(row) for row in cur.fetchall()]
+
+
+def reconcile_once(db_paths: Sequence[Path]) -> None:
+    """Run a single reconciliation pass across ``db_paths``.
+
+    Any rows missing from a database are copied from the first database in the
+    list.  Schema mismatches are reported via the enterprise logging system.
+    """
+    validate_enterprise_operation()
+
+    states: List[DBState] = []
+    connections: List[sqlite3.Connection] = []
+    for path in db_paths:
+        conn = sqlite3.connect(path)
+        connections.append(conn)
+        rows = []
+        try:
+            rows = _fetch_operations(conn)
+        except sqlite3.OperationalError:
+            # Table missing – schema drift.
+            log_enterprise_operation(
+                "schema_mismatch", "WARNING", f"missing cross_database_sync_operations in {path}"
+            )
+        states.append(DBState(path, rows))
+
+    if not states or not states[0].rows:
+        for conn in connections:
+            conn.close()
+        return
+
+    source_rows = set(states[0].rows)
+    for state, conn in zip(states[1:], connections[1:]):
+        missing = source_rows.difference(state.rows)
+        if missing:
+            log_enterprise_operation(
+                "drift_detected",
+                "WARNING",
+                f"{len(missing)} rows missing in {state.path}",
+            )
+            for row in missing:
+                conn.execute(
+                    "INSERT INTO cross_database_sync_operations (operation, status, start_time, duration, timestamp)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    row,
+                )
+            conn.commit()
+
+    for conn in connections:
+        conn.close()
+
+    log_sync_operation(list(db_paths), "reconcile_databases", status="SUCCESS")
+
+
+def run_reconciler(
+    db_paths: Iterable[Path], *, interval: int = 60, cycles: int = 1
+) -> None:
+    """Periodically invoke :func:`reconcile_once`.
+
+    Parameters
+    ----------
+    db_paths:
+        Paths to databases to reconcile.
+    interval:
+        Seconds to wait between cycles.
+    cycles:
+        Number of reconciliation cycles to execute.  ``0`` runs indefinitely.
+    """
+
+    paths = [Path(p) for p in db_paths]
+    count = 0
+    while cycles == 0 or count < cycles:
+        reconcile_once(paths)
+        count += 1
+        if cycles == 0 or count < cycles:
+            time.sleep(interval)
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Cross-database reconciler")
+    parser.add_argument(
+        "--database",
+        nargs="+",
+        type=Path,
+        default=[
+            Path("databases/production.db"),
+            Path("databases/analytics.db"),
+            Path("databases/template_intelligence.db"),
+        ],
+        help="Paths to databases",
+    )
+    parser.add_argument("--interval", type=int, default=60, help="Seconds between cycles")
+    parser.add_argument(
+        "--cycles",
+        type=int,
+        default=1,
+        help="Number of cycles (0 for continuous)",
+    )
+
+    args = parser.parse_args()
+    setup_enterprise_logging()
+    run_reconciler(args.database, interval=args.interval, cycles=args.cycles)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/scripts/disaster_recovery/point_in_time_backup.py
+++ b/scripts/disaster_recovery/point_in_time_backup.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Point-in-time backup helpers for SQLite databases.
+
+This module provides simple utilities to create timestamped backups of
+SQLite databases and restore them when required.  Backups are written to
+``GH_COPILOT_BACKUP_ROOT`` to comply with anti-recursion policies.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from enterprise_modules.compliance import validate_enterprise_operation
+from utils.logging_utils import log_enterprise_operation, setup_enterprise_logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def _backup_path(name: str) -> Path:
+    root = Path(os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups"))
+    root.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    return root / f"{name}_{timestamp}.sqlite"
+
+
+def create_snapshot(db_path: Path) -> Path:
+    """Create a timestamped backup of ``db_path`` and return its path."""
+    validate_enterprise_operation()
+    backup_file = _backup_path(db_path.stem)
+    with sqlite3.connect(db_path) as src, sqlite3.connect(backup_file) as dst:
+        src.backup(dst)
+    log_enterprise_operation("snapshot_created", "SUCCESS", str(backup_file))
+    return backup_file
+
+
+def restore_snapshot(backup_file: Path, target_path: Path) -> None:
+    """Restore ``backup_file`` to ``target_path``."""
+    validate_enterprise_operation()
+    with sqlite3.connect(backup_file) as src, sqlite3.connect(target_path) as dst:
+        src.backup(dst)
+    log_enterprise_operation("snapshot_restored", "SUCCESS", str(target_path))
+
+
+def snapshot_many(paths: Iterable[Path]) -> None:
+    for path in paths:
+        create_snapshot(path)
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Point-in-time database backups")
+    parser.add_argument("database", nargs="+", type=Path, help="Databases to snapshot")
+    parser.add_argument("--restore", type=Path, help="Restore from backup to target")
+    parser.add_argument("--target", type=Path, help="Target database when using --restore")
+
+    args = parser.parse_args()
+    setup_enterprise_logging()
+
+    if args.restore and args.target:
+        restore_snapshot(args.restore, args.target)
+    else:
+        snapshot_many(args.database)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/scripts/monitoring/database_event_monitor.py
+++ b/scripts/monitoring/database_event_monitor.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Database event rate monitoring utilities.
+
+This module records row counts from the ``cross_database_sync_operations``
+table for a set of databases and persists aggregated metrics to
+``analytics.db``.  Sudden spikes in event rate trigger warning logs to help
+operators investigate potential issues.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from enterprise_modules.compliance import validate_enterprise_operation
+from utils.logging_utils import log_enterprise_operation, setup_enterprise_logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_metrics_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS event_rate_metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            db_path TEXT NOT NULL,
+            event_count INTEGER NOT NULL
+        )
+        """
+    )
+
+
+def _record_metrics(analytics_db: Path, db_path: Path, count: int) -> None:
+    with sqlite3.connect(analytics_db) as conn:
+        _ensure_metrics_table(conn)
+        conn.execute(
+            "INSERT INTO event_rate_metrics (timestamp, db_path, event_count) VALUES (?, ?, ?)",
+            (datetime.now(timezone.utc).isoformat(), str(db_path), count),
+        )
+        conn.commit()
+
+
+def collect_metrics(
+    db_paths: Sequence[Path], analytics_db: Path, *, threshold: int = 100
+) -> None:
+    """Collect metrics for ``db_paths`` and store them in ``analytics_db``.
+
+    A warning is logged if a database's row count exceeds ``threshold`` since
+    the previous measurement.
+    """
+    validate_enterprise_operation()
+
+    last_counts = {}
+    for db_path in db_paths:
+        with sqlite3.connect(db_path) as conn:
+            try:
+                count = conn.execute(
+                    "SELECT COUNT(*) FROM cross_database_sync_operations"
+                ).fetchone()[0]
+            except sqlite3.OperationalError:
+                log_enterprise_operation(
+                    "schema_mismatch", "WARNING", f"missing cross_database_sync_operations in {db_path}"
+                )
+                continue
+
+        _record_metrics(analytics_db, db_path, count)
+
+        previous = last_counts.get(db_path)
+        if previous is not None and count - previous > threshold:
+            log_enterprise_operation(
+                "anomalous_event_rate",
+                "WARNING",
+                f"count jumped from {previous} to {count} for {db_path}",
+            )
+        last_counts[db_path] = count
+
+
+def monitor_databases(
+    db_paths: Iterable[Path],
+    analytics_db: Path,
+    *,
+    interval: int = 60,
+    cycles: int = 1,
+    threshold: int = 100,
+) -> None:
+    """Periodically record metrics for ``db_paths``."""
+    paths = [Path(p) for p in db_paths]
+    cycle = 0
+    while cycles == 0 or cycle < cycles:
+        collect_metrics(paths, analytics_db, threshold=threshold)
+        cycle += 1
+        if cycles == 0 or cycle < cycles:
+            time.sleep(interval)
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Database event monitor")
+    parser.add_argument(
+        "--database",
+        nargs="+",
+        type=Path,
+        default=[
+            Path("databases/production.db"),
+            Path("databases/analytics.db"),
+            Path("databases/template_intelligence.db"),
+        ],
+        help="Paths to databases",
+    )
+    parser.add_argument(
+        "--analytics",
+        type=Path,
+        default=Path("databases/analytics.db"),
+        help="Path to analytics database",
+    )
+    parser.add_argument("--interval", type=int, default=60)
+    parser.add_argument("--cycles", type=int, default=1)
+    parser.add_argument("--threshold", type=int, default=100)
+
+    args = parser.parse_args()
+    setup_enterprise_logging()
+    monitor_databases(
+        args.database,
+        args.analytics,
+        interval=args.interval,
+        cycles=args.cycles,
+        threshold=args.threshold,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/tests/test_cross_database_reconciler.py
+++ b/tests/test_cross_database_reconciler.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone
+
+import sqlite3
+
+from scripts.database.cross_database_reconciler import reconcile_once
+from scripts.database.cross_database_sync_logger import log_sync_operation
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def test_reconcile_once_fills_missing_rows(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "enterprise_modules.compliance.validate_enterprise_operation", lambda: True
+    )
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    db1 = tmp_path / "db1.db"
+    db2 = tmp_path / "db2.db"
+    initialize_database(db1)
+    initialize_database(db2)
+    for db in (db1, db2):
+        with sqlite3.connect(db) as conn:
+            conn.execute("DELETE FROM cross_database_sync_operations")
+            conn.commit()
+    start = datetime.now(timezone.utc)
+    log_sync_operation(db1, "op1", start_time=start)
+
+    reconcile_once([db1, db2])
+
+    with sqlite3.connect(db1) as conn:
+        count1 = conn.execute(
+            "SELECT COUNT(*) FROM cross_database_sync_operations"
+        ).fetchone()[0]
+    with sqlite3.connect(db2) as conn:
+        count2 = conn.execute(
+            "SELECT COUNT(*) FROM cross_database_sync_operations"
+        ).fetchone()[0]
+    assert count1 == count2
+    assert count1 == 2
+

--- a/tests/test_database_event_monitor.py
+++ b/tests/test_database_event_monitor.py
@@ -1,0 +1,27 @@
+import sqlite3
+from datetime import datetime, timezone
+
+from scripts.database.cross_database_sync_logger import log_sync_operation
+from scripts.database.unified_database_initializer import initialize_database
+from scripts.monitoring.database_event_monitor import collect_metrics
+
+
+def test_collect_metrics_records_counts(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "enterprise_modules.compliance.validate_enterprise_operation", lambda: True
+    )
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    db1 = tmp_path / "db1.db"
+    db2 = tmp_path / "db2.db"
+    analytics = tmp_path / "analytics.db"
+    initialize_database(db1)
+    initialize_database(db2)
+    start = datetime.now(timezone.utc)
+    log_sync_operation(db1, "op1", start_time=start)
+
+    collect_metrics([db1, db2], analytics)
+
+    with sqlite3.connect(analytics) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM event_rate_metrics").fetchone()[0]
+    assert count == 2
+

--- a/tests/test_point_in_time_backup.py
+++ b/tests/test_point_in_time_backup.py
@@ -1,0 +1,35 @@
+import sqlite3
+
+from scripts.database.unified_database_initializer import initialize_database
+from scripts.disaster_recovery.point_in_time_backup import (
+    create_snapshot,
+    restore_snapshot,
+)
+
+
+def test_snapshot_and_restore(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "enterprise_modules.compliance.validate_enterprise_operation", lambda: True
+    )
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+
+    src = tmp_path / "src.db"
+    initialize_database(src)
+    with sqlite3.connect(src) as conn:
+        conn.execute("DELETE FROM cross_database_sync_operations")
+        conn.execute(
+            "INSERT INTO cross_database_sync_operations (operation, status, start_time, duration, timestamp) VALUES ('a','b','c',1,'d')"
+        )
+        conn.commit()
+
+    backup = create_snapshot(src)
+    restored = tmp_path / "restored.db"
+    restore_snapshot(backup, restored)
+
+    with sqlite3.connect(restored) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM cross_database_sync_operations"
+        ).fetchone()[0]
+    assert count == 1
+


### PR DESCRIPTION
## Summary
- add cross-database reconciler to detect drift and copy missing sync operations
- monitor database event rates and persist metrics in analytics.db
- provide point-in-time SQLite backup and restore helpers
- document new database tooling

## Testing
- `ruff check scripts/database/cross_database_reconciler.py scripts/monitoring/database_event_monitor.py scripts/disaster_recovery/point_in_time_backup.py tests/test_cross_database_reconciler.py tests/test_database_event_monitor.py tests/test_point_in_time_backup.py`
- `pytest tests/test_cross_database_reconciler.py tests/test_database_event_monitor.py tests/test_point_in_time_backup.py tests/test_cross_database_sync_logger.py`


------
https://chatgpt.com/codex/tasks/task_e_688ff71f794483319a574c696c3ae391