### PR TITLE
fix: ensure setup script resolves run_migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,9 @@ Set these variables in your `.env` file or shell before running scripts:
 ## 🛠️ Troubleshooting
 
 - **Setup script fails** – ensure network access and rerun `bash setup.sh`.
+- **ImportError in `setup_environment.py`** – the script now adds the repository root to
+  `sys.path` when executed directly. Update to the latest commit if you see
+  `attempted relative import` errors.
 - **`clw` not found** – run `tools/install_clw.sh` to install and then `clw --help`.
 - **Database errors** – verify `GH_COPILOT_WORKSPACE` is configured correctly.
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -11,7 +11,13 @@ from pathlib import Path
 from typing import Iterable
 import logging
 
-from . import run_migrations
+# When executed directly, ensure the repository root is on ``sys.path`` so that
+# imports from the ``scripts`` package resolve correctly.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import run_migrations
 
 
 def ensure_env() -> None:


### PR DESCRIPTION
## Summary
- fix setup_environment to import run_migrations when executed directly
- document troubleshooting tip for setup_environment ImportError

## Testing
- `ruff check .`
- `pyright scripts/setup_environment.py`
- `pytest` *(tests: 2 skipped, 40 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689236f466388331929280f4671a0e5d