### PR TITLE
feat: log sync decisions and add retry logic

### DIFF
--- a/documentation/database_integration_enhancement_system.md
+++ b/documentation/database_integration_enhancement_system.md
@@ -493,6 +493,20 @@ python scripts/database_integration_enhancer.py --generate-report
 4. **Performance Optimization**: Design queries for optimal performance
 5. **Schema Evolution**: Plan schema changes with integration considerations
 
+### 📑 Synchronization Audit Log and Failure Modes
+
+- **Log Format**: Each synchronization action is written to `logs/synchronization.log`
+  using the pattern `"<action> <table>:<id>"` (e.g., `"update items:42"`).
+- **Audit Table**: Decisions are persisted to `analytics.db` in the
+  `sync_audit_log` table with columns `source_db`, `target_db`, `action`, and
+  `timestamp`.
+- **Conflict Handling**: When the target row has a newer timestamp than the
+  source, the engine records `conflict_skip <table>:<id>` in both the log file
+  and audit table.
+- **Retry Logic**: Transient `sqlite3` errors trigger a rollback and automatic
+  retry (default three attempts) to prevent partial updates. A final failure
+  raises the exception after all retries are exhausted.
+
 ---
 
 *Database Integration Enhancement System v1.0*

--- a/tests/test_database_synchronization_engine.py
+++ b/tests/test_database_synchronization_engine.py
@@ -1,11 +1,7 @@
-"""Integration tests for the DatabaseSynchronizationEngine."""
-
-from __future__ import annotations
-
 import sqlite3
 from pathlib import Path
 
-from scripts.database_synchronization_engine import (
+from db_tools.database_synchronization_engine import (
     DATABASE_SCHEMA_MAP,
     DatabaseSynchronizationEngine,
 )
@@ -13,7 +9,9 @@ from scripts.database_synchronization_engine import (
 
 def _create_db(path: Path, rows: list[tuple[int, str, int]]) -> None:
     with sqlite3.connect(path) as conn:
-        conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, data TEXT, updated_at INTEGER)")
+        conn.execute(
+            "CREATE TABLE items (id INTEGER PRIMARY KEY, data TEXT, updated_at INTEGER)"
+        )
         conn.executemany(
             "INSERT INTO items (id, data, updated_at) VALUES (?, ?, ?)",
             rows,
@@ -22,7 +20,9 @@ def _create_db(path: Path, rows: list[tuple[int, str, int]]) -> None:
 
 def _read_rows(path: Path) -> list[tuple[int, str, int]]:
     with sqlite3.connect(path) as conn:
-        return conn.execute("SELECT id, data, updated_at FROM items ORDER BY id").fetchall()
+        return conn.execute(
+            "SELECT id, data, updated_at FROM items ORDER BY id"
+        ).fetchall()
 
 
 def test_schema_map_contains_expected_keys() -> None:
@@ -30,40 +30,39 @@ def test_schema_map_contains_expected_keys() -> None:
     assert "analytics.db" in DATABASE_SCHEMA_MAP
 
 
-def test_sync_updates_inserts_and_deletes(tmp_path: Path) -> None:
+def test_sync_audit_log_captures_actions(tmp_path: Path) -> None:
     source = tmp_path / "source.db"
     target = tmp_path / "target.db"
-    log_file = Path("logs/synchronization.log")
-    if log_file.exists():
-        log_file.unlink()
+    audit = tmp_path / "analytics.db"
+    log_file = tmp_path / "sync.log"
 
-    _create_db(source, [(1, "new", 2), (2, "insert", 1)])
-    _create_db(target, [(1, "old", 1), (3, "remove", 1)])
+    _create_db(source, [(1, "new", 2), (2, "insert", 1), (4, "stale", 1)])
+    _create_db(target, [(1, "old", 1), (3, "remove", 1), (4, "fresh", 5)])
 
-    engine = DatabaseSynchronizationEngine(log_path=log_file)
+    engine = DatabaseSynchronizationEngine(log_path=log_file, audit_db_path=audit)
     engine.sync(source, target)
 
-    assert _read_rows(target) == [(1, "new", 2), (2, "insert", 1)]
+    assert _read_rows(target) == [
+        (1, "new", 2),
+        (2, "insert", 1),
+        (4, "fresh", 5),
+    ]
 
-    assert log_file.exists()
     log_content = log_file.read_text()
     assert "insert items:2" in log_content
-    assert "delete items:3" in log_content
     assert "update items:1" in log_content
+    assert "delete items:3" in log_content
+    assert "conflict_skip items:4" in log_content
 
-
-def test_log_hook_receives_events(tmp_path: Path) -> None:
-    source = tmp_path / "src.db"
-    target = tmp_path / "tgt.db"
-    _create_db(source, [(1, "a", 1)])
-    _create_db(target, [])
-
-    events: list[tuple[str, str]] = []
-
-    def hook(level: str, message: str) -> None:
-        events.append((level, message))
-
-    engine = DatabaseSynchronizationEngine(log_path=tmp_path / "log.log", log_hook=hook)
-    engine.sync(source, target)
-
-    assert any("insert items:1" in msg for _, msg in events)
+    with sqlite3.connect(audit) as conn:
+        actions = [
+            row[0] for row in conn.execute(
+                "SELECT action FROM sync_audit_log ORDER BY id"
+            ).fetchall()
+        ]
+    assert set(actions) == {
+        "insert items:2",
+        "update items:1",
+        "delete items:3",
+        "conflict_skip items:4",
+    }


### PR DESCRIPTION
## Summary
- log synchronization decisions in analytics audit table
- add retry handling around SQLite operations
- document audit log format and failure modes

## Testing
- `ruff check db_tools/database_synchronization_engine.py tests/test_database_synchronization_engine.py`
- `pytest tests/test_database_synchronization_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6890df16e1fc83318cd20171c1a44b43