### PR TITLE
feat: enforce session anti recursion

### DIFF
--- a/documentation/SESSION_STARTUP_GUIDE.md
+++ b/documentation/SESSION_STARTUP_GUIDE.md
@@ -41,6 +41,21 @@ Batch options are also available via `start_all_services.bat`, `start_all_servic
 
 Standard session patterns are defined in `.github/instructions/SESSION_TEMPLATES.instructions.md`. They describe database-first workflows and validation steps for consistent enterprise sessions.
 
+## Anti-Recursion Guard
+
+Entry points that start or end a session should apply the
+`anti_recursion_guard` decorator from `scripts.session.anti_recursion_enforcer`.
+This guard uses both a lock file and process checks to prevent accidentally
+starting multiple session managers at the same time.
+
+```python
+from scripts.session.anti_recursion_enforcer import anti_recursion_guard
+
+@anti_recursion_guard
+def main():
+    ...
+```
+
 ## Response Chunking
 
 All Copilot responses must follow the rules in `.github/instructions/RESPONSE_CHUNKING.instructions.md`:

--- a/tests/session/test_anti_recursion.py
+++ b/tests/session/test_anti_recursion.py
@@ -1,0 +1,48 @@
+import pytest
+from scripts.session.anti_recursion_enforcer import (
+    AntiRecursionEnforcer,
+    anti_recursion_guard,
+)
+
+
+def test_decorator_blocks_on_recursion(monkeypatch):
+    calls = []
+
+    def fake_enforce(self, current_pid=None):
+        calls.append("check")
+        raise RuntimeError("recursion")
+
+    monkeypatch.setattr(
+        AntiRecursionEnforcer,
+        "enforce_no_recursion",
+        fake_enforce,
+    )
+
+    @anti_recursion_guard
+    def wrapped():
+        calls.append("run")
+
+    with pytest.raises(RuntimeError):
+        wrapped()
+    assert calls == ["check"]
+
+
+def test_decorator_allows_single_call(monkeypatch):
+    calls = []
+
+    def fake_enforce(self, current_pid=None):
+        calls.append("check")
+
+    monkeypatch.setattr(
+        AntiRecursionEnforcer,
+        "enforce_no_recursion",
+        fake_enforce,
+    )
+
+    @anti_recursion_guard
+    def wrapped():
+        calls.append("run")
+        return "ok"
+
+    assert wrapped() == "ok"
+    assert calls == ["check", "run"]

--- a/unified_session_management_system.py
+++ b/unified_session_management_system.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Callable
 import logging
 
-from utils.validation_utils import detect_zero_byte_files, anti_recursion_guard
+from utils.validation_utils import detect_zero_byte_files
+from scripts.session.anti_recursion_enforcer import anti_recursion_guard
 from enterprise_modules.compliance import validate_environment, ComplianceError
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- expand anti-recursion enforcement with lock-file based decorator
- guard unified session management entry point against recursive runs
- document anti-recursion guard usage

## Testing
- `ruff check scripts/session/anti_recursion_enforcer.py unified_session_management_system.py tests/session/test_anti_recursion.py`
- `pytest` *(fails: tests/dashboard/test_actionable_endpoints.py)*
- `pytest tests/session/test_anti_recursion.py tests/test_anti_recursion_enforcer.py`


------
https://chatgpt.com/codex/tasks/task_e_68902a1c3aa483318497f6caca2716a0