### PR TITLE
feat: add SSE metrics streaming with fallback

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -341,6 +341,7 @@ class ComplianceMetricsUpdater:
         self.dashboard_dir.mkdir(parents=True, exist_ok=True)
         dashboard_file = self.dashboard_dir / "metrics.json"
         rollback_file = self.dashboard_dir / "rollback_logs.json"
+        placeholder_file = self.dashboard_dir / "placeholder_summary.json"
         import json
 
         dashboard_content = {
@@ -351,6 +352,10 @@ class ComplianceMetricsUpdater:
         dashboard_file.write_text(json.dumps(dashboard_content, indent=2), encoding="utf-8")
         rollback_file.write_text(
             json.dumps(metrics.get("recent_rollbacks", []), indent=2),
+            encoding="utf-8",
+        )
+        placeholder_file.write_text(
+            json.dumps(metrics.get("placeholder_breakdown", {}), indent=2),
             encoding="utf-8",
         )
         logging.info(f"Dashboard metrics updated: {dashboard_file}")

--- a/tests/dashboard/test_metrics_stream_fallback.py
+++ b/tests/dashboard/test_metrics_stream_fallback.py
@@ -1,0 +1,40 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dashboard import enterprise_dashboard as ed
+
+
+@pytest.fixture()
+def app(tmp_path: Path, monkeypatch):
+    metrics = tmp_path / "metrics.json"
+    metrics.write_text(json.dumps({"metrics": {"placeholder_removal": 1}}))
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE rollback_logs(timestamp TEXT, target TEXT, backup TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO rollback_logs VALUES ('2024-01-01', 'file.py', 'file.bak')"
+        )
+    monkeypatch.setattr(ed, "METRICS_FILE", metrics)
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+    return ed.app
+
+
+def test_metrics_stream_once(app):
+    client = app.test_client()
+    resp = client.get("/metrics_stream?once=1")
+    assert resp.status_code == 200
+    line = resp.data.decode().split("\n")[0]
+    assert line.startswith("data:")
+    metrics = json.loads(line.split("data: ")[1])
+    assert metrics["placeholder_removal"] == 1
+
+
+def test_metrics_polling(app):
+    client = app.test_client()
+    data = client.get("/metrics").get_json()
+    assert data["metrics"]["placeholder_removal"] == 1

--- a/tests/dashboard/test_placeholder_summary.py
+++ b/tests/dashboard/test_placeholder_summary.py
@@ -1,0 +1,66 @@
+import json
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Stub problematic dependency before importing module
+sys.modules.setdefault(
+    "scripts.correction_logger_and_rollback",
+    types.SimpleNamespace(
+        CorrectionLoggerRollback=type(
+            "_Stub",
+            (),
+            {
+                "__init__": lambda self, *a, **k: None,
+                "log_violation": lambda self, *a, **k: None,
+                "log_change": lambda self, *a, **k: None,
+            },
+        )
+    ),
+)
+from dashboard import compliance_metrics_updater as cmu
+
+
+@pytest.fixture()
+def updater(tmp_path: Path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking (placeholder_type TEXT, status TEXT)"
+        )
+        conn.execute("INSERT INTO todo_fixme_tracking VALUES ('TODO', 'open')")
+        conn.execute(
+            "CREATE TABLE correction_logs (event TEXT, score REAL, timestamp TEXT)"
+        )
+        conn.execute("INSERT INTO correction_logs VALUES ('update', 0.1, '2024-01-01')")
+        conn.execute(
+            "CREATE TABLE violation_logs (details TEXT, timestamp TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE rollback_logs (target TEXT, backup TEXT, timestamp TEXT)"
+        )
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
+    monkeypatch.setattr(cmu, "ANALYTICS_DB", db)
+    monkeypatch.setattr(
+        cmu.ComplianceMetricsUpdater,
+        "_sync_external_systems",
+        lambda self, metrics: None,
+        raising=False,
+    )
+    updater = cmu.ComplianceMetricsUpdater(tmp_path, test_mode=True)
+    return updater, tmp_path
+
+
+def test_placeholder_summary_created(updater):
+    updater_obj, path = updater
+    updater_obj.update()
+    summary = path / "placeholder_summary.json"
+    assert summary.exists()
+    data = json.loads(summary.read_text())
+    assert data.get("TODO") == 1

--- a/web_gui/templates/dashboard.html
+++ b/web_gui/templates/dashboard.html
@@ -9,11 +9,13 @@
     <h3>Placeholder Types</h3>
     <ul id="placeholder_breakdown"></ul>
     <h3>Compliance Trend</h3>
+    <canvas id="trendChart" width="400" height="150"></canvas>
     <span id="compliance_trend">
         {% for score in metrics.compliance_trend or [] %}
             {{ score }}{% if not loop.last %}, {% endif %}
         {% endfor %}
     </span>
+    <button id="toggleUpdates">Pause</button>
 </div>
 <h2>Violations</h2>
 <ul id="violations">
@@ -40,7 +42,9 @@ function updateMetrics(data){
             pb.appendChild(li);
         });
     }
