### PR TITLE
fix: resolve undefined variables in compliance metrics updater

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -312,9 +312,12 @@ class ComplianceMetricsUpdater:
             tests_failed,
             metrics.get("open_placeholders", 0),
         )
-        metrics["composite_score"] = composite
-        metrics["composite_compliance_score"] = composite
-        metrics["score_breakdown"] = breakdown
+        # ``calculate_composite_compliance_score`` returns a dictionary of
+        # individual scores along with the combined ``composite`` value. Use
+        # those values directly rather than undefined temporary variables.
+        metrics["composite_score"] = scores["composite"]
+        metrics["composite_compliance_score"] = scores["composite"]
+        metrics["score_breakdown"] = scores
         record_code_quality_metrics(
             ruff_issues,
             tests_passed,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import threading
 from pathlib import Path
+import time
 
 from dashboard import compliance_metrics_updater as cmu
 from dashboard import enterprise_dashboard as ed


### PR DESCRIPTION
## Summary
- fix composite score calculation in compliance metrics updater
- import missing time module in dashboard tests

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/test_dashboard.py`
- `pyright dashboard/compliance_metrics_updater.py tests/test_dashboard.py`
- `pytest tests/test_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68921ef13b288331a17a81a71544aabb