### PR TITLE
test: add ingestion pipeline duplication test

### DIFF
--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -1,70 +1,54 @@
 import sqlite3
+from pathlib import Path
 
-import pytest
-
-from scripts.database import template_asset_ingestor as tai
-from scripts.database import documentation_ingestor as di
+from scripts.database.template_asset_ingestor import ingest_templates
+from scripts.database.documentation_ingestor import ingest_documentation
 from scripts.database.cross_database_sync_logger import _table_exists
 from scripts.database.ingestion_validator import IngestionValidator
 
 
-@pytest.fixture()
-def temp_workspace(tmp_path, monkeypatch):
+def _create_duplicate_files(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "first.md").write_text("duplicate", encoding="utf-8")
+    (directory / "second.md").write_text("duplicate", encoding="utf-8")
+
+
+def test_ingestion_pipeline(tmp_path, monkeypatch):
     workspace = tmp_path
-    (workspace / "prompts").mkdir()
-    (workspace / "documentation").mkdir()
-    (workspace / "databases").mkdir()
+    db_dir = workspace / "databases"
+    prompts_dir = workspace / "prompts"
+    docs_dir = workspace / "documentation"
+    _create_duplicate_files(prompts_dir)
+    _create_duplicate_files(docs_dir)
 
-    monkeypatch.setattr(tai, "validate_enterprise_operation", lambda *a, **k: True)
-    monkeypatch.setattr(di, "validate_enterprise_operation", lambda *a, **k: True)
-    monkeypatch.setattr("scripts.database.cross_database_sync_logger.validate_enterprise_operation", lambda *a, **k: True)
-    monkeypatch.setattr(tai, "get_dataset_sources", lambda w: [])
-    monkeypatch.setattr(tai, "get_lesson_templates", lambda: {})
-
-    class DummyValidator:
-        def validate_corrections(self, paths):
-            return None
-
-    monkeypatch.setattr(di, "SecondaryCopilotValidator", lambda: DummyValidator())
-    monkeypatch.setenv("ANALYTICS_DB", str(workspace / "databases" / "analytics.db"))
+    analytics_db = db_dir / "analytics.db"
+    monkeypatch.setenv("ANALYTICS_DB", str(analytics_db))
+    monkeypatch.setenv("TEST_MODE", "1")
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
-    return workspace
 
+    ingest_templates(workspace, prompts_dir)
+    ingest_documentation(workspace, docs_dir)
 
-def _read_table(conn, table):
-    return [row for row in conn.execute(f"SELECT * FROM {table}")]
-
-
-def test_ingestion_pipeline(temp_workspace):
-    workspace = temp_workspace
-    tmpl_dir = workspace / "prompts"
-    doc_dir = workspace / "documentation"
-
-    (tmpl_dir / "a.md").write_text("template")
-    (tmpl_dir / "b.md").write_text("template")  # duplicate
-    (doc_dir / "a.md").write_text("doc")
-    (doc_dir / "b.md").write_text("doc")  # duplicate
-
-    tai.ingest_templates(workspace)
-    di.ingest_documentation(workspace)
-
-    db_path = workspace / "databases" / "enterprise_assets.db"
-    analytics_db = workspace / "databases" / "analytics.db"
-
+    db_path = db_dir / "enterprise_assets.db"
     with sqlite3.connect(db_path) as conn:
-        templates = _read_table(conn, "template_assets")
-        docs = _read_table(conn, "documentation_assets")
-        sync_logs = _read_table(conn, "cross_database_sync_operations")
+        template_count = conn.execute("SELECT COUNT(*) FROM template_assets").fetchone()[0]
+        doc_count = conn.execute("SELECT COUNT(*) FROM documentation_assets").fetchone()[0]
+        statuses = {
+            row[0]
+            for row in conn.execute(
+                "SELECT status FROM cross_database_sync_operations"
+            ).fetchall()
+        }
         assert _table_exists(conn, "cross_database_sync_operations")
+    assert template_count == 1
+    assert doc_count == 1
+    assert "DUPLICATE" in statuses
+    assert "SUCCESS" in statuses
 
     with sqlite3.connect(analytics_db) as conn:
-        events = _read_table(conn, "event_log")
-
-    assert len(templates) == 1
-    assert len(docs) == 1
-    statuses = {row[2] for row in sync_logs}
-    assert {"SUCCESS", "DUPLICATE"}.issubset(statuses)
-    assert events, "Analytics log should not be empty"
+        assert _table_exists(conn, "event_log")
+        event_count = conn.execute("SELECT COUNT(*) FROM event_log").fetchone()[0]
+    assert event_count > 0
 
     validator = IngestionValidator(workspace, db_path, analytics_db)
-    assert validator.validate()
+    assert validator.validate() is True


### PR DESCRIPTION
## Summary
- add regression test verifying duplicate detection and logging for template and documentation ingestion

## Testing
- `ruff check tests/test_ingestion_pipeline.py`
- `pytest tests/test_ingestion_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689282e9124c8331a47e7c7c88486e0d