### PR TITLE
docs: fix Quick Start formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 ## 🚀 QUICK START
 
 ### **Prerequisites**
-- Python 1,679.8+
+- Python 3.8+
 - PowerShell (for Windows automation)
 - SQLite3
 - Required packages: `pip install -r requirements.txt` (includes `py7zr` for 7z archive support)
- - Quantum routines use the Qiskit simulator only; installing `qiskit-ibm-provider` or setting `QUANTUM_USE_HARDWARE=1` has no effect because hardware execution is not yet supported
+- Quantum routines use the Qiskit simulator only; installing `qiskit-ibm-provider` or setting `QUANTUM_USE_HARDWARE=1` has no effect because hardware execution is not yet supported
 
 ### **Installation & Setup**
 ```bash
@@ -136,6 +136,8 @@ tools/install_clw.sh
 ls -l /usr/local/bin/clw
 /usr/local/bin/clw --help
 
+```
+
 ### Add Lessons After a Run
 Store new insights directly from the gap analyzer:
 
@@ -155,6 +157,7 @@ rate limiting and retry behavior. The client now respects `Retry-After` headers
 for HTTP 429 responses and surfaces the message from 4xx errors like invalid
 credentials.
 
+```bash
 # 3. Initialize databases
 python scripts/database/unified_database_initializer.py
 


### PR DESCRIPTION
## Summary
- correct Python version and bullet formatting in Quick Start prerequisites
- fix missing code fence and wrap database initialization steps in bash block

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68911dc0bb608331a861431e5952b0ad