### PR TITLE
docs: clarify simulation-only quantum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,21 @@
 
 > Tests: run `pytest` before committing. Current repository tests report multiple failures.
 > Lint: run `ruff check .` before committing.
-> Quantum modules default to simulation mode. Hardware flags and IBM Quantum credentials prepare the environment for upcoming real-device execution. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Compliance auditing remains in progress.
+> Quantum modules run in simulation only. Hardware flags and IBM Quantum credentials are ignored until the planned `QuantumExecutor` module arrives. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Compliance auditing remains in progress.
 > Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards.
 
 ---
 
 ## 📊 SYSTEM OVERVIEW
 
-The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality exists only as placeholder modules operating in simulation mode. Hooks for real hardware are planned but are not yet fully integrated, even when `qiskit-ibm-provider` is configured.
+The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality exists only as placeholder modules operating in simulation mode. Hooks for real hardware are planned but are not yet integrated, and several quantum modules remain stubs even when `qiskit-ibm-provider` is configured.
 
 > **Note**
-> Real hardware execution will be enabled through a forthcoming `QuantumExecutor` module. When tokens and backend flags are supplied, modules verify credentials but fall back to simulators until hardware access is released.
+> Real hardware execution will be enabled through a forthcoming `QuantumExecutor` module. When tokens and backend flags are supplied, modules verify credentials but always fall back to simulators until hardware access is released.
 > **Roadmap**
-> Hardware integration is in progress and will automatically leverage IBM Quantum backends when available, with simulator fallback as a safety net.
+> Hardware integration is in progress and will eventually leverage IBM Quantum backends, but no hardware execution is available today.
 > **Phase 5 AI**
-> Advanced AI integration features are fully integrated. They default to simulation mode unless real hardware is configured.
+> Advanced AI integration features are fully integrated. They operate in simulation mode; hardware configuration currently has no effect.
 
 ### 🎯 **Recent Milestones**
 - **Lessons Learned Integration:** sessions automatically apply lessons from `learning_monitor.db`
@@ -101,7 +101,7 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - PowerShell (for Windows automation)
 - SQLite3
 - Required packages: `pip install -r requirements.txt` (includes `py7zr` for 7z archive support)
