### PR TITLE
feat: log dual copilot analytics metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,8 @@ Toward Enterprise-Grade Output (tests pending)
 
 Optimization and security scripts must invoke their main logic via
 `DualCopilotOrchestrator` so that a `SecondaryCopilotValidator` review
-follows every primary execution.
+follows every primary execution and runtime metrics are captured for
+analytics.
 
 ### **Implementation Example**
 ```python

--- a/scripts/bot/assign_copilot_license.py
+++ b/scripts/bot/assign_copilot_license.py
@@ -87,7 +87,7 @@ def main() -> None:
     def _primary() -> bool:
         return assign_license(args.username, not args.revoke)
 
-    primary_success, validation_success = orchestrator.run(_primary, [__file__])
+    primary_success, validation_success, _ = orchestrator.run(_primary, [__file__])
 
     duration = (datetime.now() - start).total_seconds()
     if primary_success and validation_success:

--- a/scripts/optimization/optimize_to_100_percent.py
+++ b/scripts/optimization/optimize_to_100_percent.py
@@ -19,7 +19,6 @@ from typing import Any, Dict
 from tqdm import tqdm
 
 from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
-from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 from importlib import import_module
 
 # Text-based indicators (cross-platform)
@@ -875,5 +874,5 @@ def main():
 if __name__ == "__main__":
     pkg = import_module("scripts.optimization.optimize_to_100_percent")
     orchestrator = DualCopilotOrchestrator()
-    success, validated = orchestrator.run(pkg.main, [pkg.__file__])
+    success, validated, _ = orchestrator.run(pkg.main, [pkg.__file__])
     sys.exit(0 if success and validated else 1)

--- a/scripts/optimization/security_compliance_enhancer.py
+++ b/scripts/optimization/security_compliance_enhancer.py
@@ -24,7 +24,6 @@ from typing import Any, Dict
 from tqdm import tqdm
 
 from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
-from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 from importlib import import_module
 
 from utils.db_utils import get_validated_connection
@@ -514,5 +513,5 @@ def main():
 if __name__ == "__main__":
     pkg = import_module("scripts.optimization.security_compliance_enhancer")
     orchestrator = DualCopilotOrchestrator()
-    success, validated = orchestrator.run(pkg.main, [pkg.__file__])
+    success, validated, _ = orchestrator.run(pkg.main, [pkg.__file__])
     sys.exit(0 if success and validated else 1)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -59,7 +59,7 @@ def test_main_uses_dual_orchestrator(monkeypatch):
 
     def fake_run(self, primary, targets, timeout_minutes=30):
         called["ran"] = True
-        return True, True
+        return True, True, {}
 
     monkeypatch.setattr("scripts.bot.assign_copilot_license.DualCopilotOrchestrator.run", fake_run)
 

--- a/tests/test_continuous_monitoring_engine.py
+++ b/tests/test_continuous_monitoring_engine.py
@@ -42,7 +42,7 @@ def test_cli_runs_orchestrated_cycles(monkeypatch, tmp_path):
         def run(self, primary, targets):
             calls.append("run")
             primary()
-            return True, True
+            return True, True, {}
 
     monkeypatch.setattr(
         "scripts.monitoring.continuous_monitoring_engine.DualCopilotOrchestrator",

--- a/tests/test_primary_executor_orchestrator.py
+++ b/tests/test_primary_executor_orchestrator.py
@@ -4,7 +4,7 @@ from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
 
 
 def test_orchestrator_invokes_executor_and_validator(monkeypatch):
-    calls = {"exec": False, "validate": False}
+    calls = {"exec": False, "validate": False, "logged": False}
 
     class DummyExecutor:
         def __init__(self, task_name: str, timeout_minutes: int = 30, logger=None) -> None:
@@ -22,6 +22,10 @@ def test_orchestrator_invokes_executor_and_validator(monkeypatch):
             calls["validate"] = True
             return True
 
+    class DummyMonitor:
+        def execute_utility(self):
+            return True
+
     monkeypatch.setattr(
         "scripts.validation.dual_copilot_orchestrator.PrimaryCopilotExecutor",
         DummyExecutor,
@@ -30,11 +34,30 @@ def test_orchestrator_invokes_executor_and_validator(monkeypatch):
         "scripts.validation.dual_copilot_orchestrator.SecondaryCopilotValidator",
         DummyValidator,
     )
+    monkeypatch.setattr(
+        "scripts.validation.dual_copilot_orchestrator.EnterpriseUtility",
+        DummyMonitor,
+    )
+    monkeypatch.setattr(
+        "scripts.validation.dual_copilot_orchestrator.collect_metrics",
+        lambda: {"session_id": "s1"},
+    )
+
+    def fake_log(event, **_):
+        calls["logged"] = True
+        assert event["event"] == "dual_copilot_run"
+
+    monkeypatch.setattr(
+        "scripts.validation.dual_copilot_orchestrator._log_event",
+        fake_log,
+    )
 
     orch = DualCopilotOrchestrator()
-    success, validated = orch.run(lambda: True, ["a.py"], timeout_minutes=1)
+    success, validated, metrics = orch.run(lambda: True, ["a.py"], timeout_minutes=1)
 
     assert success
     assert validated
+    assert metrics["session_id"] == "s1"
     assert calls["exec"]
     assert calls["validate"]
+    assert calls["logged"]

--- a/validation/dual_copilot_database_check.py
+++ b/validation/dual_copilot_database_check.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Dict
 
 from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
 
@@ -19,13 +19,14 @@ def _database_has_tables() -> bool:
         return len(cur.fetchall()) > 0
 
 
-def run_validation(timeout_minutes: int = 5) -> Tuple[bool, bool]:
+def run_validation(timeout_minutes: int = 5) -> Tuple[bool, bool, Dict[str, float]]:
     orchestrator = DualCopilotOrchestrator()
     primary = _database_has_tables
     return orchestrator.run(primary, [str(PRODUCTION_DB)], timeout_minutes)
 
 
 if __name__ == "__main__":
-    success, validated = run_validation()
+    success, validated, metrics = run_validation()
     print(f"Primary success: {success}")
     print(f"Secondary success: {validated}")
+    print(f"Metrics session id: {metrics.get('session_id')}")


### PR DESCRIPTION
## Summary
- log runtime metrics to analytics in DualCopilotOrchestrator
- capture returned metrics and adapt call sites
- test logging and metrics collection

## Testing
- `ruff check scripts/validation/dual_copilot_orchestrator.py scripts/bot/assign_copilot_license.py scripts/optimization/security_compliance_enhancer.py scripts/optimization/optimize_to_100_percent.py validation/dual_copilot_database_check.py tests/test_primary_executor_orchestrator.py tests/test_bot.py tests/test_continuous_monitoring_engine.py`
- `pytest tests/test_primary_executor_orchestrator.py tests/test_bot.py tests/test_continuous_monitoring_engine.py tests/test_workspace_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_688ff951dc588331be6eab7b32d677d8