### PR TITLE
feat: expose placeholder metrics on dashboard

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -137,7 +137,10 @@ The `/dashboard/compliance` endpoint returns compliance information as JSON, com
 {
   "metrics": {
     "placeholder_removal": 0,
+    "open_placeholders": 0,
+    "resolved_placeholders": 0,
     "compliance_score": 0.0,
+    "progress": 0.0,
     "violation_count": 0,
     "rollback_count": 0,
     "progress_status": "unknown",
@@ -164,7 +167,7 @@ The `/dashboard/compliance` endpoint returns compliance information as JSON, com
 }
 ```
 
-- `metrics` — Aggregated compliance metrics (e.g., placeholder removal count, compliance score); includes `progress_status` to summarize placeholder resolution progress
+- `metrics` — Aggregated compliance metrics (e.g., placeholder removal count, open and resolved placeholder totals, compliance score, remediation progress); includes `progress_status` to summarize placeholder resolution progress
 - `rollbacks` — List of correction and rollback events
 - `notes` — Array of status messages using text tags like `[SUCCESS]`
 

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -11,6 +11,10 @@
             if(data.composite_score !== undefined){
                 document.getElementById('composite_score').textContent = data.composite_score.toFixed(2);
             }
+            document.getElementById('open_placeholders').textContent = data.open_placeholders || 0;
+            document.getElementById('resolved_placeholders').textContent = data.resolved_placeholders || 0;
+            const prog = data.progress !== undefined ? (data.progress * 100).toFixed(1) + '%' : '0%';
+            document.getElementById('remediation_progress').textContent = prog;
             document.getElementById('lessons_integration_status').textContent = data.lessons_integration_status || 'UNKNOWN';
             document.getElementById('lessons_hook_coverage').textContent =
                 data.lessons_hook_coverage !== undefined ? (data.lessons_hook_coverage * 100).toFixed(1) + '%' : '0%';
@@ -77,6 +81,9 @@
     <strong>Placeholder Removals:</strong> <span id="placeholder_removal">{{ metrics.placeholder_removal | default(0) }}</span><br>
     <strong>Compliance Score:</strong> <span id="compliance_score">{{ metrics.compliance_score | default(0) }}</span><br>
     <strong>Composite Score:</strong> <span id="composite_score">{{ metrics.composite_score | default(0) }}</span><br>
+    <strong>Open Placeholders:</strong> <span id="open_placeholders">{{ metrics.open_placeholders | default(0) }}</span><br>
+    <strong>Resolved Placeholders:</strong> <span id="resolved_placeholders">{{ metrics.resolved_placeholders | default(0) }}</span><br>
+    <strong>Remediation Progress:</strong> <span id="remediation_progress">{{ ((metrics.progress or 0) * 100) | round(1) }}%</span><br>
     <strong>Lessons Integration Status:</strong> <span id="lessons_integration_status">UNKNOWN</span><br>
     <strong>Lessons Hook Coverage:</strong> <span id="lessons_hook_coverage">0%</span><br>
     <strong>Missing Lesson Hooks:</strong> <span id="missing_lesson_hooks">none</span><br>

--- a/dashboard/templates/metrics.html
+++ b/dashboard/templates/metrics.html
@@ -7,6 +7,9 @@
 <h1>Compliance Metrics</h1>
 <p><strong>Compliance Score:</strong> {{ metrics.compliance_score | default(0) }}</p>
 <p><strong>Composite Score:</strong> {{ metrics.composite_score | default(0) }}</p>
+<p><strong>Open Placeholders:</strong> {{ metrics.open_placeholders | default(0) }}</p>
+<p><strong>Resolved Placeholders:</strong> {{ metrics.resolved_placeholders | default(0) }}</p>
+<p><strong>Remediation Progress:</strong> {{ ((metrics.progress or 0) * 100) | round(1) }}%</p>
 
 <h2>Correction Logs</h2>
 <ul>

--- a/tests/placeholder_audit/test_dashboard_rendering.py
+++ b/tests/placeholder_audit/test_dashboard_rendering.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from flask import Flask, render_template
+
+
+def test_dashboard_template_renders_counts(tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    app = Flask(
+        __name__,
+        template_folder=str(repo_root / "dashboard" / "templates"),
+        static_folder=str(repo_root / "dashboard" / "static"),
+    )
+    metrics = {
+        "placeholder_removal": 0,
+        "compliance_score": 1.0,
+        "composite_score": 1.0,
+        "open_placeholders": 2,
+        "resolved_placeholders": 3,
+        "progress": 0.6,
+        "placeholder_breakdown": {},
+        "compliance_trend": [],
+    }
+    with app.test_request_context("/"):
+        html = render_template("dashboard.html", metrics=metrics, rollbacks=[])
+    assert "Open Placeholders:" in html
+    assert "Resolved Placeholders:" in html
+    assert "Remediation Progress:" in html
+    assert "60.0%" in html

--- a/tests/placeholder_audit/test_metrics_logging.py
+++ b/tests/placeholder_audit/test_metrics_logging.py
@@ -1,0 +1,47 @@
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import secondary_copilot_validator
+
+from scripts.code_placeholder_audit import main
+
+
+def test_metrics_logged_and_dashboard_updated(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "a.py").write_text("# TODO\n")
+
+    analytics = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dashboard"
+
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setattr(secondary_copilot_validator, "run_flake8", lambda *a, **k: True)
+    monkeypatch.setattr(
+        secondary_copilot_validator,
+        "SecondaryCopilotValidator",
+        lambda: SimpleNamespace(validate_corrections=lambda *a, **k: True),
+    )
+    monkeypatch.setattr(
+        "scripts.code_placeholder_audit.ComplianceMetricsUpdater",
+        lambda *a, **k: SimpleNamespace(update=lambda *a, **k: None, validate_update=lambda *a, **k: True),
+    )
+
+    assert main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(dash_dir / "compliance"),
+    )
+
+    metrics_file = dash_dir / "compliance" / "metrics.json"
+    assert metrics_file.exists()
+    metrics = json.loads(metrics_file.read_text())
+    assert metrics["metrics"]["open_placeholders"] >= 1
+    assert "progress" in metrics["metrics"]
+
+    with sqlite3.connect(analytics) as conn:
+        cur = conn.execute("SELECT open_placeholders, resolved_placeholders FROM placeholder_metrics")
+        row = cur.fetchone()
+        assert row[0] >= 1
+        assert row[1] == 0


### PR DESCRIPTION
## Summary
- log placeholder counts and remediation progress to analytics.db and metrics.json
- show open/resolved placeholder metrics in dashboard templates
- document metrics schema and add tests for dashboard rendering and metric logging

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder_audit/test_metrics_logging.py tests/placeholder_audit/test_dashboard_rendering.py`
- `pytest tests/placeholder_audit`
- `PYTHONPATH=. python dashboard/compliance_metrics_updater.py --simulate` *(fails: Recursive folder violation)*

------
https://chatgpt.com/codex/tasks/task_e_689236ccb0848331ad48d3c5606cab31