### PR TITLE
docs: clarify simulation-only modules and compliance scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ score = (lint_score + test_score + placeholder_score) / 3
 ```
 
 This value is persisted to `analytics.db` and surfaced via
-`dashboard/enterprise_dashboard.py`.
+`dashboard/enterprise_dashboard.py`. Anti-recursion guards such as
+`validate_enterprise_operation` and `anti_recursion_guard` run alongside these
+calculations; runs that trigger recursion violations are excluded from
+scoring.
 
 ### 🏆 **Enterprise Achievements**
  - ✅ **Script Validation**: 1,679 scripts synchronized

--- a/docs/COMPLIANCE_METRICS.md
+++ b/docs/COMPLIANCE_METRICS.md
@@ -5,7 +5,9 @@ This document describes how compliance scores are calculated for the dashboard.
 ## Compliance Score
 
 The compliance score measures progress resolving placeholders while
-accounting for outstanding issues. It is computed as:
+accounting for outstanding issues. Anti-recursion validation via
+`enterprise_modules.compliance.enforce_anti_recursion` must succeed before
+any score is recorded. The score is computed as:
 
 ```
 base = resolved_placeholders / (resolved_placeholders + open_placeholders)

--- a/docs/quantum_integration_plan.md
+++ b/docs/quantum_integration_plan.md
@@ -5,14 +5,20 @@
 - **QuantumExecutor**: manages backend selection and executes registered algorithms.
 - **QuantumIntegrationOrchestrator**: high level interface that coordinates algorithm execution using the registry and executor.
 
-## Simulation Fallback
-- Hardware execution is not implemented; even with `QISKIT_IBM_TOKEN` the system uses `qasm_simulator` from `qiskit`.
-- Interfaces mirror potential hardware usage for future parity.
-- Maintains identical interfaces so future hardware support can plug in without API changes.
+## Simulation Only
+- Hardware execution is not implemented; the integration always uses
+  `qasm_simulator` from `qiskit`.
+- Interfaces mirror potential hardware usage for future parity but currently
+  ignore hardware-specific settings.
+- Maintains identical interfaces so future hardware support can plug in without
+  API changes.
 
 ## Hardware Requirements
-- Future hardware execution will require `qiskit` plus `qiskit-ibm-provider` and a valid IBM Quantum token provided via the `QISKIT_IBM_TOKEN` environment variable.
-- Setting `QUANTUM_USE_HARDWARE=1` enables hardware mode; when these prerequisites are missing the integration continues to run on simulators.
+- Future hardware execution will require `qiskit` plus `qiskit-ibm-provider`
+  and a valid IBM Quantum token provided via the `QISKIT_IBM_TOKEN` environment
+  variable.
+- Environment variables such as `QUANTUM_USE_HARDWARE` and `IBM_BACKEND` are
+  currently **no-ops**; the system always runs on simulators.
 
 ## Placeholder Modules
 

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - gh_COPILOT Enterprise Toolkit
 
+## [4.1.5] - 2025-07-27
+### Changed
+- Documentation updates to clarify simulation-only quantum modules and reflect
+  new compliance scoring and anti-recursion safeguards.
+
 ## [4.1.4] - 2025-07-27
 ### Added
 - Script `ensure_enhanced_lessons_learned_table.py` validates defaults and creates

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -27,7 +27,12 @@ The gh_COPILOT Toolkit v4.0 represents a revolutionary enterprise-grade automati
 - **Web Interface**: Flask dashboard with basic endpoints and templates
 - **Advanced AI Integration**: tooling supports further automation efforts
 - **Quantum-Enhanced Processing**: placeholder algorithms under exploration
- - *All Qiskit-based functions run in simulation mode only. Installing `qiskit-ibm-provider` and setting `QISKIT_IBM_TOKEN` has no effect because IBM Quantum hardware integration is not yet available and several quantum modules remain stubs.*
+ - *All Qiskit-based functions run in simulation mode only. Installing
+   `qiskit-ibm-provider` and setting `QISKIT_IBM_TOKEN` has no effect because
+   IBM Quantum hardware integration is not yet available and several quantum
+   modules remain stubs. Environment variables like `QUANTUM_USE_HARDWARE` and
+   `IBM_BACKEND` are retained for future compatibility but are currently
+   ignored.*
  - Module completion and placeholder tracking are detailed in [../docs/STUB_MODULE_STATUS.md](../docs/STUB_MODULE_STATUS.md).
 - **Enterprise Security Framework**: Zero-tolerance anti-recursion and comprehensive session integrity
  - *Note: earlier drafts referenced a 32+ database ecosystem. The current repository contains **27** SQLite databases for testing.*

