### PR TITLE
feat: track unresolved placeholders

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -161,6 +161,7 @@ class ComplianceMetricsUpdater:
             "open_placeholders": 0,
             "resolved_placeholders": 0,
             "auto_resolved_placeholders": 0,
+            "ticketed_placeholders": 0,
             "compliance_score": 1.0,
             "violation_count": 0,
             "rollback_count": 0,
@@ -191,6 +192,8 @@ class ComplianceMetricsUpdater:
                     metrics["resolved_placeholders"] = cur.fetchone()[0]
                     cur.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='open'")
                     metrics["open_placeholders"] = cur.fetchone()[0]
+                    cur.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='ticketed'")
+                    metrics["ticketed_placeholders"] = cur.fetchone()[0]
                 metrics["placeholder_removal"] = metrics["resolved_placeholders"]
 
                 open_ph = metrics["open_placeholders"]

--- a/docs/AUDITING_WORKFLOW.md
+++ b/docs/AUDITING_WORKFLOW.md
@@ -2,15 +2,21 @@
 
 This project includes an automated placeholder audit to keep the codebase compliant.
 
-1. Run `scripts/code_placeholder_audit.py` to scan the workspace. It logs unresolved
-   placeholders to `analytics.db` and updates `dashboard/compliance/placeholder_summary.json`.
-2. When placeholders are removed from the codebase, rerun the audit with
+1. Run `scripts/code_placeholder_audit.py --task-report reports/placeholder_tasks.json`
+   to scan the workspace. It logs unresolved placeholders to `analytics.db`, writes a
+   task report (JSON or Markdown), and updates
+   `dashboard/compliance/placeholder_summary.json`.
+2. Use `scripts/placeholder_enforcer.py --report reports/placeholder_tasks.json` to
+   open tracking tickets or PR stubs for each unresolved placeholder. The enforcer
+   marks matching entries in `analytics.db.todo_fixme_tracking` and refreshes the
+   dashboard metrics.
+3. When placeholders are removed from the codebase, rerun the audit with
    `--update-resolutions` to automatically purge resolved entries from the tracking table.
-3. Pass `--apply-fixes` to remove placeholder comments directly from source files. The
+4. Pass `--apply-fixes` to remove placeholder comments directly from source files. The
    audit also cleans up any placeholder metadata that is no longer needed.
