### PR TITLE
docs: update architecture and compliance guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ The enterprise dashboard reports an overall code quality score derived from
 lint, test and placeholder metrics:
 
 ```
-lint_score = max(0, 100 - ruff_issues)
-test_score = (tests_passed / total_tests) * 100
-placeholder_score = (placeholders_resolved / total_placeholders) * 100
-score = (lint_score + test_score + placeholder_score) / 3
+L = max(0, 100 - ruff_issues)
+T = (tests_passed / total_tests) * 100
+P = (placeholders_resolved / (placeholders_open + placeholders_resolved)) * 100
+score = 0.3 * L + 0.5 * T + 0.2 * P
 ```
 
 This value is persisted to `analytics.db` and surfaced via
@@ -79,6 +79,11 @@ This value is persisted to `analytics.db` and surfaced via
 `validate_enterprise_operation` and `anti_recursion_guard` run alongside these
 calculations; runs that trigger recursion violations are excluded from
 scoring.
+
+Compliance enforcement also blocks destructive commands (`rm -rf`, `mkfs`,
+`shutdown`, `reboot`, `dd if=`) and flags unresolved `TODO` or `FIXME`
+placeholders in accordance with `enterprise_modules/compliance.py` and the
+Phase 5 scoring guidelines.
 
 ### 🏆 **Enterprise Achievements**
  - ✅ **Script Validation**: 1,679 scripts synchronized
@@ -97,7 +102,9 @@ scoring.
 - **Script Validation**: automated checks available
 - **Self-Healing Systems:** correction scripts
 - **Autonomous File Management:** see [Using AutonomousFileManager](docs/USING_AUTONOMOUS_FILE_MANAGER.md)
- - **Continuous Operation Mode:** optional monitoring utilities
+- **Quantum Modules:** all quantum features execute on Qiskit simulators; hardware
+  backends are currently disabled.
+- **Continuous Operation Mode:** optional monitoring utilities
    - **Simulated Quantum Monitoring Scripts:** `scripts/monitoring/continuous_operation_monitor.py`,
     `scripts/monitoring/enterprise_compliance_monitor.py`, and
     `scripts/monitoring/unified_monitoring_optimization_system.py`.

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -88,7 +88,7 @@ class UnifiedMonitoringOptimizationSystem:
 #### **Database Integration**
 - **Primary Database**: production.db for operational metrics
 - **Analytics Database**: analytics.db for performance data
-- **Optimization Database**: optimization_metrics.db for optimization tracking
+- **Optimization Database**: *(deprecated)* `optimization_metrics.db`
 - **Cross-Database Intelligence**: Aggregation across available development databases
 
 ### **2. Unified Script Generation System**
@@ -990,12 +990,16 @@ test success, and placeholder backlog:
 ```
 L = max(0, 100 - lint_warnings)
 T = passed / (passed + failed) * 100
-P = max(0, 100 - 10 * placeholders)
+P = (placeholders_resolved / (placeholders_open + placeholders_resolved)) * 100
 score = 0.3 * L + 0.5 * T + 0.2 * P
 ```
 
 This composite score is persisted to `code_quality_metrics` in `analytics.db`
 and exposed on the compliance dashboard.
+
+Compliance checks also prohibit destructive commands such as `rm -rf`, `mkfs`,
+`shutdown`, `reboot`, and `dd if=` while flagging unresolved `TODO` or `FIXME`
+placeholders, mirroring `enterprise_modules/compliance.py` guidelines.
 
 ### **Quantum Optimization Engine (Placeholder)**
 *Planned placeholder – algorithms not yet implemented.*

--- a/documentation/SYSTEM_OVERVIEW.md
+++ b/documentation/SYSTEM_OVERVIEW.md
@@ -4,7 +4,7 @@
 
 - **Deployment Date**: 2025-07-06 19:01:26
 - **Version**: 1.0.0
-- **Target Environment**: e:\gh_COPILOT
+- **Target Environment**: `$GH_COPILOT_WORKSPACE`
 
 ## Components Deployed
 
@@ -22,7 +22,6 @@
 - analytics.db
 - template_completion.db
 - enhanced_intelligence.db
-- optimization_metrics.db
 - executive_alerts.db
 - instruction_orchestrator.db
 - documentation_sync.db
@@ -55,10 +54,11 @@
 - autonomous_regeneration: Enabled
 - web_gui_dashboard: Enabled
 - enterprise_compliance: Enabled
+- quantum_modules_simulation: Enabled (all quantum features run via simulators; hardware execution is disabled)
 
 ## Directory Structure
 - core: Core system components
-- databases: 32 SQLite databases
+- databases: 27 SQLite databases
 - templates: Template Intelligence Platform
 - web_gui: Flask enterprise dashboard
 - scripts: about 440 Python scripts
@@ -73,6 +73,6 @@
 ### Database Synchronization
 
 The `database_sync_scheduler.py` script consumes
-`documentation/DATABASE_LIST.md` to loop over all 32 databases.
+`documentation/DATABASE_LIST.md` to loop over all 27 databases.
 It copies the master `production.db` into every other database,
 keeping the entire toolkit in sync.


### PR DESCRIPTION
## Summary
- clarify composite compliance scoring and forbid destructive commands in docs
- mark `optimization_metrics.db` deprecated and note that quantum modules run via simulators
- refresh system overview with simulator-only quantum features and correct database counts

## Testing
- `markdownlint README.md documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md documentation/SYSTEM_OVERVIEW.md` *(fails: command not found)*
- `sphinx-build -b html docs docs/_build` *(fails: command not found)*
- `ruff check .`
- `pytest -q` *(fails: tests/dashboard/test_score_serialization.py::test_metrics_include_composite_score)*

------
https://chatgpt.com/codex/tasks/task_e_68922fc5d608833197c5b66cac4b6b37