### PR TITLE
docs: add daily state white-paper index

### DIFF
--- a/documentation/generated/README.md
+++ b/documentation/generated/README.md
@@ -53,6 +53,9 @@ The gh_COPILOT Toolkit is an enterprise-grade system following database-first ar
 3. **Documentation Access**: Use web-GUI dashboard or database queries
 4. **Script Execution**: All scripts enterprise-validated and database-tracked
 
+### 📅 Daily White‑Paper Updates
+See [daily state index](daily_state_index.md) for links to daily white‑paper PDFs and their Markdown versions.
+
 For detailed instructions, see the generated documentation files in this directory.
 
 ---

--- a/documentation/generated/daily_state_index.md
+++ b/documentation/generated/daily_state_index.md
@@ -1,0 +1,10 @@
+# Daily State White‑Paper Index
+
+| Date | Summary | PDF | Markdown |
+|------|---------|-----|----------|
+| 2025‑07‑30 | Snapshot of gh_COPILOT project state for 2025‑07‑30 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9107%E2%80%9130%29.pdf>) | [Markdown](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9107%E2%80%9130%29.md>) |
+| 2025‑07‑31 | Snapshot of gh_COPILOT project state for 2025‑07‑31 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9107%E2%80%9131%29.pdf>) | [Markdown](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9107%E2%80%9131%29.md>) |
+| 2025‑08‑01 | Snapshot of gh_COPILOT project state for 2025‑08‑01 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9101%29.pdf>) | [Markdown](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9101%29.md>) |
+| 2025‑08‑02 | Snapshot of gh_COPILOT project state for 2025‑08‑02 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9102%29.pdf>) | [Markdown](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9102%29.md>) |
+| 2025‑08‑03 | Snapshot of gh_COPILOT project state for 2025‑08‑03 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9103%29.pdf>) | [Markdown](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9103%29.md>) |
+| 2025‑08‑04 | Snapshot of gh_COPILOT project state for 2025‑08‑04 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9104%29.pdf>) | [Markdown](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9104%29.md>) |


### PR DESCRIPTION
## Summary
- add generated `daily_state_index.md` listing daily white-paper PDFs with links to Markdown versions
- reference the new index from `documentation/generated/README.md`

## Testing
- `ruff check .` *(fails: F821 Undefined name `breakdown` and `time`)*
- `pytest` *(fails: tests/dashboard/test_live_metrics.py::test_metrics_table)*

------
https://chatgpt.com/codex/tasks/task_e_68921914ba94833186c8018acfc831cc