### PR TITLE
feat: integrate IBM backend selection with simulator fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - PowerShell (for Windows automation)
 - SQLite3
 - Required packages: `pip install -r requirements.txt` (includes `py7zr` for 7z archive support)
+- Optional for IBM Quantum hardware: install `qiskit-ibm-provider` and set `QUANTUM_USE_HARDWARE=1` with a valid `QISKIT_IBM_TOKEN`; otherwise the toolkit runs in simulator mode
 
 ### **Installation & Setup**
 ```bash

--- a/docs/quantum/QUANTUM_OPTIMIZATION_OVERVIEW.md
+++ b/docs/quantum/QUANTUM_OPTIMIZATION_OVERVIEW.md
@@ -4,6 +4,9 @@
 > **Note**
 > All quantum features operate in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
 
+### Hardware Requirements
+Running against IBM Quantum hardware requires the `qiskit` and `qiskit-ibm-provider` packages, a valid API token set via `QISKIT_IBM_TOKEN`, and the environment variable `QUANTUM_USE_HARDWARE=1`. Without these settings the library falls back to the local Aer simulator.
+
 ### Executive Summary
 The PIS (Plan Issued Statement) Framework integrates quantum optimization algorithms to achieve unprecedented performance improvements in code analysis, error detection, and compliance validation. The latest update introduces the **Quantum Database Search** module for Grover-based queries.
 

--- a/docs/quantum_integration_plan.md
+++ b/docs/quantum_integration_plan.md
@@ -10,6 +10,10 @@
 - Interfaces mirror potential hardware usage for future parity.
 - Maintains identical interfaces so future hardware support can plug in without API changes.
 
+## Hardware Requirements
+- Future hardware execution will require `qiskit` plus `qiskit-ibm-provider` and a valid IBM Quantum token provided via the `QISKIT_IBM_TOKEN` environment variable.
+- Setting `QUANTUM_USE_HARDWARE=1` enables hardware mode; when these prerequisites are missing the integration continues to run on simulators.
+
 ## Placeholder Modules
 
 Prototype implementations reside under `scripts/quantum_placeholders/`.

--- a/tests/quantum/test_backend_selection.py
+++ b/tests/quantum/test_backend_selection.py
@@ -1,11 +1,31 @@
 from quantum.optimizers.quantum_optimizer import QuantumOptimizer
 
 
+class _DummyHardwareBackend:
+    name = "dummy_hardware"
+
+    class _Cfg:
+        simulator = False
+
+    def configuration(self):
+        return self._Cfg()
+
+
+class _DummySimulatorBackend:
+    name = "dummy_simulator"
+
+    class _Cfg:
+        simulator = True
+
+    def configuration(self):
+        return self._Cfg()
+
+
 def test_backend_selection_hardware(monkeypatch):
-    backend = object()
+    backend = _DummyHardwareBackend()
     monkeypatch.setattr(
-        "quantum.optimizers.quantum_optimizer.init_ibm_backend",
-        lambda **_: (backend, True),
+        "quantum.optimizers.quantum_optimizer.get_backend",
+        lambda name, use_hardware: backend,
     )
     opt = QuantumOptimizer(lambda x: 0, [(0, 1)], use_hardware=True)
     opt.set_backend(None, use_hardware=True)
@@ -14,10 +34,10 @@ def test_backend_selection_hardware(monkeypatch):
 
 
 def test_backend_selection_simulator(monkeypatch):
-    simulator = object()
+    simulator = _DummySimulatorBackend()
     monkeypatch.setattr(
-        "quantum.optimizers.quantum_optimizer.init_ibm_backend",
-        lambda **_: (simulator, False),
+        "quantum.optimizers.quantum_optimizer.get_backend",
+        lambda name, use_hardware: simulator,
     )
     opt = QuantumOptimizer(lambda x: 0, [(0, 1)], use_hardware=True)
     opt.set_backend(None, use_hardware=True)

--- a/tests/quantum/test_scoring.py
+++ b/tests/quantum/test_scoring.py
@@ -41,6 +41,39 @@ def test_quantum_text_score_simulated(tmp_path, monkeypatch):
     assert detail == "simulated"
 
 
+def test_quantum_text_score_use_hardware_flag(tmp_path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    qal.ANALYTICS_DB = db
+    db.touch()
+    qal.QISKIT_AVAILABLE = True
+    called = {}
+
+    def _fake_backend(use_hardware=None):
+        called["flag"] = use_hardware
+        return _DummyBackend()
+
+    monkeypatch.setattr(qal, "get_backend", _fake_backend)
+    score = qal.quantum_text_score("hi", use_hardware=True)
+    assert called.get("flag") is True
+    assert 0 <= score <= 1
+    with sqlite3.connect(db) as conn:
+        detail = conn.execute("SELECT details FROM quantum_events ORDER BY ROWID DESC LIMIT 1").fetchone()[0]
+    assert detail == "qiskit"
+
+
+def test_quantum_text_score_backend_none_fallback(tmp_path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    qal.ANALYTICS_DB = db
+    db.touch()
+    qal.QISKIT_AVAILABLE = True
+    monkeypatch.setattr(qal, "get_backend", lambda use_hardware=None: None)
+    score = qal.quantum_text_score("hi", use_hardware=True)
+    assert 0 <= score <= 1
+    with sqlite3.connect(db) as conn:
+        detail = conn.execute("SELECT details FROM quantum_events ORDER BY ROWID DESC LIMIT 1").fetchone()[0]
+    assert detail == "simulated"
+
+
 def test_quantum_similarity_and_cluster_scores(tmp_path):
     db = tmp_path / "analytics.db"
     qal.ANALYTICS_DB = db


### PR DESCRIPTION
## Summary
- route QuantumOptimizer backend selection through `get_backend` with IBM hardware detection and simulator fallback
- implement KMeans cluster representatives and expose hardware requirements in quantum docs and README
- test backend flag paths and `quantum_text_score` simulator fallback

## Testing
- `ruff check quantum/optimizers/quantum_optimizer.py quantum_algorithm_library_expansion.py tests/quantum/test_backend_selection.py tests/quantum/test_optimizer_backend.py tests/quantum/test_scoring.py`
- `pytest tests/quantum/test_backend_selection.py tests/quantum/test_optimizer_backend.py tests/quantum/test_scoring.py`


------
https://chatgpt.com/codex/tasks/task_e_6890f00b4f3c83319d477664b9470ba3