### PR TITLE
feat: sync compliance metrics with monitoring systems

### DIFF
--- a/web_gui/dashboard_actionable_gui.py
+++ b/web_gui/dashboard_actionable_gui.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
 
-METRICS_PATH = Path("dashboard/metrics.json")
+METRICS_PATH = Path("dashboard/compliance/metrics.json")
 CORRECTIONS_DIR = Path("dashboard/compliance")
 ANALYTICS_DB = Path("databases/analytics.db")
 


### PR DESCRIPTION
## Summary
- push compliance metrics to unified monitoring and correction logger for closed-loop tracking
- adjust web GUI to read compliance metrics from the compliance dashboard directory
- cover integration with tests verifying monitoring sync and correction summarization

## Testing
- `ruff check dashboard/compliance_metrics_updater.py web_gui/dashboard_actionable_gui.py tests/test_compliance_metrics_updater.py`
- `pytest tests/test_compliance_metrics_updater.py tests/dashboard/test_actionable_endpoints.py`
- `python scripts/wlc_session_manager.py --steps 1`


------
https://chatgpt.com/codex/tasks/task_e_688ff89eeeec8331aacf797e45ad5010