### PR TITLE
feat: expose weighted compliance score components

### DIFF
--- a/tests/validation/test_compliance_scoring.py
+++ b/tests/validation/test_compliance_scoring.py
@@ -1,0 +1,40 @@
+"""Tests for compliance scoring helpers."""
+
+from enterprise_modules.compliance import (
+    calculate_compliance_score,
+    calculate_composite_score,
+)
+
+
+def test_calculate_compliance_score_matches_phase5_tasks() -> None:
+    """Compliance score should match the weighted formula in phase5_tasks.md."""
+
+    score = calculate_compliance_score(
+        ruff_issues=10,
+        tests_passed=80,
+        tests_failed=20,
+        placeholders_open=5,
+        placeholders_resolved=5,
+    )
+    assert score == 77.0
+
+
+def test_calculate_composite_score_surfaces_weighted_components() -> None:
+    """Composite score should expose individual weighted contributions."""
+
+    score, breakdown = calculate_composite_score(10, 80, 20, 5, 5)
+
+    assert score == 77.0
+    assert breakdown["lint_score"] == 90.0
+    assert breakdown["test_score"] == 80.0
+    assert breakdown["placeholder_score"] == 50.0
+    assert breakdown["lint_weighted"] == 27.0
+    assert breakdown["test_weighted"] == 40.0
+    assert breakdown["placeholder_weighted"] == 10.0
+    assert (
+        breakdown["lint_weighted"]
+        + breakdown["test_weighted"]
+        + breakdown["placeholder_weighted"]
+        == score
+    )
+


### PR DESCRIPTION
## Summary
- weight compliance scoring components and surface weighted values in composite breakdown
- cover phase5 score formula with dedicated tests

## Testing
- `pytest tests/validation`
- `ruff check enterprise_modules/compliance.py`


------
https://chatgpt.com/codex/tasks/task_e_68922fc13b68833191cc4094c6e60dba