### PR TITLE
fix: harden placeholder audit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ tmp/
 databases/analytics.db
 databases/*.db
 databases/*.zip
+analytics.db
+database_cleanup.log
+artifacts/logs/
+.coverage*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ extend-exclude = [
     "deployment_package_*",
     "databases/*.db",
     "*.log",
+    "misc",
     "scripts/enterprise/*",
     "scripts/optimization/*",
     "scripts/utilities/*",

--- a/scripts/database/cross_database_sync_logger.py
+++ b/scripts/database/cross_database_sync_logger.py
@@ -23,7 +23,6 @@ from enterprise_modules.compliance import validate_enterprise_operation
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.log_utils import log_event
 from utils.logging_utils import setup_enterprise_logging
-from utils.log_utils import log_event
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_cross_database_sync_logger.py
+++ b/tests/test_cross_database_sync_logger.py
@@ -3,10 +3,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from scripts.database.cross_database_sync_logger import (
-    log_sync_operation,
-    log_sync_operation_with_analytics,
-)
+from scripts.database.cross_database_sync_logger import log_sync_operation
 from scripts.database.unified_database_initializer import initialize_database
 
 


### PR DESCRIPTION
## Summary
- handle missing columns when logging compliance violations
- trim ruff checks and cleanup duplicate imports
- stabilize placeholder audit test with lightweight stubs
- ignore coverage and temp analytics artifacts

## Testing
- `ruff check .`
- `pyright tests/dashboard/test_placeholder_summary.py scripts/correction_logger_and_rollback.py scripts/database/cross_database_sync_logger.py tests/test_cross_database_sync_logger.py tests/placeholder_audit/test_full_scan.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68913e2516588331bb1d1a852679af3b