### PR TITLE
feat: add configurable quantum backend with simulator fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@
 The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality exists only as placeholder modules operating in simulation mode. Hooks for real hardware are planned but are not yet integrated, and several quantum modules remain stubs even when `qiskit-ibm-provider` is configured.
 
 > **Note**
-> Real hardware execution will be enabled through a forthcoming `QuantumExecutor` module. When tokens and backend flags are supplied, modules verify credentials but always fall back to simulators until hardware access is released.
+> Modules now expose backend selection via environment variables such as `QUANTUM_USE_HARDWARE`, `QUANTUM_BACKEND`, and `QISKIT_IBM_TOKEN`. When credentials or hardware are unavailable, they automatically fall back to simulators.
 > **Roadmap**
-> Hardware integration is in progress and will eventually leverage IBM Quantum backends, but no hardware execution is available today.
+> Hardware integration continues to mature and will eventually leverage IBM Quantum backends, with graceful simulator fallback when devices cannot be reached.
 > **Phase 5 AI**
-> Advanced AI integration features are fully integrated. They operate in simulation mode; hardware configuration currently has no effect.
+> Advanced AI integration features operate in simulation mode by default and only attempt hardware execution when explicitly configured.
 
 ### 🎯 **Recent Milestones**
 - **Lessons Learned Integration:** sessions automatically apply lessons from `learning_monitor.db`

--- a/tests/quantum/test_root_quantum_optimizer_backend.py
+++ b/tests/quantum/test_root_quantum_optimizer_backend.py
@@ -1,0 +1,29 @@
+import quantum_optimizer as qo
+
+
+class _DummyHardwareBackend:
+    name = "dummy_hardware"
+
+    class _Cfg:
+        simulator = False
+
+    def configuration(self):
+        return self._Cfg()
+
+
+def test_configure_backend_hardware(monkeypatch):
+    monkeypatch.setattr(
+        qo, "get_backend", lambda name, use_hardware: _DummyHardwareBackend()
+    )
+    opt = qo.QuantumOptimizer(lambda x: 0, [(0, 1)], use_hardware=True)
+    backend = opt.configure_backend(use_hardware=True)
+    assert backend.name == "dummy_hardware"
+    assert opt.use_hardware
+
+
+def test_run_fallback_to_simulator(monkeypatch):
+    monkeypatch.setattr(qo, "get_backend", lambda name, use_hardware: None)
+    opt = qo.QuantumOptimizer(lambda x: 0, [(0, 1)], use_hardware=True)
+    summary = opt.run()
+    assert "result" in summary
+    assert not opt.use_hardware

--- a/tests/test_quantum_algorithm_library_expansion.py
+++ b/tests/test_quantum_algorithm_library_expansion.py
@@ -80,7 +80,7 @@ def test_quantum_score_stub():
 
 
 def test_quantum_text_score_fallback(monkeypatch):
-    monkeypatch.setattr(qalexp, "get_backend", lambda **_: None)
+    monkeypatch.setattr(qalexp, "configure_backend", lambda **_: None)
     score = qalexp.quantum_text_score("abc", use_hardware=True)
     assert 0.0 <= score <= 1.0
 
@@ -105,7 +105,7 @@ def test_quantum_text_score_backend(monkeypatch):
         def run(self, *_, **__):
             return DummyJob()
 
-    monkeypatch.setattr(qalexp, "get_backend", lambda **_: DummyBackend())
+    monkeypatch.setattr(qalexp, "configure_backend", lambda **_: DummyBackend())
 
     score = qalexp.quantum_text_score("abc", use_hardware=True)
     assert 0.0 <= score <= 1.0


### PR DESCRIPTION
## Summary
- allow QuantumOptimizer to configure hardware backends with API tokens and automatic simulator fallback
- expose backend selection in quantum algorithm library with new `configure_backend`
- document environment variables for backend selection

## Testing
- `ruff check quantum_optimizer.py quantum_algorithm_library_expansion.py tests/test_quantum_algorithm_library_expansion.py tests/quantum/test_root_quantum_optimizer_backend.py`
- `pytest tests/quantum/test_root_quantum_optimizer_backend.py tests/test_quantum_algorithm_library_expansion.py`

------
https://chatgpt.com/codex/tasks/task_e_689129ec385c833187dc455d6795a804