### PR TITLE
docs: clarify quantum simulation scope and compliance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > Tests: run `pytest` before committing. Current repository tests report multiple failures.
 > Lint: run `ruff check .` before committing.
-> Quantum modules run in simulation only. Hardware flags and IBM Quantum credentials are ignored until the planned `QuantumExecutor` module arrives. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Compliance auditing remains in progress.
+> Quantum modules run in simulation only. Hardware flags and IBM Quantum credentials are ignored until the planned `QuantumExecutor` module arrives. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Compliance auditing is enforced via `EnterpriseComplianceValidator` with metrics stored in `analytics.db`.
 > Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards.
 
 ---

--- a/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -10,6 +10,8 @@
 ### **System Classification**
 The gh_COPILOT Toolkit v4.0 represents an enterprise-grade automation platform in active development that implements a database-first, unified system architecture with advanced AI integration capabilities. Several subsystems—including disaster recovery, the web dashboard, and the database synchronization engine—remain incomplete, and the current test suite reports multiple failures.
 
+Compliance and audit metrics are logged to `analytics.db` via the `EnterpriseComplianceValidator`.
+
 *All quantum modules run exclusively in simulation mode; any hardware configuration is currently ignored until future integration lands.*
 *Phase&nbsp;5 advanced AI features are partially integrated and not yet production ready.*
 
@@ -20,6 +22,7 @@ The gh_COPILOT Toolkit v4.0 represents an enterprise-grade automation platform i
 - **Advanced AI Integration**: tooling supports further automation efforts
 - **Quantum-Inspired Processing**: placeholder routines for annealing and search operate in simulation mode; the `use_hardware` flag is currently ignored.
 - **Quantum-Inspired Communication**: prototype modules simulate secure channels and query encryption; real quantum encryption is not implemented.
+- **Compliance & Audit Framework**: `EnterpriseComplianceValidator` records code audits, rollback history, and compliance metrics in `analytics.db`.
 - **Enterprise Security Framework**: Zero-tolerance anti-recursion and comprehensive session integrity
 - *Note: earlier drafts referenced a 32+ database ecosystem. The current repository ships with a handful of SQLite databases for testing.*
 

--- a/docs/QUANTUM_HARDWARE_SETUP.md
+++ b/docs/QUANTUM_HARDWARE_SETUP.md
@@ -1,8 +1,8 @@
 # Quantum Hardware Setup
 
 This guide outlines configuration steps for IBM Quantum integration. Current releases
-use simulators by default, but supplying tokens and backend names prepares the system
-for real-device execution as soon as access is enabled.
+use simulators only; tokens and backend names are stored for future use but have no
+effect until real-device access is enabled.
 
 ## 1. Acquire a Token
 1. Create an IBM Quantum account.
@@ -17,23 +17,23 @@ for real-device execution as soon as access is enabled.
    ```
 
 ## 2. Backend Selection
-Specify a backend name via `IBM_BACKEND`:
+Specify a backend name via `IBM_BACKEND` (currently ignored):
 ```bash
 export IBM_BACKEND="ibmq_qasm_simulator"
 ```
-The orchestrator attempts to use this backend; if unavailable it falls back to the default simulator.
+The orchestrator records this value but always uses the default simulator.
 
 ## 3. CLI Usage
-Use the executor CLI or orchestrator with hardware flags:
+Use the executor CLI or orchestrator with hardware flags (placeholders):
 ```bash
 python -m quantum.cli.executor_cli --use-hardware --backend ibm_nairobi
 python quantum_integration_orchestrator.py --hardware
 ```
-If the specified backend is unavailable, execution falls back to simulators with a warning.
+Regardless of backend settings, execution always uses simulators and logs a notice.
 
 ## 4. Expected Outputs
-When hardware access is configured, logs reflect the chosen backend. Without access,
-the system logs a fallback message and uses the simulator.
+When hardware access becomes available, logs will reflect the chosen backend. Until then,
+the system logs that simulation mode is enforced.
 
 ## 5. Roadmap
 Upcoming releases will introduce a `QuantumExecutor` module that manages credential

--- a/docs/quantum/QUANTUM_ENTERPRISE_COMPLIANCE.md
+++ b/docs/quantum/QUANTUM_ENTERPRISE_COMPLIANCE.md
@@ -4,14 +4,13 @@
 ## Regulatory and Security Compliance
 
 > **Note**
-> All quantum capabilities operate in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+> All quantum capabilities operate in simulation only. Installing `qiskit-ibm-provider` or configuring IBM Quantum tokens has no effect because hardware execution is not supported.
 
 ### Simulation Mode
 The PIS Framework defaults to a high‑fidelity simulator. All quantum features
-mirror production logic but run classically unless a hardware backend is
-explicitly configured. This ensures deterministic results for testing and
-compliance audits. Hardware support can be enabled as described in the
-**Optional Hardware Setup** section below.
+mirror production logic and run classically for deterministic testing and
+compliance audits. Hardware support is not yet available; the steps in the
+**Optional Hardware Setup** section are placeholders for future integration.
 
 ### Compliance Framework
 The quantum-enhanced PIS Framework meets all enterprise compliance requirements:
@@ -36,7 +35,7 @@ The quantum-enhanced PIS Framework meets all enterprise compliance requirements:
 ### Implemented Quantum Routines
 - **Quantum Annealing Optimization**: Transverse-field Ising model that flips
   qubits when given negative costs. Simulation uses Qiskit's Aer backend and
-  hardware can be enabled with `use_hardware=True`. Example:
+  the `use_hardware` parameter is ignored. Example:
   ```python
   from quantum.quantum_annealing import run_quantum_annealing
   run_quantum_annealing([1, -1])

