### PR TITLE
feat: enable hardware execution for quantum modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@
 
 > Tests: run `pytest` before committing. Current repository tests report multiple failures.
 > Lint: run `ruff check .` before committing.
-> Quantum modules run in simulation only. Hardware flags and IBM Quantum credentials are ignored until the planned `QuantumExecutor` module arrives. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Compliance auditing is enforced via `EnterpriseComplianceValidator` with metrics stored in `analytics.db`.
+> Quantum modules attempt hardware execution when IBM Quantum credentials are provided and fall back to simulators when devices or tokens are unavailable. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Compliance auditing is enforced via `EnterpriseComplianceValidator` with metrics stored in `analytics.db`.
 > Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards.
 
 ---
 
 ## 📊 SYSTEM OVERVIEW
 
-The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality exists only as placeholder modules operating in simulation mode. Hooks for real hardware are planned but are not yet integrated, and several quantum modules remain stubs even when `qiskit-ibm-provider` is configured.
+The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality now supports optional hardware execution through IBM Quantum when credentials are supplied, with automatic simulator fallback when devices are unavailable.
 
 > **Note**
-> Modules now expose backend selection via environment variables such as `QUANTUM_USE_HARDWARE`, `QUANTUM_BACKEND`, and `QISKIT_IBM_TOKEN`. When credentials or hardware are unavailable, they automatically fall back to simulators.
+> Modules expose backend selection via environment variables such as `QUANTUM_USE_HARDWARE`, `QUANTUM_BACKEND`, and `QISKIT_IBM_TOKEN`. When credentials or hardware are unavailable, they automatically fall back to simulators.
 > **Roadmap**
 > Hardware integration continues to mature and will eventually leverage IBM Quantum backends, with graceful simulator fallback when devices cannot be reached.
 > **Phase 5 AI**
@@ -101,7 +101,9 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - PowerShell (for Windows automation)
 - SQLite3
 - Required packages: `pip install -r requirements.txt` (includes `py7zr` for 7z archive support)
-- Quantum routines use the Qiskit simulator only; installing `qiskit-ibm-provider` or setting `QUANTUM_USE_HARDWARE=1` has no effect because hardware execution is not yet supported
+- Quantum routines default to the Qiskit simulator but can use IBM Quantum
+  hardware when `qiskit-ibm-provider` is installed and credentials are
+  available
 
 ### **Installation & Setup**
 ```bash
@@ -287,14 +289,20 @@ print(f"[SUCCESS] Generated with {result.confidence_score}% confidence")
 python simplified_quantum_integration_orchestrator.py
 ```
 
-By default the orchestrator uses the simulator. Flags `--hardware` and `--backend` are placeholders with no effect; real-device execution is not available. A future `QuantumExecutor` module will handle IBM Quantum backends when hardware integration arrives.
+By default the orchestrator uses the simulator. Flags `--hardware` and
+`--backend` enable IBM Quantum devices when credentials are available and
+transparently fall back to the simulator otherwise.
 
 ```bash
-# placeholder flags; still executes on simulators
+# request hardware; falls back to simulator if unavailable
 python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
 ```
 
