### PR TITLE
docs: clarify simulation-only quantum operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@
 The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality operates solely through simulators; hardware execution is not yet available.
 
 > **Note**
-> Modules accept backend-selection environment variables such as `QUANTUM_USE_HARDWARE`, `QUANTUM_BACKEND`, and `QISKIT_IBM_TOKEN`, but these flags are no-ops until hardware support lands.
+> Modules accept backend-selection environment variables such as `QUANTUM_USE_HARDWARE`, `QUANTUM_BACKEND`, and `QISKIT_IBM_TOKEN`, but these flags are ignored and the simulator is always used.
 > **Roadmap**
-> Hardware integration is planned for future phases; current builds always use simulators.
+> Hardware integration is planned for future phases; current builds forcibly select simulator backends regardless of configuration.
 > **Phase 5 AI**
-> Advanced AI integration features operate in simulation mode by default and only attempt hardware execution when explicitly configured.
+> Advanced AI integration features operate in simulation mode by default and ignore hardware execution flags.
 
 ### 🎯 **Recent Milestones**
 - **Lessons Learned Integration:** sessions automatically apply lessons from `learning_monitor.db`

--- a/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -15,7 +15,7 @@ Compliance and audit metrics are logged to `analytics.db` via the
 placeholder metrics before being computed by the `WLC_SESSION_MANAGER` during
 session wrap-up.
 
-*All quantum modules run exclusively in simulation mode; any hardware configuration is currently ignored until future integration lands.*
+*All quantum modules run exclusively in simulation mode; any hardware configuration is currently ignored until future integration lands. Hardware flags and tokens are retained for interface parity but have no effect.*
 *Phase&nbsp;5 advanced AI features are partially integrated and not yet production ready.*
 
 Module completion status and outstanding tasks are tracked in
@@ -27,7 +27,7 @@ available in [STUB_MODULE_STATUS.md](STUB_MODULE_STATUS.md).
 - **Multiple SQLite Databases**: `production.db` and related databases provide a central data source
 - **Web Interface**: planned Flask dashboard (implementation pending)
 - **Advanced AI Integration**: tooling supports further automation efforts
-- **Quantum-Inspired Processing**: placeholder routines for annealing and search operate in simulation mode; the `use_hardware` flag is currently ignored.
+- **Quantum-Inspired Processing**: placeholder routines for annealing and search operate in simulation mode; `use_hardware` flags and IBM tokens are ignored.
 - **Quantum-Inspired Communication**: prototype modules simulate secure channels and query encryption; real quantum encryption is not implemented.
 - **Compliance & Audit Framework**: `EnterpriseComplianceValidator` records code audits, rollback history, and compliance metrics in `analytics.db`.
 - **Enterprise Security Framework**: Zero-tolerance anti-recursion and comprehensive session integrity

--- a/docs/QUANTUM_HARDWARE_SETUP.md
+++ b/docs/QUANTUM_HARDWARE_SETUP.md
@@ -1,8 +1,8 @@
-# Quantum Hardware Setup
+# Quantum Simulation Setup
 
 > **Status:** Hardware execution is not supported. This guide is retained for
 future reference. Current modules always use local simulators and ignore all
-hardware flags.
+hardware flags; tokens and backend selections are treated as placeholders.
 
 This document outlines prospective configuration steps for IBM Quantum
 integration. At present, modules run exclusively in simulation mode.
@@ -18,8 +18,8 @@ integration. At present, modules run exclusively in simulation mode.
    ```json
    {"QISKIT_IBM_TOKEN": "your_token_here"}
    ```
-   Tokens are currently unused but will be required once hardware
-   integration lands.
+   Tokens are currently unused and act solely as placeholders until
+   hardware integration lands.
 
 ## 2. Backend Selection (Future)
 Specify a backend name via `IBM_BACKEND`:
@@ -29,7 +29,7 @@ export IBM_BACKEND="ibm_nairobi"
 Backend variables are ignored today; the system always uses `aer_simulator`.
 
 ## 3. CLI Usage
-Hardware flags are accepted but currently have no effect. Example commands run
+Hardware flags are accepted but have no effect. Example commands run
 in simulation regardless of the parameters:
 ```bash
 python -m quantum.cli.executor_cli --use-hardware --backend ibm_nairobi --token "$QISKIT_IBM_TOKEN"

--- a/docs/quantum/QUANTUM_INTEGRATION_GUIDE.md
+++ b/docs/quantum/QUANTUM_INTEGRATION_GUIDE.md
@@ -2,7 +2,7 @@
 ## Implementation and Deployment
 
 > **Note**
-> All quantum features run in simulation only. Installing `qiskit-ibm-provider` or setting `QISKIT_IBM_TOKEN` has no effect because hardware execution is not yet supported.
+> All quantum features run in simulation only. Installing `qiskit-ibm-provider`, setting `QISKIT_IBM_TOKEN`, or toggling `QUANTUM_USE_HARDWARE` has no effect because hardware execution is not supported.
 
 ### Integration Architecture
 ```
@@ -73,8 +73,9 @@ result = quantum_engine.optimize_code_analysis(
 ```
 
 ### Hardware Backends
-Hardware backends are not yet supported. The orchestrator accepts `--hardware`
-and `--backend` flags but always runs on the local simulator. See
+Hardware backends are not supported. The orchestrator accepts `--hardware` and
+`--backend` flags but always runs on the local simulator. Tokens and backend
+requests are treated as placeholders. See
 [docs/QUANTUM_HARDWARE_SETUP.md](../QUANTUM_HARDWARE_SETUP.md) for the future
 integration roadmap.
 


### PR DESCRIPTION
## Summary
- clarify that quantum flags, tokens, and backends are placeholders and simulators are always used
- rename quantum hardware setup guide to simulation-oriented instructions
- refresh enterprise whitepaper to reiterate simulation-only architecture

## Testing
- `ruff check README.md`
- `pytest` *(fails: KeyboardInterrupt)*
- `python scripts/wlc_session_manager.py` *(fails: NotADirectoryError)*

Request technical writer review for clarity and consistency.

------
https://chatgpt.com/codex/tasks/task_e_689228bcb58c8331a622eebd4febd85f