### PR TITLE
feat: add database-first template loading

### DIFF
--- a/enterprise_modules/task_stubs.py
+++ b/enterprise_modules/task_stubs.py
@@ -7,7 +7,10 @@ serve as placeholders so downstream systems can reference
 emerging work without requiring full functionality yet.
 """
 from dataclasses import dataclass
-from typing import List
+from pathlib import Path
+from typing import List, Union, Optional
+
+from .database_utils import fetch_template
 
 
 @dataclass
@@ -20,6 +23,36 @@ class TaskStub:
     testing: str
     documentation: str
     planning: str
+
+
+def load_template(
+    name: str,
+    templates_dir: Union[str, Path] = Path("templates"),
+    extension: str = ".tpl",
+) -> str:
+    """Load template content preferring database entries.
+
+    Parameters
+    ----------
+    name:
+        Template name to retrieve.
+    templates_dir:
+        Directory containing file-based templates.
+    extension:
+        File extension for template files.
+    """
+
+    content: Optional[str] = fetch_template(name)
+    if content is not None:
+        return content
+
+    file_path = Path(templates_dir) / f"{name}{extension}"
+    if file_path.exists():
+        return file_path.read_text()
+
+    raise FileNotFoundError(
+        f"Template '{name}' not found in database or at {file_path}"
+    )
 
 
 TASK_STUBS: List[TaskStub] = [
@@ -185,4 +218,4 @@ TASK_STUBS: List[TaskStub] = [
     ),
 ]
 
-__all__ = ["TaskStub", "TASK_STUBS"]
+__all__ = ["TaskStub", "TASK_STUBS", "load_template"]

--- a/tests/template_engine/test_database_first_templates.py
+++ b/tests/template_engine/test_database_first_templates.py
@@ -1,0 +1,39 @@
+import sqlite3
+from pathlib import Path
+
+from enterprise_modules.task_stubs import load_template
+
+
+def _setup_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE template_repository (template_name TEXT PRIMARY KEY, template_content TEXT, template_category TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO template_repository (template_name, template_content, template_category) VALUES (?, ?, ?)",
+            ("sample", "db version", "test"),
+        )
+
+
+def test_db_template_overrides_file(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    db_path = tmp_path / "databases" / "production.db"
+    _setup_db(db_path)
+
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "sample.tpl").write_text("file version")
+
+    content = load_template("sample", templates_dir=templates_dir)
+    assert content == "db version"
+
+
+def test_falls_back_to_file_when_db_missing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "sample.tpl").write_text("file version")
+
+    content = load_template("sample", templates_dir=templates_dir)
+    assert content == "file version"


### PR DESCRIPTION
## Summary
- add `fetch_template` helper to query template bodies from `production.db`
- load templates via database-first approach with file fallback
- test database templates override file templates and fallback when absent

## Testing
- `ruff check enterprise_modules/database_utils.py enterprise_modules/task_stubs.py tests/template_engine/test_database_first_templates.py`
- `pytest tests/template_engine/test_database_first_templates.py tests/test_task_stubs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890fd03ac44833197fae8c7c600ac23