### PR TITLE
docs: add issue and PR stubs for upcoming tasks

### DIFF
--- a/docs/issues/automate_documentation_metrics_ci_hooks.md
+++ b/docs/issues/automate_documentation_metrics_ci_hooks.md
@@ -1,0 +1,19 @@
+# Issue: Automate documentation metrics and CI hooks
+
+## Summary
+Remove manual steps by linking documentation metrics scripts to the continuous integration pipeline.
+
+## Tasks
+- Create or update `scripts/documentation_metrics.py` to emit metrics during CI.
+- Add CI configuration under `.github/` to run the metrics script.
+- Write tests verifying metrics output format.
+
+## Acceptance Criteria
+- CI pipeline runs documentation metrics automatically.
+- Metrics script outputs validated format.
+- `ruff` and `pytest` succeed.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/issues/consolidate_update_documentation.md
+++ b/docs/issues/consolidate_update_documentation.md
@@ -1,0 +1,19 @@
+# Issue: Consolidate and update documentation
+
+## Summary
+Remove outdated references, synchronize content across files, and add diagrams for clarity.
+
+## Tasks
+- Remove outdated references such as inert quantum flags.
+- Synchronize terminology across `README.md` and docs.
+- Add diagrams or tables where helpful.
+
+## Acceptance Criteria
+- Documentation no longer includes outdated references.
+- Content is synchronized and clarified with diagrams or tables.
+- `ruff` and `pytest` pass.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/issues/design_quantum_hardware_integration_plan.md
+++ b/docs/issues/design_quantum_hardware_integration_plan.md
@@ -1,0 +1,18 @@
+# Issue: Design quantum hardware integration plan
+
+## Summary
+Move beyond simulation‑only routines and stubbed helpers to enable execution on real quantum hardware when available.
+
+## Tasks
+- Draft a document (`docs/quantum_hardware_integration_plan.md`) describing required APIs, execution flow, and hardware fallbacks.
+- Outline refactors needed to replace simulation stubs.
+- Gather feedback and iterate on the plan before implementation.
+
+## Acceptance Criteria
+- Comprehensive integration plan drafted and reviewed.
+- Plan covers API design, execution flow, and fallback strategies.
+- No code changes until the design is approved.
+
+## Testing
+- Document review
+

--- a/docs/issues/extend_dual_copilot_coverage.md
+++ b/docs/issues/extend_dual_copilot_coverage.md
@@ -1,0 +1,19 @@
+# Issue: Extend dual‑Copilot coverage
+
+## Summary
+Integrate the secondary validator into all wrappers and orchestration scripts, addressing failing modules in documentation, template caching, session management, and compliance metrics.
+
+## Tasks
+- Audit wrappers and orchestrators for missing `SecondaryCopilotValidator` calls.
+- Add secondary validation where absent.
+- Expand tests under `tests/` to exercise validation paths.
+
+## Acceptance Criteria
+- Every wrapper and orchestrator invokes `SecondaryCopilotValidator`.
+- Updated tests cover dual‑Copilot paths and pass.
+- `ruff` and `pytest` run cleanly.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/issues/finish_dashboard_front_end.md
+++ b/docs/issues/finish_dashboard_front_end.md
@@ -1,0 +1,19 @@
+# Issue: Finish dashboard front‑end
+
+## Summary
+Replace placeholder pages with real‑time graphs and interactive controls, stabilizing SSE/polling for live metrics.
+
+## Tasks
+- Implement dynamic components in `dashboard/` or `web_gui/` to display live metrics.
+- Stabilize SSE/polling endpoints for real‑time updates.
+- Add tests covering live‑metrics updates.
+
+## Acceptance Criteria
+- Dashboard displays real‑time graphs and interactive controls.
+- SSE/polling endpoints function reliably under tests.
+- CSS/JS assets pass linting rules.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/issues/harden_compliance_automation.md
+++ b/docs/issues/harden_compliance_automation.md
@@ -1,0 +1,19 @@
+# Issue: Harden compliance automation
+
+## Summary
+Ensure composite compliance scoring, anti‑recursion guards, correction logging, and lessons‑learned capture run without manual triggers.
+
+## Tasks
+- Introduce composite compliance scoring and anti‑recursion guards in compliance scripts.
+- Implement correction logging with lessons‑learned capture.
+- Add automated tests for each mechanism.
+
+## Acceptance Criteria
+- Compliance automation runs unattended with composite scoring and anti‑recursion safeguards.
+- Corrections and lessons are logged automatically.
+- `ruff` and `pytest` succeed.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/issues/streamline_placeholder_remediation.md
+++ b/docs/issues/streamline_placeholder_remediation.md
@@ -1,0 +1,19 @@
+# Issue: Streamline placeholder remediation
+
+## Summary
+Integrate automatic resolution into the placeholder audit workflow and surface progress in dashboard metrics.
+
+## Tasks
+- Enhance `scripts/code_placeholder_audit.py` to auto‑resolve simple placeholders.
+- Report remediation progress through dashboard metrics.
+- Add tests demonstrating automatic resolution.
+
+## Acceptance Criteria
+- Placeholder audit resolves simple cases automatically.
+- Dashboard displays remediation progress.
+- `ruff` and `pytest` pass.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/prs/automate_documentation_metrics_ci_hooks.md
+++ b/docs/prs/automate_documentation_metrics_ci_hooks.md
@@ -1,0 +1,14 @@
+# PR Plan: Automate documentation metrics and CI hooks
+
+## Summary
+Link documentation metrics scripts into the CI pipeline to remove manual steps.
+
+## Implementation
+- Implement `scripts/documentation_metrics.py` for CI use.
+- Configure CI under `.github/` to call the metrics script.
+- Add tests verifying metrics output format.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/prs/consolidate_update_documentation.md
+++ b/docs/prs/consolidate_update_documentation.md
@@ -1,0 +1,14 @@
+# PR Plan: Consolidate and update documentation
+
+## Summary
+Clean up outdated references, synchronize documentation, and add diagrams for clarity.
+
+## Implementation
+- Remove obsolete references such as inert quantum flags.
+- Align terminology across `README.md` and docs.
+- Introduce diagrams or tables as needed.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/prs/design_quantum_hardware_integration_plan.md
+++ b/docs/prs/design_quantum_hardware_integration_plan.md
@@ -1,0 +1,13 @@
+# PR Plan: Design quantum hardware integration plan
+
+## Summary
+Introduce a comprehensive document outlining APIs, execution flow, and fallbacks for future real‑hardware quantum execution.
+
+## Implementation
+- Draft `docs/quantum_hardware_integration_plan.md` with required APIs and execution model.
+- Highlight refactors needed to replace simulation stubs.
+- Submit plan for review before code changes.
+
+## Testing
+- Document review
+

