### PR TITLE
feat: add compliance scoring and dashboard integration

### DIFF
--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 """Enterprise compliance helpers and enforcement routines."""
 
 import os
+import re
 import shutil
 import sqlite3
+import subprocess
 import sys
 import json
 from datetime import datetime
@@ -25,6 +27,7 @@ class ComplianceError(Exception):
 # Forbidden command patterns that must not appear in operations
 FORBIDDEN_COMMANDS = ["rm -rf", "mkfs", "shutdown", "reboot", "dd if="]
 MAX_RECURSION_DEPTH = 5
+PLACEHOLDER_PATTERNS = ["TODO", "FIXME"]
 
 
 def _load_forbidden_paths() -> list[str]:
@@ -86,6 +89,108 @@ def _detect_recursion(path: Path) -> bool:
                 continue
             return True
     return False
+
+
+def _run_ruff() -> int:
+    """Return the number of lint issues reported by Ruff."""
+    try:
+        result = subprocess.run(
+            ["ruff", ".", "--output-format", "json"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return len(json.loads(result.stdout or "[]"))
+    except Exception:  # pragma: no cover - lint fallback
+        return 0
+
+
+def _run_pytest() -> tuple[int, int]:
+    """Return numbers of passed and failed tests from pytest."""
+    try:
+        result = subprocess.run(
+            ["pytest", "-q"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        m_pass = re.search(r"(\d+) passed", result.stdout)
+        m_fail = re.search(r"(\d+) failed", result.stdout)
+        passed = int(m_pass.group(1)) if m_pass else 0
+        failed = int(m_fail.group(1)) if m_fail else 0
+        return passed, failed
+    except Exception:  # pragma: no cover - test fallback
+        return 0, 0
+
+
+def _count_placeholders() -> int:
+    """Return count of placeholder patterns (TODO/FIXME) in repository."""
+    workspace = CrossPlatformPathManager.get_workspace_path()
+    count = 0
+    for path in workspace.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for pat in PLACEHOLDER_PATTERNS:
+            count += text.count(pat)
+    return count
+
+
+def calculate_compliance_score(
+    ruff_issues: int,
+    tests_passed: int,
+    tests_failed: int,
+    placeholder_count: int,
+) -> float:
+    """Return composite compliance score combining lint, tests and placeholders."""
+
+    lint_score = max(0.0, 1 - ruff_issues / 50)
+    total_tests = tests_passed + tests_failed
+    test_score = (tests_passed / total_tests) if total_tests else 0.0
+    placeholder_score = 1 / (1 + placeholder_count)
+    return round((lint_score + test_score + placeholder_score) / 3, 3)
+
+
+def persist_compliance_score(score: float, db_path: Path | None = None) -> None:
+    """Persist ``score`` to the ``compliance_scores`` table in analytics.db."""
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    db = db_path or (workspace / "databases" / "analytics.db")
+    db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS compliance_scores (timestamp TEXT, score REAL)"
+        )
+        conn.execute(
+            "INSERT INTO compliance_scores (timestamp, score) VALUES (?, ?)",
+            (datetime.now().isoformat(), float(score)),
+        )
+        conn.commit()
+
+
+def get_latest_compliance_score(db_path: Path | None = None) -> float:
+    """Return the most recent compliance score from analytics.db."""
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    db = db_path or (workspace / "databases" / "analytics.db")
+    if not db.exists():
+        return 0.0
+    with sqlite3.connect(db) as conn:
+        cur = conn.execute(
+            "SELECT score FROM compliance_scores ORDER BY timestamp DESC LIMIT 1"
+        )
+        row = cur.fetchone()
+        return float(row[0]) if row else 0.0
+
+
+def calculate_and_persist_compliance_score() -> float:
+    """Run lint, tests and placeholder scan to compute and store score."""
+    issues = _run_ruff()
+    passed, failed = _run_pytest()
+    placeholders = _count_placeholders()
+    score = calculate_compliance_score(issues, passed, failed, placeholders)
+    persist_compliance_score(score)
+    send_dashboard_alert({"event": "compliance_score", "score": score})
+    return score
 
 
 def generate_compliance_summary() -> dict:
@@ -246,5 +351,9 @@ __all__ = [
     "validate_environment",
     "enforce_anti_recursion",
     "generate_compliance_summary",
+    "calculate_compliance_score",
+    "persist_compliance_score",
+    "get_latest_compliance_score",
+    "calculate_and_persist_compliance_score",
     "ComplianceError",
 ]

--- a/phase5_tasks.md
+++ b/phase5_tasks.md
@@ -1,0 +1,15 @@
+# Phase 5 Compliance Scoring
+
+The compliance score blends linting, testing, and placeholder hygiene:
+
+- **Lint component (L):** `L = max(0, 1 - issues/50)` where `issues` is the number of Ruff findings.
+- **Test component (T):** `T = passed / (passed + failed)` from pytest results.
+- **Placeholder component (P):** `P = 1 / (1 + placeholders)` where `placeholders` counts TODO/FIXME markers.
+
+The overall score is the average of the three components:
+
+```
+score = (L + T + P) / 3
+```
+
+This score is stored in `analytics.db` and surfaced at `/dashboard/compliance`.

--- a/tests/test_compliance_score.py
+++ b/tests/test_compliance_score.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from enterprise_modules import compliance
+
+
+def test_score_persistence_and_fetch(tmp_path: Path) -> None:
+    db = tmp_path / "analytics.db"
+    score = compliance.calculate_compliance_score(0, 3, 0, 0)
+    compliance.persist_compliance_score(score, db_path=db)
+    assert compliance.get_latest_compliance_score(db_path=db) == score

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -24,6 +24,7 @@ from dashboard.compliance_metrics_updater import ComplianceMetricsUpdater
 
 from config.secret_manager import get_secret
 from utils.cross_platform_paths import CrossPlatformPathManager
+from enterprise_modules.compliance import get_latest_compliance_score
 
 workspace_root = CrossPlatformPathManager.get_workspace_path()
 ANALYTICS_DB = Path(os.getenv("ANALYTICS_DB", workspace_root / "databases" / "analytics.db"))
@@ -88,6 +89,7 @@ def _fetch_metrics() -> Dict[str, Any]:
     metrics.setdefault("lessons_integration_status", "UNKNOWN")
     metrics.setdefault("average_query_latency", 0.0)
     metrics.setdefault("composite_score", 0.0)
+    metrics["compliance_score"] = get_latest_compliance_score(ANALYTICS_DB)
     if ANALYTICS_DB.exists():
         with sqlite3.connect(ANALYTICS_DB) as conn:
             cur = conn.cursor()


### PR DESCRIPTION
## Summary
- document lint/test/placeholder-based compliance formula
- compute and persist compliance score
- surface score on dashboard endpoints and add basic tests

## Testing
- `ruff check enterprise_modules/compliance.py web_gui/scripts/flask_apps/enterprise_dashboard.py dashboard/enterprise_dashboard.py tests/test_compliance_score.py`
- `pytest tests/test_compliance_score.py`

------
https://chatgpt.com/codex/tasks/task_e_68910731ac988331b809d9cbd644e678