### PR TITLE
docs: clarify simulation-only quantum modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > Tests: run `pytest` before committing. Current repository tests report multiple failures.
 > Lint: run `ruff check .` before committing.
-> Quantum modules run exclusively in simulation mode; hardware flags are currently ignored. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics.db`.
+> Quantum modules run exclusively in simulation mode; hardware flags are currently ignored. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Module completion status is tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics.db`.
 > Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards.
 
 ---
@@ -303,20 +303,20 @@ print(f"[SUCCESS] Generated with {result.confidence_score}% confidence")
 python simplified_quantum_integration_orchestrator.py
 ```
 
-By default the orchestrator uses the simulator. Flags `--hardware` and
-`--backend` enable IBM Quantum devices when credentials are available and
-transparently fall back to the simulator otherwise.
+The orchestrator always uses the simulator. Flags `--hardware` and
+`--backend` are placeholders for future IBM Quantum device selection and are
+currently ignored.
 
 ```bash
-# request hardware; falls back to simulator if unavailable
+# hardware flags are no-ops; simulator always used
 python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
 ```
 
-Provide an IBM Quantum token via the `QISKIT_IBM_TOKEN` environment variable or
-`--token` flag to enable hardware execution. Without credentials or when devices
-are unreachable, the orchestrator automatically falls back to simulation.
-See [docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for
-configuration details.
+IBM Quantum tokens and the `--token` flag are currently ignored; hardware
+execution is not implemented. See
+[docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for future
+configuration notes and [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md)
+for module status.
 
 ### Quantum Placeholder Modules
 
@@ -1162,9 +1162,9 @@ Set these variables in your `.env` file or shell before running scripts:
 - `OPENAI_API_KEY` – enables optional OpenAI features.
 - `FLASK_SECRET_KEY` – Flask dashboard secret.
 - `FLASK_RUN_PORT` – dashboard port (default `5000`).
- - `QISKIT_IBM_TOKEN` – IBM Quantum API token for hardware execution.
- - `IBM_BACKEND` – preferred hardware backend; defaults to `ibmq_qasm_simulator`.
- - `QUANTUM_USE_HARDWARE` – set to `1` to attempt hardware use when a token is available.
+ - `QISKIT_IBM_TOKEN` – placeholder for a future IBM Quantum API token; currently ignored.
+ - `IBM_BACKEND` – preferred hardware backend for future use; defaults to `ibmq_qasm_simulator`.
+ - `QUANTUM_USE_HARDWARE` – no-op flag reserved for eventual hardware execution.
 - `LOG_WEBSOCKET_ENABLED` – set to `1` to stream logs.
 - `CLW_MAX_LINE_LENGTH` – max line length for the `clw` wrapper (default `1550`).
 

--- a/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -19,7 +19,8 @@ session wrap-up.
 *Phase&nbsp;5 advanced AI features are partially integrated and not yet production ready.*
 
 Module completion status and outstanding tasks are tracked in
-[PHASE5_TASKS_STARTED.md](PHASE5_TASKS_STARTED.md).
+[PHASE5_TASKS_STARTED.md](PHASE5_TASKS_STARTED.md). Detailed stub progress is
+available in [STUB_MODULE_STATUS.md](STUB_MODULE_STATUS.md).
 
 ### **Core Technical Architecture**
 - **Unified Enterprise Systems**: Gradual consolidation of legacy scripts into modular packages

--- a/docs/QUANTUM_HARDWARE_SETUP.md
+++ b/docs/QUANTUM_HARDWARE_SETUP.md
@@ -1,10 +1,13 @@
 # Quantum Hardware Setup
 
-This guide outlines configuration steps for IBM Quantum integration. Modules
-attempt hardware execution when valid credentials are provided and gracefully
-fall back to local simulators when devices are unavailable.
+> **Status:** Hardware execution is not supported. This guide is retained for
+future reference. Current modules always use local simulators and ignore all
+hardware flags.
 
-## 1. Acquire a Token
+This document outlines prospective configuration steps for IBM Quantum
+integration. At present, modules run exclusively in simulation mode.
+
+## 1. Acquire a Token (Future)
 1. Create an IBM Quantum account.
 2. Generate an API token from the account dashboard.
 3. Set the token as an environment variable:
@@ -15,28 +18,31 @@ fall back to local simulators when devices are unavailable.
    ```json
    {"QISKIT_IBM_TOKEN": "your_token_here"}
    ```
+   Tokens are currently unused but will be required once hardware
+   integration lands.
 
-## 2. Backend Selection
+## 2. Backend Selection (Future)
 Specify a backend name via `IBM_BACKEND`:
 ```bash
 export IBM_BACKEND="ibm_nairobi"
 ```
-If the backend is unavailable the system falls back to `aer_simulator`.
+Backend variables are ignored today; the system always uses `aer_simulator`.
 
 ## 3. CLI Usage
-Use the executor CLI or orchestrator with hardware flags:
+Hardware flags are accepted but currently have no effect. Example commands run
+in simulation regardless of the parameters:
 ```bash
 python -m quantum.cli.executor_cli --use-hardware --backend ibm_nairobi --token "$QISKIT_IBM_TOKEN"
 python quantum_integration_orchestrator.py --hardware --backend ibm_nairobi --token "$QISKIT_IBM_TOKEN"
 ```
-If credentials are missing or the provider cannot reach the backend, execution
-falls back to simulation and logs a notice.
+All executions log that the simulator was used.
 
 ## 4. Expected Outputs
-Logs indicate whether a hardware backend or simulator was used. When hardware
-execution succeeds, backend names appear with `[QUANTUM_BACKEND]` tags; otherwise
-messages note the simulator fallback.
+Logs currently always show `[QUANTUM_BACKEND] aer_simulator`; hardware backends
+are not reachable.
 
 ## 5. Roadmap
 Future releases will expand hardware provider support beyond IBM Quantum and add
-automated credential management.
+automated credential management. Track progress in
+[STUB_MODULE_STATUS.md](STUB_MODULE_STATUS.md) and
+[QUANTUM_PLACEHOLDERS.md](QUANTUM_PLACEHOLDERS.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,3 +101,5 @@ utilities detect this marker to skip the modules so they are never included
 in production builds. Importing them while `GH_COPILOT_ENV` is set to
 `"production"` raises a `RuntimeError` via `ensure_not_production`.
 They remain importable for experimentation and planning.
+Progress on these placeholders and other pending modules is tracked in
+[STUB_MODULE_STATUS.md](STUB_MODULE_STATUS.md).

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -28,6 +28,7 @@ The gh_COPILOT Toolkit v4.0 represents a revolutionary enterprise-grade automati
 - **Advanced AI Integration**: tooling supports further automation efforts
 - **Quantum-Enhanced Processing**: placeholder algorithms under exploration
  - *All Qiskit-based functions run in simulation mode only. Installing `qiskit-ibm-provider` and setting `QISKIT_IBM_TOKEN` has no effect because IBM Quantum hardware integration is not yet available and several quantum modules remain stubs.*
+ - Module completion and placeholder tracking are detailed in [../docs/STUB_MODULE_STATUS.md](../docs/STUB_MODULE_STATUS.md).
 - **Enterprise Security Framework**: Zero-tolerance anti-recursion and comprehensive session integrity
  - *Note: earlier drafts referenced a 32+ database ecosystem. The current repository contains **27** SQLite databases for testing.*
 


### PR DESCRIPTION
## Summary
- note simulation-only quantum modules in README and link to STUB_MODULE_STATUS
- mark quantum hardware setup guide as future reference and cross-link placeholder status
- update whitepapers and docs README with module status references

## Testing
- `ruff check .` *(fails: 18 errors, 7 fixable)*
- `pytest` *(23 passed, 2 skipped, 101 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68913e17b168833195fb57ff87848254