### PR TITLE
fix: guard file operations and external commands

### DIFF
--- a/quantum/benchmarking.py
+++ b/quantum/benchmarking.py
@@ -8,6 +8,11 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, Dict
 
+from enterprise_modules.compliance import (
+    anti_recursion_guard,
+    validate_enterprise_operation,
+)
+
 # Imports are deferred in functions to avoid heavy dependencies at import time
 
 try:
@@ -34,9 +39,12 @@ __all__ = [
 ]
 
 
+@anti_recursion_guard
 def load_metrics(path: str | Path = "production_performance_validation.json") -> Dict[str, Any]:
     """Load production performance metrics from a JSON file."""
     metrics_path = Path(path)
+    if not validate_enterprise_operation(str(metrics_path)):
+        raise RuntimeError("Invalid target path")
     with metrics_path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
 

--- a/scripts/binary_to_base64.py
+++ b/scripts/binary_to_base64.py
@@ -38,6 +38,10 @@ import zipfile
 from pathlib import Path
 
 from misc.legacy.Base64ImageTransformer import EncodeWorker
+from enterprise_modules.compliance import (
+    anti_recursion_guard,
+    validate_enterprise_operation,
+)
 
 TEXT_INDICATORS = {
     "start": "[START]",
@@ -46,16 +50,23 @@ TEXT_INDICATORS = {
 }
 
 
+@anti_recursion_guard
 def run_git(*args: str) -> None:
     """Run a Git command, ignoring errors."""
 
+    command = f"git {' '.join(args)}"
+    if not validate_enterprise_operation(command=command):
+        raise RuntimeError("forbidden command")
     subprocess.run(["git", *args], check=False)
 
 
+@anti_recursion_guard
 def append_gitignore(path: Path) -> None:
     """Append the given path to .gitignore if not already present."""
 
     gitignore = Path(".gitignore")
+    if not validate_enterprise_operation(str(gitignore)):
+        raise RuntimeError("Invalid target path")
     existing = gitignore.read_text(encoding="utf-8").splitlines()
     if str(path) not in existing:
         with gitignore.open("a", encoding="utf-8") as fh:
@@ -75,13 +86,18 @@ def encode_zip(zip_path: Path) -> str:
     return encoded[0]
 
 
+@anti_recursion_guard
 def process_file(file_path: Path) -> Path:
     """Process a single file and return path to the encoded text file."""
 
+    if not validate_enterprise_operation(str(file_path)):
+        raise RuntimeError("Invalid target path")
     run_git("rm", "--cached", str(file_path))
     append_gitignore(file_path)
 
     zip_path = file_path.with_suffix(file_path.suffix + ".zip")
+    if not validate_enterprise_operation(str(zip_path)):
+        raise RuntimeError("Invalid target path")
     with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.write(file_path, arcname=file_path.name)
 
@@ -89,6 +105,8 @@ def process_file(file_path: Path) -> Path:
     zip_path.unlink()
 
     output_path = file_path.with_name(f"{file_path.name}_zip_base64.txt")
+    if not validate_enterprise_operation(str(output_path)):
+        raise RuntimeError("Invalid target path")
     output_path.write_text(b64_text, encoding="utf-8")
     run_git("add", str(output_path))
     return output_path
@@ -100,6 +118,8 @@ def main() -> int:
     args = parser.parse_args()
 
     file_path = args.file
+    if not validate_enterprise_operation(str(file_path)):
+        raise RuntimeError("Invalid target path")
     if not file_path.exists():
         print(f"{TEXT_INDICATORS['error']} File not found: {file_path}")
         return 1

--- a/tests/scripts/test_security_guards.py
+++ b/tests/scripts/test_security_guards.py
@@ -1,0 +1,89 @@
+import os
+import importlib.util
+import os
+from pathlib import Path
+import pytest
+import types
+import sys
+
+
+def _load_module(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+dummy_worker = types.SimpleNamespace(
+    encoding_successful=type("Sig", (), {"connect": lambda self, cb: None})(),
+    run_encode=lambda self: None,
+)
+sys.modules.setdefault(
+    "misc.legacy.Base64ImageTransformer",
+    types.SimpleNamespace(EncodeWorker=lambda *_a, **_k: dummy_worker),
+)
+sys.modules.setdefault("tqdm", types.SimpleNamespace(tqdm=lambda x: x))
+
+class _ComplianceModule(types.ModuleType):
+    MAX_DEPTH = 5
+
+    def anti_recursion_guard(self, func):
+        depth = {"n": 0}
+
+        def wrapper(*args, **kwargs):
+            depth["n"] += 1
+            if depth["n"] > self.MAX_DEPTH:
+                raise RuntimeError("Recursion depth exceeded")
+            try:
+                return func(*args, **kwargs)
+            finally:
+                depth["n"] -= 1
+
+        return wrapper
+
+    @staticmethod
+    def validate_enterprise_operation(target_path: str | None = None, *, command: str | None = None) -> bool:
+        if command and "rm -rf" in command.lower():
+            return False
+        return True
+
+compliance_stub = _ComplianceModule("enterprise_modules.compliance")
+sys.modules.setdefault("enterprise_modules.compliance", compliance_stub)
+sys.modules.setdefault(
+    "scripts.run_migrations", types.SimpleNamespace(ensure_migrations_applied=lambda: None)
+)
+
+b2b = _load_module(Path(__file__).resolve().parents[2] / "scripts" / "binary_to_base64.py")
+rr = _load_module(Path(__file__).resolve().parents[2] / "scripts" / "reclone_repo.py")
+
+
+def _setup_env(tmp_path):
+    workspace = tmp_path / "ws"
+    backup = tmp_path / "backup"
+    workspace.mkdir()
+    backup.mkdir()
+    os.environ["GH_COPILOT_WORKSPACE"] = str(workspace)
+    os.environ["GH_COPILOT_BACKUP_ROOT"] = str(backup)
+    return workspace
+
+
+def test_run_git_blocks_forbidden_command(monkeypatch, tmp_path):
+    _setup_env(tmp_path)
+    monkeypatch.setattr(b2b.subprocess, "run", lambda *a, **k: None)
+    with pytest.raises(RuntimeError):
+        b2b.run_git("rm", "-rf", "/")
+
+
+def test_clone_repository_recursion(monkeypatch, tmp_path):
+    workspace = _setup_env(tmp_path)
+
+    monkeypatch.setattr(rr, "validate_enterprise_operation", lambda *a, **k: True)
+
+    def fake_run(*args, **kwargs):
+        rr.clone_repository("url", str(workspace / "dest"), "main")
+
+    monkeypatch.setattr(rr.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError):
+        rr.clone_repository("url", str(workspace / "dest"), "main")


### PR DESCRIPTION
## Summary
- add anti-recursion guard and enterprise path validation to quantum benchmarking helpers
- enforce command and path validation in binary handling and repository cloning scripts
- test recursion guard violations and forbidden command detection

## Testing
- `pytest tests/scripts/test_security_guards.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68926615afd08331a11354586212a0f5