### PR TITLE
fix: remove duplicate import and add lint-test report

### DIFF
--- a/results/module_test_and_lint_report.md
+++ b/results/module_test_and_lint_report.md
@@ -1,0 +1,5 @@
+# Module Test and Lint Report
+
+- Ruff issues: 0
+- Tests passed: 55
+- Tests failed: 1

--- a/tests/scripts/test_security_guards.py
+++ b/tests/scripts/test_security_guards.py
@@ -1,4 +1,3 @@
-import os
 import importlib.util
 import os
 from pathlib import Path


### PR DESCRIPTION
## Summary
- remove duplicate `os` import in security guard tests
- add module test and lint report summarizing ruff and pytest outcomes

## Testing
- `ruff check .`
- `pytest` *(fails: tests/placeholder/test_code_placeholder_audit.py::test_apply_fixes_updates_db_and_file)*

------
https://chatgpt.com/codex/tasks/task_e_6892a78bc5f08331936231b0ffac6805