### PR TITLE
feat: validate backups and docs metrics with secondary copilot

### DIFF
--- a/docs/PHASE5_TASKS_STARTED.md
+++ b/docs/PHASE5_TASKS_STARTED.md
@@ -100,3 +100,4 @@ These task stubs originate from the gap analysis report and have been formally s
 - [ ] 18. Standardize Dual-Copilot Validation — 40% complete
 - [ ] 19. Clarify Quantum Placeholder Features — 90% complete
 - [ ] 20. Implement Compliance Metrics Calculations — 40% complete
+- [x] Dual-copilot hooks added to `docs_metrics_validator.py` and `backup_archiver.py`

--- a/scripts/backup_archiver.py
+++ b/scripts/backup_archiver.py
@@ -13,6 +13,7 @@ import py7zr
 from enterprise_modules.compliance import validate_enterprise_operation
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.validation_utils import anti_recursion_guard
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 
 @anti_recursion_guard
@@ -37,6 +38,7 @@ def archive_backups() -> Path:
                 zf.write(item, item.relative_to(backup_root))
 
     logging.info("Archived backups to %s", archive_path)
+    SecondaryCopilotValidator().validate_corrections([], primary_success=True)
     return archive_path
 
 

--- a/scripts/docs_metrics_validator.py
+++ b/scripts/docs_metrics_validator.py
@@ -12,6 +12,8 @@ import argparse
 import sys
 from pathlib import Path
 
+from secondary_copilot_validator import SecondaryCopilotValidator
+
 if __package__ in {None, ""}:
     # Allow running as a script directly without module context
     SCRIPT_DIR = Path(__file__).resolve().parent
@@ -38,6 +40,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     success = validate(args.db_path)
+    SecondaryCopilotValidator().validate_corrections([], primary_success=success)
     return 0 if success else 1
 
 

--- a/tests/test_backup_archiver.py
+++ b/tests/test_backup_archiver.py
@@ -34,3 +34,30 @@ def test_archive_backups_disallows_internal_backup(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError):
         backup_archiver.archive_backups()
+
+
+def test_archive_backups_runs_secondary_validator(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = tmp_path / "bk"
+    backup_root.mkdir()
+    (backup_root / "file.txt").write_text("x")
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    from scripts import backup_archiver
+
+    called: dict[str, object] = {}
+
+    class DummyValidator:
+        def validate_corrections(self, files, primary_success=None):
+            called["args"] = (files, primary_success)
+            return True
+
+    monkeypatch.setattr(backup_archiver, "SecondaryCopilotValidator", lambda: DummyValidator())
+
+    archive_path = backup_archiver.archive_backups()
+
+    assert archive_path.exists()
+    assert called["args"] == ([], True)


### PR DESCRIPTION
## Summary
- run SecondaryCopilotValidator after docs metrics primary validation
- ensure backup archive process triggers secondary validator
- record dual-copilot hooks progress in phase 5 tasks

## Testing
- `ruff check scripts/backup_archiver.py scripts/docs_metrics_validator.py tests/test_docs_metrics.py tests/test_backup_archiver.py`
- `pytest tests/test_docs_metrics.py tests/test_backup_archiver.py`


------
https://chatgpt.com/codex/tasks/task_e_68913453de008331b6d368135db25886