### PR TITLE
feat: add weighted composite compliance score

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,21 @@ The `summarize_corrections()` routine now keeps only the most recent entries
 (configurable via the `max_entries` argument). Existing summary files are moved
 to `dashboard/compliance/archive/` before new summaries are written. The main
 report remains `dashboard/compliance/correction_summary.json`.
+
+### Composite Compliance Score
+
+Lint warnings, test results, and remaining placeholders are combined into a
+single weighted score:
+
+```
+L = max(0, 100 - lint_warnings)
+T = passed / (passed + failed) * 100
+P = max(0, 100 - 10 * placeholders)
+score = 0.3 * L + 0.5 * T + 0.2 * P
+```
+
+The composite score is stored in `code_quality_metrics` within `analytics.db`
+and displayed on the dashboard.
 Set `GH_COPILOT_WORKSPACE` before running these utilities:
 
 ```bash

--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -46,6 +46,16 @@ def _load_metrics() -> dict[str, Any]:
         except json.JSONDecodeError as exc:  # pragma: no cover - log and fall back
             logging.error("Metrics decode error: %s", exc)
     metrics["compliance_score"] = get_latest_compliance_score(ANALYTICS_DB)
+    try:
+        with sqlite3.connect(ANALYTICS_DB) as conn:
+            cur = conn.execute(
+                "SELECT composite_score FROM code_quality_metrics ORDER BY id DESC LIMIT 1"
+            )
+            row = cur.fetchone()
+            if row:
+                metrics["composite_score"] = row[0]
+    except sqlite3.Error as exc:  # pragma: no cover - log and continue
+        logging.error("Composite fetch error: %s", exc)
     return {"metrics": metrics, "notes": []}
 
 

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -8,6 +8,9 @@
         function updateMetrics(data){
             document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
             document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
+            if(data.composite_score !== undefined){
+                document.getElementById('composite_score').textContent = data.composite_score.toFixed(2);
+            }
             document.getElementById('lessons_integration_status').textContent = data.lessons_integration_status || 'UNKNOWN';
             document.getElementById('lessons_hook_coverage').textContent =
                 data.lessons_hook_coverage !== undefined ? (data.lessons_hook_coverage * 100).toFixed(1) + '%' : '0%';
@@ -73,6 +76,7 @@
 <div>
     <strong>Placeholder Removals:</strong> <span id="placeholder_removal">{{ metrics.placeholder_removal | default(0) }}</span><br>
     <strong>Compliance Score:</strong> <span id="compliance_score">{{ metrics.compliance_score | default(0) }}</span><br>
+    <strong>Composite Score:</strong> <span id="composite_score">{{ metrics.composite_score | default(0) }}</span><br>
     <strong>Lessons Integration Status:</strong> <span id="lessons_integration_status">UNKNOWN</span><br>
     <strong>Lessons Hook Coverage:</strong> <span id="lessons_hook_coverage">0%</span><br>
     <strong>Missing Lesson Hooks:</strong> <span id="missing_lesson_hooks">none</span><br>

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -976,6 +976,21 @@ class Phase5AIIntegrationEngine:
         )
 ```
 
+#### Composite Compliance Scoring
+
+Phase 5 introduces a weighted compliance metric combining lint hygiene,
+test success, and placeholder backlog:
+
+```
+L = max(0, 100 - lint_warnings)
+T = passed / (passed + failed) * 100
+P = max(0, 100 - 10 * placeholders)
+score = 0.3 * L + 0.5 * T + 0.2 * P
+```
+
+This composite score is persisted to `code_quality_metrics` in `analytics.db`
+and exposed on the compliance dashboard.
+
 ### **Quantum Optimization Engine (Placeholder)**
 *Planned placeholder – algorithms not yet implemented.*
 ```python

--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -143,13 +143,15 @@ def calculate_compliance_score(
     tests_failed: int,
     placeholder_count: int,
 ) -> float:
-    """Return composite compliance score combining lint, tests and placeholders."""
+    """Return weighted compliance score combining lint, tests and placeholders."""
 
-    lint_score = max(0.0, 1 - ruff_issues / 50)
+    lint_score = max(0.0, 1 - ruff_issues / 100)
     total_tests = tests_passed + tests_failed
     test_score = (tests_passed / total_tests) if total_tests else 0.0
-    placeholder_score = 1 / (1 + placeholder_count)
-    return round((lint_score + test_score + placeholder_score) / 3, 3)
+    placeholder_score = max(0.0, 1 - (placeholder_count / 10))
+    return round(
+        0.3 * lint_score + 0.5 * test_score + 0.2 * placeholder_score, 3
+    )
 
 
 def persist_compliance_score(score: float, db_path: Path | None = None) -> None:

--- a/phase5_tasks.md
+++ b/phase5_tasks.md
@@ -2,14 +2,14 @@
 
 The compliance score blends linting, testing, and placeholder hygiene:
 
-- **Lint component (L):** `L = max(0, 1 - issues/50)` where `issues` is the number of Ruff findings.
-- **Test component (T):** `T = passed / (passed + failed)` from pytest results.
-- **Placeholder component (P):** `P = 1 / (1 + placeholders)` where `placeholders` counts TODO/FIXME markers.
+- **Lint component (L):** `L = max(0, 100 - issues)` where `issues` is the number of Ruff findings.
+- **Test component (T):** `T = passed / (passed + failed) * 100` from pytest results.
+- **Placeholder component (P):** `P = max(0, 100 - 10 * placeholders)` where `placeholders` counts TODO/FIXME markers.
 
-The overall score is the average of the three components:
+The weighted composite score is:
 
 ```
