### PR TITLE
feat: add placeholder audit tasks and CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,16 @@ jobs:
       - name: Validate roadmap
         run: python scripts/validate_roadmap.py docs/continuous_improvement_roadmap.md
 
+      - name: Placeholder audit
+        env:
+          GH_COPILOT_DISABLE_VALIDATION: "1"
+        run: |
+          python scripts/code_placeholder_audit.py --workspace-path . \
+            --analytics-db databases/analytics.db \
+            --production-db databases/production.db \
+            --dashboard-dir dashboard/compliance \
+            --simulate --fail-on-findings
+
       - name: Run tests with coverage
         run: |
           mkdir -p reports/coverage artifacts

--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -101,6 +101,7 @@ class ComplianceMetricsUpdater:
             "placeholder_removal": 0,
             "open_placeholders": 0,
             "resolved_placeholders": 0,
+            "auto_resolved_placeholders": 0,
             "compliance_score": 1.0,
             "violation_count": 0,
             "rollback_count": 0,
@@ -147,6 +148,14 @@ class ComplianceMetricsUpdater:
                     }
                 except sqlite3.Error:
                     metrics["placeholder_breakdown"] = {}
+
+                try:
+                    cur.execute(
+                        "SELECT COUNT(*) FROM corrections WHERE rationale='Auto placeholder cleanup'"
+                    )
+                    metrics["auto_resolved_placeholders"] = cur.fetchone()[0]
+                except sqlite3.Error:
+                    metrics["auto_resolved_placeholders"] = 0
 
                 # Compliance score trend (most recent first)
                 try:

--- a/docs/placeholder_audit_guide.md
+++ b/docs/placeholder_audit_guide.md
@@ -12,6 +12,13 @@ The script ingests documentation and templates, then invokes the internal
 placeholder audit. Findings are written to `databases/analytics.db` in the
 `placeholder_audit` table.
 
+The audit now prints a list of actionable tasks for every unresolved
+placeholder so developers can quickly remove them. Example output:
+
+```
+[TASK] Remove TODO in path/to/file.py:42 - refactor needed
+```
+
 ## Viewing Results
 
 The dashboard exposes audit findings via the `/placeholder-audit` route:
@@ -22,3 +29,19 @@ python -m web_gui.dashboard_actionable_gui
 
 Then visit `http://localhost:5000/placeholder-audit` to fetch the latest
 results in JSON form.
+
+## CI Integration
+
+Fail builds if placeholders remain by running the audit with
+`--fail-on-findings`:
+
+```
+python scripts/code_placeholder_audit.py --fail-on-findings --simulate \
+  --workspace-path "$GH_COPILOT_WORKSPACE" \
+  --analytics-db databases/analytics.db \
+  --production-db databases/production.db \
+  --dashboard-dir dashboard/compliance
+```
+
+The command exits with a non-zero status when unresolved placeholders are
+found, enabling CI pipelines to block merges until cleanup is complete.

--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -104,6 +104,18 @@ def fetch_db_placeholders(production_db: Path) -> List[str]:
             return []
 
 
+# Generate human-readable tasks for removing placeholders
+def generate_removal_tasks(results: List[Dict]) -> List[str]:
+    """Return actionable tasks for each detected placeholder."""
+
+    tasks: List[str] = []
+    for item in results:
+        tasks.append(
+            f"Remove {item['pattern']} in {item['file']}:{item['line']} - {item['context']}"
+        )
+    return tasks
+
+
 # Insert findings into analytics.db.code_audit_log
 def log_findings(
     results: List[Dict],
@@ -560,6 +572,7 @@ def main(
     apply_fixes: bool = False,
     export: Optional[Path] = None,
     summary_json: Optional[str] = None,
+    fail_on_findings: bool = False,
 ) -> bool:
     """Entry point for placeholder auditing with full enterprise compliance.
 
@@ -657,6 +670,9 @@ def main(
         )
     if export:
         export.write_text(json.dumps(results, indent=2), encoding="utf-8")
+    tasks = generate_removal_tasks(results)
+    for task in tasks:
+        log_message(__name__, f"[TASK] {task}")
     if apply_fixes and not simulate:
         auto_remove_placeholders(results, production, analytics)
     SecondaryCopilotValidator().validate_corrections([r["file"] for r in results])
@@ -677,6 +693,8 @@ def main(
 
     # DUAL COPILOT validation
     valid = validate_results(len(results), analytics)
+    if fail_on_findings and results:
+        valid = False
     secondary = SecondaryCopilotValidator()
     secondary.validate_corrections([r["file"] for r in results])
     if valid:
@@ -746,6 +764,11 @@ def parse_args(argv: Optional[List[str]] | None = None) -> argparse.Namespace:
         type=str,
         help="Explicit path for placeholder_summary.json output",
     )
+    parser.add_argument(
+        "--fail-on-findings",
+        action="store_true",
+        help="Exit with failure if any placeholders are found",
+    )
     return parser.parse_args(argv)
 
 
@@ -781,5 +804,6 @@ if __name__ == "__main__":
         apply_fixes=args.apply_fixes,
         export=args.export,
         summary_json=args.summary_json,
+        fail_on_findings=args.fail_on_findings,
     )
     raise SystemExit(0 if success else 1)

--- a/tests/test_placeholder_task_generation.py
+++ b/tests/test_placeholder_task_generation.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import types
+
+stub = types.ModuleType("scripts.correction_logger_and_rollback")
+stub.CorrectionLoggerRollback = object  # type: ignore[attr-defined]
+sys.modules.setdefault("scripts.correction_logger_and_rollback", stub)
+
+import scripts.code_placeholder_audit as audit
+from secondary_copilot_validator import SecondaryCopilotValidator
+
+os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+
+
+def test_generate_removal_tasks():
+    results = [{"file": "f.py", "line": 1, "pattern": "TODO", "context": "fix"}]
+    tasks = audit.generate_removal_tasks(results)
+    assert tasks == ["Remove TODO in f.py:1 - fix"]
+
+
+def test_fail_on_findings(tmp_path, monkeypatch):
+    monkeypatch.setattr(audit, "validate_results", lambda *a, **k: True)
+    monkeypatch.setattr(SecondaryCopilotValidator, "validate_corrections", lambda self, files: True)
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    target = tmp_path / "demo.py"
+    target.write_text("x = 1  # TODO remove\n", encoding="utf-8")
+    analytics = tmp_path / "analytics.db"
+    dash = tmp_path / "dashboard"
+    result = audit.main(
+        workspace_path=str(tmp_path),
+        analytics_db=str(analytics),
+        dashboard_dir=str(dash),
+        simulate=True,
+        fail_on_findings=True,
+    )
+    assert result is False


### PR DESCRIPTION
## Summary
- output actionable tasks in placeholder audit and allow failing on findings
- track automated placeholder resolutions in compliance metrics
- document and run placeholder audit in CI

## Testing
- `ruff check scripts/code_placeholder_audit.py dashboard/compliance_metrics_updater.py tests/test_placeholder_task_generation.py`
- `pytest tests/test_placeholder_task_generation.py`
- `pytest tests/test_code_placeholder_audit_utils.py tests/test_placeholder_audit.py tests/test_placeholder_task_generation.py` *(fails: SyntaxError: duplicate argument 'correction_type' in scripts/correction_logger_and_rollback.py)*

------
https://chatgpt.com/codex/tasks/task_e_6890f01470e48331a039cddc89fe66a8