### PR TITLE
feat: add session finalization and analytics logging

### DIFF
--- a/unified_session_management_system.py
+++ b/unified_session_management_system.py
@@ -3,20 +3,45 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from hashlib import sha256
 from pathlib import Path
 from typing import Callable
 import logging
+import sqlite3
+from datetime import datetime
 
 from utils.validation_utils import detect_zero_byte_files
 from scripts.session.anti_recursion_enforcer import anti_recursion_guard
 from enterprise_modules.compliance import validate_environment, ComplianceError
+from utils.logging_utils import ANALYTICS_DB
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
     "ensure_no_zero_byte_files",
+    "finalize_session",
+    "prevent_recursion",
     "main",
 ]
+
+
+def _record_zero_byte_findings(paths: list[Path], phase: str) -> None:
+    """Persist zero-byte scan results to ``analytics.db``."""
+    timestamp = datetime.utcnow().isoformat()
+    with sqlite3.connect(ANALYTICS_DB) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS zero_byte_files (
+                path TEXT NOT NULL,
+                phase TEXT NOT NULL,
+                ts   TEXT NOT NULL
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO zero_byte_files (path, phase, ts) VALUES (?, ?, ?)",
+            [(str(p), phase, timestamp) for p in paths] or [],
+        )
 
 
 @contextmanager
@@ -24,12 +49,14 @@ def ensure_no_zero_byte_files(root: str | Path):
     """Verify the workspace is free of zero-byte files before and after the block."""
     root_path = Path(root)
     before = detect_zero_byte_files(root_path)
+    _record_zero_byte_findings(before, "before")
     if before:
         for path in before:
             path.unlink(missing_ok=True)
         raise RuntimeError(f"Zero-byte files detected: {before}")
     yield
     after = detect_zero_byte_files(root_path)
+    _record_zero_byte_findings(after, "after")
     if after:
         for path in after:
             path.unlink(missing_ok=True)
@@ -47,6 +74,50 @@ def prevent_recursion(func: Callable) -> Callable:
 
     return anti_recursion_guard(func)
 
+
+@prevent_recursion
+def finalize_session(log_dir: str | Path) -> str:
+    """Verify logs are complete and record a session integrity hash.
+
+    Parameters
+    ----------
+    log_dir:
+        Directory containing session log files.
+
+    Returns
+    -------
+    str
+        SHA256 hash of concatenated log contents.
+    """
+
+    log_path = Path(log_dir)
+    logs = sorted(p for p in log_path.glob("*.log") if p.is_file())
+    if not logs:
+        raise RuntimeError("No log files found for session")
+    for entry in logs:
+        if entry.stat().st_size == 0:
+            raise RuntimeError(f"Empty log file detected: {entry}")
+
+    digest = sha256()
+    for entry in logs:
+        digest.update(entry.read_bytes())
+    hash_value = digest.hexdigest()
+
+    with sqlite3.connect(ANALYTICS_DB) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS session_hashes (
+                hash TEXT PRIMARY KEY,
+                ts   TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO session_hashes (hash, ts) VALUES (?, ?)",
+            (hash_value, datetime.utcnow().isoformat()),
+        )
+
+    return hash_value
 
 @anti_recursion_guard
 def main() -> int:
@@ -66,6 +137,7 @@ def main() -> int:
     success = system.start_session()
     with ensure_no_zero_byte_files(system.workspace_root):
         system.end_session()
+        finalize_session(Path(system.workspace_root) / "logs")
     logger.info("Lifecycle end")
     print("Valid" if success else "Invalid")
     return 0 if success else 1


### PR DESCRIPTION
## Summary
- log zero-byte file scans to analytics.db
- finalize sessions by hashing log contents with recursion protection
- export new finalize_session utility and related tests

## Testing
- `ruff check unified_session_management_system.py tests/test_session_management.py`
- `pytest tests/test_session_management.py`


------
https://chatgpt.com/codex/tasks/task_e_6890d3169bf08331895bdc16b666066d