### PR TITLE
feat: ensure PDFs include accessible text versions

### DIFF
--- a/documentation/generated/AGENT_NOTES.md
+++ b/documentation/generated/AGENT_NOTES.md
@@ -3,6 +3,9 @@
 
 *Generated from Documentation Database on 2025-07-10 12:58:26*
 
+> **Accessibility Reminder:** When adding PDFs here, also generate a Markdown
+> or HTML version using the automated converter so content remains accessible.
+
 ### 📊 **RECENT AGENT INSIGHTS**
 
 #### 🚀 ENVIRONMENT EFFICIENCY OPTIMIZATION: 86.3% → 100%

--- a/scripts/documentation/enterprise_documentation_manager.py
+++ b/scripts/documentation/enterprise_documentation_manager.py
@@ -62,6 +62,14 @@ def _create_simple_pdf(path: Path, text: str) -> None:
     path.write_bytes(pdf_bytes)
 
 
+def _ensure_accessible_formats(formats: Iterable[str]) -> List[str]:
+    """Return output formats ensuring PDFs have a text companion."""
+    fmt_list = list(formats)
+    if "pdf" in fmt_list and not any(f in {"md", "html"} for f in fmt_list):
+        fmt_list.append("md")
+    return fmt_list
+
+
 TEXT_INDICATORS = {
     "start": "[START]",
     "success": "[SUCCESS]",
@@ -121,8 +129,12 @@ class EnterpriseDocumentationManager:
 
     # ------------------------------------------------------------------
     def generate_files(self, doc_type: str, output_formats: Iterable[str] | None = None) -> List[Path]:
-        """Generate documentation files for ``doc_type`` in multiple formats."""
-        formats = list(output_formats or ["md"])  # default markdown for backward compat
+        """Generate documentation files for ``doc_type`` in multiple formats.
+
+        If ``pdf`` is requested without a text-based format, a Markdown copy is
+        automatically produced to preserve accessible structure.
+        """
+        formats = _ensure_accessible_formats(output_formats or ["md"])  # default markdown for backward compat
         docs = self.query_documentation(doc_type)
         if not docs:
             return []


### PR DESCRIPTION
## Summary
- add format guard so PDF outputs generate a Markdown companion for accessibility
- instruct contributors in generated notes to provide text versions
- test that PDF-only requests still emit Markdown preserving headings

## Testing
- `ruff check scripts/documentation/enterprise_documentation_manager.py tests/test_documentation_manager.py`
- `pytest tests/test_documentation_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68921916303483318bba63cf06c98c2f