### PR TITLE
feat: enforce session anti recursion guard

### DIFF
--- a/documentation/SESSION_STARTUP_GUIDE.md
+++ b/documentation/SESSION_STARTUP_GUIDE.md
@@ -46,7 +46,9 @@ Standard session patterns are defined in `.github/instructions/SESSION_TEMPLATES
 Entry points that start or end a session should apply the
 `anti_recursion_guard` decorator from `scripts.session.anti_recursion_enforcer`.
 This guard uses both a lock file and process checks to prevent accidentally
-starting multiple session managers at the same time.
+starting multiple session managers at the same time. The
+`scripts/session/unified_session_management_system.py` CLI wrapper applies
+this decorator to its ``main`` function.
 
 ```python
 from scripts.session.anti_recursion_enforcer import anti_recursion_guard

--- a/scripts/session/anti_recursion_enforcer.py
+++ b/scripts/session/anti_recursion_enforcer.py
@@ -12,7 +12,8 @@ __all__ = ["AntiRecursionEnforcer", "anti_recursion_guard"]
 
 
 _LOCK_DIR = Path(tempfile.gettempdir()) / "gh_copilot_locks"
-_LOCK_DIR.mkdir(exist_ok=True)
+# Ensure the lock directory exists even if the parent path is missing
+_LOCK_DIR.mkdir(parents=True, exist_ok=True)
 
 
 F = TypeVar("F", bound=Callable[..., object])

--- a/scripts/session/unified_session_management_system.py
+++ b/scripts/session/unified_session_management_system.py
@@ -7,10 +7,12 @@ avoid code duplication.
 from scripts.utilities.unified_session_management_system import (
     UnifiedSessionManagementSystem,
 )
+from .anti_recursion_enforcer import anti_recursion_guard
 
 __all__ = ["UnifiedSessionManagementSystem", "main"]
 
 
+@anti_recursion_guard
 def main() -> int:
     """Start a session validation run."""
     system = UnifiedSessionManagementSystem()

--- a/tests/session/test_anti_recursion.py
+++ b/tests/session/test_anti_recursion.py
@@ -46,3 +46,12 @@ def test_decorator_allows_single_call(monkeypatch):
 
     assert wrapped() == "ok"
     assert calls == ["check", "run"]
+
+
+def test_decorator_prevents_reentrancy():
+    @anti_recursion_guard
+    def recur():
+        recur()
+
+    with pytest.raises(RuntimeError):
+        recur()


### PR DESCRIPTION
## Summary
- ensure anti-recursion lock directory is created with parents
- guard session CLI entrypoint with `anti_recursion_guard`
- expand tests and docs for anti-recursion workflow

## Testing
- `ruff check scripts/session/anti_recursion_enforcer.py scripts/session/unified_session_management_system.py tests/session/test_anti_recursion.py`
- `pytest tests/session/test_anti_recursion.py`


------
https://chatgpt.com/codex/tasks/task_e_689057868a048331abcd044491277818