### PR TITLE
test: expand dual copilot validation coverage

### DIFF
--- a/documentation/DUAL_COPILOT_PATTERN.md
+++ b/documentation/DUAL_COPILOT_PATTERN.md
@@ -19,6 +19,17 @@ def secondary():
 run_dual_copilot_validation(primary, secondary)
 ```
 
+### Behavior
+
+* Validations run in order: the primary function executes before the
+  secondary.
+* The secondary validation always runs, even if the primary raises an
+  exception.
+* Exceptions from both steps are aggregated and reported in the order they
+  occurred.
+* The helper returns `True` only when **both** validations succeed; otherwise it
+  returns `False` or raises a combined `RuntimeError`.
+
 Recent orchestrators such as
 `scripts/orchestrators/unified_wrapup_orchestrator.py` delegate their primary
 and secondary checks through this helper, ensuring a unified validation

--- a/tests/test_dual_copilot_validation.py
+++ b/tests/test_dual_copilot_validation.py
@@ -55,3 +55,36 @@ def test_both_validations_return_false_ordered():
     result = run_dual_copilot_validation(primary, secondary)
     assert result is False
     assert order == ["primary", "secondary"]
+
+
+def test_secondary_exception_reports_order():
+    order = []
+
+    def primary() -> bool:
+        order.append("primary")
+        return True
+
+    def secondary() -> bool:
+        order.append("secondary")
+        raise ValueError("boom")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        run_dual_copilot_validation(primary, secondary)
+
+    assert "Secondary validation error" in str(excinfo.value)
+    assert order == ["primary", "secondary"]
+
+
+def test_both_validations_succeed_ordered():
+    order = []
+
+    def primary() -> bool:
+        order.append("primary")
+        return True
+
+    def secondary() -> bool:
+        order.append("secondary")
+        return True
+
+    assert run_dual_copilot_validation(primary, secondary) is True
+    assert order == ["primary", "secondary"]


### PR DESCRIPTION
## Summary
- extend dual copilot validation tests for secondary failure and success paths
- document dual copilot behavior in developer guide

## Testing
- `ruff check tests/test_dual_copilot_validation.py`
- `TEST_MODE=1 pytest tests/test_dual_copilot_validation.py tests/test_unified_wrapup_orchestrator_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68905787ab3c8331bf7148bd2b6d2d59