### PR TITLE
feat: add dual copilot validation hooks

### DIFF
--- a/tests/test_dual_copilot_hooks.py
+++ b/tests/test_dual_copilot_hooks.py
@@ -6,17 +6,26 @@ from unittest.mock import patch
 import pytest
 
 
-def test_code_placeholder_audit_hook(monkeypatch, tmp_path):
-    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
-    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "1")
-    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
-    module = importlib.reload(importlib.import_module("scripts.code_placeholder_audit"))
-    with patch("scripts.code_placeholder_audit.DualCopilotOrchestrator") as orch_cls:
-        instance = orch_cls.return_value
-        instance.validator.validate_corrections.side_effect = RuntimeError("fail")
+def test_simple_placeholder_audit_hook(tmp_path):
+    (tmp_path / "f.txt").write_text("TODO\n")
+    module = importlib.reload(importlib.import_module("scripts.simple_placeholder_audit"))
+    with patch("scripts.simple_placeholder_audit.SecondaryCopilotValidator") as sec_cls, patch(
+        "scripts.simple_placeholder_audit.DualCopilotOrchestrator"
+    ) as orch_cls:
+        sec_cls.return_value.validate_corrections.return_value = True
+        inst = orch_cls.return_value
+        inst.validator.validate_corrections.side_effect = RuntimeError("fail")
         with pytest.raises(RuntimeError):
-            module.main(workspace_path=str(tmp_path))
-        instance.validator.validate_corrections.assert_called_once()
+            module.main(
+                [
+                    str(tmp_path),
+                    "--analytics-db",
+                    str(tmp_path / "a.db"),
+                    "--production-db",
+                    str(tmp_path / "p.db"),
+                ]
+            )
+        inst.validator.validate_corrections.assert_called_once()
 
 
 def test_dashboard_updater_hook(monkeypatch, tmp_path):
@@ -30,18 +39,22 @@ def test_dashboard_updater_hook(monkeypatch, tmp_path):
         inst.validator.validate_corrections.assert_called_once()
 
 
-def test_autonomous_setup_and_audit_hook(monkeypatch, tmp_path):
+def test_template_asset_ingestor_hook(monkeypatch, tmp_path):
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
-    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
-    monkeypatch.setenv("GH_COPILOT_TEST_MODE", "1")
     (tmp_path / "databases").mkdir()
-    (tmp_path / "dashboard" / "compliance").mkdir(parents=True)
-    module = importlib.reload(importlib.import_module("scripts.autonomous_setup_and_audit"))
-    with patch("scripts.database.cross_database_sync_logger.log_sync_operation", lambda *a, **k: None):
-        with patch("scripts.autonomous_setup_and_audit.DualCopilotOrchestrator") as orch_cls:
-            inst = orch_cls.return_value
-            inst.validator.validate_corrections.side_effect = RuntimeError("boom")
-            with pytest.raises(RuntimeError):
-                module.main()
-            inst.validator.validate_corrections.assert_called_once()
-
+    tmpl_dir = tmp_path / "prompts"
+    tmpl_dir.mkdir()
+    (tmpl_dir / "t.md").write_text("hello")
+    module = importlib.reload(importlib.import_module("scripts.database.template_asset_ingestor"))
+    with patch("scripts.database.template_asset_ingestor.validate_enterprise_operation", lambda *a, **k: None), patch(
+        "scripts.database.template_asset_ingestor.get_dataset_sources", return_value=[]
+    ), patch("scripts.database.template_asset_ingestor.get_lesson_templates", return_value={}), patch(
+        "scripts.database.template_asset_ingestor.log_sync_operation", lambda *a, **k: None
+    ), patch("scripts.database.template_asset_ingestor.check_database_sizes", return_value=True), patch(
+        "scripts.database.template_asset_ingestor.DualCopilotOrchestrator"
+    ) as orch_cls:
+        inst = orch_cls.return_value
+        inst.validator.validate_corrections.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            module.ingest_templates(tmp_path, tmpl_dir)
+        inst.validator.validate_corrections.assert_called_once()


### PR DESCRIPTION
## Summary
- integrate DualCopilotOrchestrator into simple placeholder audit and asset ingestion scripts
- validate corrections after placeholder audits, dashboard updates, and template ingestions
- test orchestrator hooks to ensure validation runs and propagates failures

## Testing
- `ruff check scripts/simple_placeholder_audit.py scripts/database/template_asset_ingestor.py tests/test_dual_copilot_hooks.py dashboard/compliance_metrics_updater.py`
- `pyright scripts/simple_placeholder_audit.py scripts/database/template_asset_ingestor.py tests/test_dual_copilot_hooks.py dashboard/compliance_metrics_updater.py`
- `pytest tests/test_dual_copilot_hooks.py`


------
https://chatgpt.com/codex/tasks/task_e_6892a784abc08331a17925608f5b9d39