### PR TITLE
fix: resolve correction logger syntax and update stub status

### DIFF
--- a/docs/STUB_MODULE_STATUS.md
+++ b/docs/STUB_MODULE_STATUS.md
@@ -58,13 +58,11 @@ The following table summarizes `pytest` failures observed in the latest test run
 | Test Module | Brief Description |
 |-------------|------------------|
 | `tests/documentation/test_documentation_manager_templates.py` | Template selection from documentation database |
-| `tests/template_engine/test_template_caching.py` | Template caching and ranking |
 | `tests/test_archive_scripts.py` | Archive utility function checks |
 | `tests/test_autonomous_setup_and_audit.py` | Asset ingestion validation |
 | `tests/test_complete_consolidation_orchestrator.py` | Consolidation export and compression routines |
 | `tests/test_complete_template_generator.py` | Template generation workflow |
 | `tests/test_compliance_metrics_updater.py` | Compliance metrics updater logic |
-| `tests/test_comprehensive_workspace_manager.py` | Session start/end recording |
 | `tests/test_comprehensive_workspace_manager_cli.py` | CLI environment requirements |
 | `tests/test_compress_database.py` | Database compression effect |
 | `tests/test_correction_history.py` | Correction history logging |
@@ -73,7 +71,6 @@ The following table summarizes `pytest` failures observed in the latest test run
 | `tests/test_database_list.py` | Database presence verification |
 | `tests/test_db_helper_usage.py` | DB helper invocation |
 | `tests/test_disallowed_paths.py` | Disallowed path validation |
-| `tests/test_documentation_consolidator.py` | Documentation consolidation |
 | `tests/test_documentation_db_analyzer.py` | Documentation DB analyzer |
 | `tests/test_documentation_manager_validator.py` | Documentation validator |
 | `tests/test_enterprise_database_driven_documentation_manager.py` | Dual copilot validation hooks |

--- a/scripts/correction_logger_and_rollback.py
+++ b/scripts/correction_logger_and_rollback.py
@@ -168,7 +168,6 @@ class CorrectionLoggerRollback:
         correction_type: str = "general",
         compliance_score: float = 1.0,
         rollback_reference: Optional[str] = None,
-        correction_type: str = "general",
         score_delta: float = 0.0,
         compliance_delta: float = 0.0,
         session_id: Optional[str] = None,
@@ -188,7 +187,7 @@ class CorrectionLoggerRollback:
                 compliance_score - prev_score if prev_score is not None else compliance_score
             )
             conn.execute(
-                "INSERT INTO corrections (file_path, rationale, correction_type, compliance_score, compliance_delta, score_delta, rollback_reference, session_id, ts) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO corrections (file_path, rationale, correction_type, compliance_score, score_delta, compliance_delta, rollback_reference, session_id, process_id, script, ts) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     str(file_path),
                     rationale,
@@ -216,7 +215,6 @@ class CorrectionLoggerRollback:
                 "score": compliance_score,
                 "score_delta": score_delta,
                 "delta": compliance_delta,
-                "correction_type": correction_type,
                 "session_id": session_id,
             },
             table="corrections",


### PR DESCRIPTION
## Summary
- fix CorrectionLoggerRollback.log_change schema alignment and duplicate keys
- prune passing modules from STUB_MODULE_STATUS

## Testing
- `ruff check scripts/correction_logger_and_rollback.py`
- `pyright scripts/correction_logger_and_rollback.py`
- `pytest tests/template_engine/test_template_caching.py`
- `pytest` *(fails: tests/dashboard/test_audit_results_view.py)*

------
https://chatgpt.com/codex/tasks/task_e_6890f0115e348331b7b44090290b66c2