### PR TITLE
feat: integrate compliance validation into session management

### DIFF
--- a/tests/test_session_management_cli_compliance.py
+++ b/tests/test_session_management_cli_compliance.py
@@ -1,0 +1,34 @@
+import sys
+import types
+import unified_session_management_system as usm
+
+
+def test_main_invokes_compliance_validation(monkeypatch, tmp_path):
+    called = []
+    monkeypatch.setattr(
+        usm,
+        "validate_environment",
+        lambda: called.append(True) or True,
+    )
+
+    class DummySystem:
+        workspace_root = tmp_path
+
+        def start_session(self):
+            return True
+
+        def end_session(self):
+            return True
+
+    dummy_module = types.ModuleType("usms")
+    dummy_module.UnifiedSessionManagementSystem = lambda: DummySystem()
+    sys.modules[
+        "scripts.utilities.unified_session_management_system"
+    ] = dummy_module
+
+    monkeypatch.setattr(
+        "utils.validation_utils.detect_zero_byte_files",
+        lambda root: [],
+    )
+    assert usm.main() == 0
+    assert called


### PR DESCRIPTION
## Summary
- enforce enterprise compliance checks before session lifecycle runs
- add CLI test verifying compliance validation is invoked

## Testing
- `ruff check unified_session_management_system.py tests/test_session_management_cli_compliance.py`
- `pytest tests/test_session_management_cli_compliance.py`
- `pytest tests/test_session_management_cli_compliance.py tests/test_session_management.py tests/test_wlc_session_manager.py tests/test_session_management_integrity.py tests/test_session_management_system.py` *(fails: SyntaxError in scripts/correction_logger_and_rollback.py)*

------
https://chatgpt.com/codex/tasks/task_e_688ffbab6494833198426ad26045bed4