--- a/documentation/validation/compliance_metrics.md
+++ b/documentation/validation/compliance_metrics.md
@@ -1,14 +1,19 @@
 # Compliance Metrics
 
-The compliance report combines linting and test results into a single
-**composite compliance score** that ranges from 0 to 100.
+The compliance report combines linting, testing, and placeholder resolution
+results into a single **composite compliance score** that ranges from 0 to 100.
+Anti-recursion checks are enforced separately and must pass before scores are
+recorded.
 
 ## Metric Formulas
 
 - **Lint Score** = `max(0, 100 - ruff_issues)`
 - **Test Score** = `(tests_passed / (tests_passed + tests_failed)) * 100` if any
   tests were executed, otherwise `0`.
-- **Composite Compliance Score** = `(Lint Score + Test Score) / 2`
+- **Placeholder Score** = `(placeholders_resolved / total_placeholders) * 100`
+  where `total_placeholders` is the sum of open and resolved placeholders. If no
+  placeholders were found the component defaults to `100`.
+- **Composite Compliance Score** = `(Lint Score + Test Score + Placeholder Score) / 3`
 
 The composite score is stored in `databases/analytics.db` alongside the raw
 metrics and is surfaced in the Enterprise Dashboard for visibility.

--- a/quantum/README.md
+++ b/quantum/README.md
@@ -4,33 +4,32 @@ This package provides experimental quantum-inspired utilities used across the
 gh_COPILOT toolkit.
 
 > **Note**
-> Modules automatically attempt hardware execution when IBM Quantum credentials
-> are supplied. Set `QISKIT_IBM_TOKEN` or pass a token directly to APIs. The
-> `QUANTUM_USE_HARDWARE` environment variable forces hardware mode when set to
-> `"1"`. If hardware access is unavailable the local simulator is used.
+> All utilities currently run **exclusively** on local Qiskit simulators.
+> Environment variables such as `QISKIT_IBM_TOKEN`, `QUANTUM_USE_HARDWARE`, and
+> `IBM_BACKEND` are accepted for future compatibility but are treated as
+> no-ops. Hardware execution is not yet supported.
 
 ## Optimizers
 - `optimizers.quantum_optimizer.QuantumOptimizer` – classical/quantum hybrid
   optimizer with progress logging. Events are recorded using
   `utils.log_utils._log_event` when executed via higher-level workflows.
-  Use `configure_backend()` for consistent configuration; credentials may be
-  supplied via argument or environment variable. Hardware backends are used
-  when available, otherwise the local simulator is selected.
+Use `configure_backend()` for consistent configuration; credentials may be
+supplied via argument or environment variable. The function always selects the
+local simulator and ignores hardware-specific settings.
 
 ## Database Search
 - `quantum.quantum_database_search` – lightweight helpers for SQL, NoSQL and
   hybrid search. All queries are logged to `analytics.db` for compliance.
 
-These modules run on IBM Quantum hardware when credentials are provided and the
-environment supports the provider. The `--hardware` flag in
+These modules always execute on simulators regardless of command-line flags or
+environment variables. The `--hardware` flag in
 `quantum_integration_orchestrator.py` and the `QUANTUM_USE_HARDWARE` environment
-variable enable hardware execution with automatic simulator fallback.
+variable are placeholders for future hardware support.
 
 ## IBM Quantum Access
 
-Set `QISKIT_IBM_TOKEN` or provide a token argument to enable hardware use. When
-no token is supplied or the provider fails to initialize, the system falls back
-to simulation.
+Setting `QISKIT_IBM_TOKEN` or providing a token argument has no effect today;
+the system always runs in simulation mode.
 
 ## Algorithms
 
@@ -43,8 +42,8 @@ to simulation.
 
 ## Backend utilities
 
-  - `utils.backend_provider.get_backend` – selects an IBM Quantum backend when
-    credentials are available, otherwise returns the local `Aer` simulator.
+  - `utils.backend_provider.get_backend` – returns the local `Aer` simulator.
+    Backend selection logic for real hardware is reserved for future phases.
 
 ## Pattern Recognition
 


### PR DESCRIPTION
## Summary
- clarify quantum docs to note simulator-only behavior and noop hardware flags
- document updated compliance scoring formula and anti-recursion enforcement
- record documentation updates in changelog

## Testing
- `ruff check .`
- `pytest` *(fails: assert 'placeholder_removal' in '<!doctype html>\n<title>Me...')*

------
https://chatgpt.com/codex/tasks/task_e_689220ae95ec83318c07d2812d3a3269