### PR TITLE
feat: add recursion depth and pid tracking

### DIFF
--- a/tests/test_compliance_anti_recursion_guard.py
+++ b/tests/test_compliance_anti_recursion_guard.py
@@ -1,0 +1,39 @@
+import threading
+import time
+
+import pytest
+
+from enterprise_modules.compliance import anti_recursion_guard, MAX_RECURSION_DEPTH
+
+
+def test_guard_aborts_on_nested_directories(tmp_path):
+    """The guard aborts when recursion depth exceeds the limit."""
+
+    current = tmp_path
+    for i in range(MAX_RECURSION_DEPTH + 1):
+        current = current / f"lvl{i}"
+        current.mkdir()
+
+    @anti_recursion_guard
+    def walk(path):
+        for child in path.iterdir():
+            if child.is_dir():
+                walk(child)
+
+    with pytest.raises(RuntimeError):
+        walk(tmp_path)
+
+
+def test_guard_aborts_on_duplicate_pid():
+    """Concurrent invocation by the same PID triggers early abort."""
+
+    @anti_recursion_guard
+    def slow_call():
+        time.sleep(0.2)
+
+    t = threading.Thread(target=slow_call)
+    t.start()
+    time.sleep(0.05)
+    with pytest.raises(RuntimeError):
+        slow_call()
+    t.join()


### PR DESCRIPTION
## Summary
- add anti_recursion_guard decorator with recursion depth and PID tracking
- ensure guard exported from compliance module
- add tests for nested directory recursion and duplicate PID handling

## Testing
- `ruff check enterprise_modules/compliance.py tests/test_compliance_anti_recursion_guard.py`
- `pytest tests/test_compliance_anti_recursion_guard.py tests/test_anti_recursion_guard.py tests/test_validation_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68921d7659b8833185d4f88500224502