### PR TITLE
test: fix metrics expectations and speed up audit test

### DIFF
--- a/tests/dashboard/test_score_serialization.py
+++ b/tests/dashboard/test_score_serialization.py
@@ -48,8 +48,8 @@ def test_metrics_include_composite_score(tmp_path, monkeypatch):
     _, ed_module = _prepare_metrics(tmp_path, monkeypatch)
     data = ed_module._load_metrics()["metrics"]
     assert data["compliance_score"] == 84.0
-    assert data["code_quality_score"] == pytest.approx(81.67, rel=1e-3)
-    assert data["composite_score"] == pytest.approx(81.67, rel=1e-3)
+    assert data["code_quality_score"] == pytest.approx(82.5, rel=1e-3)
+    assert data["composite_score"] == pytest.approx(82.5, rel=1e-3)
     assert data["score_breakdown"]["placeholder_score"] == pytest.approx(70.0, rel=1e-3)
 
 
@@ -57,5 +57,5 @@ def test_dashboard_compliance_route(tmp_path, monkeypatch):
     client, _ = _prepare_metrics(tmp_path, monkeypatch)
     resp = client.get("/dashboard/compliance")
     data = resp.get_json()["metrics"]
-    assert data["code_quality_score"] == pytest.approx(81.67, rel=1e-3)
+    assert data["code_quality_score"] == pytest.approx(82.5, rel=1e-3)
     assert data["score_breakdown"]["lint_score"] == pytest.approx(95.0, rel=1e-3)

--- a/tests/placeholder_audit/test_history_and_rollback.py
+++ b/tests/placeholder_audit/test_history_and_rollback.py
@@ -10,6 +10,16 @@ def test_history_and_rollback(tmp_path, monkeypatch):
         "secondary_copilot_validator.SecondaryCopilotValidator.validate_corrections",
         lambda self, files: True,
     )
+    monkeypatch.setattr(
+        "secondary_copilot_validator.run_flake8", lambda files: None
+    )
+    import types
+    monkeypatch.setattr(
+        "scripts.code_placeholder_audit.ComplianceMetricsUpdater",
+        lambda dashboard, test_mode=False: types.SimpleNamespace(
+            update=lambda **kwargs: None, validate_update=lambda: None
+        ),
+    )
     import scripts.correction_logger_and_rollback as clr
     monkeypatch.setattr(
         clr,


### PR DESCRIPTION
## Summary
- align dashboard score serialization tests with weighted scoring
- stub heavy audit dependencies for faster placeholder audit tests

## Testing
- `ruff check tests/dashboard/test_score_serialization.py tests/placeholder_audit/test_history_and_rollback.py`
- `pyright tests/dashboard/test_score_serialization.py tests/placeholder_audit/test_history_and_rollback.py`
- `pytest tests/dashboard/test_score_serialization.py tests/placeholder_audit/test_history_and_rollback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68922fc7d0288331abf6f08772339496