### PR TITLE
feat: add retention policy and CLI for disaster recovery

### DIFF
--- a/scripts/utilities/unified_disaster_recovery_system.py
+++ b/scripts/utilities/unified_disaster_recovery_system.py
@@ -33,9 +33,14 @@ TEXT_INDICATORS = {
 class ComplianceLogger:
     """Record compliance events for disaster recovery operations."""
 
-    def log(self, event: str, **details: str) -> None:
-        payload = {"module": "disaster_recovery", "event": event, **details}
+    def log_to_db(self, event: str, **details: str) -> None:
+        """Persist an event to ``analytics.db``."""
+
+        payload = {"module": "disaster_recovery", "description": event, **details}
         enterprise_logging.log_event(payload)
+
+    def log(self, event: str, **details: str) -> None:
+        self.log_to_db(event, **details)
         log_backup_event(event, details)
 
 
@@ -47,7 +52,7 @@ class BackupScheduler:
         self.compliance_logger = logger
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def schedule(self) -> Path:
+    def schedule(self, max_backups: Optional[int] = None) -> Path:
         backup_root = Path(
             os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_COPILOT_Backups")
         ).resolve()
@@ -72,6 +77,14 @@ class BackupScheduler:
             hashlib.sha256(backup_file.read_bytes()).hexdigest(), encoding="utf-8"
         )
         self.compliance_logger.log("backup_scheduled", path=str(backup_file))
+
+        if max_backups is not None:
+            backups = sorted(backup_root.glob("scheduled_backup_*.bak"), key=os.path.getmtime, reverse=True)
+            for old in backups[max_backups:]:
+                old.unlink(missing_ok=True)
+                old.with_suffix(old.suffix + ".sha256").unlink(missing_ok=True)
+                self.compliance_logger.log("backup_pruned", path=str(old))
+
         return backup_file
 
 
@@ -166,18 +179,43 @@ class UnifiedDisasterRecoverySystem:
         self.logger.info("%s Disaster recovery completed in %.1fs", TEXT_INDICATORS["success"], duration)
         return True
 
-    def schedule_backups(self) -> Path:
-        """Create a timestamped backup in ``GH_COPILOT_BACKUP_ROOT``."""
-        return self.scheduler.schedule()
+    def schedule_backups(self, max_backups: Optional[int] = None) -> Path:
+        """Create a timestamped backup in ``GH_COPILOT_BACKUP_ROOT``.
+
+        Parameters
+        ----------
+        max_backups:
+            Maximum number of backups to retain. Older backups beyond this
+            count are removed.
+        """
+
+        return self.scheduler.schedule(max_backups=max_backups)
 
     def restore_backup(self, path: str | Path) -> bool:
         """Restore a single backup file with integrity verification."""
         return self.restore_executor.restore(path)
 
 