--- a/docs/prs/extend_dual_copilot_coverage.md
+++ b/docs/prs/extend_dual_copilot_coverage.md
@@ -1,0 +1,14 @@
+# PR Plan: Extend dual‑Copilot coverage
+
+## Summary
+Integrate `SecondaryCopilotValidator` across wrappers and orchestrators and expand tests for dual‑Copilot paths.
+
+## Implementation
+- Audit wrappers/orchestrators for missing secondary validation.
+- Add `SecondaryCopilotValidator` checks.
+- Update tests to cover validation paths.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/prs/finish_dashboard_front_end.md
+++ b/docs/prs/finish_dashboard_front_end.md
@@ -1,0 +1,14 @@
+# PR Plan: Finish dashboard front‑end
+
+## Summary
+Deliver real‑time graphs and interactive controls with stable SSE/polling for live metrics.
+
+## Implementation
+- Replace placeholder pages with components rendering live metrics.
+- Stabilize SSE/polling endpoints.
+- Add tests for live‑metrics updates and ensure assets pass linting.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/prs/harden_compliance_automation.md
+++ b/docs/prs/harden_compliance_automation.md
@@ -1,0 +1,14 @@
+# PR Plan: Harden compliance automation
+
+## Summary
+Automate composite compliance scoring, anti‑recursion guards, correction logging, and lessons‑learned capture.
+
+## Implementation
+- Add composite scoring and anti‑recursion safeguards to compliance scripts.
+- Log corrections and lessons automatically.
+- Provide tests for new compliance mechanisms.
+
+## Testing
+- `ruff`
+- `pytest`
+

--- a/docs/prs/streamline_placeholder_remediation.md
+++ b/docs/prs/streamline_placeholder_remediation.md
@@ -1,0 +1,14 @@
+# PR Plan: Streamline placeholder remediation
+
+## Summary
+Integrate automatic placeholder resolution into audits and surface progress in dashboard metrics.
+
+## Implementation
+- Extend `scripts/code_placeholder_audit.py` with auto‑resolution logic.
+- Emit remediation metrics to the dashboard.
+- Add tests verifying automatic resolution.
+
+## Testing
+- `ruff`
+- `pytest`
+


### PR DESCRIPTION
## Summary
- add issue stubs for dual-Copilot coverage, quantum hardware integration plan, dashboard front-end, documentation metrics automation, placeholder remediation, compliance automation, and documentation consolidation
- add matching PR planning stubs for each issue

## Testing
- `bash setup.sh` *(failed: ImportError: attempted relative import with no known parent package)*
- `ruff check .` *(found 21 errors)*
- `pytest tests/test_add_code_audit_log.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689101e3e35c83318a2661c42e39fa5f