### PR TITLE
test: ensure quantum stubs warn when hardware missing

### DIFF
--- a/documentation/quantum_placeholder_roadmap.md
+++ b/documentation/quantum_placeholder_roadmap.md
@@ -10,3 +10,20 @@ purposes. Current placeholders include:
 
 Future iterations will replace these modules with fully implemented algorithms
 within the production `quantum` package.
+
+## Milestones
+
+The following milestones track the replacement of each stub with hardware-ready
+implementations coordinated by `quantum_integration_orchestrator.py` and
+governed by `quantum_compliance_engine.py`:
+
+- **Q3 2025 – `quantum_annealing.py`**: integrate a hardware-backed annealing
+  solver through the orchestrator with compliance scoring enabled.
+- **Q4 2025 – `quantum_superposition_search.py`**: deploy an orchestrator-managed
+  superposition search module validated by the compliance engine.
+- **Q1 2026 – `quantum_entanglement_correction.py`**: deliver a production-grade
+  entanglement correction routine with full orchestrator and compliance
+  integration.
+
+These milestones ensure each simulation placeholder evolves into a fully
+validated component once compatible quantum hardware becomes available.


### PR DESCRIPTION
## Summary
- add milestones for replacing quantum placeholders via orchestrator and compliance engine
- test backend provider, hardware-aware algorithm, and compliance engine warnings when hardware is unavailable

## Testing
- `ruff check tests/quantum/test_simulation_markers.py`
- `pytest tests/quantum/test_simulation_markers.py`

------
https://chatgpt.com/codex/tasks/task_e_6892a78d4a408331827cc1dc7ef45e34