-def main() -> int:
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point for scheduling and restoring backups."""
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Unified disaster recovery utilities")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--schedule", action="store_true", help="Create a scheduled backup")
+    group.add_argument("--restore", metavar="PATH", help="Restore backup at PATH")
+    parser.add_argument("--max-backups", type=int, default=None, help="Maximum backups to retain")
+    args = parser.parse_args(argv)
+
     system = UnifiedDisasterRecoverySystem()
-    return 0 if system.perform_recovery() else 1
+
+    if args.schedule:
+        system.schedule_backups(max_backups=args.max_backups)
+        return 0
+
+    ok = system.restore_backup(args.restore)
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_disaster_recovery_restore.py
+++ b/tests/test_disaster_recovery_restore.py
@@ -41,7 +41,7 @@ def test_restore_backup_success(tmp_path, monkeypatch):
     assert restore_backup(backup_file)
     restored = workspace / "data.txt"
     assert restored.exists()
-    assert any(evt["event"] == "restore_success" for evt in events)
+    assert any(evt["description"] == "restore_success" for evt in events)
 
 
 def test_restore_backup_hash_mismatch(tmp_path, monkeypatch):
@@ -58,7 +58,7 @@ def test_restore_backup_hash_mismatch(tmp_path, monkeypatch):
 
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
     assert not restore_backup(backup_file)
-    assert any(evt["event"] == "restore_failed" for evt in events)
+    assert any(evt["description"] == "restore_failed" for evt in events)
 
 
 def test_restore_backup_missing_checksum(tmp_path, monkeypatch):
@@ -74,4 +74,4 @@ def test_restore_backup_missing_checksum(tmp_path, monkeypatch):
 
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
     assert not restore_backup(backup_file)
-    assert any(evt["event"] == "restore_failed" for evt in events)
+    assert any(evt["description"] == "restore_failed" for evt in events)

--- a/tests/test_unified_disaster_recovery_system.py
+++ b/tests/test_unified_disaster_recovery_system.py
@@ -29,7 +29,7 @@ def test_scheduler_logs_and_creates_backup(tmp_path, monkeypatch):
     assert backup_file.exists()
     checksum = backup_file.with_suffix(backup_file.suffix + ".sha256")
     assert checksum.exists()
-    assert any(evt["event"] == "backup_scheduled" for evt in events)
+    assert any(evt["description"] == "backup_scheduled" for evt in events)
 
 
 def test_restore_executor_verifies_integrity(tmp_path, monkeypatch):
@@ -59,5 +59,60 @@ def test_restore_executor_verifies_integrity(tmp_path, monkeypatch):
     restored = workspace / "data.txt"
     assert restored.exists()
     assert restored.read_text() == data
-    assert any(evt["event"] == "restore_success" for evt in events)
+    assert any(evt["description"] == "restore_success" for evt in events)
+
+
+def test_retention_policy_prunes_old_backups(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = tmp_path / "backup"
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    import datetime as dt
+
+    times = [
+        dt.datetime(2020, 1, 1, 0, 0, 0),
+        dt.datetime(2020, 1, 1, 0, 0, 1),
+        dt.datetime(2020, 1, 1, 0, 0, 2),
+    ]
+
+    monkeypatch.setattr(util_module, "datetime", type("_dt", (), {"utcnow": lambda: times.pop(0)}))
+
+    system = UnifiedDisasterRecoverySystem(str(workspace))
+    first = system.schedule_backups(max_backups=2)
+    system.schedule_backups(max_backups=2)
+    system.schedule_backups(max_backups=2)
+
+    backups = list(backup_root.glob("scheduled_backup_*.bak"))
+    assert len(backups) == 2
+    assert first not in backups
+
+
+def test_cli_schedule_and_restore_logs_to_db(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = tmp_path / "backup"
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+    db_path = tmp_path / "analytics.db"
+    monkeypatch.setenv("ANALYTICS_DB", str(db_path))
+    orig_log_event = util_module.enterprise_logging.log_event
+
+    def _log_event(event, *, table=util_module.enterprise_logging.DEFAULT_LOG_TABLE, db_path=db_path):
+        orig_log_event(event, table=table, db_path=db_path)
+
+    monkeypatch.setattr(util_module.enterprise_logging, "log_event", _log_event)
+
+    assert util_module.main(["--schedule"]) == 0
+    backup_file = next(backup_root.glob("scheduled_backup_*.bak"))
+    assert util_module.main(["--restore", str(backup_file)]) == 0
+
+    import sqlite3
+
+    with sqlite3.connect(db_path) as conn:
+        events = {row[0] for row in conn.execute("SELECT description FROM event_log")}
+
+    assert "backup_scheduled" in events
+    assert "restore_success" in events
 


### PR DESCRIPTION
## Summary
- add compliance logger helper that writes backup and restore events to analytics.db
- enforce configurable retention policy when scheduling backups
- expose CLI to run backup scheduling and restore from the command line

## Testing
- `ruff check scripts/utilities/unified_disaster_recovery_system.py tests/test_unified_disaster_recovery_system.py tests/test_disaster_recovery_restore.py`
- `pytest tests/test_unified_disaster_recovery_system.py tests/test_disaster_recovery_backup_validation.py tests/test_disaster_recovery_restore.py`

Setup script attempted but failed:
- `./setup.sh` (ImportError: attempted relative import with no known parent package)


------
https://chatgpt.com/codex/tasks/task_e_6890d30d2aec8331b4af2fd9b3faf695