### PR TITLE
feat: add auto-resolve placeholder audit option

### DIFF
--- a/tests/placeholder_audit/test_auto_resolve.py
+++ b/tests/placeholder_audit/test_auto_resolve.py
@@ -1,0 +1,53 @@
+import os
+import sqlite3
+from types import SimpleNamespace
+
+import secondary_copilot_validator
+from scripts.code_placeholder_audit import main
+
+os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+
+
+def test_auto_resolve_updates_db_and_file(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    target = workspace / "sample.py"
+    target.write_text("x = 1  # TODO remove\n")
+    analytics = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dashboard"
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+
+    monkeypatch.setattr(
+        secondary_copilot_validator,
+        "run_flake8",
+        lambda *a, **k: True,
+    )
+    monkeypatch.setattr(
+        secondary_copilot_validator,
+        "SecondaryCopilotValidator",
+        lambda: SimpleNamespace(validate_corrections=lambda *a, **k: True),
+    )
+    monkeypatch.setattr(
+        "scripts.code_placeholder_audit.ComplianceMetricsUpdater",
+        lambda *a, **k: SimpleNamespace(update=lambda *a, **k: None, validate_update=lambda *a, **k: None),
+    )
+
+    assert main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(dash_dir),
+        auto_resolve=True,
+    )
+
+    assert "TODO" not in target.read_text()
+
+    with sqlite3.connect(analytics) as conn:
+        row = conn.execute(
+            "SELECT resolved, status FROM todo_fixme_tracking"
+        ).fetchone()
+        rationale = conn.execute(
+            "SELECT rationale FROM corrections"
+        ).fetchone()[0]
+    assert row == (1, "resolved")
+    assert "Remove TODO" in rationale


### PR DESCRIPTION
## Summary
- add `--auto-resolve` flag to placeholder audit script to resolve TODO/FIXME entries
- log resolutions to `todo_fixme_tracking` with `CorrectionLoggerRollback`
- test auto resolution updates analytics and removes placeholders

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder_audit/test_auto_resolve.py`
- `pytest tests/placeholder_audit/test_auto_resolve.py --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6892a785c4ec8331aaa23db4173bab99