### PR TITLE
feat: validate wrap-up orchestrator with dual copilot pattern

### DIFF
--- a/documentation/DUAL_COPILOT_PATTERN.md
+++ b/documentation/DUAL_COPILOT_PATTERN.md
@@ -1,0 +1,25 @@
+# Dual Copilot Pattern
+
+The dual copilot pattern pairs a primary action with a secondary validator to
+provide an extra layer of assurance for critical workflows. The secondary step
+runs even if the primary fails and any exceptions are aggregated.
+
+Use `secondary_copilot_validator.run_dual_copilot_validation` to coordinate
+these checks:
+
+```python
+from secondary_copilot_validator import run_dual_copilot_validation
+
+def primary():
+    ...
+
+def secondary():
+    ...
+
+run_dual_copilot_validation(primary, secondary)
+```
+
+Recent orchestrators such as
+`scripts/orchestrators/unified_wrapup_orchestrator.py` delegate their primary
+and secondary checks through this helper, ensuring a unified validation
+workflow across the toolkit.

--- a/scripts/orchestrators/unified_wrapup_orchestrator.py
+++ b/scripts/orchestrators/unified_wrapup_orchestrator.py
@@ -30,6 +30,7 @@ from tqdm import tqdm
 
 from scripts.wlc_session_manager import run_session
 from enterprise_modules.compliance import validate_enterprise_operation
+from secondary_copilot_validator import run_dual_copilot_validation
 
 # Configure enterprise logging
 logging.basicConfig(
@@ -244,6 +245,16 @@ class UnifiedWrapUpOrchestrator:
         result = WrapUpResult(session_id=self.session_id, start_time=self.start_time)
 
         try:
+            def _primary_start() -> bool:
+                logger.info("🔍 PRIMARY VALIDATION")
+                return self.primary_validate()
+
+            def _secondary_start() -> bool:
+                logger.info("🔍 SECONDARY VALIDATION")
+                return self.secondary_validate()
+
+            run_dual_copilot_validation(_primary_start, _secondary_start)
+
             logger.info("=" * 80)
             logger.info("🚀 UNIFIED WRAP-UP ORCHESTRATOR - MASTER EXECUTION")
             logger.info("=" * 80)
@@ -286,8 +297,7 @@ class UnifiedWrapUpOrchestrator:
 
             logger.info("✅ UNIFIED WRAP-UP ORCHESTRATOR COMPLETED SUCCESSFULLY")
 
-            self.primary_validate()
-            self.secondary_validate()
+            run_dual_copilot_validation(self.primary_validate, self.secondary_validate)
 
         except Exception as e:
             result.status = "FAILED"

--- a/secondary_copilot_validator.py
+++ b/secondary_copilot_validator.py
@@ -1,5 +1,6 @@
-"""Compatibility wrapper for tests."""
+"""Compatibility wrapper exposing secondary validation utilities."""
 
 from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
+from utils.validation_utils import run_dual_copilot_validation
 
-__all__ = ["SecondaryCopilotValidator"]
+__all__ = ["SecondaryCopilotValidator", "run_dual_copilot_validation"]

--- a/tests/test_dual_copilot_validation.py
+++ b/tests/test_dual_copilot_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.validation_utils import run_dual_copilot_validation
+from secondary_copilot_validator import run_dual_copilot_validation
 
 
 def test_primary_exception_still_runs_secondary():

--- a/tests/test_unified_wrapup_orchestrator_validation.py
+++ b/tests/test_unified_wrapup_orchestrator_validation.py
@@ -1,0 +1,81 @@
+import scripts.orchestrators.unified_wrapup_orchestrator as uwo
+
+
+def _noop(*args, **kwargs):
+    """Helper no-op function for monkeypatching heavy phases."""
+
+
+def test_execute_unified_wrapup_runs_validators_in_order(monkeypatch):
+    calls = []
+
+    def fake_run_dual(primary, secondary):
+        primary()
+        secondary()
+        return True
+
+    monkeypatch.setattr(uwo, "run_dual_copilot_validation", fake_run_dual)
+
+    def primary(self):
+        calls.append("primary")
+        return True
+
+    def secondary(self):
+        calls.append("secondary")
+        return True
+
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "primary_validate", primary)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "secondary_validate", secondary)
+
+    # Patch heavy phases and storage
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase1_root_discovery", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase2_file_organization", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase3_config_validation", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase4_script_modularization", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase5_compliance_validation", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase6_final_reporting", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_store_wrapup_results", _noop)
+
+    orchestrator = uwo.UnifiedWrapUpOrchestrator()
+    result = orchestrator.execute_unified_wrapup()
+
+    assert result.status == "COMPLETED"
+    assert calls == ["primary", "secondary", "primary", "secondary"]
+
+
+def test_execute_unified_wrapup_reports_failure_order(monkeypatch):
+    calls = []
+
+    def fake_run_dual(primary, secondary):
+        try:
+            primary()
+        except Exception:
+            pass
+        secondary()
+        raise RuntimeError("validation failed")
+
+    monkeypatch.setattr(uwo, "run_dual_copilot_validation", fake_run_dual)
+
+    def primary(self):
+        calls.append("primary")
+        raise ValueError("boom")
+
+    def secondary(self):
+        calls.append("secondary")
+        return True
+
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "primary_validate", primary)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "secondary_validate", secondary)
+
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase1_root_discovery", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase2_file_organization", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase3_config_validation", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase4_script_modularization", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase5_compliance_validation", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_execute_phase6_final_reporting", _noop)
+    monkeypatch.setattr(uwo.UnifiedWrapUpOrchestrator, "_store_wrapup_results", _noop)
+
+    orchestrator = uwo.UnifiedWrapUpOrchestrator()
+    result = orchestrator.execute_unified_wrapup()
+
+    assert result.status == "FAILED"
+    assert calls == ["primary", "secondary"]


### PR DESCRIPTION
## Summary
- ensure `unified_wrapup_orchestrator` uses `run_dual_copilot_validation` before and after execution
- expose `run_dual_copilot_validation` from `secondary_copilot_validator`
- document dual copilot pattern and add tests for success and failure order

## Testing
- `ruff check scripts/orchestrators/unified_wrapup_orchestrator.py secondary_copilot_validator.py tests/test_dual_copilot_validation.py tests/test_unified_wrapup_orchestrator_validation.py`
- `pytest tests/test_dual_copilot_validation.py tests/test_unified_wrapup_orchestrator_validation.py tests/test_orchestrator_wlc_integration.py tests/test_unified_wrapup_orchestrator_postinit.py`


------
https://chatgpt.com/codex/tasks/task_e_68902a1d53948331a66bbfbdbf0094cc