### PR TITLE
feat: add dual-copilot validation helpers

### DIFF
--- a/scripts/database/documentation_db_analyzer.py
+++ b/scripts/database/documentation_db_analyzer.py
@@ -193,12 +193,17 @@ def analyze_documentation_tables(db_paths: list[Path], analytics: Path) -> list[
 
 
 def validate_analysis(analytics_db: Path, expected: int) -> bool:
-    """Check that at least ``expected`` records exist in ``doc_audit``."""
+    """Check that at least ``expected`` records exist in ``doc_audit``.
+
+    A secondary validator confirms the analytics database was touched,
+    aligning with the dual-copilot requirement.
+    """
     if not analytics_db.exists():
         return False
     with sqlite3.connect(analytics_db) as conn:
         cur = conn.execute("SELECT COUNT(*) FROM doc_audit")
         count = cur.fetchone()[0]
+    SecondaryCopilotValidator().validate_corrections([str(analytics_db)])
     return count >= expected
 
 

--- a/template_engine/workflow_enhancer.py
+++ b/template_engine/workflow_enhancer.py
@@ -292,6 +292,7 @@ class TemplateWorkflowEnhancer:
         with open(report_file, "r", encoding="utf-8") as f:
             data = json.load(f)
         actual_count = data.get("total_templates", 0)
+        SecondaryCopilotValidator().validate_corrections([str(report_file)])
         return actual_count >= expected_count
 
 


### PR DESCRIPTION
## Summary
- add analytics score validation with dual-copilot check in DBFirstCodeGenerator
- run secondary validator on documentation analysis results
- validate workflow enhancement reports via dual-copilot hook

## Testing
- `ruff check scripts/database/documentation_db_analyzer.py template_engine/db_first_code_generator.py template_engine/workflow_enhancer.py tests/test_db_first_codegen_analytics.py tests/test_documentation_db_analyzer.py tests/test_workflow_enhancer_extended.py`
- `pytest tests/test_db_first_codegen_analytics.py tests/test_documentation_db_analyzer.py tests/test_workflow_enhancer_extended.py`


------
https://chatgpt.com/codex/tasks/task_e_68921d77c9b88331a0e7c55d836e5fc3