### PR TITLE
docs: clarify simulation-only quantum status

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 
 > **Note**
 > Qiskit-based operations currently run in **simulation mode** only. Hardware tokens and backend flags are accepted for future use but are ignored; real hardware execution is not yet implemented.
+> **Roadmap**
+> A dedicated `QuantumExecutor` module will enable IBM Quantum hardware in a future release. Until then, all hardware options are inert and default to simulator backends.
 > **Phase 5 AI**
 > Advanced AI integration features are fully integrated. They default to simulation mode unless real hardware is configured.
 
@@ -272,13 +274,14 @@ print(f"[SUCCESS] Generated with {result.confidence_score}% confidence")
 python simplified_quantum_integration_orchestrator.py
 ```
 
-By default the orchestrator uses the simulator. To execute algorithms on IBM Quantum hardware install `qiskit-ibm-provider` and run:
+By default the orchestrator uses the simulator. Flags `--hardware` and `--backend` are placeholders that currently have no effect; they will enable IBM Quantum backends once the planned `QuantumExecutor` module arrives.
 
 ```bash
+# placeholder flags; still executes on simulators
 python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
 ```
 
-Set `QISKIT_IBM_TOKEN` to your IBM Quantum API token for hardware execution. If the provider cannot be initialized the orchestrator automatically falls back to simulation.
+Set `QISKIT_IBM_TOKEN` for future hardware execution. The value is ignored today and the orchestrator always falls back to simulation. See [docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for the integration roadmap.
 
 ### Quantum Placeholder Modules
 

--- a/databases/migrations/README.md
+++ b/databases/migrations/README.md
@@ -46,7 +46,8 @@ extend_todo_fixme_tracking.sql
 ```
 
 An accompanying Graphviz file at `docs/diagrams/migration_dependencies.dot` visualizes
-these relationships.
+these relationships. For entity-relationship diagrams of the databases, see
+[docs/ER_DIAGRAMS.md](../../docs/ER_DIAGRAMS.md).
 
 ## Migration Prerequisites
 

--- a/docs/ER_DIAGRAMS.md
+++ b/docs/ER_DIAGRAMS.md
@@ -7,5 +7,6 @@ This directory contains automatically generated diagrams for core SQLite databas
 - **production.db** – see [diagrams/production_er.dot](diagrams/production_er.dot)
 - **analytics.db** – see [diagrams/analytics_er.dot](diagrams/analytics_er.dot)
 - **monitoring.db** – see [diagrams/monitoring_er.dot](diagrams/monitoring_er.dot)
+- **Migration dependencies** – see [diagrams/migration_dependencies.dot](diagrams/migration_dependencies.dot) and [databases/migrations/README.md](../databases/migrations/README.md)
 
 These databases work together to track enterprise scripts, analytics events, and system monitoring data. Tables within `production.db` hold primary configuration and tracking records. `analytics.db` mirrors key events and maintains performance metrics, while `monitoring.db` stores health reports and optimization logs. Data flows from `production.db` into `analytics.db` for reporting, and `monitoring.db` consumes data from both databases to evaluate system status.

--- a/docs/QUANTUM_HARDWARE_SETUP.md
+++ b/docs/QUANTUM_HARDWARE_SETUP.md
@@ -14,20 +14,23 @@ Hardware execution is not yet supported. This guide documents the preparatory st
    {"QISKIT_IBM_TOKEN": "your_token_here"}
    ```
 
-## 2. Optional Backend Selection
+## 2. Optional Backend Selection *(placeholder)*
 Specify a backend name via `IBM_BACKEND`:
 ```bash
 export IBM_BACKEND="ibmq_qasm_simulator"
 ```
 The value is recorded for future use, but all executions fall back to the default simulator regardless of this setting.
 
-## 3. CLI Usage
-Use the executor CLI or orchestrator to demonstrate where hardware flags will eventually apply (currently no-ops):
+## 3. CLI Usage *(flags are inert)*
+Use the executor CLI or orchestrator to demonstrate where hardware flags will eventually apply:
 ```bash
-python -m quantum.cli.executor_cli --use-hardware --backend ibm_nairobi
-python quantum_integration_orchestrator.py --hardware
+python -m quantum.cli.executor_cli --use-hardware --backend ibm_nairobi  # no-op
+python quantum_integration_orchestrator.py --hardware  # no-op
 ```
-Both flags validate that `QISKIT_IBM_TOKEN` is present but still run against simulators; backend selection is ignored.
+These options merely check for `QISKIT_IBM_TOKEN` and always execute on simulators; backend selection is ignored.
 
 ## 4. Expected Outputs
 Hardware backends are not invoked. Logs always reflect simulator usage, emitting a warning when hardware options are requested.
+
+## 5. Roadmap
+Future releases will introduce a `QuantumExecutor` module to enable real hardware execution once IBM backend support is finalized.

--- a/docs/quantum/QUANTUM_ENTERPRISE_COMPLIANCE.md
+++ b/docs/quantum/QUANTUM_ENTERPRISE_COMPLIANCE.md
@@ -90,16 +90,17 @@ CREATE TABLE quantum_audit_log (
 - **Quantum Secure**: ✅ Compliant
 - **Audit Ready**: ✅ Documentation Complete
 
-### Optional Hardware Setup
-To execute routines on IBM Quantum hardware:
+### Optional Hardware Setup *(placeholder)
+Hardware execution is not yet supported. The steps below outline the future flow:
 1. Install `qiskit-ibm-provider` in the project virtual environment.
 2. Set the environment variable `QISKIT_IBM_TOKEN` with your IBM Quantum API key.
 3. Launch the orchestrator with the desired backend:
    ```bash
+   # placeholder; still runs on simulators
    python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
    ```
-If the backend or token is unavailable, the toolkit automatically falls back to
-simulation mode.
+The toolkit ignores backend selection and token values and always operates in
+simulation mode. Hardware integration will arrive with the upcoming `QuantumExecutor` module.
 
 ---
 *Compliance Report v1.0*

--- a/docs/quantum/QUANTUM_INTEGRATION_GUIDE.md
+++ b/docs/quantum/QUANTUM_INTEGRATION_GUIDE.md
@@ -72,17 +72,18 @@ result = quantum_engine.optimize_code_analysis(
 }
 ```
 
-### Hardware Backends
-To run on real quantum hardware, install `qiskit-ibm-provider` and set the
-environment variable `QISKIT_IBM_TOKEN` with your IBM Quantum API key. Then
-enable hardware mode via the orchestrator:
+### Hardware Backends *(planned)
+Real hardware support is not yet available. Install `qiskit-ibm-provider` and set
+`QISKIT_IBM_TOKEN` only to prepare for future integration.
+The orchestrator accepts hardware flags but they are currently inert:
 
 ```bash
+# placeholder; still runs on simulators
 python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
 ```
 
-If the backend or token is unavailable the toolkit automatically falls back to
-simulation.
+The toolkit ignores backend selection and always falls back to simulation. See
+[docs/QUANTUM_HARDWARE_SETUP.md](../QUANTUM_HARDWARE_SETUP.md) for roadmap details.
 
 ### Deployment Checklist
 - [ ] Quantum simulation environment *(not started)*


### PR DESCRIPTION
## Summary
- mark hardware flags as inert placeholders in quantum docs and README
- document simulation-only status with roadmap to `QuantumExecutor`
- cross-link ER diagrams with migration documentation

## Testing
- `ruff check .` *(fails: unused imports and undefined names)*
- `pytest` *(fails: tests/dashboard/test_actionable_endpoints.py)*

------
https://chatgpt.com/codex/tasks/task_e_6890f01673c08331a154839e6749139a