### PR TITLE
feat: track recursion pid and depth

### DIFF
--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -43,6 +43,8 @@ _PID_DEPTHS: dict[int, int] = {}
 _PID_PARENTS: dict[int, int] = {}
 _PID_CHILDREN: dict[int, set[int]] = {}
 _GUARD_LOCK = threading.Lock()
+_PID_LOG_LOCK = threading.Lock()
+_PID_THREADS: dict[int, set[int]] = {}
 
 
 def anti_recursion_guard(func: F) -> F:
@@ -57,12 +59,16 @@ def anti_recursion_guard(func: F) -> F:
     def wrapper(*args: Any, **kwargs: Any):
         pid = os.getpid()
         ppid = os.getppid()
+        tid = threading.get_ident()
         with _GUARD_LOCK:
             ancestor = ppid
             while ancestor:
                 if ancestor == pid:
                     raise RuntimeError("PID loop detected")
                 ancestor = _PID_PARENTS.get(ancestor)
+            threads = _PID_THREADS.setdefault(pid, set())
+            if threads and tid not in threads:
+                raise RuntimeError("Duplicate PID execution")
 
             depth = _PID_DEPTHS.get(pid, 0)
             if depth >= MAX_RECURSION_DEPTH:
@@ -70,11 +76,23 @@ def anti_recursion_guard(func: F) -> F:
             depth += 1
             _PID_DEPTHS[pid] = depth
             _ACTIVE_PIDS.add(pid)
+            threads.add(tid)
             _PID_PARENTS[pid] = ppid
             _PID_CHILDREN.setdefault(ppid, set()).add(pid)
             _record_recursion_pid(Path(f"{func.__qualname__}/entry"), pid, ppid, depth)
 
         try:
+            target: Path | None = None
+            if args:
+                candidate = args[0]
+                if isinstance(candidate, (str, os.PathLike)):
+                    target = Path(candidate)
+            if target is None and "path" in kwargs:
+                candidate = kwargs["path"]
+                if isinstance(candidate, (str, os.PathLike)):
+                    target = Path(candidate)
+            if target is not None and _detect_recursion(target):
+                raise RuntimeError("Path recursion detected")
             return func(*args, **kwargs)
         finally:
             with _GUARD_LOCK:
@@ -85,6 +103,11 @@ def anti_recursion_guard(func: F) -> F:
                 if remaining <= 0:
                     _PID_DEPTHS.pop(pid, None)
                     _ACTIVE_PIDS.discard(pid)
+                    threads = _PID_THREADS.get(pid)
+                    if threads is not None:
+                        threads.discard(tid)
+                        if not threads:
+                            _PID_THREADS.pop(pid, None)
                     parent = _PID_PARENTS.pop(pid, None)
                     if parent is not None:
                         children = _PID_CHILDREN.get(parent)
