### PR TITLE
docs: clarify quantum simulation and add consistency tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,9 @@ python archive/consolidated_scripts/enterprise_database_driven_documentation_man
 ```
 This script pulls templates from both `documentation.db` and `production.db` and outputs Markdown, HTML and JSON files under `logs/template_rendering/`. Each render is logged to `analytics.db` and progress appears under `dashboard/compliance`.
 Both ``session_protocol_validator.py`` and ``session_management_consolidation_executor.py``
-are thin CLI wrappers. They delegate to the core implementations under
-``validation.protocols.session`` and ``session_management_consolidation_executor``.
+are stable CLI wrappers. They delegate to the core implementations under
+``validation.protocols.session`` and ``session_management_consolidation_executor`` and can
+be used directly in automation scripts.
 - ``unified_session_management_system.py`` starts new sessions via enterprise compliance checks.
 - ``continuous_operation_monitor.py`` records uptime and resource usage to ``analytics.db``.
 Import these modules directly in your own scripts for easier maintenance.
@@ -286,14 +287,14 @@ print(f"[SUCCESS] Generated with {result.confidence_score}% confidence")
 python simplified_quantum_integration_orchestrator.py
 ```
 
-By default the orchestrator uses the simulator. Flags `--hardware` and `--backend` are placeholders that currently have no effect; they will enable IBM Quantum backends once the planned `QuantumExecutor` module arrives.
+By default the orchestrator uses the simulator. Flags `--hardware` and `--backend` are placeholders with no effect; real-device execution is not available. A future `QuantumExecutor` module will handle IBM Quantum backends when hardware integration arrives.
 
 ```bash
 # placeholder flags; still executes on simulators
 python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
 ```
 
