### PR TITLE
fix: cast previous compliance score

### DIFF
--- a/docs/placeholder_audit_guide.md
+++ b/docs/placeholder_audit_guide.md
@@ -12,11 +12,12 @@ The script ingests documentation and templates, then invokes the internal
 placeholder audit. Findings are written to `databases/analytics.db` in the
 `placeholder_audit` table.
 
-The audit now prints a list of actionable tasks for every unresolved
-placeholder so developers can quickly remove them. Example output:
+The audit prints a list of actionable tasks for every unresolved
+placeholder so developers can quickly remove them. When the codebase is
+clean, the output confirms that no work remains:
 
 ```
-[TASK] Remove TODO in path/to/file.py:42 - refactor needed
+[SUCCESS] No TODO or FIXME placeholders found
 ```
 
 ## Viewing Results

--- a/scripts/correction_logger_and_rollback.py
+++ b/scripts/correction_logger_and_rollback.py
@@ -182,7 +182,10 @@ class CorrectionLoggerRollback:
                 (str(file_path),),
             )
             row = cur.fetchone()
-            prev_score = row[0] if row else None
+            try:
+                prev_score = float(row[0]) if row and row[0] is not None else None
+            except (TypeError, ValueError):
+                prev_score = None
             compliance_delta = (
                 compliance_score - prev_score if prev_score is not None else compliance_score
             )


### PR DESCRIPTION
## Summary
- handle non-numeric compliance scores when logging corrections
- clarify placeholder audit guide when no TODO/FIXME markers remain

## Testing
- `pytest tests/test_placeholder_apply_fixes.py::test_apply_fixes_removes_placeholders -vv` *(fails: AssertionError)*
- `ruff check scripts/correction_logger_and_rollback.py`


------
https://chatgpt.com/codex/tasks/task_e_68922fc3a8bc8331b16b7353f0eeefc5