### PR TITLE
feat: add dual copilot orchestrator hooks

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -37,6 +37,7 @@ from unified_monitoring_optimization_system import (
     push_metrics,
 )
 from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
+from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
 
 
 # Enterprise logging setup
@@ -619,11 +620,13 @@ def main(simulate: bool = False, stream: bool = False, test_mode: bool = False) 
     """Command-line entry point."""
     dashboard_dir = DASHBOARD_DIR
     updater = ComplianceMetricsUpdater(dashboard_dir, test_mode=test_mode)
+    orchestrator = DualCopilotOrchestrator(logging.getLogger(__name__))
     if stream:
         for metrics in updater.stream_metrics():
             print(metrics)
     else:
         updater.update(simulate=simulate)
+        orchestrator.validator.validate_corrections([str(updater.dashboard_dir / "metrics.json")])
         updater.validate_update()
 
 

--- a/scripts/autonomous_setup_and_audit.py
+++ b/scripts/autonomous_setup_and_audit.py
@@ -11,12 +11,12 @@ from typing import Optional
 
 from tqdm import tqdm
 
-from secondary_copilot_validator import SecondaryCopilotValidator
 from scripts.code_placeholder_audit import main as placeholder_audit
 from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
 from template_engine.template_synchronizer import _compliance_score
 from utils.log_utils import _log_event, TABLE_SCHEMAS
 from utils.lessons_learned_integrator import load_lessons, apply_lessons
+from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
 
 
 LOGGER = logging.getLogger(__name__)
@@ -378,8 +378,8 @@ def main() -> None:
 
     run_audit(workspace, analytics_db, production_db, dashboard_dir)
 
-    validator = SecondaryCopilotValidator()
-    valid = validator.validate_corrections([__file__])
+    orchestrator = DualCopilotOrchestrator()
+    valid = orchestrator.validator.validate_corrections([__file__])
     _log_event({"event": "secondary_validation", "result": valid}, table="correction_logs", db_path=analytics_db)
 
     LOGGER.info("Automation complete")

--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -42,6 +42,7 @@ import secondary_copilot_validator
 from utils.log_utils import log_message
 from dashboard.compliance_metrics_updater import ComplianceMetricsUpdater
 from unified_script_generation_system import EnterpriseUtility
+from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
 
 # Visual processing indicator constants
 TEXT = {
@@ -824,8 +825,8 @@ def main(
     valid = validate_results(len(results), analytics)
     if fail_on_findings and results:
         valid = False
-    secondary = secondary_copilot_validator.SecondaryCopilotValidator()
-    secondary.validate_corrections([r["file"] for r in results])
+    orchestrator = DualCopilotOrchestrator()
+    orchestrator.validator.validate_corrections([r["file"] for r in results])
     if valid:
         log_message(__name__, f"{TEXT['success']} audit logged {len(results)} findings")
     else:

--- a/tests/test_dual_copilot_hooks.py
+++ b/tests/test_dual_copilot_hooks.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+
+
+def test_code_placeholder_audit_hook(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "1")
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    module = importlib.reload(importlib.import_module("scripts.code_placeholder_audit"))
+    with patch("scripts.code_placeholder_audit.DualCopilotOrchestrator") as orch_cls:
+        instance = orch_cls.return_value
+        instance.validator.validate_corrections.side_effect = RuntimeError("fail")
+        with pytest.raises(RuntimeError):
+            module.main(workspace_path=str(tmp_path))
+        instance.validator.validate_corrections.assert_called_once()
+
+
+def test_dashboard_updater_hook(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    module = importlib.reload(importlib.import_module("dashboard.compliance_metrics_updater"))
+    with patch("dashboard.compliance_metrics_updater.DualCopilotOrchestrator") as orch_cls:
+        inst = orch_cls.return_value
+        inst.validator.validate_corrections.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            module.main(simulate=True, test_mode=True)
+        inst.validator.validate_corrections.assert_called_once()
+
+
+def test_autonomous_setup_and_audit_hook(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "1")
+    (tmp_path / "databases").mkdir()
+    (tmp_path / "dashboard" / "compliance").mkdir(parents=True)
+    module = importlib.reload(importlib.import_module("scripts.autonomous_setup_and_audit"))
+    with patch("scripts.database.cross_database_sync_logger.log_sync_operation", lambda *a, **k: None):
+        with patch("scripts.autonomous_setup_and_audit.DualCopilotOrchestrator") as orch_cls:
+            inst = orch_cls.return_value
+            inst.validator.validate_corrections.side_effect = RuntimeError("boom")
+            with pytest.raises(RuntimeError):
+                module.main()
+            inst.validator.validate_corrections.assert_called_once()
+


### PR DESCRIPTION
## Summary
- integrate DualCopilotOrchestrator into placeholder audit, dashboard metrics updater, and autonomous setup scripts
- add tests ensuring orchestrator hooks run and propagate validation failures

## Testing
- `ruff check scripts/code_placeholder_audit.py dashboard/compliance_metrics_updater.py scripts/autonomous_setup_and_audit.py tests/test_dual_copilot_hooks.py`
- `pytest tests/test_dual_copilot_hooks.py`
- `pytest tests/test_ingestion_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_689297eb5548833191e196f559a24972