### PR TITLE
feat: add dual validation to backup and migration scripts

### DIFF
--- a/scripts/backup_archiver.py
+++ b/scripts/backup_archiver.py
@@ -13,7 +13,10 @@ import py7zr
 from enterprise_modules.compliance import validate_enterprise_operation
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.validation_utils import anti_recursion_guard
-from secondary_copilot_validator import SecondaryCopilotValidator
+from secondary_copilot_validator import (
+    SecondaryCopilotValidator,
+    run_dual_copilot_validation,
+)
 
 
 @anti_recursion_guard
@@ -38,7 +41,16 @@ def archive_backups() -> Path:
                 zf.write(item, item.relative_to(backup_root))
 
     logging.info("Archived backups to %s", archive_path)
-    SecondaryCopilotValidator().validate_corrections([], primary_success=True)
+
+    validator = SecondaryCopilotValidator()
+
+    def _primary() -> bool:
+        return archive_path.exists()
+
+    def _secondary() -> bool:
+        return validator.validate_corrections([], primary_success=True)
+
+    run_dual_copilot_validation(_primary, _secondary)
     return archive_path
 
 

--- a/scripts/database/database_migration_verifier.py
+++ b/scripts/database/database_migration_verifier.py
@@ -11,6 +11,11 @@ from datetime import datetime
 from pathlib import Path
 
 
+from secondary_copilot_validator import (
+    SecondaryCopilotValidator,
+    run_dual_copilot_validation,
+)
+
 class DatabaseMigrationVerifier:
     """✅ Verify Database Migration Completion"""
 
@@ -237,7 +242,15 @@ def main():
     """🎯 Main execution function"""
     verifier = DatabaseMigrationVerifier()
     verifier.execute_verification()
+    validator = SecondaryCopilotValidator()
 
+    def _primary() -> bool:
+        return True
+
+    def _secondary() -> bool:
+        return validator.validate_corrections([])
+
+    run_dual_copilot_validation(_primary, _secondary)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_backup_archiver.py
+++ b/tests/test_backup_archiver.py
@@ -50,14 +50,34 @@ def test_archive_backups_runs_secondary_validator(tmp_path, monkeypatch):
 
     called: dict[str, object] = {}
 
-    class DummyValidator:
-        def validate_corrections(self, files, primary_success=None):
-            called["args"] = (files, primary_success)
-            return True
+    def fake_validation(primary, secondary):
+        called["called"] = True
+        return primary() and secondary()
 
-    monkeypatch.setattr(backup_archiver, "SecondaryCopilotValidator", lambda: DummyValidator())
+    monkeypatch.setattr(backup_archiver, "run_dual_copilot_validation", fake_validation)
 
     archive_path = backup_archiver.archive_backups()
 
     assert archive_path.exists()
-    assert called["args"] == ([], True)
+    assert called["called"] is True
+
+
+def test_archive_backups_validator_failure(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = tmp_path / "bk"
+    backup_root.mkdir()
+    (backup_root / "file.txt").write_text("x")
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    from scripts import backup_archiver
+
+    def fake_validation(primary, secondary):
+        raise RuntimeError("validation failed")
+
+    monkeypatch.setattr(backup_archiver, "run_dual_copilot_validation", fake_validation)
+
+    with pytest.raises(RuntimeError, match="validation failed"):
+        backup_archiver.archive_backups()

--- a/tests/test_database_migration_verifier.py
+++ b/tests/test_database_migration_verifier.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+def test_database_migration_verifier_runs_validator(monkeypatch):
+    from scripts.database import database_migration_verifier as dmv
+
+    monkeypatch.setattr(dmv.DatabaseMigrationVerifier, "execute_verification", lambda self: None)
+
+    called = {}
+
+    def fake_validation(primary, secondary):
+        called["called"] = True
+        return primary() and secondary()
+
+    monkeypatch.setattr(dmv, "run_dual_copilot_validation", fake_validation)
+
+    dmv.main()
+    assert called["called"] is True
+
+
+def test_database_migration_verifier_validator_failure(monkeypatch):
+    from scripts.database import database_migration_verifier as dmv
+
+    monkeypatch.setattr(dmv.DatabaseMigrationVerifier, "execute_verification", lambda self: None)
+
+    def fake_validation(primary, secondary):
+        raise RuntimeError("validation failed")
+
+    monkeypatch.setattr(dmv, "run_dual_copilot_validation", fake_validation)
+
+    with pytest.raises(RuntimeError, match="validation failed"):
+        dmv.main()


### PR DESCRIPTION
## Summary
- ensure backup_archiver archives backups and runs dual-copilot validator
- run dual-copilot validator after database migration verification
- test backup and migration scripts handle validator success and failure

## Testing
- `ruff check scripts/backup_archiver.py scripts/database/database_migration_verifier.py tests/test_backup_archiver.py tests/test_database_migration_verifier.py`
- `pytest tests/test_backup_archiver.py tests/test_database_migration_verifier.py`


------
https://chatgpt.com/codex/tasks/task_e_68913e1194588331bf2bca8b0b1332a8