-Set `QISKIT_IBM_TOKEN` for future hardware execution. The value is ignored today and the orchestrator always falls back to simulation because hardware support and related modules are incomplete. See [docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for the integration roadmap.
+Set `QISKIT_IBM_TOKEN` for future hardware execution. The value is ignored today and the orchestrator always falls back to simulation because hardware support is not yet implemented. See [docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for the integration roadmap.
 
 ### Quantum Placeholder Modules
 

--- a/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -10,7 +10,9 @@
 ### **System Classification**
 The gh_COPILOT Toolkit v4.0 represents an enterprise-grade automation platform in active development that implements a database-first, unified system architecture with advanced AI integration capabilities. Several subsystems—including disaster recovery, the web dashboard, and the database synchronization engine—remain incomplete, and the current test suite reports multiple failures.
 
-Compliance and audit metrics are logged to `analytics.db` via the `EnterpriseComplianceValidator`.
+Compliance and audit metrics are logged to `analytics.db` via the
+`EnterpriseComplianceValidator`, and compliance scores are computed by the
+`WLC_SESSION_MANAGER` during session wrap-up.
 
 *All quantum modules run exclusively in simulation mode; any hardware configuration is currently ignored until future integration lands.*
 *Phase&nbsp;5 advanced AI features are partially integrated and not yet production ready.*
@@ -35,7 +37,7 @@ Prototype quantum-inspired communication utilities simulate secure SQL queries v
 
 ### **1. Unified Monitoring & Optimization System**
 **File**: [`unified_monitoring_optimization_system.py`](unified_monitoring_optimization_system.py)
-Status: thin wrapper for `scripts.monitoring.unified_monitoring_optimization_system`
+Status: stable CLI wrapper for `scripts.monitoring.unified_monitoring_optimization_system`
 
 #### **Technical Intent**
 - **Primary Function**: Centralized monitoring, performance optimization, and analytics with optional quantum-inspired enhancements
@@ -74,7 +76,7 @@ class UnifiedMonitoringOptimizationSystem:
 
 ### **2. Unified Script Generation System**
 **File**: [`unified_script_generation_system.py`](unified_script_generation_system.py)
-Status: thin wrapper for `scripts.utilities.unified_script_generation_system`
+Status: stable CLI wrapper for `scripts.utilities.unified_script_generation_system`
 
 #### **Technical Intent**
 - **Primary Function**: Enterprise-grade script generation with template intelligence and optional quantum-inspired enhancements (simulation only)
@@ -112,7 +114,7 @@ class UnifiedScriptGenerationSystem:
 
 ### **3. Unified Session Management System**
 **File**: [`unified_session_management_system.py`](unified_session_management_system.py)
-Status: thin wrapper for `scripts.utilities.unified_session_management_system`
+Status: stable CLI wrapper for `scripts.utilities.unified_session_management_system`
 
 #### **Technical Intent**
 - **Primary Function**: Enterprise-compliant session management with comprehensive integrity validation
@@ -148,7 +150,7 @@ class UnifiedSessionManagementSystem:
 
 ### **4. Unified Disaster Recovery System**
 **File**: [`unified_disaster_recovery_system.py`](unified_disaster_recovery_system.py)
-Status: thin wrapper for `scripts.utilities.unified_disaster_recovery_system`
+Status: stable CLI wrapper for `scripts.utilities.unified_disaster_recovery_system`
 
 #### **Technical Intent**
 - **Primary Function**: Enterprise-grade backup, recovery, and business continuity
@@ -224,7 +226,7 @@ class UnifiedLegacyCleanupSystem:
 
 ### **6. Web-GUI Integration System**
 **File**: [`web_gui_integration_system.py`](web_gui_integration_system.py)
-Status: thin wrapper for `scripts.utilities.web_gui_integration_system`
+Status: stable CLI wrapper for `scripts.utilities.web_gui_integration_system`
 
 #### **Technical Intent**
 - **Primary Function**: Enterprise-grade web interface for system management and monitoring

--- a/docs/QUANTUM_HARDWARE_SETUP.md
+++ b/docs/QUANTUM_HARDWARE_SETUP.md
@@ -1,8 +1,10 @@
 # Quantum Hardware Setup
 
-This guide outlines configuration steps for IBM Quantum integration. Current releases
-use simulators only; tokens and backend names are stored for future use but have no
-effect until real-device access is enabled.
+This guide outlines placeholder configuration steps for eventual IBM Quantum
+integration. Current releases operate **only** in simulator mode; tokens and
+backend names are stored for future use but have no effect until real-device
+access is enabled. Following these steps will not enable hardware execution
+today.
 
 ## 1. Acquire a Token
 1. Create an IBM Quantum account.
@@ -24,7 +26,7 @@ export IBM_BACKEND="ibmq_qasm_simulator"
 The orchestrator records this value but always uses the default simulator.
 
 ## 3. CLI Usage
-Use the executor CLI or orchestrator with hardware flags (placeholders):
+Use the executor CLI or orchestrator with hardware flags (placeholders only):
 ```bash
 python -m quantum.cli.executor_cli --use-hardware --backend ibm_nairobi
 python quantum_integration_orchestrator.py --hardware

--- a/tests/test_documentation_consistency.py
+++ b/tests/test_documentation_consistency.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+DOC_REFERENCES = {
+    "README.md": [
+        "simplified_quantum_integration_orchestrator.py",
+        "quantum_integration_orchestrator.py",
+        "scripts/wlc_session_manager.py",
+    ],
+    "docs/QUANTUM_HARDWARE_SETUP.md": [
+        "quantum_integration_orchestrator.py",
+    ],
+}
+
+
+def test_documentation_paths_exist():
+    repo_root = Path(__file__).resolve().parents[1]
+    for doc, refs in DOC_REFERENCES.items():
+        content = (repo_root / doc).read_text()
+        for ref in refs:
+            assert ref in content, f"{ref} not referenced in {doc}"
+            assert (repo_root / ref).exists(), f"{ref} missing in repository"
+
+
+def test_quantum_docs_refer_to_simulation():
+    repo_root = Path(__file__).resolve().parents[1]
+    readme_text = (repo_root / "README.md").read_text().lower()
+    hardware_doc_text = (repo_root / "docs/QUANTUM_HARDWARE_SETUP.md").read_text().lower()
+    assert "simulation" in readme_text
+    assert "simulation" in hardware_doc_text


### PR DESCRIPTION
## Summary
- clarify that hardware flags do not enable real quantum devices and wrappers are stable
- document placeholder status for IBM Quantum setup and log compliance scoring in the whitepaper
- add doc consistency test checking module paths and simulation-only statements

## Testing
- `ruff check tests/test_documentation_consistency.py`
- `pytest tests/test_documentation_consistency.py tests/test_documentation_validator.py`


------
https://chatgpt.com/codex/tasks/task_e_689129f1ba148331bbc02c348a8f3976