### PR TITLE
fix: align composite compliance score with documented formula

### DIFF
--- a/documentation/phase5_tasks.md
+++ b/documentation/phase5_tasks.md
@@ -1,0 +1,17 @@
+# Phase 5 Composite Compliance Score
+
+The composite compliance score blends linting, tests, and placeholder hygiene into a single 0–100 metric.
+
+## Components
+
+- **Lint (L):** `L = max(0, 100 - issues)` where *issues* is the number of ruff findings.
+- **Tests (T):** `T = passed / (passed + failed) * 100`; defaults to `0` if no tests run.
+- **Placeholders (P):** `P = resolved / (open + resolved) * 100`; defaults to `100` when no placeholders exist.
+
+## Formula
+
+```
+score = 0.3 * L + 0.5 * T + 0.2 * P
+```
+
+The function `calculate_composite_score` in `enterprise_modules/compliance.py` returns the overall score and a breakdown of each weighted component, allowing dashboards to surface detailed compliance metrics.

--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -361,12 +361,10 @@ def calculate_composite_score(
         if total_placeholders
         else 100.0
     )
-    score = calculate_compliance_score(
-        ruff_issues,
-        tests_passed,
-        tests_failed,
-        placeholders_open,
-        placeholders_resolved,
+    score = (
+        LINT_WEIGHT * lint_score
+        + TEST_WEIGHT * test_score
+        + PLACEHOLDER_WEIGHT * placeholder_score
     )
     breakdown = {
         "ruff_issues": ruff_issues,
@@ -381,7 +379,7 @@ def calculate_composite_score(
         "test_weighted": round(TEST_WEIGHT * test_score, 2),
         "placeholder_weighted": round(PLACEHOLDER_WEIGHT * placeholder_score, 2),
     }
-    return score, breakdown
+    return round(score, 2), breakdown
 
 
 def calculate_code_quality_score(

--- a/tests/validation/test_compliance_scoring.py
+++ b/tests/validation/test_compliance_scoring.py
@@ -38,3 +38,25 @@ def test_calculate_composite_score_surfaces_weighted_components() -> None:
         == score
     )
 
+
+def test_calculate_composite_score_handles_no_tests_or_placeholders() -> None:
+    """Score should fall back to lint and placeholder defaults when data missing."""
+
+    score, breakdown = calculate_composite_score(0, 0, 0, 0, 0)
+
+    assert score == 50.0
+    assert breakdown["lint_weighted"] == 30.0
+    assert breakdown["test_weighted"] == 0.0
+    assert breakdown["placeholder_weighted"] == 20.0
+
+
+def test_calculate_composite_score_perfect_results() -> None:
+    """A spotless run should yield a perfect composite score."""
+
+    score, breakdown = calculate_composite_score(0, 10, 0, 0, 0)
+
+    assert score == 100.0
+    assert breakdown["lint_weighted"] == 30.0
+    assert breakdown["test_weighted"] == 50.0
+    assert breakdown["placeholder_weighted"] == 20.0
+


### PR DESCRIPTION
## Summary
- document phase 5 composite compliance score
- compute composite score using weighted lint, test and placeholder components
- test score calculations including edge cases

## Testing
- `pytest tests/validation -q`
- `ruff check enterprise_modules/compliance.py tests/validation`


------
https://chatgpt.com/codex/tasks/task_e_689236e4a0248331b12fec2df7131efc