### PR TITLE
feat: enhance enterprise compliance monitoring

### DIFF
--- a/tests/monitoring/test_enterprise_compliance_monitor.py
+++ b/tests/monitoring/test_enterprise_compliance_monitor.py
@@ -1,0 +1,24 @@
+from scripts.monitoring import enterprise_compliance_monitor as ecm
+
+
+def test_functions_decorated():
+    assert hasattr(ecm.setup_logger, "__wrapped__")
+    assert hasattr(ecm.validate_logs, "__wrapped__")
+
+
+def test_validator_called_each_cycle(tmp_path, monkeypatch):
+    calls: list[list[str]] = []
+
+    class DummyValidator:
+        def validate_corrections(self, files):
+            calls.append(list(files))
+            return True
+
+    monkeypatch.setattr(ecm, "SecondaryCopilotValidator", lambda: DummyValidator())
+
+    logger = ecm.setup_logger(tmp_path)
+    ecm.run_monitor(logger, cycles=2)
+
+    log_file = tmp_path / "logs" / "enterprise_compliance_monitor.log"
+    assert len(calls) == 2
+    assert all(call == [str(log_file)] for call in calls)


### PR DESCRIPTION
## Summary
- add enterprise validation and recursion guard to enterprise compliance monitor
- validate log files each cycle using secondary copilot validator
- test anti-recursion decoration and validator invocation

## Testing
- `ruff check scripts/monitoring/enterprise_compliance_monitor.py tests/monitoring/test_enterprise_compliance_monitor.py`
- `pytest tests/monitoring/test_enterprise_compliance_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_68926c5bbff88331a870d2d4c7872eee