### PR TITLE
feat: expose rollback logs on compliance dashboard

### DIFF
--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -24,7 +24,13 @@
                     pb.appendChild(li);
                 });
             }
-            document.getElementById('compliance_trend').textContent = (data.compliance_trend||[]).join(', ');
+            const ct = document.getElementById('compliance_trend');
+            ct.innerHTML = '';
+            (data.compliance_trend || []).forEach(v => {
+                const li = document.createElement('li');
+                li.textContent = v;
+                ct.appendChild(li);
+            });
         }
         function updateRollbacks(logs){
             const list = document.getElementById('rollbacks');
@@ -76,7 +82,7 @@
     <h3>Placeholder Types</h3>
     <ul id="placeholder_breakdown"></ul>
     <h3>Compliance Trend</h3>
-    <span id="compliance_trend"></span>
+    <ul id="compliance_trend"></ul>
 </div>
 <h2>Recent Rollbacks</h2>
 <ul id="rollbacks"></ul>

--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+import sys
+import types
+
+
+class DummyCorrectionLoggerRollback:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+sys.modules.setdefault(
+    "scripts.correction_logger_and_rollback",
+    types.SimpleNamespace(CorrectionLoggerRollback=DummyCorrectionLoggerRollback),
+)
 from dashboard import compliance_metrics_updater as cmu
 
 
@@ -43,7 +56,9 @@ def test_dashboard_compliance_endpoint():
     client = app.test_client()
     resp = client.get("/dashboard/compliance")
     assert resp.status_code == 200
-    assert isinstance(resp.get_json(), dict)
+    data = resp.get_json()
+    assert "metrics" in data
+    assert "rollbacks" in data
 
 
 def test_rollback_alerts_endpoint():


### PR DESCRIPTION
## Summary
- add helper to read rollback logs from analytics.db
- expose `/dashboard/compliance` returning metrics and rollback logs
- render compliance trend and rollback history in dashboard UI

## Testing
- `ruff check dashboard/enterprise_dashboard.py tests/test_dashboard_endpoints.py`
- `pytest tests/test_dashboard_endpoints.py`
- `./setup.sh` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_6890d30f7ad8833190b01970dc8adf8e