### PR TITLE
feat: validate documentation ingestion events

### DIFF
--- a/tests/database/test_documentation_ingestor.py
+++ b/tests/database/test_documentation_ingestor.py
@@ -1,0 +1,57 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.database.documentation_ingestor import ingest_documentation
+
+
+def test_duplicate_detection(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    workspace = tmp_path
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+    analytics_db = db_dir / "analytics.db"
+    monkeypatch.setenv("ANALYTICS_DB", str(analytics_db))
+    docs_dir = workspace / "documentation"
+    docs_dir.mkdir()
+    (docs_dir / "a.md").write_text("# Guide")
+    (docs_dir / "b.md").write_text("# Guide")
+    ingest_documentation(workspace, docs_dir)
+    with sqlite3.connect(db_dir / "enterprise_assets.db") as conn:
+        count = conn.execute("SELECT COUNT(*) FROM documentation_assets").fetchone()[0]
+    assert count == 1
+    with sqlite3.connect(analytics_db) as conn:
+        module_events = conn.execute(
+            "SELECT COUNT(*) FROM event_log WHERE module=?",
+            ("documentation_ingestor",),
+        ).fetchone()[0]
+    assert module_events == 2
+
+
+def test_validator_invoked(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    workspace = tmp_path
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+    analytics_db = db_dir / "analytics.db"
+    monkeypatch.setenv("ANALYTICS_DB", str(analytics_db))
+    docs_dir = workspace / "documentation"
+    docs_dir.mkdir()
+    doc = docs_dir / "guide.md"
+    doc.write_text("# Guide")
+
+    called: dict[str, list[str]] = {}
+
+    class DummyValidator:
+        def validate_corrections(self, files: list[str]) -> bool:  # pragma: no cover - simple stub
+            called["files"] = files
+            return True
+
+    monkeypatch.setattr(
+        "scripts.database.documentation_ingestor.SecondaryCopilotValidator",
+        lambda: DummyValidator(),
+    )
+
+    ingest_documentation(workspace, docs_dir)
+    assert called["files"] == [str(doc)]


### PR DESCRIPTION
## Summary
- run SecondaryCopilotValidator during documentation ingestion
- prevent duplicate docs via SHA256/MD5 checks and log events to analytics.db
- test validator invocation and duplicate detection

## Testing
- `ruff check scripts/database/documentation_ingestor.py tests/database/test_documentation_ingestor.py`
- `pytest tests/database/test_documentation_ingestor.py tests/test_documentation_ingestor.py tests/test_documentation_ingestor_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68926c57dddc83318128427e356d7c87