-score = (L + T + P) / 3
+score = 0.3 * L + 0.5 * T + 0.2 * P
 ```
 
 This score is stored in `analytics.db` and surfaced at `/dashboard/compliance`.

--- a/tests/test_compliance_metrics.py
+++ b/tests/test_compliance_metrics.py
@@ -1,19 +1,25 @@
 from utils.validation_utils import calculate_composite_compliance_score
 
+
 def test_composite_score_returns_components():
-    scores = calculate_composite_compliance_score(0, 10, 0)
+    scores = calculate_composite_compliance_score(0, 10, 0, 0)
     assert scores["lint_score"] == 100.0
     assert scores["test_score"] == 100.0
+    assert scores["placeholder_score"] == 100.0
     assert scores["composite"] == 100.0
 
+
 def test_composite_score_mixed_inputs():
-    scores = calculate_composite_compliance_score(10, 8, 2)
+    scores = calculate_composite_compliance_score(10, 8, 2, 3)
     assert scores["lint_score"] == 90.0
     assert scores["test_score"] == 80.0
-    assert scores["composite"] == 85.0
+    assert scores["placeholder_score"] == 70.0
+    assert scores["composite"] == 81.0
+
 
 def test_composite_score_handles_zero_tests():
-    scores = calculate_composite_compliance_score(5, 0, 0)
+    scores = calculate_composite_compliance_score(5, 0, 0, 2)
     assert scores["lint_score"] == 95.0
     assert scores["test_score"] == 0.0
-    assert scores["composite"] == 47.5
+    assert scores["placeholder_score"] == 80.0
+    assert scores["composite"] == 44.5

--- a/utils/validation_utils.py
+++ b/utils/validation_utils.py
@@ -17,6 +17,7 @@ def calculate_composite_compliance_score(
     ruff_issues: int,
     tests_passed: int,
     tests_failed: int,
+    placeholders: int,
 ) -> Dict[str, float]:
     """Return detailed compliance scores for dashboard display.
 
@@ -28,20 +29,27 @@ def calculate_composite_compliance_score(
         Number of tests that passed.
     tests_failed: int
         Number of tests that failed.
+    placeholders: int
+        Remaining TODO/FIXME markers in the repository.
 
     Returns
     -------
     Dict[str, float]
-        Dictionary containing ``lint_score``, ``test_score`` and ``composite``.
+        Dictionary containing ``lint_score``, ``test_score``,
+        ``placeholder_score`` and ``composite``.
     """
 
     total_tests = tests_passed + tests_failed
     test_score = (tests_passed / total_tests * 100) if total_tests else 0.0
     lint_score = max(0.0, 100 - ruff_issues)
-    composite = round((lint_score + test_score) / 2, 2)
+    placeholder_score = max(0.0, 100 - (10 * placeholders))
+    composite = round(
+        0.3 * lint_score + 0.5 * test_score + 0.2 * placeholder_score, 2
+    )
     return {
         "lint_score": round(lint_score, 2),
         "test_score": round(test_score, 2),
+        "placeholder_score": round(placeholder_score, 2),
         "composite": composite,
     }
 


### PR DESCRIPTION
## Summary
- weight lint issues, test success, and placeholders in a single composite score
- store placeholder counts and composite score in analytics database
- surface composite score on dashboard with updated docs

## Testing
- `ruff check utils/validation_utils.py enterprise_modules/compliance.py validation/compliance_report_generator.py dashboard/enterprise_dashboard.py tests/test_compliance_metrics.py`
- `pytest tests/test_compliance_metrics.py tests/test_compliance_report_generator.py tests/dashboard/test_compliance_metrics.py tests/test_unified_monitoring_optimization_system.py`


------
https://chatgpt.com/codex/tasks/task_e_6891193724f083319384c6ccd3884296