### PR TITLE
feat: enhance disaster recovery helpers and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,13 @@ to create and manage backups. This variable ensures backups never reside in the
 workspace, maintaining anti-recursion compliance.
 The `validate_enterprise_environment` helper enforces these settings at script startup.
 
+Run scheduled backups and restore them with:
+
+```bash
+python scripts/utilities/unified_disaster_recovery_system.py --schedule
+python scripts/utilities/unified_disaster_recovery_system.py --restore /path/to/backup.bak
+```
+
 ### Session Management CLI
 Use ``COMPREHENSIVE_WORKSPACE_MANAGER.py`` to manage session start and end
 operations:

--- a/documentation/BACKUP_COMPLIANCE_GUIDE.md
+++ b/documentation/BACKUP_COMPLIANCE_GUIDE.md
@@ -22,13 +22,19 @@ The system automatically validates that backup locations are external to the wor
 Usage
 
 ### Scheduling Backups
+The scheduler keeps the most recent five backups by default. Override the
+retention by passing ``max_backups``.
+
 ```python
 from unified_disaster_recovery_system import schedule_backups
 
-backup_path = schedule_backups()
+backup_path = schedule_backups()  # retains up to 5 backups
 ```
 
 ### Restoring a Backup
+``restore_backup`` validates that the file resides under
+``$GH_COPILOT_BACKUP_ROOT`` and outside the workspace before restoring it.
+
 ```python
 from unified_disaster_recovery_system import restore_backup
 
@@ -46,6 +52,18 @@ system.perform_recovery()
 The utility copies data from `$GH_COPILOT_BACKUP_ROOT/production_backup` into a `restored/` directory and logs `[START]` and `[SUCCESS]` indicators. Recovery aborts if the backup root is inside the workspace.
 
 Both scheduling and restore operations record compliance events through the built-in `ComplianceLogger` for auditing.
+
+Advanced users may directly configure helpers:
+
+```python
+from unified_disaster_recovery_system import (
+    get_backup_scheduler, get_restore_executor, get_compliance_logger,
+)
+
+logger = get_compliance_logger()
+scheduler = get_backup_scheduler(logger=logger)
+executor = get_restore_executor(logger=logger)
+```
 
 ### Appendix: Using `validate_enterprise_operation()`
 Before any script performs file changes, call:

--- a/unified_disaster_recovery_system.py
+++ b/unified_disaster_recovery_system.py
@@ -9,6 +9,7 @@ but we keep this thin wrapper so downstream code can simply import from
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -40,6 +41,50 @@ from scripts.utilities.unified_disaster_recovery_system import (  # noqa: E402
 )
 
 
+def get_compliance_logger() -> ComplianceLogger:
+    """Return a :class:`ComplianceLogger` configured for the workspace."""
+
+    return ComplianceLogger()
+
+
+def get_backup_scheduler(
+    workspace_path: str | Path | None = None, logger: ComplianceLogger | None = None
+) -> BackupScheduler:
+    """Create a :class:`BackupScheduler` for ``workspace_path``.
+
+    Parameters
+    ----------
+    workspace_path:
+        Optional path to the workspace root. Defaults to ``GH_COPILOT_WORKSPACE``
+        or ``."`` when not provided.
+    logger:
+        Pre-configured :class:`ComplianceLogger`. A new logger is created when
+        omitted.
+    """
+
+    workspace = Path(workspace_path or os.getenv("GH_COPILOT_WORKSPACE", "."))
+    return BackupScheduler(workspace, logger or get_compliance_logger())
+
+
+def get_restore_executor(
+    workspace_path: str | Path | None = None, logger: ComplianceLogger | None = None
+) -> RestoreExecutor:
+    """Create a :class:`RestoreExecutor` for ``workspace_path``.
+
+    Parameters
+    ----------
+    workspace_path:
+        Optional path to the workspace root. Defaults to ``GH_COPILOT_WORKSPACE``
+        or ``."`` when not provided.
+    logger:
+        Pre-configured :class:`ComplianceLogger`. A new logger is created when
+        omitted.
+    """
+
+    workspace = Path(workspace_path or os.getenv("GH_COPILOT_WORKSPACE", "."))
+    return RestoreExecutor(workspace, logger or get_compliance_logger())
+
+
 def schedule_backups() -> Path:
     """Convenience wrapper to schedule backups using the default system.
 
@@ -49,8 +94,8 @@ def schedule_backups() -> Path:
         Location of the created backup file.
     """
 
-    system = _UnifiedDisasterRecoverySystem()
-    return system.schedule_backups()
+    scheduler = get_backup_scheduler()
+    return scheduler.schedule()
 
 
 def restore_backup(path: str | Path) -> bool:
@@ -67,8 +112,8 @@ def restore_backup(path: str | Path) -> bool:
         ``True`` when restoration succeeds, ``False`` otherwise.
     """
 
-    system = _UnifiedDisasterRecoverySystem()
-    return system.restore_backup(path)
+    executor = get_restore_executor()
+    return executor.restore(path)
 
 
 # Re-export class for public consumers
@@ -82,5 +127,8 @@ __all__ = [
     "schedule_backups",
     "restore_backup",
     "log_backup_event",
+    "get_compliance_logger",
+    "get_backup_scheduler",
+    "get_restore_executor",
 ]
 


### PR DESCRIPTION
## Summary
- add top-level helpers for BackupScheduler, RestoreExecutor, and ComplianceLogger
- enforce default backup retention and restore path validation
- document backup compliance and provide CLI examples

## Testing
- `ruff check unified_disaster_recovery_system.py scripts/utilities/unified_disaster_recovery_system.py tests/test_unified_disaster_recovery_system.py`
- `pytest tests/test_unified_disaster_recovery_system.py`


------
https://chatgpt.com/codex/tasks/task_e_6890df1617fc8331b17d3841c1463acd