### PR TITLE
test: add ingestion duplicate log coverage

### DIFF
--- a/reports/ingestion_validation.md
+++ b/reports/ingestion_validation.md
@@ -1,0 +1,9 @@
+# Ingestion Validation Report
+
+## Test Summary
+- `pytest tests/test_ingestion_pipeline.py`
+- Result: 2 passed, 61 warnings
+
+## Notes
+- Tests cover duplicate ingestion handling and event logging for the ingestion pipeline.
+


### PR DESCRIPTION
## Summary
- verify SHA-256 hashing and duplicate log handling
- test duplicate ingestion logging and create report

## Testing
- `ruff check tests/test_ingestion_pipeline.py scripts/database/template_asset_ingestor.py scripts/database/ingestion_validator.py`
- `pytest tests/test_ingestion_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892ce52931c833181db7e68a58e0ace