### PR TITLE
feat: add quantum pattern ranking

### DIFF
--- a/template_engine/README.md
+++ b/template_engine/README.md
@@ -6,6 +6,10 @@ Lesson templates are returned by `get_lesson_templates()` in
 initialization and ranking. To extend behavior, add new entries to the lesson
 store and they will influence template generation automatically.
 
+`pattern_mining_engine.rank_patterns_quantum` can rank mined patterns against a
+target string using quantum-inspired scoring, enabling adaptive template
+selection when quantum modules are available.
+
 `TemplateWorkflowEnhancer` can generate in-memory compliance summaries via
 `generate_compliance_report`, combining clustering, pattern mining and
 compliance scoring for downstream analytics.

--- a/tests/test_pattern_mining_engine.py
+++ b/tests/test_pattern_mining_engine.py
@@ -167,6 +167,15 @@ def test_mine_patterns_metrics(tmp_path: Path, monkeypatch) -> None:
     assert metrics["n_clusters"] > 0
 
 
+def test_rank_patterns_quantum(monkeypatch) -> None:
+    patterns = ["alpha beta gamma", "foo bar baz"]
+    scores = {"alpha beta gamma": 0.2, "foo bar baz": 0.8, "foo bar baz qux": 0.9}
+    monkeypatch.setattr(pme, "quantum_text_score", lambda text: scores[text])
+    ranked = pme.rank_patterns_quantum(patterns, "foo bar baz qux")
+    assert ranked[0][0] == "foo bar baz"
+    assert ranked[0][1] > ranked[1][1]
+
+
 def test_log_pattern_audit_and_compliance(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     analytics = tmp_path / "analytics.db"


### PR DESCRIPTION
## Summary
- integrate optional quantum scoring into pattern mining
- rank mined patterns relative to a target string
- document quantum pattern ranking and add unit test

## Testing
- `ruff check template_engine/pattern_mining_engine.py tests/test_pattern_mining_engine.py`
- `pytest` *(fails: SyntaxError: duplicate argument 'correction_type' in scripts/correction_logger_and_rollback.py)*
- `pytest tests/test_pattern_mining_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_688ff18562b88331b4e0567c1a7757c7