### PR TITLE
fix: ensure quantum placeholders are excluded from builds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,5 +85,7 @@ a compliance report to ``dashboard/compliance``. Use
 
 Modules under `scripts/quantum_placeholders/` act as stubs for upcoming
 quantum features. Each file sets `PLACEHOLDER_ONLY = True`, and packaging
-utilities skip these modules so they are never included in production
-builds. They remain importable for experimentation and planning.
+utilities detect this marker to skip the modules so they are never included
+in production builds. Importing them while `GH_COPILOT_ENV` is set to
+`"production"` raises a `RuntimeError` via `ensure_not_production`.
+They remain importable for experimentation and planning.

--- a/docs/quantum_integration_plan.md
+++ b/docs/quantum_integration_plan.md
@@ -13,6 +13,8 @@
 ## Placeholder Modules
 
 Prototype implementations reside under `scripts/quantum_placeholders/`.
-Each module defines `PLACEHOLDER_ONLY = True`, and build tooling skips
-them during packaging. These stubs document planned functionality while
-keeping production deployments free of unfinished quantum code.
+Each module defines `PLACEHOLDER_ONLY = True`, and build tooling
+detects this marker to exclude them during packaging. Importing a
+placeholder when `GH_COPILOT_ENV` is set to `"production"` raises a
+`RuntimeError`, keeping production deployments free of unfinished
+quantum code while preserving importability for planning.

--- a/scripts/quantum_placeholders/__init__.py
+++ b/scripts/quantum_placeholders/__init__.py
@@ -18,6 +18,14 @@ def ensure_not_production() -> None:
         msg = "Quantum placeholder modules should not be used in production."
         raise RuntimeError(msg)
 
+
+from . import (
+    quantum_placeholder_algorithm,
+    quantum_annealing,
+    quantum_superposition_search,
+    quantum_entanglement_correction,
+)
+
 __all__ = [
     "quantum_placeholder_algorithm",
     "quantum_annealing",

--- a/scripts/utilities/production_template_utils.py
+++ b/scripts/utilities/production_template_utils.py
@@ -32,14 +32,16 @@ def generate_script_from_repository(workspace: Path, output_name: str) -> bool:
             return False
 
         src_file = workspace / row[0]
-        if "scripts/quantum_placeholders" in src_file.as_posix():
+        if not src_file.exists():
+            logger.error("%s Missing script at %s", TEXT_INDICATORS["error"], src_file)
+            return False
+
+        content = src_file.read_text(encoding="utf-8")
+        if "PLACEHOLDER_ONLY" in content:
             logger.error(
                 "%s Placeholder modules are excluded from packaging",
                 TEXT_INDICATORS["error"],
             )
-            return False
-        if not src_file.exists():
-            logger.error("%s Missing script at %s", TEXT_INDICATORS["error"], src_file)
             return False
 
         output_file = output_dir / output_name

--- a/tests/quantum/test_placeholders.py
+++ b/tests/quantum/test_placeholders.py
@@ -1,3 +1,5 @@
+"""Tests for placeholder quantum modules."""
+
 from importlib import import_module
 from typing import Any, Sequence
 


### PR DESCRIPTION
## Summary
- mark quantum placeholder package and modules explicitly
- skip placeholder modules in packaging when `PLACEHOLDER_ONLY` is detected
- document placeholder-only behavior and update tests

## Testing
- `ruff check scripts/utilities/production_template_utils.py scripts/quantum_placeholders/__init__.py tests/quantum/test_placeholders.py`
- `pytest tests/quantum/test_placeholders.py`


------
https://chatgpt.com/codex/tasks/task_e_68905788ae9c83318f18db0cd0c08e39