### PR TITLE
feat: enable hardware backend selection and quantum database search

### DIFF
--- a/quantum/README.md
+++ b/quantum/README.md
@@ -5,8 +5,9 @@ gh_COPILOT toolkit.
 
 > **Note**
 > Modules automatically attempt hardware execution when IBM Quantum credentials
-> are supplied. Set `QISKIT_IBM_TOKEN` or pass a token directly to APIs. If
-> hardware access is unavailable the local simulator is used.
+> are supplied. Set `QISKIT_IBM_TOKEN` or pass a token directly to APIs. The
+> `QUANTUM_USE_HARDWARE` environment variable forces hardware mode when set to
+> `"1"`. If hardware access is unavailable the local simulator is used.
 
 ## Optimizers
 - `optimizers.quantum_optimizer.QuantumOptimizer` – classical/quantum hybrid

--- a/quantum/orchestration/executor.py
+++ b/quantum/orchestration/executor.py
@@ -45,7 +45,8 @@ class QuantumExecutor:
         self.backend_name = backend_name or env_backend
         self.backend = None
         self.token = token or os.getenv("QISKIT_IBM_TOKEN")
-        self.use_hardware = use_hardware or bool(self.token)
+        env_use = os.getenv("QUANTUM_USE_HARDWARE", "0") == "1"
+        self.use_hardware = use_hardware or bool(self.token) or env_use
         if self.use_hardware and not HAS_IBM_PROVIDER:
             self.logger.warning("IBM provider unavailable; using simulator")
             self.use_hardware = False

--- a/tests/quantum/test_database_search_hardware.py
+++ b/tests/quantum/test_database_search_hardware.py
@@ -1,0 +1,44 @@
+"""Integration tests for QuantumDatabaseSearch hardware execution."""
+
+import sqlite3
+
+import pytest
+
+from quantum.algorithms.database_search import QuantumDatabaseSearch
+
+
+class DummyBackend:
+    def __init__(self):
+        self.called = False
+
+    def run(self, *_args, **_kwargs):
+        self.called = True
+
+        class _Result:
+            def result(self):  # pragma: no cover - simple container
+                class _Counts:
+                    def get_counts(self):
+                        return {"01": 1024}
+
+                return _Counts()
+
+        return _Result()
+
+
+def test_hardware_path_invoked(monkeypatch, tmp_path):
+    pytest.importorskip("qiskit")
+
+    db = tmp_path / "db.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE items(val INTEGER)")
+    conn.executemany("INSERT INTO items VALUES (?)", [(1,), (2,)])
+    conn.commit()
+    conn.close()
+
+    algo = QuantumDatabaseSearch(str(db), "items", "val")
+    backend = DummyBackend()
+    algo.set_backend(backend, use_hardware=True)
+
+    assert algo.execute_algorithm(2)
+    assert backend.called
+


### PR DESCRIPTION
## Summary
- support `QUANTUM_USE_HARDWARE` env var for `QuantumExecutor`
- run Grover-based hardware search in `QuantumDatabaseSearch`
- document hardware env variable and add hardware integration test

## Testing
- `ruff check quantum/orchestration/executor.py quantum/algorithms/database_search.py tests/quantum/test_database_search_hardware.py`
- `pytest tests/quantum/test_executor_hardware.py tests/quantum/test_database_search_hardware.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68921da90a4883319edc16bc810e1100