-Set `QISKIT_IBM_TOKEN` for future hardware execution. The value is ignored today and the orchestrator always falls back to simulation because hardware support is not yet implemented. See [docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for the integration roadmap.
+Provide an IBM Quantum token via the `QISKIT_IBM_TOKEN` environment variable or
+`--token` flag to enable hardware execution. Without credentials or when devices
+are unreachable, the orchestrator automatically falls back to simulation.
+See [docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for
+configuration details.
 
 ### Quantum Placeholder Modules
 
@@ -1140,8 +1148,9 @@ Set these variables in your `.env` file or shell before running scripts:
 - `OPENAI_API_KEY` – enables optional OpenAI features.
 - `FLASK_SECRET_KEY` – Flask dashboard secret.
 - `FLASK_RUN_PORT` – dashboard port (default `5000`).
- - `QISKIT_IBM_TOKEN` – placeholder for future IBM Quantum access (currently ignored).
- - `IBM_BACKEND` – placeholder for future hardware selection; defaults to `ibmq_qasm_simulator` with no real hardware support.
+ - `QISKIT_IBM_TOKEN` – IBM Quantum API token for hardware execution.
+ - `IBM_BACKEND` – preferred hardware backend; defaults to `ibmq_qasm_simulator`.
+ - `QUANTUM_USE_HARDWARE` – set to `1` to attempt hardware use when a token is available.
 - `LOG_WEBSOCKET_ENABLED` – set to `1` to stream logs.
 - `CLW_MAX_LINE_LENGTH` – max line length for the `clw` wrapper (default `1550`).
 

--- a/docs/QUANTUM_HARDWARE_SETUP.md
+++ b/docs/QUANTUM_HARDWARE_SETUP.md
@@ -1,10 +1,8 @@
 # Quantum Hardware Setup
 
-This guide outlines placeholder configuration steps for eventual IBM Quantum
-integration. Current releases operate **only** in simulator mode; tokens and
-backend names are stored for future use but have no effect until real-device
-access is enabled. Following these steps will not enable hardware execution
-today.
+This guide outlines configuration steps for IBM Quantum integration. Modules
+attempt hardware execution when valid credentials are provided and gracefully
+fall back to local simulators when devices are unavailable.
 
 ## 1. Acquire a Token
 1. Create an IBM Quantum account.
@@ -19,24 +17,26 @@ today.
    ```
 
 ## 2. Backend Selection
-Specify a backend name via `IBM_BACKEND` (currently ignored):
+Specify a backend name via `IBM_BACKEND`:
 ```bash
-export IBM_BACKEND="ibmq_qasm_simulator"
+export IBM_BACKEND="ibm_nairobi"
 ```
-The orchestrator records this value but always uses the default simulator.
+If the backend is unavailable the system falls back to `aer_simulator`.
 
 ## 3. CLI Usage
-Use the executor CLI or orchestrator with hardware flags (placeholders only):
+Use the executor CLI or orchestrator with hardware flags:
 ```bash
-python -m quantum.cli.executor_cli --use-hardware --backend ibm_nairobi
-python quantum_integration_orchestrator.py --hardware
+python -m quantum.cli.executor_cli --use-hardware --backend ibm_nairobi --token "$QISKIT_IBM_TOKEN"
+python quantum_integration_orchestrator.py --hardware --backend ibm_nairobi --token "$QISKIT_IBM_TOKEN"
 ```
-Regardless of backend settings, execution always uses simulators and logs a notice.
+If credentials are missing or the provider cannot reach the backend, execution
+falls back to simulation and logs a notice.
 
 ## 4. Expected Outputs
-When hardware access becomes available, logs will reflect the chosen backend. Until then,
-the system logs that simulation mode is enforced.
+Logs indicate whether a hardware backend or simulator was used. When hardware
+execution succeeds, backend names appear with `[QUANTUM_BACKEND]` tags; otherwise
+messages note the simulator fallback.
 
 ## 5. Roadmap
-Upcoming releases will introduce a `QuantumExecutor` module that manages credential
-authentication, backend selection, and automatic simulator fallback.
+Future releases will expand hardware provider support beyond IBM Quantum and add
+automated credential management.

--- a/quantum/README.md
+++ b/quantum/README.md
@@ -4,27 +4,32 @@ This package provides experimental quantum-inspired utilities used across the
 gh_COPILOT toolkit.
 
 > **Note**
-> All quantum modules run in simulation only. Installing `qiskit-ibm-provider` or setting `QISKIT_IBM_TOKEN` has no effect because hardware execution is not yet supported.
+> Modules automatically attempt hardware execution when IBM Quantum credentials
+> are supplied. Set `QISKIT_IBM_TOKEN` or pass a token directly to APIs. If
+> hardware access is unavailable the local simulator is used.
 
 ## Optimizers
 - `optimizers.quantum_optimizer.QuantumOptimizer` – classical/quantum hybrid
   optimizer with progress logging. Events are recorded using
   `utils.log_utils._log_event` when executed via higher-level workflows.
-  Use `configure_backend()` for consistent configuration; credentials are ignored and the local simulator is always selected.
+  Use `configure_backend()` for consistent configuration; credentials may be
+  supplied via argument or environment variable. Hardware backends are used
+  when available, otherwise the local simulator is selected.
 
 ## Database Search
 - `quantum.quantum_database_search` – lightweight helpers for SQL, NoSQL and
   hybrid search. All queries are logged to `analytics.db` for compliance.
 
-These modules always run on local simulators. The `--hardware` flag in
-`quantum_integration_orchestrator.py` and the `QUANTUM_USE_HARDWARE`
-environment variable are placeholders with no effect.
+These modules run on IBM Quantum hardware when credentials are provided and the
+environment supports the provider. The `--hardware` flag in
+`quantum_integration_orchestrator.py` and the `QUANTUM_USE_HARDWARE` environment
+variable enable hardware execution with automatic simulator fallback.
 
 ## IBM Quantum Access
 
-Hardware access is planned but not yet available. You may set
-`QISKIT_IBM_TOKEN` for future use, but it is currently ignored and the
-modules always fall back to local simulation.
+Set `QISKIT_IBM_TOKEN` or provide a token argument to enable hardware use. When
+no token is supplied or the provider fails to initialize, the system falls back
+to simulation.
 
 ## Algorithms
 
@@ -37,7 +42,8 @@ modules always fall back to local simulation.
 
 ## Backend utilities
 
-- `utils.backend_provider.get_backend` – currently returns the `Aer` simulator; hardware backends are ignored.
+  - `utils.backend_provider.get_backend` – selects an IBM Quantum backend when
+    credentials are available, otherwise returns the local `Aer` simulator.
 
 ## Pattern Recognition
 

--- a/quantum/ibm_backend.py
+++ b/quantum/ibm_backend.py
@@ -28,16 +28,30 @@ def _load_token_from_config() -> str | None:
 
 
 def init_ibm_backend(
+    token: str | None = None,
     token_env: str = "QISKIT_IBM_TOKEN",
     backend_env: str = "IBM_BACKEND",
 ) -> Tuple[Any, bool]:
     """Initialize an IBM quantum backend.
 
-    Returns a tuple ``(backend, use_hardware)``. If hardware initialization
-    fails or dependencies are missing, a simulator backend is returned with
-    ``use_hardware`` set to ``False``.
+    Parameters
+    ----------
+    token:
+        Optional API token. When provided it takes precedence over
+        environment variables and configuration files.
+    token_env:
+        Name of the environment variable that may contain the token.
+    backend_env:
+        Environment variable for selecting a specific backend.
+
+    Returns
+    -------
+    tuple
+        ``(backend, use_hardware)`` where ``backend`` is either a hardware
+        backend or the local simulator and ``use_hardware`` indicates whether
+        hardware execution will be used.
     """
-    token = os.getenv(token_env) or _load_token_from_config()
+    token = token or os.getenv(token_env) or _load_token_from_config()
     backend_name = os.getenv(backend_env)
 
     if IBMProvider is None or Aer is None:

--- a/quantum/optimizers/quantum_optimizer.py
+++ b/quantum/optimizers/quantum_optimizer.py
@@ -195,9 +195,9 @@ class QuantumOptimizer:
         requests an IBM Quantum backend and otherwise returns the local
         simulator.  ``ImportError`` is raised if no backend can be obtained.
         """
-        if token:
-            os.environ.setdefault("QISKIT_IBM_TOKEN", token)
-        backend = get_backend(backend_name, use_hardware=use_hardware)
+        backend = get_backend(
+            backend_name, use_hardware=use_hardware, token=token
+        )
         self.set_backend(backend, use_hardware)
         if backend is not None:
             return backend

--- a/quantum/orchestration/executor.py
+++ b/quantum/orchestration/executor.py
@@ -35,6 +35,7 @@ class QuantumExecutor:
         max_workers: int = 4,
         use_hardware: bool = False,
         backend_name: Optional[str] = None,
+        token: str | None = None,
     ):
         self.max_workers = max_workers
         self.logger = logging.getLogger(__name__)
@@ -43,13 +44,13 @@ class QuantumExecutor:
         env_backend = os.getenv("IBM_BACKEND", "ibmq_qasm_simulator")
         self.backend_name = backend_name or env_backend
         self.backend = None
-        env_token = os.getenv("QISKIT_IBM_TOKEN")
-        self.use_hardware = use_hardware or bool(env_token)
+        self.token = token or os.getenv("QISKIT_IBM_TOKEN")
+        self.use_hardware = use_hardware or bool(self.token)
         if self.use_hardware and not HAS_IBM_PROVIDER:
             self.logger.warning("IBM provider unavailable; using simulator")
             self.use_hardware = False
         if self.use_hardware:
-            backend, success = init_ibm_backend()
+            backend, success = init_ibm_backend(token=self.token)
             self.backend = backend
             self.use_hardware = success
         elif QISKIT_AVAILABLE:
@@ -62,7 +63,7 @@ class QuantumExecutor:
             if QISKIT_AVAILABLE:
                 return Aer.get_backend("qasm_simulator")
             return None
-        backend, success = init_ibm_backend()
+        backend, success = init_ibm_backend(token=self.token)
         self.use_hardware = success
         if success:
             return backend

--- a/tests/quantum/test_backend_provider.py
+++ b/tests/quantum/test_backend_provider.py
@@ -8,15 +8,31 @@ class DummyBackend:
 
 
 class DummyProvider:
+    def __init__(self, token=None):
+        self.token = token
+
     def get_backend(self, name):
         return DummyBackend()
 
 
 @pytest.mark.skipif(backend_provider.Aer is None, reason="Qiskit not available")
 def test_get_backend_uses_provider(monkeypatch):
-    monkeypatch.setattr(backend_provider, "IBMProvider", lambda: DummyProvider())
-    backend = backend_provider.get_backend("dummy", use_hardware=True)
+    monkeypatch.setattr(backend_provider, "IBMProvider", lambda token=None: DummyProvider(token))
+    backend = backend_provider.get_backend("dummy", use_hardware=True, token="abc")
     assert isinstance(backend, DummyBackend)
+
+
+@pytest.mark.skipif(backend_provider.Aer is None, reason="Qiskit not available")
+def test_get_backend_token_forwarded(monkeypatch):
+    captured = {}
+
+    def provider_factory(token=None):
+        captured["token"] = token
+        return DummyProvider(token)
+
+    monkeypatch.setattr(backend_provider, "IBMProvider", provider_factory)
+    backend_provider.get_backend("dummy", use_hardware=True, token="secret")
+    assert captured["token"] == "secret"
 
 
 @pytest.mark.skipif(backend_provider.Aer is None, reason="Qiskit not available")

--- a/tests/quantum/test_database_search_token.py
+++ b/tests/quantum/test_database_search_token.py
@@ -1,0 +1,70 @@
+import sqlite3
+
+from quantum import quantum_database_search as qdb
+
+
+class DummyCircuit:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def h(self, *_):
+        pass
+
+    def measure(self, *_):
+        pass
+
+
+class DummyBackend:
+    def run(self, *_args, **_kwargs):
+        class Result:
+            def result(self):
+                return None
+
+        return Result()
+
+
+class DummyProvider:
+    def __init__(self, token=None):
+        self.token = token
+
+    def get_backend(self, name):
+        return DummyBackend()
+
+
+def test_quantum_search_sql_token_forward(monkeypatch, tmp_path):
+    captured = {}
+
+    def provider_factory(token=None):
+        captured["token"] = token
+        return DummyProvider(token)
+    import sys
+    import types
+
+    monkeypatch.setitem(
+        sys.modules,
+        "qiskit_ibm_provider",
+        types.SimpleNamespace(IBMProvider=provider_factory),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "qiskit",
+        types.SimpleNamespace(QuantumCircuit=DummyCircuit),
+    )
+    monkeypatch.setenv("QUANTUM_DB_PATH", str(tmp_path / "log.db"))
+
+    db = tmp_path / "db.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE items(x INTEGER)")
+    conn.execute("INSERT INTO items VALUES (1)")
+    conn.commit()
+    conn.close()
+
+    qdb.quantum_search_sql(
+        "SELECT x FROM items",
+        db_path=db,
+        use_hardware=True,
+        backend_name="dummy",
+        token="tok",
+    )
+
+    assert captured["token"] == "tok"

--- a/tests/quantum/test_executor_hardware.py
+++ b/tests/quantum/test_executor_hardware.py
@@ -41,14 +41,14 @@ class MockProvider:
 
 def test_missing_token_fallback(monkeypatch):
     monkeypatch.delenv("QISKIT_IBM_TOKEN", raising=False)
-    monkeypatch.setattr(qexec, "init_ibm_backend", lambda: (MockBackend(), False))
+    monkeypatch.setattr(qexec, "init_ibm_backend", lambda token=None: (MockBackend(), False))
     exec_ = QuantumExecutor(use_hardware=True, backend_name="mock")
     assert exec_.use_hardware is False
 
 
 def test_hardware_execution(monkeypatch):
     backend = MockBackend()
-    monkeypatch.setattr(qexec, "init_ibm_backend", lambda: (backend, True))
+    monkeypatch.setattr(qexec, "init_ibm_backend", lambda token=None: (backend, True))
     exec_ = QuantumExecutor(use_hardware=True, backend_name="mock")
     result = exec_.execute_algorithm("dummy_test")
     assert result["success"]
@@ -80,3 +80,15 @@ def test_hardware_fallback(monkeypatch):
     assert exec_.use_hardware is False
     result = exec_.execute_algorithm("dummy_test")
     assert result["success"]
+
+
+def test_token_passed_to_init(monkeypatch):
+    captured = {}
+
+    def fake_init(token=None):
+        captured["token"] = token
+        return (MockBackend(), True)
+
+    monkeypatch.setattr(qexec, "init_ibm_backend", fake_init)
+    QuantumExecutor(use_hardware=True, backend_name="mock", token="abc")
+    assert captured["token"] == "abc"

--- a/tests/quantum/test_hardware_backend.py
+++ b/tests/quantum/test_hardware_backend.py
@@ -8,6 +8,7 @@ def test_init_backend_success(monkeypatch):
     provider = MagicMock()
     provider.return_value.get_backend.return_value = backend
     monkeypatch.setenv("QISKIT_IBM_TOKEN", "token")
+    monkeypatch.setenv("IBM_BACKEND", "backend")
     monkeypatch.setattr("quantum.ibm_backend.IBMProvider", provider)
     def _stub_get_backend_backend(name):
         return backend


### PR DESCRIPTION
## Summary
- allow `init_ibm_backend` and supporting utilities to accept explicit IBM Quantum credentials and select hardware when available
- expose token-aware hardware options across quantum database search and orchestrator modules with simulator fallback
- document IBM Quantum setup in docs and README, including new environment variables and CLI examples

## Testing
- `ruff check quantum tests/quantum/test_backend_provider.py tests/quantum/test_executor_hardware.py tests/quantum/test_database_search_token.py tests/quantum/test_hardware_backend.py`
- `pytest tests/quantum/test_backend_provider.py tests/quantum/test_executor_hardware.py tests/quantum/test_database_search_token.py tests/quantum/test_hardware_backend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891345e2d4483319a3e9ce1563e1cb3