### PR TITLE
feat: add composite compliance score

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -26,11 +26,11 @@ from tqdm import tqdm
 from utils.log_utils import ensure_tables, insert_event
 from enterprise_modules.compliance import (
     validate_enterprise_operation,
-    calculate_composite_score,
     record_code_quality_metrics,
     _run_ruff,
     _run_pytest,
 )
+from utils.validation_utils import calculate_composite_compliance_score
 from disaster_recovery_orchestrator import DisasterRecoveryOrchestrator
 from unified_monitoring_optimization_system import (
     EnterpriseUtility,
@@ -254,22 +254,21 @@ class ComplianceMetricsUpdater:
         else:
             ruff_issues = _run_ruff()
             tests_passed, tests_failed = _run_pytest()
-        composite, breakdown = calculate_composite_score(
+        scores = calculate_composite_compliance_score(
             ruff_issues,
             tests_passed,
             tests_failed,
             metrics.get("open_placeholders", 0),
-            metrics.get("resolved_placeholders", 0),
         )
-        metrics["composite_score"] = composite
-        metrics["score_breakdown"] = breakdown
+        metrics["composite_score"] = scores["composite"]
+        metrics["score_breakdown"] = scores
         record_code_quality_metrics(
             ruff_issues,
             tests_passed,
             tests_failed,
             metrics.get("open_placeholders", 0),
             metrics.get("resolved_placeholders", 0),
-            composite,
+            scores["composite"],
             db_path=ANALYTICS_DB,
             test_mode=test_mode,
         )

--- a/tests/dashboard/test_score_serialization.py
+++ b/tests/dashboard/test_score_serialization.py
@@ -6,7 +6,7 @@ import pytest
 import dashboard.enterprise_dashboard as ed
 
 
-def test_metrics_include_composite_score(tmp_path, monkeypatch):
+def _prepare_metrics(tmp_path, monkeypatch):
     metrics_file = tmp_path / "metrics.json"
     metrics_file.write_text(json.dumps({"metrics": {}}), encoding="utf-8")
     db = tmp_path / "analytics.db"
@@ -27,7 +27,7 @@ def test_metrics_include_composite_score(tmp_path, monkeypatch):
             """
         )
         conn.execute(
-            "INSERT INTO compliance_scores VALUES ('ts', 81.67)"
+            "INSERT INTO compliance_scores VALUES ('ts', 84.0)"
         )
         conn.execute(
             """
@@ -41,7 +41,20 @@ def test_metrics_include_composite_score(tmp_path, monkeypatch):
         conn.commit()
     monkeypatch.setattr(ed, "METRICS_FILE", metrics_file)
     monkeypatch.setattr(ed, "ANALYTICS_DB", db)
-    data = ed._load_metrics()["metrics"]
-    assert data["compliance_score"] == 81.67
-    assert data["composite_score"] == pytest.approx(81.67, rel=1e-3)
+    return ed.app.test_client(), ed
+
+
+def test_metrics_include_composite_score(tmp_path, monkeypatch):
+    _, ed_module = _prepare_metrics(tmp_path, monkeypatch)
+    data = ed_module._load_metrics()["metrics"]
+    assert data["compliance_score"] == 84.0
+    assert data["composite_score"] == pytest.approx(84.0, rel=1e-3)
     assert data["score_breakdown"]["placeholder_score"] == pytest.approx(70.0, rel=1e-3)
+
+
+def test_dashboard_compliance_route(tmp_path, monkeypatch):
+    client, _ = _prepare_metrics(tmp_path, monkeypatch)
+    resp = client.get("/dashboard/compliance")
+    data = resp.get_json()["metrics"]
+    assert data["composite_score"] == pytest.approx(84.0, rel=1e-3)
+    assert data["score_breakdown"]["lint_score"] == pytest.approx(95.0, rel=1e-3)

--- a/tests/test_compliance_metrics.py
+++ b/tests/test_compliance_metrics.py
@@ -14,7 +14,7 @@ def test_composite_score_mixed_inputs():
     assert scores["lint_score"] == 90.0
     assert scores["test_score"] == 80.0
     assert scores["placeholder_score"] == 70.0
-    assert scores["composite"] == 81.0
+    assert scores["composite"] == 82.0
 
 
 def test_composite_score_handles_zero_tests():
@@ -22,4 +22,4 @@ def test_composite_score_handles_zero_tests():
     assert scores["lint_score"] == 95.0
     assert scores["test_score"] == 0.0
     assert scores["placeholder_score"] == 80.0
-    assert scores["composite"] == 44.5
+    assert scores["composite"] == 54.0

--- a/utils/validation_utils.py
+++ b/utils/validation_utils.py
@@ -36,7 +36,8 @@ def calculate_composite_compliance_score(
     -------
     Dict[str, float]
         Dictionary containing ``lint_score``, ``test_score``,
-        ``placeholder_score`` and ``composite``.
+        ``placeholder_score`` and ``composite``. The composite score is
+        weighted at 40% lint, 40% tests, and 20% placeholders.
     """
 
     total_tests = tests_passed + tests_failed
@@ -44,7 +45,8 @@ def calculate_composite_compliance_score(
     lint_score = max(0.0, 100 - ruff_issues)
     placeholder_score = max(0.0, 100 - (10 * placeholders))
     composite = round(
-        0.3 * lint_score + 0.5 * test_score + 0.2 * placeholder_score, 2
+        0.4 * lint_score + 0.4 * test_score + 0.2 * placeholder_score,
+        2,
     )
     return {
         "lint_score": round(lint_score, 2),


### PR DESCRIPTION
## Summary
- weight lint, test, and placeholder metrics in `calculate_composite_compliance_score`
- compute and persist composite score for dashboard metrics
- surface composite score on enterprise dashboard and compliance endpoint

## Testing
- `ruff check utils/validation_utils.py dashboard/compliance_metrics_updater.py dashboard/enterprise_dashboard.py tests/test_compliance_metrics.py tests/dashboard/test_score_serialization.py`
- `pytest tests/test_compliance_metrics.py tests/dashboard/test_score_serialization.py`


------
https://chatgpt.com/codex/tasks/task_e_68913e211c18833190ff3d9fca29970e