--- a/docs/quantum/QUANTUM_INTEGRATION_GUIDE.md
+++ b/docs/quantum/QUANTUM_INTEGRATION_GUIDE.md
@@ -2,7 +2,7 @@
 ## Implementation and Deployment
 
 > **Note**
-> All quantum features run in simulation unless `qiskit-ibm-provider` is installed and configured with `QISKIT_IBM_TOKEN`.
+> All quantum features run in simulation only. Installing `qiskit-ibm-provider` or setting `QISKIT_IBM_TOKEN` has no effect because hardware execution is not yet supported.
 
 ### Integration Architecture
 ```
@@ -73,17 +73,10 @@ result = quantum_engine.optimize_code_analysis(
 ```
 
 ### Hardware Backends
-Install `qiskit-ibm-provider` and set `QISKIT_IBM_TOKEN` to enable hardware access.
-The orchestrator validates credentials and uses the requested backend when available;
-otherwise it automatically falls back to simulation:
-
-```bash
-python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
-```
-
-See [docs/QUANTUM_HARDWARE_SETUP.md](../QUANTUM_HARDWARE_SETUP.md) for setup details and
-[../diagrams/quantum_hardware_flow.dot](../diagrams/quantum_hardware_flow.dot) for the
-integration flow.
+Hardware backends are not yet supported. The orchestrator accepts `--hardware`
+and `--backend` flags but always runs on the local simulator. See
+[docs/QUANTUM_HARDWARE_SETUP.md](../QUANTUM_HARDWARE_SETUP.md) for the future
+integration roadmap.
 
 ### Deployment Checklist
 - [ ] Quantum simulation environment *(not started)*

--- a/docs/quantum/QUANTUM_OPTIMIZATION_OVERVIEW.md
+++ b/docs/quantum/QUANTUM_OPTIMIZATION_OVERVIEW.md
@@ -2,10 +2,10 @@
 ## Enterprise-Grade PIS Framework Quantum Integration
 
 > **Note**
-> All quantum features operate in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+> All quantum features operate in simulation only. Installing `qiskit-ibm-provider` or setting IBM Quantum tokens has no effect because hardware execution is not yet supported.
 
 ### Hardware Requirements
-Running against IBM Quantum hardware requires the `qiskit` and `qiskit-ibm-provider` packages, a valid API token set via `QISKIT_IBM_TOKEN`, and the environment variable `QUANTUM_USE_HARDWARE=1`. Without these settings the library falls back to the local Aer simulator.
+Hardware execution is not supported. The library always uses the local Aer simulator and ignores `QISKIT_IBM_TOKEN` and `QUANTUM_USE_HARDWARE` settings.
 
 ### Executive Summary
 The PIS (Plan Issued Statement) Framework integrates quantum optimization algorithms to achieve unprecedented performance improvements in code analysis, error detection, and compliance validation. The latest update introduces the **Quantum Database Search** module for Grover-based queries.
@@ -17,10 +17,7 @@ The PIS (Plan Issued Statement) Framework integrates quantum optimization algori
 - **Quantum Phase Estimation**: Performance optimization
 
 ### Performance Metrics
-- **Quantum Fidelity**: 98.7% (Industry Leading)
-- **Quantum Efficiency**: 95.7% (Enterprise Grade)
-- **Classical Speedup**: 2.5x average improvement
-- **Error Detection**: 99.2% accuracy
+Simulation results are logged to `analytics.db` for audit purposes. No real hardware benchmarking has been performed.
 
 ### Enterprise Benefits
 1. **Unprecedented Speed**: Quantum algorithms provide exponential speedup for complex optimization problems
