### PR TITLE
fix: improve metrics fetching and add db sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,15 @@ jobs:
           echo "PATH=${{ github.workspace }}/.venv/bin:$PATH" >> $GITHUB_ENV
 
       - name: Install lint dependencies
-        run: pip install flake8 ruff
+        run: pip install flake8 ruff pyright
 
       - name: Run ruff
         run: |
           mkdir -p reports/lint
           ruff check . | tee reports/lint/ruff.txt
+
+      - name: Run pyright
+        run: pyright
 
       - name: Run flake8
         run: flake8 --config=.flake8 .

--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -45,7 +45,11 @@ def _load_metrics() -> dict[str, Any]:
             metrics = json.loads(METRICS_FILE.read_text()).get("metrics", {})
         except json.JSONDecodeError as exc:  # pragma: no cover - log and fall back
             logging.error("Metrics decode error: %s", exc)
-    metrics["compliance_score"] = get_latest_compliance_score(ANALYTICS_DB)
+    try:
+        metrics["compliance_score"] = get_latest_compliance_score(ANALYTICS_DB)
+    except sqlite3.Error as exc:  # pragma: no cover - missing table
+        logging.error("Compliance score fetch error: %s", exc)
+        metrics["compliance_score"] = 0.0
     try:
         with sqlite3.connect(ANALYTICS_DB) as conn:
             conn.row_factory = sqlite3.Row

--- a/tests/dashboard/test_additional_metrics.py
+++ b/tests/dashboard/test_additional_metrics.py
@@ -61,7 +61,9 @@ def test_app(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(cmu, "ensure_tables", lambda *a, **k: None)
     monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
     monkeypatch.setattr(cmu, "insert_event", lambda *a, **k: None)
+    import importlib
     from web_gui.scripts.flask_apps import enterprise_dashboard as ed
+    ed = importlib.reload(ed)
 
     monkeypatch.setattr(ed, "ANALYTICS_DB", db)
     monkeypatch.setattr(
@@ -79,6 +81,7 @@ def test_additional_metrics_present(test_app):
     metrics = resp.get_json()["metrics"]
     assert metrics["lessons_integration_status"] == "FULLY_INTEGRATED"
     assert metrics["average_query_latency"] == pytest.approx(12.5)
+    assert metrics["compliance_score"] == 0.0
 
 
 def test_metrics_endpoint_additional_metrics(test_app):
@@ -88,4 +91,5 @@ def test_metrics_endpoint_additional_metrics(test_app):
     metrics = resp.get_json()
     assert metrics["lessons_integration_status"] == "FULLY_INTEGRATED"
     assert metrics["average_query_latency"] == pytest.approx(12.5)
+    assert metrics["compliance_score"] == 0.0
 


### PR DESCRIPTION
## Summary
- handle missing compliance score tables gracefully
- add SQLite sync utility and tests
- run pyright during CI

## Testing
- `ruff check tools/automation_setup.py web_gui/scripts/flask_apps/enterprise_dashboard.py dashboard/enterprise_dashboard.py tests/dashboard/test_additional_metrics.py tests/test_tools_automation_setup.py`
- `pyright tools/automation_setup.py web_gui/scripts/flask_apps/enterprise_dashboard.py dashboard/enterprise_dashboard.py`
- `pytest` *(fails: tests/dashboard/test_placeholder_summary.py::test_placeholder_summary_created - sqlite3.OperationalError: table violation_logs already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68913467ca9c833190be14cbfbd3b84a