-4. `dashboard/compliance_metrics_updater.py` reads `analytics.db` and recomputes the
-   `compliance_score` based on remaining open placeholders. Run it to refresh the
-   dashboard after each audit.
+5. `dashboard/compliance_metrics_updater.py` reads `analytics.db` and recomputes the
+   `compliance_score` based on remaining open or ticketed placeholders. Run it to
+   refresh the dashboard after each audit/enforcement.
 
 The `DatabaseComplianceChecker` now corrects common issues automatically. Its
 `correct_file` routine removes placeholder markers (such as `TODO` or

--- a/scripts/placeholder_enforcer.py
+++ b/scripts/placeholder_enforcer.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from tqdm import tqdm
+
+from enterprise_modules.compliance import validate_enterprise_operation
+from dashboard.compliance_metrics_updater import ComplianceMetricsUpdater
+from utils.log_utils import log_message
+
+
+TEXT = {
+    "start": "[START]",
+    "success": "[SUCCESS]",
+    "error": "[ERROR]",
+    "info": "[INFO]",
+    "progress": "[PROGRESS]",
+    "complete": "[COMPLETE]",
+}
+
+
+def _parse_report(path: Path) -> List[Dict[str, str]]:
+    """Return tasks extracted from a JSON or Markdown report."""
+
+    if path.suffix.lower() == ".md":
+        tasks: List[Dict[str, str]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            match = re.match(r"- \[ \] (.*)", line)
+            if not match:
+                continue
+            desc = match.group(1)
+            file_match = re.search(r" in (.*):(\d+)", desc)
+            pattern_match = re.search(r"Remove (.*?) in", desc)
+            context_match = re.search(r" - (.*)$", desc)
+            tasks.append(
+                {
+                    "task": desc,
+                    "file": file_match.group(1) if file_match else "",
+                    "line": file_match.group(2) if file_match else "0",
+                    "pattern": pattern_match.group(1) if pattern_match else "",
+                    "context": context_match.group(1) if context_match else "",
+                }
+            )
+        return tasks
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, dict) and "tasks" in data:
+        return data["tasks"]
+    return data
+
+
+def _open_stub(task: Dict[str, str], ticket_dir: Path) -> Path:
+    """Create a tracking ticket/PR stub for ``task``."""
+
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    validate_enterprise_operation(str(ticket_dir))
+    name = f"{Path(task['file']).name}_{task['line']}_{task['pattern']}".replace(" ", "_")
+    stub = ticket_dir / f"{name}.md"
+    content = (
+        f"# Placeholder Resolution\n\n{task['task']}\n\n"
+        f"Created: {datetime.now().isoformat()}\n"
+    )
+    stub.write_text(content, encoding="utf-8")
+    return stub
+
+
+def _update_tracking(db_path: Path, task: Dict[str, str]) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE todo_fixme_tracking
+               SET status='ticketed'
+             WHERE file_path=? AND line_number=? AND placeholder_type=? AND resolved=0
+            """,
+            (task["file"], int(task["line"]), task["pattern"]),
+        )
+        conn.commit()
+
+
+def main(
+    *,
+    report: str,
+    analytics_db: str,
+    ticket_dir: str = "reports/placeholder_tickets",
+    dashboard_dir: str = "dashboard/compliance",
+    simulate: bool = False,
+) -> int:
+    """Read placeholder report and open tracking stubs."""
+
+    report_path = Path(report)
+    analytics = Path(analytics_db)
+    tickets = Path(ticket_dir)
+    tasks = _parse_report(report_path)
+
+    log_message(__name__, f"{TEXT['start']} enforcing {len(tasks)} placeholders")
+    created = 0
+    with tqdm(total=len(tasks), desc=f"{TEXT['progress']} enforcing", unit="task") as bar:
+        for task in tasks:
+            _open_stub(task, tickets)
+            if not simulate:
+                _update_tracking(analytics, task)
+            created += 1
+            bar.update(1)
+    if not simulate:
+        updater = ComplianceMetricsUpdater(Path(dashboard_dir), test_mode=simulate)
+        updater.update(simulate=simulate)
+        updater.validate_update()
+    log_message(__name__, f"{TEXT['complete']} created {created} stubs")
+    return created
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create tracking tickets or PR stubs from placeholder report",
+    )
+    parser.add_argument("--report", required=True, help="Path to placeholder task report")
+    parser.add_argument("--analytics-db", required=True, help="analytics.db location")
+    parser.add_argument(
+        "--ticket-dir",
+        default="reports/placeholder_tickets",
+        help="Directory to write ticket stubs",
+    )
+    parser.add_argument(
+        "--dashboard-dir",
+        default="dashboard/compliance",
+        help="Dashboard compliance directory",
+    )
+    parser.add_argument(
+        "--simulate",
+        action="store_true",
+        help="Run in test mode without database writes",
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(
+        report=args.report,
+        analytics_db=args.analytics_db,
+        ticket_dir=args.ticket_dir,
+        dashboard_dir=args.dashboard_dir,
+        simulate=args.simulate,
+    )

--- a/tests/placeholder_audit/test_placeholder_enforcer.py
+++ b/tests/placeholder_audit/test_placeholder_enforcer.py
@@ -1,0 +1,57 @@
+import json
+import sqlite3
+from types import SimpleNamespace
+
+from scripts.code_placeholder_audit import main as audit_main
+from scripts.placeholder_enforcer import main as enforce_main
+import secondary_copilot_validator
+
+
+def test_placeholder_enforcer_updates_tracking(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "a.py").write_text("# TODO\n")
+    analytics = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dashboard"
+
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setattr(secondary_copilot_validator, "run_flake8", lambda *a, **k: True)
+    monkeypatch.setattr(
+        secondary_copilot_validator,
+        "SecondaryCopilotValidator",
+        lambda: SimpleNamespace(validate_corrections=lambda *a, **k: True),
+    )
+    monkeypatch.setattr(
+        "scripts.code_placeholder_audit.ComplianceMetricsUpdater",
+        lambda *a, **k: SimpleNamespace(update=lambda *a, **k: None, validate_update=lambda *a, **k: True),
+    )
+
+    report = tmp_path / "tasks.json"
+    audit_main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(dash_dir),
+        task_report=report,
+    )
+    assert json.loads(report.read_text())
+
+    ticket_dir = tmp_path / "tickets"
+    monkeypatch.setattr(
+        "scripts.placeholder_enforcer.ComplianceMetricsUpdater",
+        lambda *a, **k: SimpleNamespace(update=lambda *a, **k: None, validate_update=lambda *a, **k: True),
+    )
+    created = enforce_main(
+        report=str(report),
+        analytics_db=str(analytics),
+        ticket_dir=str(ticket_dir),
+        dashboard_dir=str(dash_dir),
+    )
+
+    assert created == 1
+    assert ticket_dir.exists()
+    assert len(list(ticket_dir.iterdir())) == 1
+    with sqlite3.connect(analytics) as conn:
+        status = conn.execute("SELECT status FROM todo_fixme_tracking").fetchone()[0]
+    assert status == "ticketed"

--- a/tests/placeholder_audit/test_task_report_generation.py
+++ b/tests/placeholder_audit/test_task_report_generation.py
@@ -1,0 +1,42 @@
+import json
+import sqlite3
+from types import SimpleNamespace
+
+from scripts.code_placeholder_audit import main
+import secondary_copilot_validator
+
+
+def test_task_report_written(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "a.py").write_text("# TODO\n")
+    analytics = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dashboard"
+
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setattr(secondary_copilot_validator, "run_flake8", lambda *a, **k: True)
+    monkeypatch.setattr(
+        secondary_copilot_validator,
+        "SecondaryCopilotValidator",
+        lambda: SimpleNamespace(validate_corrections=lambda *a, **k: True),
+    )
+    monkeypatch.setattr(
+        "scripts.code_placeholder_audit.ComplianceMetricsUpdater",
+        lambda *a, **k: SimpleNamespace(update=lambda *a, **k: None, validate_update=lambda *a, **k: True),
+    )
+
+    report = tmp_path / "tasks.json"
+    assert main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(dash_dir),
+        task_report=report,
+    )
+
+    assert report.exists()
+    data = json.loads(report.read_text())
+    assert data and data[0]["task"].startswith("Remove")
+    with sqlite3.connect(analytics) as conn:
+        status = conn.execute("SELECT status FROM todo_fixme_tracking").fetchone()[0]
+    assert status == "open"


### PR DESCRIPTION
## Summary
- export placeholder audit tasks to JSON or Markdown report
- add placeholder enforcer to convert reports into ticket stubs and update analytics
- surface ticketed placeholder counts on compliance dashboard

## Testing
- `ruff check scripts/code_placeholder_audit.py scripts/placeholder_enforcer.py dashboard/compliance_metrics_updater.py tests/placeholder_audit/test_task_report_generation.py tests/placeholder_audit/test_placeholder_enforcer.py`
- `pytest tests/placeholder_audit`


------
https://chatgpt.com/codex/tasks/task_e_68926611c1908331b1f34bcfbf6d4043