### PR TITLE
Implement composite compliance score persistence

### DIFF
--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -24,7 +24,7 @@ from utils.validation_utils import validate_enterprise_environment
 from database_first_synchronization_engine import list_events
 from enterprise_modules.compliance import (
     get_latest_compliance_score,
-    calculate_code_quality_score,
+    calculate_composite_score,
 )
 
 
@@ -66,7 +66,7 @@ def _load_metrics() -> dict[str, Any]:
             )
             row = cur.fetchone()
             if row:
-                score, breakdown = calculate_code_quality_score(
+                score, breakdown = calculate_composite_score(
                     row["ruff_issues"],
                     row["tests_passed"],
                     row["tests_failed"],

--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -547,10 +547,18 @@ def calculate_and_persist_compliance_score() -> float:
     issues = _run_ruff()
     passed, failed = _run_pytest()
     placeholders_open = _count_placeholders()
-    score = calculate_compliance_score(
+    score, _ = calculate_composite_score(
         issues, passed, failed, placeholders_open, 0
     )
     persist_compliance_score(score)
+    record_code_quality_metrics(
+        issues,
+        passed,
+        failed,
+        placeholders_open,
+        0,
+        score,
+    )
     send_dashboard_alert({"event": "compliance_score", "score": score})
     return score
 

--- a/phase5_tasks.md
+++ b/phase5_tasks.md
@@ -13,3 +13,5 @@ score = 0.3 * L + 0.5 * T + 0.2 * P
 ```
 
 This applies weights of **30%** to lint results, **50%** to tests, and **20%** to placeholder cleanup. The score is stored in `analytics.db` and surfaced at `/dashboard/compliance`.
+
+Implemented in [`calculate_composite_score`](enterprise_modules/compliance.py), the function returns the overall score and a breakdown of each weighted component for dashboard use.

--- a/tests/dashboard/test_composite_score_persistence.py
+++ b/tests/dashboard/test_composite_score_persistence.py
@@ -1,0 +1,32 @@
+import json
+import pytest
+
+import dashboard.enterprise_dashboard as ed
+from enterprise_modules.compliance import (
+    calculate_composite_score,
+    persist_compliance_score,
+    record_code_quality_metrics,
+)
+
+
+def test_composite_score_persisted_and_served(tmp_path, monkeypatch):
+    metrics_file = tmp_path / "metrics.json"
+    metrics_file.write_text(json.dumps({"metrics": {}}), encoding="utf-8")
+    db = tmp_path / "analytics.db"
+    monkeypatch.setattr(ed, "METRICS_FILE", metrics_file)
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+
+    score, breakdown = calculate_composite_score(5, 8, 2, 1, 4)
+    persist_compliance_score(score, db_path=db)
+    record_code_quality_metrics(5, 8, 2, 1, 4, score, db_path=db)
+
+    client = ed.app.test_client()
+    resp = client.get("/dashboard/compliance")
+    data = resp.get_json()["metrics"]
+
+    assert data["compliance_score"] == pytest.approx(score, rel=1e-3)
+    assert data["composite_score"] == pytest.approx(score, rel=1e-3)
+    assert data["score_breakdown"]["placeholder_score"] == pytest.approx(
+        breakdown["placeholder_score"], rel=1e-3
+    )
+


### PR DESCRIPTION
## Summary
- compute weighted composite score in `calculate_composite_score`
- persist code quality metrics and expose them on `/dashboard/compliance`
- document formula and link to implementation

## Testing
- `pytest tests/test_compliance_score.py tests/validation/test_compliance_scoring.py tests/dashboard/test_score_serialization.py tests/dashboard/test_composite_score_persistence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68925da0e7e4833199fcdf152214ddd1