-    document.getElementById('compliance_trend').textContent = (data.compliance_trend||[]).join(', ');
+    const trend = data.compliance_trend || [];
+    document.getElementById('compliance_trend').textContent = trend.join(', ');
+    drawTrend(trend);
 }
 function updateAlerts(data){
     const v = document.getElementById('violations');
@@ -70,23 +74,50 @@ function loadRollbackHistory(){
     });
 }
 window.onload = function(){
+function drawTrend(trend){
+    const canvas = document.getElementById('trendChart');
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    if(trend.length === 0){return;}
+    const max = Math.max(...trend);
+    const step = canvas.width / Math.max(1, trend.length - 1);
+    ctx.beginPath();
+    trend.forEach((v,i)=>{
+        const x = i * step;
+        const y = canvas.height - (v / max) * canvas.height;
+        if(i===0){ctx.moveTo(x,y);} else {ctx.lineTo(x,y);} });
+    ctx.stroke();
+}
+let esMetrics, esAlerts, pollTimer, alertTimer;
+function startUpdates(){
     if(window.EventSource){
-        const esMetrics = new EventSource('/metrics_stream');
-        esMetrics.addEventListener('message', (evt) => {
-            const metrics = JSON.parse(evt.data);
-            updateMetrics(metrics);
-        });
-        const esAlerts = new EventSource('/alerts_stream');
-        esAlerts.addEventListener('message', (evt) => {
-            const alerts = JSON.parse(evt.data);
-            updateAlerts(alerts);
-        });
+        esMetrics = new EventSource('/metrics_stream');
+        esMetrics.onmessage = (evt)=>updateMetrics(JSON.parse(evt.data));
+        esAlerts = new EventSource('/alerts_stream');
+        esAlerts.onmessage = (evt)=>updateAlerts(JSON.parse(evt.data));
     } else {
-        setInterval(function(){
-            fetch('/metrics').then(r => r.json()).then(updateMetrics);
-            fetch('/alerts').then(r => r.json()).then(updateAlerts);
-        }, 5000);
+        pollTimer = setInterval(()=>fetch('/metrics').then(r=>r.json()).then(updateMetrics),5000);
+        alertTimer = setInterval(()=>fetch('/alerts').then(r=>r.json()).then(updateAlerts),5000);
     }
     loadRollbackHistory();
+}
+function stopUpdates(){
+    if(esMetrics){esMetrics.close(); esMetrics=null;}
+    if(esAlerts){esAlerts.close(); esAlerts=null;}
+    if(pollTimer){clearInterval(pollTimer); pollTimer=null;}
+    if(alertTimer){clearInterval(alertTimer); alertTimer=null;}
+}
+window.onload = function(){
+    startUpdates();
+    const btn = document.getElementById('toggleUpdates');
+    btn.onclick = function(){
+        if(esMetrics || pollTimer){
+            stopUpdates();
+            btn.textContent = 'Resume';
+        } else {
+            startUpdates();
+            btn.textContent = 'Pause';
+        }
+    };
 };
 </script>


### PR DESCRIPTION
## Summary
- stream dashboard metrics via SSE with polling fallback
- expose placeholder summary data and dashboard controls with live charts
- test live metric stream and placeholder summary generation

## Testing
- `ruff check dashboard/enterprise_dashboard.py dashboard/compliance_metrics_updater.py tests/dashboard/test_metrics_stream_fallback.py tests/dashboard/test_placeholder_summary.py`
- `pytest tests/dashboard/test_metrics_stream_fallback.py tests/dashboard/test_placeholder_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_6890f00db64c8331a849eda2a2ce8fb7