### PR TITLE
docs: clarify quantum modules run in simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@
 
 > Tests: run `pytest` before committing. Current repository tests report multiple failures.
 > Lint: run `ruff check .` before committing.
-> Quantum modules run in simulation mode by default; compliance auditing is still in progress. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) for details.
+> Quantum modules run **exclusively** in simulation mode unless explicit hardware flags and credentials are provided. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Compliance auditing remains in progress.
 > Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards.
 
 ---
 
 ## 📊 SYSTEM OVERVIEW
 
-The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality currently exists as placeholder modules that run in simulation mode. Hooks for real hardware are planned but are not yet fully integrated, even when `qiskit-ibm-provider` is configured.
+The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality exists only as placeholder modules operating in simulation mode. Hooks for real hardware are planned but are not yet fully integrated, even when `qiskit-ibm-provider` is configured.
 
 > **Note**
 > Qiskit-based operations run in **simulation mode** unless hardware access is configured. Install `qiskit-ibm-provider` and set the optional `QISKIT_IBM_TOKEN` environment variable to use real IBM Quantum backends. When `IBM_BACKEND` is unset the system automatically selects an available backend. Use the `--hardware` flag in `quantum_integration_orchestrator.py` or `--use-hardware` in `quantum/cli/executor_cli.py` to enforce hardware execution.

--- a/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -10,7 +10,7 @@
 ### **System Classification**
 The gh_COPILOT Toolkit v4.0 represents an enterprise-grade automation platform in active development that implements a database-first, unified system architecture with advanced AI integration capabilities. Several subsystems—including disaster recovery, the web dashboard, and the database synchronization engine—remain incomplete, and the current test suite reports multiple failures.
 
-*All quantum modules run in simulation mode; enterprise deployment capabilities are still in progress.*
+*All quantum modules run exclusively in simulation mode; enterprise deployment capabilities are still in progress and require explicit hardware configuration.*
 *Phase&nbsp;5 advanced AI features are partially integrated and not yet production ready.*
 
 ### **Core Technical Architecture**

--- a/docs/PHASE5_TASKS_STARTED.md
+++ b/docs/PHASE5_TASKS_STARTED.md
@@ -28,8 +28,8 @@ These task stubs originate from the gap analysis report and have been formally s
 
 ## 7. Align Documentation with Implementation
 - **Statement Excerpt:** "Audit Pass: Review whitepaper, README and guides; reconcile overstated claims (quantum features, test success)."
-- **Status:** In Progress – placeholder quantum features documented; README and Complete Technical Specifications whitepaper now highlight simulation-only quantum modules.
-- [ ] **Progress:** 85% – backup guide now documents module-level helpers alongside the updated README and whitepaper statements.
+ - **Status:** In Progress – placeholder quantum features documented; [README.md](../README.md) and [Complete Technical Specifications whitepaper](COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md) now explicitly state that quantum modules run exclusively in simulation mode.
+ - [ ] **Progress:** 90% – backup guide now documents module-level helpers alongside the updated README and whitepaper statements.
 
 ## 8. Establish Robust Testing & Compliance Checks
 - **Statement Excerpt:** "Comprehensive Tests: Run full pytest suite; resolve failures; add coverage for new modules."
@@ -91,7 +91,7 @@ These task stubs originate from the gap analysis report and have been formally s
 
 ### Progress Checklist
 
-- [ ] 7. Align Documentation with Implementation — 85% complete
+- [ ] 7. Align Documentation with Implementation — 90% complete
 - [x] 12. Update Changelog and User Prompts — 100% complete
 - [ ] 17. Implement Anti-Recursion Guards — 50% complete
 - [ ] 18. Standardize Dual-Copilot Validation — 40% complete

--- a/docs/task_stubs.md
+++ b/docs/task_stubs.md
@@ -12,7 +12,7 @@ lightweight references for future implementation.
 | MonitoringOptimization | ML enhanced monitoring with quantum hooks | Link metrics to session lifecycle | Validate metric calculations and alerts | Monitoring guidelines and metrics reference | Expand observability | 0% |
 | SessionManagementEnhancements | Zero byte detection and anti recursion | Lifecycle enforcement logging states | Unit tests for validation rules | Revised session protocol docs | Strengthen session integrity | 0% |
 | ScriptGenerationCleanup | Template intelligence via clustering | Pattern library and legacy asset cleanup | Tests for pattern matching and cleanup | Template generation and cleanup guides | Improve script generator | 0% |
-| DocumentationAlignment | Audit whitepaper, README, guides | Regenerate metrics using docs scripts | Validator confirms accuracy | Changelog and guides current | Ensure docs match implementation | 85% |
+| DocumentationAlignment | Audit whitepaper, README, guides | Regenerate metrics using docs scripts | Validator confirms accuracy | Changelog and guides current | Ensure docs match implementation | 90% |
 | TestingComplianceChecks | Full pytest suite and compliance scoring | Placeholder audit integration | Run audits and verify rollback paths | Testing procedures documented | Maintain high coverage | 0% |
 | TimelineRiskMitigationPlan | Week by week rollout | Structured module milestones | Review integration points weekly | Planning artifacts for stakeholders | Reduce delivery risk | 0% |
 | SuccessCriteriaRiskMitigation | Quantitative and qualitative goals | Stakeholder signoff workflows | Coverage enforcement and latency checks | Risk controls and mitigation notes | Define success metrics | 0% |
@@ -32,6 +32,6 @@ lightweight references for future implementation.
 - [x] BackupValidationChecks – 100%
 - [ ] AntiRecursionGuards – 60%
 - [ ] DualCopilotValidationStandardization – 40%
-- [ ] DocumentationAlignment — 85% complete
+- [ ] DocumentationAlignment — 90% complete
 - [x] ChangelogUserPrompts — 100%
 - [ ] QuantumPlaceholderFeatures — 60% complete


### PR DESCRIPTION
## Summary
- clarify in README and whitepaper that quantum modules operate only in simulation mode
- cross-reference documentation alignment in Phase 5 tracking and bump progress
- refresh task stubs progress after regenerating docs metrics

## Testing
- `python scripts/docs_metrics_validator.py`
- `ruff check .` *(fails: F821 Undefined name `UnifiedSessionManagementSystem` and others)*
- `pytest` *(fails: tests/dashboard/test_actionable_endpoints.py)*

------
https://chatgpt.com/codex/tasks/task_e_68905786789c833191324cc8f8687bb1