@@ -175,12 +198,13 @@ def _record_recursion_pid(
         path_str = str(path.resolve())
     except Exception:
         path_str = str(path)
-    with sqlite3.connect(analytics_db) as conn:
-        conn.execute(
-            "INSERT INTO recursion_pid_log (path, pid, parent_pid, depth, timestamp) VALUES (?, ?, ?, ?, ?)",
-            (path_str, pid, parent_pid, depth, datetime.now().isoformat()),
-        )
-        conn.commit()
+    with _PID_LOG_LOCK:
+        with sqlite3.connect(analytics_db) as conn:
+            conn.execute(
+                "INSERT INTO recursion_pid_log (path, pid, parent_pid, depth, timestamp) VALUES (?, ?, ?, ?, ?)",
+                (path_str, pid, parent_pid, depth, datetime.now().isoformat()),
+            )
+            conn.commit()
 
 
 def _detect_recursion(path: Path, *, max_depth: int = MAX_RECURSION_DEPTH) -> bool:

--- a/tests/session/test_anti_recursion.py
+++ b/tests/session/test_anti_recursion.py
@@ -1,57 +1,48 @@
+import os
+import sqlite3
+from pathlib import Path
+
 import pytest
-from scripts.session.anti_recursion_enforcer import (
-    AntiRecursionEnforcer,
-    anti_recursion_guard,
-)
+
+from enterprise_modules.compliance import anti_recursion_guard, MAX_RECURSION_DEPTH
 
 
-def test_decorator_blocks_on_recursion(monkeypatch):
-    calls = []
+def _fetch_logs(db: Path) -> list[tuple[str, int, int]]:
+    with sqlite3.connect(db) as conn:
+        return conn.execute(
+            "SELECT path, pid, depth FROM recursion_pid_log"
+        ).fetchall()
 
-    def fake_enforce(self, current_pid=None):
-        calls.append("check")
-        raise RuntimeError("recursion")
 
-    monkeypatch.setattr(
-        AntiRecursionEnforcer,
-        "enforce_no_recursion",
-        fake_enforce,
-    )
+def test_guard_logs_pid(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    db = tmp_path / "databases" / "analytics.db"
 
     @anti_recursion_guard
-    def wrapped():
-        calls.append("run")
-
-    with pytest.raises(RuntimeError):
-        wrapped()
-    assert calls == ["check"]
-
-
-def test_decorator_allows_single_call(monkeypatch):
-    calls = []
-
-    def fake_enforce(self, current_pid=None):
-        calls.append("check")
-
-    monkeypatch.setattr(
-        AntiRecursionEnforcer,
-        "enforce_no_recursion",
-        fake_enforce,
-    )
-
-    @anti_recursion_guard
-    def wrapped():
-        calls.append("run")
+    def wrapped(path: Path) -> str:
         return "ok"
 
-    assert wrapped() == "ok"
-    assert calls == ["check", "run"]
+    assert wrapped(tmp_path) == "ok"
+    logs = _fetch_logs(db)
+    assert any(
+        row[1] == os.getpid() and "wrapped/entry" in row[0] and row[2] == 1
+        for row in logs
+    )
 
 
-def test_decorator_prevents_reentrancy():
+def test_guard_aborts_on_nested_directories(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    current = tmp_path
+    for i in range(MAX_RECURSION_DEPTH + 1):
+        current = current / f"lvl{i}"
+        current.mkdir()
+
     @anti_recursion_guard
-    def recur():
-        recur()
+    def walk(path: Path) -> None:
+        for child in path.iterdir():
+            if child.is_dir():
+                walk(child)
 
     with pytest.raises(RuntimeError):
-        recur()
+        walk(tmp_path)
+

--- a/tests/test_compliance_anti_recursion_guard.py
+++ b/tests/test_compliance_anti_recursion_guard.py
@@ -7,9 +7,10 @@ import pytest
 from enterprise_modules.compliance import anti_recursion_guard, MAX_RECURSION_DEPTH
 
 
-def test_guard_aborts_on_nested_directories(tmp_path):
+def test_guard_aborts_on_nested_directories(monkeypatch, tmp_path):
     """The guard aborts when recursion depth exceeds the limit."""
 
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     current = tmp_path
     for i in range(MAX_RECURSION_DEPTH + 1):
         current = current / f"lvl{i}"
@@ -25,8 +26,10 @@ def test_guard_aborts_on_nested_directories(tmp_path):
         walk(tmp_path)
 
 
-def test_guard_aborts_on_duplicate_pid():
+def test_guard_aborts_on_duplicate_pid(monkeypatch, tmp_path):
     """Concurrent invocation by the same PID triggers early abort."""
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
 
     @anti_recursion_guard
     def slow_call():
@@ -40,18 +43,29 @@ def test_guard_aborts_on_duplicate_pid():
     t.join()
 
 
-def test_guard_allows_single_invocation():
+def test_guard_allows_single_invocation(monkeypatch, tmp_path):
     """Single invocation proceeds normally and records parent-child PID."""
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    db = tmp_path / "databases" / "analytics.db"
 
     @anti_recursion_guard
     def hello():
         return "ok"
 
     assert hello() == "ok"
+    import sqlite3
+    with sqlite3.connect(db) as conn:
+        rows = conn.execute(
+            "SELECT path, pid, depth FROM recursion_pid_log"
+        ).fetchall()
+    assert any("hello/entry" in r[0] and r[2] == 1 for r in rows)
 
 
-def test_guard_aborts_on_pid_loop():
+def test_guard_aborts_on_pid_loop(monkeypatch, tmp_path):
     """Artificial parent/child PID loop triggers early abort."""
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
 
     @anti_recursion_guard
     def invoke():


### PR DESCRIPTION
## Summary
- integrate path recursion detection and PID logging into anti_recursion_guard
- serialize recursion PID writes for thread safety
- test anti-recursion guard for PID logging and nested depth failures

## Testing
- `ruff check enterprise_modules/compliance.py tests/session/test_anti_recursion.py tests/test_compliance_anti_recursion_guard.py`
- `pytest tests/session/test_anti_recursion.py`
- `pytest tests/test_compliance_anti_recursion_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_689236e38b9c833192ee77fb235d3bac