### PR TITLE
docs: clarify quantum modules as simulation only

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > Tests: run `pytest` before committing. Current repository tests report multiple failures.
 > Lint: run `ruff check .` before committing.
-> Quantum modules run exclusively in simulation mode; hardware flags are currently ignored. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Module completion status is tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics.db`.
+> Quantum modules run exclusively in simulation mode; hardware flags are currently ignored. Documentation and guides now clearly mark these components as simulation-only. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Module completion status is tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics.db`.
 > Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards.
 
 ---

--- a/docs/quantum/ADVANCED_QUANTUM_OPTIMIZATION_GUIDE.md
+++ b/docs/quantum/ADVANCED_QUANTUM_OPTIMIZATION_GUIDE.md
@@ -3,7 +3,7 @@
 This guide outlines how to extend the existing quantum module with an advanced optimization algorithm. It assumes familiarity with the repository's quantum package and the base `QuantumAlgorithmBase` class.
 
 > **Note**
-> All quantum functionality runs in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+> All quantum functionality runs in simulation mode only. Installing `qiskit-ibm-provider` or configuring an IBM Quantum token has no effect because hardware execution is not supported.
 
 ## 1. Create the Module
 1. Navigate to `quantum/algorithms/`.
@@ -13,7 +13,7 @@ This guide outlines how to extend the existing quantum module with an advanced o
 
 ## 2. Implement the Algorithm Logic
 1. Prepare your quantum circuit using Qiskit or another supported framework.
-2. Configure a suitable backend (simulator or hardware if available).
+2. Configure a simulator backend; hardware execution is not available.
 3. Encode the problem instance into the circuit using variational forms or oracle-based methods.
 4. Apply iterative optimization (e.g., variational quantum eigensolver or quantum annealing) while logging progress via the base class utilities.
 5. Record execution statistics with fidelity and performance metrics for later analysis.

--- a/docs/quantum/INDEX.md
+++ b/docs/quantum/INDEX.md
@@ -5,7 +5,7 @@
 This documentation suite provides comprehensive information about the quantum optimization features integrated into the PIS (Plan Issued Statement) Framework.
 
 > **Note**
-> All quantum functionality operates in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+> All quantum functionality operates in simulation mode only. Installing `qiskit-ibm-provider` or configuring an IBM Quantum token has no effect because hardware execution is not supported.
 
 ### Available Documents
 1. **[Quantum Optimization Overview](QUANTUM_OPTIMIZATION_OVERVIEW.md)**

--- a/docs/quantum/QUANTUM_ALGORITHMS_SPECIFICATION.md
+++ b/docs/quantum/QUANTUM_ALGORITHMS_SPECIFICATION.md
@@ -2,7 +2,7 @@
 ## Technical Implementation Details
 
 > **Note**
-> All quantum algorithms are executed in simulation unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+> All quantum algorithms run in simulation mode only. Installing `qiskit-ibm-provider` or configuring an IBM Quantum token has no effect because hardware execution is not supported.
 
 ### Algorithm Architecture
 

--- a/docs/quantum/QUANTUM_PERFORMANCE_METRICS.md
+++ b/docs/quantum/QUANTUM_PERFORMANCE_METRICS.md
@@ -2,7 +2,7 @@
 ## Comprehensive Performance Analysis
 
 > **Note**
-> All benchmarks are generated using the simulator unless `qiskit-ibm-provider` is installed and configured with a valid IBM Quantum token.
+> All benchmarks are generated using the simulator. Installing `qiskit-ibm-provider` or configuring an IBM Quantum token has no effect because hardware execution is not supported.
 
 ### Baseline Performance Comparison
 

--- a/docs/quantum/advanced_algorithms.md
+++ b/docs/quantum/advanced_algorithms.md
@@ -3,6 +3,9 @@
 This guide documents the Qiskit-based reference implementations
 available in `quantum/advanced_quantum_algorithms.py`.
 
+> **Note**
+> All examples run on simulator backends only. Installing `qiskit-ibm-provider` or supplying IBM Quantum tokens has no effect because hardware execution is not supported.
+
 ## Grover Search
 
 ```python
@@ -22,4 +25,4 @@ print(phase)
 ```
 
 Both functions use Qiskit's simulator backend and require the
-`qiskit` package to be installed.
+`qiskit` package to be installed; real hardware backends are ignored.

--- a/docs/quantum/quantum_integration_plan.md
+++ b/docs/quantum/quantum_integration_plan.md
@@ -2,6 +2,9 @@
 
 This roadmap outlines upcoming steps for extending quantum capabilities.
 
+> **Note**
+> Current quantum modules operate in simulation mode only. Hardware connectivity remains a future roadmap item.
+
 ## Roadmap
 
 1. **Stabilize Simulator Infrastructure** – ensure deterministic fallbacks for

--- a/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/documentation/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -19,7 +19,7 @@
 ### **System Classification**
 The gh_COPILOT Toolkit v4.0 represents a revolutionary enterprise-grade automation platform that implements a database-first, unified system architecture with advanced AI integration capabilities, comprehensive security protocols, and enterprise-scale deployment readiness.
 
-*This whitepaper describes planned capabilities. Several features, including quantum optimization and full enterprise deployment, remain experimental or under development.*
+*This whitepaper describes planned capabilities. Several features, including quantum optimization and full enterprise deployment, remain experimental or under development. All quantum components operate through simulators; hardware backends are not supported.*
 
 ### **Core Technical Architecture**
 - **Unified Enterprise Systems**: Gradual consolidation of legacy scripts into modular packages

--- a/documentation/DATABASE_FIRST_EXPANSION_PLAN.md
+++ b/documentation/DATABASE_FIRST_EXPANSION_PLAN.md
@@ -5,6 +5,9 @@
 
 From the semantic search, I've identified **46 production database tables** and multiple database schemas that need to be integrated into our comprehensive PIS framework for true database-first functionality.
 
