### PR TITLE
Add PID-based recursion guard

### DIFF
--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import json
 import threading
+import logging
 from datetime import datetime
 from functools import wraps
 from pathlib import Path
@@ -45,6 +46,9 @@ _PID_CHILDREN: dict[int, set[int]] = {}
 _GUARD_LOCK = threading.Lock()
 _PID_LOG_LOCK = threading.Lock()
 _PID_THREADS: dict[int, set[int]] = {}
+# Track simple call depth per process ID to prevent excessive recursion
+_PROCESS_DEPTHS: dict[int, int] = {}
+_PROCESS_DEPTH_LOCK = threading.Lock()
 
 
 def anti_recursion_guard(func: F) -> F:
@@ -117,6 +121,45 @@ def anti_recursion_guard(func: F) -> F:
                                 _PID_CHILDREN.pop(parent, None)
                 else:
                     _PID_DEPTHS[pid] = remaining
+
+    return cast(F, wrapper)
+
+
+def pid_recursion_guard(func: F) -> F:
+    """Guard against excessive recursion per process ID.
+
+    Each process ID maintains its own call depth counter. When the
+    counter exceeds ``MAX_RECURSION_DEPTH`` the call is aborted and a
+    compliance violation is logged with the offending PID for auditing.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any):
+        pid = os.getpid()
+        with _PROCESS_DEPTH_LOCK:
+            current = _PROCESS_DEPTHS.get(pid, 0)
+            next_depth = current + 1
+            if next_depth > MAX_RECURSION_DEPTH:
+                logger.error(
+                    "Recursion depth %s exceeded for PID %s", next_depth, pid
+                )
+                _log_violation(f"recursion_violation:pid={pid}:depth={next_depth}")
+                raise ComplianceError(
+                    f"Recursion depth {next_depth} exceeded for PID {pid}"
+                )
+            _PROCESS_DEPTHS[pid] = next_depth
+
+        try:
+            return func(*args, **kwargs)
+        finally:
+            with _PROCESS_DEPTH_LOCK:
+                remaining = _PROCESS_DEPTHS.get(pid, 0) - 1
+                if remaining <= 0:
+                    _PROCESS_DEPTHS.pop(pid, None)
+                else:
+                    _PROCESS_DEPTHS[pid] = remaining
 
     return cast(F, wrapper)
 
@@ -734,6 +777,7 @@ __all__ = [
     "validate_environment",
     "enforce_anti_recursion",
     "anti_recursion_guard",
+    "pid_recursion_guard",
     "generate_compliance_summary",
     "calculate_compliance_score",
     "persist_compliance_score",

--- a/tests/test_pid_recursion_guard.py
+++ b/tests/test_pid_recursion_guard.py
@@ -1,0 +1,83 @@
+import os
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.modules.setdefault("tqdm", types.SimpleNamespace(tqdm=lambda x, **_: x))
+class _DummyPathManager:
+    @staticmethod
+    def get_workspace_path():
+        return Path.cwd()
+
+    @staticmethod
+    def get_backup_root():
+        return Path("/tmp")
+
+sys.modules.setdefault(
+    "utils.cross_platform_paths",
+    types.SimpleNamespace(CrossPlatformPathManager=_DummyPathManager),
+)
+sys.modules.setdefault(
+    "utils.log_utils", types.SimpleNamespace(send_dashboard_alert=lambda *a, **k: None)
+)
+_scripts = types.ModuleType("scripts")
+_database = types.ModuleType("scripts.database")
+def _ensure_violation_logs(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS violation_logs (timestamp TEXT, details TEXT)"
+        )
+        conn.commit()
+
+_database.add_violation_logs = types.SimpleNamespace(
+    ensure_violation_logs=_ensure_violation_logs
+)
+_database.add_rollback_logs = types.SimpleNamespace(
+    ensure_rollback_logs=lambda *a, **k: None
+)
+_scripts.database = _database
+_scripts.run_migrations = types.SimpleNamespace(
+    ensure_migrations_applied=lambda *a, **k: None
+)
+sys.modules.setdefault("scripts", _scripts)
+sys.modules.setdefault("scripts.database", _database)
+sys.modules.setdefault(
+    "scripts.database.add_violation_logs", _database.add_violation_logs
+)
+sys.modules.setdefault(
+    "scripts.database.add_rollback_logs", _database.add_rollback_logs
+)
+sys.modules.setdefault("scripts.run_migrations", _scripts.run_migrations)
+
+from enterprise_modules.compliance import (
+    MAX_RECURSION_DEPTH,
+    ComplianceError,
+    pid_recursion_guard,
+)
+
+
+@pid_recursion_guard
+def _recursive_call(level: int) -> str:
+    if level > 0:
+        return _recursive_call(level - 1)
+    return "done"
+
+
+def test_pid_recursion_guard_logs_violation(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+
+    # Within threshold executes successfully
+    assert _recursive_call(MAX_RECURSION_DEPTH - 1) == "done"
+
+    # Exceeding threshold raises and logs a violation with PID details
+    with pytest.raises(ComplianceError):
+        _recursive_call(MAX_RECURSION_DEPTH)
+
+    db = tmp_path / "databases" / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        rows = conn.execute("SELECT details FROM violation_logs").fetchall()
+    assert any(f"pid={os.getpid()}" in r[0] for r in rows)
+


### PR DESCRIPTION
## Summary
- add per-process recursion guard to compliance module
- log guard violations with PID depth details for auditing
- test that recursive calls trigger the guard and write violation logs

## Testing
- `ruff check -v enterprise_modules/compliance.py tests/test_pid_recursion_guard.py`
- `pytest tests/test_pid_recursion_guard.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68925da10ea88331b2e6d504e49c8007