### PR TITLE
fix: enforce compliance on file and database writes

### DIFF
--- a/tests/test_compliance_decorators.py
+++ b/tests/test_compliance_decorators.py
@@ -1,0 +1,40 @@
+"""Regression tests for compliance decorators."""
+
+import pytest
+
+from enterprise_modules.compliance import ComplianceError
+from enterprise_modules.file_utils import write_file_safely
+from utils.logging_utils import log_session_event
+
+
+def test_write_file_safely_forbidden(monkeypatch, tmp_path):
+    """write_file_safely raises when validation fails."""
+
+    monkeypatch.setattr(
+        "enterprise_modules.file_utils.validate_enterprise_operation",
+        lambda *a, **k: False,
+    )
+
+    target = tmp_path / "bad.txt"
+    target.touch()
+
+    with pytest.raises(ComplianceError):
+        write_file_safely(target, "data")
+
+
+def test_log_session_event_forbidden(monkeypatch, tmp_path):
+    """log_session_event raises when validation fails."""
+
+    monkeypatch.setattr(
+        "utils.logging_utils.validate_enterprise_operation",
+        lambda *a, **k: False,
+    )
+
+    db_file = tmp_path / "db.sqlite"
+    db_file.touch()
+
+    with pytest.raises(ComplianceError):
+        log_session_event("s", "e", db_path=db_file)
+
+
+


### PR DESCRIPTION
## Summary
- enforce enterprise validation for file copy/write helpers
- guard database inserts and backups with anti-recursion and validation
- add tests that reject forbidden operations

## Testing
- `ruff check enterprise_modules/file_utils.py enterprise_modules/database_utils.py utils/logging_utils.py tests/test_compliance_decorators.py`
- `pytest -q tests/test_compliance_decorators.py`


------
https://chatgpt.com/codex/tasks/task_e_6892a78660248331af14314201505f86