### PR TITLE
test: add placeholder-free repository test

### DIFF
--- a/tests/placeholder_audit/test_repo_no_placeholders.py
+++ b/tests/placeholder_audit/test_repo_no_placeholders.py
@@ -1,0 +1,45 @@
+"""Ensure repository python files are free of TODO/FIXME markers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+EXCLUDED = {
+    "tests",
+    "docs",
+    "documentation",
+    "builds",
+    "archive",
+    "archived_databases",
+    "artifacts",
+    "logs",
+    "databases",
+    "results",
+    ".venv",
+    ".git",
+    "tmp",
+}
+EXCLUDED_FILES = {
+    "scripts/code_placeholder_audit.py",
+    "scripts/simple_placeholder_audit.py",
+    "enterprise_modules/compliance.py",
+    "validation/compliance_report_generator.py",
+    "db_tools/operations/compliance.py",
+    "scripts/database/documentation_db_analyzer.py",
+}
+PATTERNS = [re.compile(r"TODO"), re.compile(r"FIXME")]
+
+
+def test_repository_has_no_placeholders() -> None:
+    """Repository should not contain TODO/FIXME placeholders."""
+    root = Path(__file__).resolve().parents[2]
+    for path in root.rglob("*.py"):
+        if any(part in EXCLUDED for part in path.parts):
+            continue
+        rel = path.relative_to(root).as_posix()
+        if rel in EXCLUDED_FILES:
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for pat in PATTERNS:
+            assert pat.search(text) is None, f"{path} contains {pat.pattern}"


### PR DESCRIPTION
## Summary
- add safety test that scans repository for TODO/FIXME markers

## Testing
- `pytest tests/placeholder_audit`
- `ruff check scripts/code_placeholder_audit.py tests/placeholder_audit/test_repo_no_placeholders.py`


------
https://chatgpt.com/codex/tasks/task_e_689236e5d11083318d9baaa63290db2b