-- Optional for IBM Quantum hardware: install `qiskit-ibm-provider` and set `QUANTUM_USE_HARDWARE=1` with a valid `QISKIT_IBM_TOKEN`; otherwise the toolkit runs in simulator mode
+ - Quantum routines use the Qiskit simulator only; installing `qiskit-ibm-provider` or setting `QUANTUM_USE_HARDWARE=1` has no effect because hardware execution is not yet supported
 
 ### **Installation & Setup**
 ```bash
@@ -282,7 +282,7 @@ By default the orchestrator uses the simulator. Flags `--hardware` and `--backen
 python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
 ```
 
-Set `QISKIT_IBM_TOKEN` for future hardware execution. The value is ignored today and the orchestrator always falls back to simulation. See [docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for the integration roadmap.
+Set `QISKIT_IBM_TOKEN` for future hardware execution. The value is ignored today and the orchestrator always falls back to simulation because hardware support and related modules are incomplete. See [docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for the integration roadmap.
 
 ### Quantum Placeholder Modules
 
@@ -1113,8 +1113,8 @@ Set these variables in your `.env` file or shell before running scripts:
 - `OPENAI_API_KEY` – enables optional OpenAI features.
 - `FLASK_SECRET_KEY` – Flask dashboard secret.
 - `FLASK_RUN_PORT` – dashboard port (default `5000`).
-- `QISKIT_IBM_TOKEN` – optional IBM Quantum token.
-- `IBM_BACKEND` – optional IBM Quantum backend name (default `ibmq_qasm_simulator`).
+ - `QISKIT_IBM_TOKEN` – placeholder for future IBM Quantum access (currently ignored).
+ - `IBM_BACKEND` – placeholder for future hardware selection; defaults to `ibmq_qasm_simulator` with no real hardware support.
 - `LOG_WEBSOCKET_ENABLED` – set to `1` to stream logs.
 - `CLW_MAX_LINE_LENGTH` – max line length for the `clw` wrapper (default `1550`).
 

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -27,7 +27,7 @@ The gh_COPILOT Toolkit v4.0 represents a revolutionary enterprise-grade automati
 - **Web Interface**: Flask dashboard with basic endpoints and templates
 - **Advanced AI Integration**: tooling supports further automation efforts
 - **Quantum-Enhanced Processing**: placeholder algorithms under exploration
-- *All Qiskit-based functions run in simulation mode by default. Install `qiskit-ibm-provider` and set the optional `QISKIT_IBM_TOKEN` environment variable to use real IBM Quantum hardware.*
+ - *All Qiskit-based functions run in simulation mode only. Installing `qiskit-ibm-provider` and setting `QISKIT_IBM_TOKEN` has no effect because IBM Quantum hardware integration is not yet available and several quantum modules remain stubs.*
 - **Enterprise Security Framework**: Zero-tolerance anti-recursion and comprehensive session integrity
  - *Note: earlier drafts referenced a 32+ database ecosystem. The current repository contains **27** SQLite databases for testing.*
 
@@ -601,7 +601,8 @@ class QuantumOptimizationEngine:
     """⚛️ Quantum-enhanced processing with classical fallback"""
     
     def apply_quantum_optimization(self, data: Any):
-        # Note: Quantum algorithms are placeholders for future implementation
+        # Note: quantum algorithms are placeholders; `quantum_hardware_available`
+        # currently always returns False and hardware execution is not supported
         if self.quantum_hardware_available():
             return self.execute_quantum_algorithms(data)
         else:

--- a/documentation/IMMEDIATE_ACTIONS_COMPLETION_REPORT.md
+++ b/documentation/IMMEDIATE_ACTIONS_COMPLETION_REPORT.md
@@ -10,7 +10,7 @@
 
 ## EXECUTIVE SUMMARY
 
-All immediate actions for the PIS (Plan Issued Statement) Framework have been successfully completed. The enterprise-grade, database-first architecture is now fully operational with integrated regeneration system, validated quantum optimization features, active Heisenbug detection monitoring, and comprehensive quantum documentation ready for enterprise review.
+All immediate actions for the PIS (Plan Issued Statement) Framework have been successfully completed. The enterprise-grade, database-first architecture is now fully operational with integrated regeneration system, validated simulation-based quantum optimization features (hardware integration pending), active Heisenbug detection monitoring, and comprehensive quantum documentation ready for enterprise review.
 
 ---
 

--- a/documentation/generated/AGENT_NOTES.md
+++ b/documentation/generated/AGENT_NOTES.md
@@ -103,7 +103,7 @@
 - **Database-First Operations**: All agents prioritize database storage
 - **Enterprise Compliance**: Focus on enterprise-grade solutions
 - **Visual Processing**: Comprehensive monitoring and feedback
-- **Quantum Enhancement**: Advanced optimization techniques
+- **Quantum Enhancement**: Simulation-based optimization techniques; hardware modules incomplete
 
 ---
 *AI Agent Knowledge Base maintained in Enterprise Database*

--- a/documentation/generated/ENTERPRISE_COMPLIANCE.md
+++ b/documentation/generated/ENTERPRISE_COMPLIANCE.md
@@ -50,7 +50,7 @@
 - ✅ **Dual Copilot Pattern**: Implementation required
 - ✅ **Visual Processing Indicators**: Mandatory for all operations
 - ✅ **Database-First Architecture**: All data in databases
-- ✅ **Quantum Enhancement**: Advanced optimization enabled
+- ✅ **Quantum Enhancement**: Simulation-based optimization enabled; hardware modules absent
 - ✅ **Anti-Recursion Protection**: Zero tolerance enforcement
 - ✅ **Web-GUI Integration**: Enterprise dashboard ready
 

--- a/documentation/generated/README.md
+++ b/documentation/generated/README.md
@@ -22,7 +22,7 @@ The gh_COPILOT Toolkit is an enterprise-grade system following database-first ar
 - ✅ **Database-First Architecture**: 100% documentation stored in databases
 - ✅ **Script Validation**: 1,679 scripts synchronized (100% coverage)
 - ✅ **Enterprise Compliance**: 95% overall compliance score achieved
-- ✅ **Quantum-Enhanced Processing**: Advanced documentation indexing
+- ✅ **Quantum-Enhanced Processing**: Simulation-based documentation indexing; hardware integration pending
 - ✅ **Dual Copilot Pattern**: Enterprise-grade validation framework
 - ✅ **Visual Processing Indicators**: Comprehensive monitoring system
 

--- a/documentation/generated/SYSTEM_STATUS.md
+++ b/documentation/generated/SYSTEM_STATUS.md
@@ -20,7 +20,7 @@
 - ✅ **Web-GUI Integration**: Flask dashboard operational
 
 #### **⚛️ QUANTUM PERFORMANCE**
-- **Quantum Algorithms**: 5 algorithms integrated (planned)
+- **Quantum Algorithms**: 5 simulation-only algorithms integrated (planned; hardware not supported)
 - **Processing Enhancement**: Database-driven optimization
 - **Index Coverage**: 52.3% quantum-indexed
 

--- a/documentation/generated/feature_matrix.csv
+++ b/documentation/generated/feature_matrix.csv
@@ -1,7 +1,7 @@
 Feature,Status
 **Algorithm Performance: ** modest improvements over baseline,Implemented
 **Template Completion: ** automation scripts demonstrate partial coverage,Implemented
-**Quantum Optimization: ** implemented via a Qiskit-based optimizer,Implemented
+**Quantum Optimization: ** simulation-based via Qiskit; hardware integration pending,Simulation-only
 **Enterprise Systems: ** monitoring and validation modules operational,Implemented
 "**Security Compliance: ** Anti-recursion, zero-byte protection, DUAL COPILOT pattern",Implemented
 **Performance Monitoring: ** monitoring scripts available,Implemented
@@ -26,7 +26,7 @@ Anti-recursion protection enabled,Implemented
 Zero-byte file prevention,Implemented
 DUAL COPILOT validation pattern,Implemented
 Enterprise compliance protocols,Implemented
-Quantum algorithm optimizer implemented with Qiskit,Implemented
+Quantum algorithm optimizer implemented with Qiskit (simulation only),Simulation-only
 Real-time monitoring and analytics,Implemented
 Advanced self-learning capabilities,Implemented
 Predictive performance optimization,Implemented

--- a/documentation/generated/feature_matrix.md
+++ b/documentation/generated/feature_matrix.md
@@ -2,7 +2,7 @@
 | --- | --- |
 | **Algorithm Performance: ** modest improvements over baseline | Implemented |
 | **Template Completion: ** automation scripts demonstrate partial coverage | Implemented |
-| **Quantum Optimization: ** implemented via a Qiskit-based optimizer | Implemented |
+| **Quantum Optimization: ** simulation-based via Qiskit; hardware integration pending | Simulation-only |
 | **Enterprise Systems: ** monitoring and validation modules operational | Implemented |
 | **Security Compliance: ** Anti-recursion, zero-byte protection, DUAL COPILOT pattern | Implemented |
 | **Performance Monitoring: ** monitoring scripts available | Implemented |
@@ -27,7 +27,7 @@
 | Zero-byte file prevention | Implemented |
 | DUAL COPILOT validation pattern | Implemented |
 | Enterprise compliance protocols | Implemented |
-| Quantum algorithm optimizer implemented with Qiskit | Implemented |
+| Quantum algorithm optimizer implemented with Qiskit (simulation only) | Simulation-only |
 | Real-time monitoring and analytics | Implemented |
 | Advanced self-learning capabilities | Implemented |
 | Predictive performance optimization | Implemented |


### PR DESCRIPTION
## Summary
- state in README and technical whitepaper that quantum modules are simulation-only and note that several quantum components remain stubs
- update immediate action report and generated docs to reflect missing quantum hardware integration
- revise feature matrix to mark quantum items as simulation-only

## Testing
- `ruff check .` *(fails: F401 unused imports, F821 undefined names, F811 redefinition, etc.)*
- `pytest tests/test_database_driven_ruff_corrector.py`

------
https://chatgpt.com/codex/tasks/task_e_68910c6cb2e483318a15543dbf356fa8