### PR TITLE
docs: align dual-copilot progress across tables

### DIFF
--- a/docs/PHASE5_TASKS_STARTED.md
+++ b/docs/PHASE5_TASKS_STARTED.md
@@ -94,5 +94,5 @@ These task stubs originate from the gap analysis report and have been formally s
 - [ ] 7. Align Documentation with Implementation — 90% complete
 - [x] 12. Update Changelog and User Prompts — 100% complete
 - [ ] 17. Implement Anti-Recursion Guards — 50% complete
-- [ ] 18. Standardize Dual-Copilot Validation — 40% complete
+- [x] 18. Standardize Dual-Copilot Validation — 100% complete
 - [ ] 19. Clarify Quantum Placeholder Features — 90% complete

--- a/docs/task_stubs.md
+++ b/docs/task_stubs.md
@@ -24,14 +24,14 @@ lightweight references for future implementation.
 | ContinuousMonitoringSetup | Metrics pushed to analytics.db | Alerts for threshold breaches | Validate monitoring endpoints | Monitoring endpoints explained | Enable live insight | 0% |
 | BackupValidationChecks | Verify external backup root | Tests for backup path logic | Ensure no backups inside workspace | Environment setup docs | Prevent recursive backups | 100% |
 | AntiRecursionGuards | Decorator tracking active sessions | Apply to risk modules | Recursion prevention tests | Developer guide usage | Avoid nested execution | 60% |
-| DualCopilotValidationStandardization | Audit scripts for secondary validation | Orchestrator coordinates modules | Verify orchestrator triggers | Dual copilot flow documented | Standardize validation pattern | 40% |
+| DualCopilotValidationStandardization | Audit scripts for secondary validation | Orchestrator coordinates modules | Verify orchestrator triggers | Dual copilot flow documented | Standardize validation pattern | 100% |
 | QuantumPlaceholderFeatures | Placeholder modules under scripts/quantum_placeholders | Exclude from production path | Importability tests | Quantum roadmap and placeholder status | Clarify future quantum features | 60% |
 
 ## Progress Tracker Checklist
 
 - [x] BackupValidationChecks – 100%
 - [ ] AntiRecursionGuards – 60%
-- [ ] DualCopilotValidationStandardization – 40%
+- [x] DualCopilotValidationStandardization – 100%
 - [ ] DocumentationAlignment — 90% complete
 - [x] ChangelogUserPrompts — 100%
 - [ ] QuantumPlaceholderFeatures — 60% complete


### PR DESCRIPTION
## Summary
- resolve conflicting progress for "Standardize Dual-Copilot Validation" by marking it 100% complete in phase tracker and task stubs
- keep progress tables in `PHASE5_TASKS_STARTED.md` and `task_stubs.md` consistent

## Testing
- `ruff check docs/task_stubs.md docs/PHASE5_TASKS_STARTED.md --exit-zero` *(fails: SyntaxError: Simple statements must be separated by newlines or semicolons)*
- `pytest tests/dashboard/test_actionable_endpoints.py -q` *(fails: SyntaxError: duplicate argument 'correction_type' in function definition)*

------
https://chatgpt.com/codex/tasks/task_e_6890d78528c88331984eb2e7223da962