+> **Note**
+> Quantum-related fields in this plan are placeholders for simulation-only algorithms. Hardware execution is not supported.
+
 **Existing Database Infrastructure:**
 - **production.db**: 46 tables including compliance_events, script_metadata, template_patterns
 - **analytics.db**: Template management and usage analytics
@@ -29,7 +32,7 @@ CREATE TABLE pis_framework_sessions (
     completed_phases INTEGER DEFAULT 0,
     overall_success_rate REAL DEFAULT 0.0,
     enterprise_enhancements_active BOOLEAN DEFAULT TRUE,
-    quantum_optimization_enabled BOOLEAN DEFAULT TRUE,
+    quantum_optimization_enabled BOOLEAN DEFAULT TRUE, -- simulation placeholder
     continuous_operation_mode BOOLEAN DEFAULT TRUE,
     anti_recursion_active BOOLEAN DEFAULT TRUE,
     dual_copilot_enabled BOOLEAN DEFAULT TRUE,
@@ -184,7 +187,7 @@ CREATE TABLE quantum_algorithms_registry (
 ```
 
 The migration to replace the legacy `PLACEHOLDER` implementation status has been executed.
-All rows in `quantum_algorithms_registry` now store `IMPLEMENTED` to reflect production-ready algorithms.
+All rows in `quantum_algorithms_registry` now store `SIMULATION_ONLY` to reflect placeholder algorithms.
 
 #### **C. Web-GUI Integration Metrics**
 ```sql

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,6 +1,6 @@
 # 🚀 gh_COPILOT Enterprise Toolkit v4.0
 
-**Notice: ** Quantum optimization and other advanced capabilities mentioned in earlier drafts are ** not ** implemented in this repository. The toolkit currently consists of standard Python scripts for deployment, monitoring, and basic template automation.
+**Notice:** Quantum optimization and other advanced capabilities operate through simulation-only placeholders. The toolkit currently consists of standard Python scripts for deployment, monitoring, and basic template automation; no quantum hardware integration is available.
 
 # Current Status
 
@@ -10,9 +10,7 @@
 
 - **Algorithm Performance: ** modest improvements over baseline
 - **Template Completion: ** automation scripts demonstrate partial coverage
-- **Quantum Optimization: ** implemented via a Qiskit-based optimizer
-  leveraging rotation-angle search. The `_deploy_quantum_algorithms()`
-  method now generates functional scripts providing this capability.
+- **Quantum Optimization:** simulation stubs demonstrate rotation-angle search concepts. The `_deploy_quantum_algorithms()` method generates placeholder scripts for demonstration only.
 - **Enterprise Systems: ** monitoring and validation modules operational
 - **Security Compliance: ** Anti-recursion, zero-byte protection, DUAL COPILOT pattern
 - **Performance Monitoring: ** monitoring scripts available
@@ -44,8 +42,8 @@
 # 🌌 Quantum-Enhanced Features (Planned)
 
 - These items describe aspirational functionality and are gradually being implemented.
-- **Quantum Algorithm Optimization**: basic optimization implemented using Qiskit rotation search
-- **Quantum Optimizer Scripts: ** `QuantumOptimizer` and related functions provide a working example
+- **Quantum Algorithm Optimization**: simulation-only examples using Qiskit rotation search
+- **Quantum Optimizer Scripts:** `QuantumOptimizer` and related functions provide simulation-only examples
 - **Ultra-Aggressive Template Completion**: target completion rate subject to future development
 - **Real-time Performance Monitoring**: conceptual self-learning analytics
 - **Substantial Algorithm Boost**: planned quantum-inspired performance enhancements

--- a/documentation/generated/daily state update/gh_COPILOT_Project_White-Paper_Blueprint_2025-08-04.md
+++ b/documentation/generated/daily state update/gh_COPILOT_Project_White-Paper_Blueprint_2025-08-04.md
@@ -1,7 +1,7 @@
-# gh_COPILOT Project White-Paper Blueprint Summary (2025-08-04)
+# gh_COPILOT Project White-Paper Blueprint Summary (2025-08-05)
 
 ## Objectives
-- Update the enterprise whitepaper to reflect current architecture and feature maturity.
+- Update the enterprise whitepaper to reflect current architecture and feature maturity, clarifying that all quantum components are simulation-only.
 - Complete anti-recursion safeguards, composite compliance scoring, and placeholder remediation.
 - Align documentation with the latest code and commit milestones.
 
@@ -16,6 +16,6 @@
 - Extend recursion checks and implement PID tracking in `compliance.py` to fully operationalize anti-recursion guards.
 - Define compliance scoring formula in `phase5_tasks.md` to implement composite compliance score.
 - Run `code_placeholder_audit` to remove remaining TODO/FIXME placeholders.
-- Update documentation and whitepapers to align with current codebase and simulation-only quantum features.
+- Update documentation and whitepapers to align with current codebase and explicitly mark quantum features as simulation-only.
 - Fix failing tests and resolve Ruff/Pyright issues to stabilise CI.
 


### PR DESCRIPTION
## Summary
- document that all quantum components are simulation-only across whitepapers, expansion plans, and quantum guides
- sync README files and daily whitepaper with updated architecture narrative

## Testing
- `ruff check documentation docs`
- `pytest tests/documentation`
- `python scripts/wlc_session_manager.py --db-path databases/production.db` *(fails: NotADirectoryError: [Errno 20] Not a directory: '/workspace/gh_COPILOT/databases/production.db')*


------
https://chatgpt.com/codex/tasks/task_e_689236e7c8e48331bb674d4f47f33ff7