@@ -33,7 +30,7 @@ The PIS (Plan Issued Statement) Framework integrates quantum optimization algori
 - **Phase 2**: Database integration complete ✅
 - **Phase 3**: Performance monitoring operational ✅
 - **Phase 4**: Production deployment finalized ✅
-- **Phase 5**: Hardware-ready quantum integration ✅
+- **Phase 5**: Hardware integration pending
 
 ### New Algorithms
 - **Grover's Search Optimization**: Accelerated database queries

--- a/quantum/README.md
+++ b/quantum/README.md
@@ -4,55 +4,40 @@ This package provides experimental quantum-inspired utilities used across the
 gh_COPILOT toolkit.
 
 > **Note**
-> All quantum modules run in simulation unless `qiskit-ibm-provider` is installed and configured with `QISKIT_IBM_TOKEN`.
+> All quantum modules run in simulation only. Installing `qiskit-ibm-provider` or setting `QISKIT_IBM_TOKEN` has no effect because hardware execution is not yet supported.
 
 ## Optimizers
 - `optimizers.quantum_optimizer.QuantumOptimizer` – classical/quantum hybrid
   optimizer with progress logging. Events are recorded using
   `utils.log_utils._log_event` when executed via higher-level workflows.
-  Use `configure_backend()` to automatically load IBM Quantum credentials from
-  `QISKIT_IBM_TOKEN` and select either hardware or the local simulator.
+  Use `configure_backend()` for consistent configuration; credentials are ignored and the local simulator is always selected.
 
 ## Database Search
 - `quantum.quantum_database_search` – lightweight helpers for SQL, NoSQL and
   hybrid search. All queries are logged to `analytics.db` for compliance.
 
-These modules default to simulation mode but can use real IBM Quantum hardware
-when `qiskit-ibm-provider` is installed and `QISKIT_IBM_TOKEN` is configured.
-Use the `--hardware` flag in `quantum_integration_orchestrator.py` to enable
-hardware execution. When no backend is specified the orchestrator automatically
-selects an available device. If hardware is unavailable, the modules
-automatically fall back to local simulation.
-
-Hardware usage can also be toggled globally by setting the environment
-variable `QUANTUM_USE_HARDWARE` to `"1"`. Modules query this flag when no
-explicit option is provided.
+These modules always run on local simulators. The `--hardware` flag in
+`quantum_integration_orchestrator.py` and the `QUANTUM_USE_HARDWARE`
+environment variable are placeholders with no effect.
 
 ## IBM Quantum Access
 
-To run on real IBM Quantum hardware you need an access token from
-<https://quantum-computing.ibm.com>. Set the environment variable
-`QISKIT_IBM_TOKEN` before executing any demo modules:
-
-```
-export QISKIT_IBM_TOKEN="YOUR_API_TOKEN"
-```
-
-If the token or requested backend is unavailable the modules automatically
-fall back to local simulation, preserving existing behavior.
+Hardware access is planned but not yet available. You may set
+`QISKIT_IBM_TOKEN` for future use, but it is currently ignored and the
+modules always fall back to local simulation.
 
 ## Algorithms
 
 - `algorithms.expansion.QuantumLibraryExpansion` – Grover search demonstration.
 - `algorithms.teleportation.QuantumTeleportation` – teleports a qubit state using a Bell pair.
-- `algorithms.hardware_aware.HardwareAwareAlgorithm` – demonstrates automatic
-  hardware selection via `qiskit-ibm-provider` with simulator fallback.
+- `algorithms.hardware_aware.HardwareAwareAlgorithm` – placeholder for automatic
+  backend selection; the simulator is always used.
 - `algorithms.vqe_demo.run_vqe_demo` – prototype VQE ground state estimation.
 - `algorithms.phase_estimation_demo.run_phase_estimation_demo` – prototype phase estimation.
 
 ## Backend utilities
 
-- `utils.backend_provider.get_backend` – loads IBM Quantum backends and falls back to `Aer` simulators when hardware is unavailable.
+- `utils.backend_provider.get_backend` – currently returns the `Aer` simulator; hardware backends are ignored.
 
 ## Pattern Recognition
 


### PR DESCRIPTION
## Summary
- clarify that quantum modules operate in simulation only and hardware flags are ignored
- document that compliance auditing leverages EnterpriseComplianceValidator and analytics.db
- update quantum guides to mark hardware setup instructions as placeholders

## Testing
- `ruff check .` *(fails: 19 errors)*
- `pytest` *(fails: tests/test_database_first_correction_engine.py)*

------
https://chatgpt.com/codex/tasks/task_e_689123175aa48331ac0e5b5bbfb49d0d