### PR TITLE
feat: ensure orchestrators use secondary validation

### DIFF
--- a/scripts/continuous_operation_orchestrator.py
+++ b/scripts/continuous_operation_orchestrator.py
@@ -46,6 +46,7 @@ from tqdm import tqdm
 from utils.cross_platform_paths import CrossPlatformPathManager
 from enterprise_modules import compliance
 from utils.validation_utils import run_dual_copilot_validation
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 # 🚨 CRITICAL: Anti-recursion validation
 
@@ -224,13 +225,15 @@ class ContinuousOperationOrchestrator:
         self._log_cycle_completion_summary(cycle_results)
 
         # Dual Copilot validation
+        validator = SecondaryCopilotValidator()
+
         def _primary():
             logging.info("🔍 PRIMARY VALIDATION")
             return self.primary_validate()
 
         def _secondary():
             logging.info("🔍 SECONDARY VALIDATION")
-            return self.secondary_validate()
+            return self.secondary_validate() and validator.validate_corrections([__file__])
 
         validation_passed = run_dual_copilot_validation(_primary, _secondary)
         cycle_results["primary_validation"] = validation_passed
@@ -381,13 +384,15 @@ class ContinuousOperationOrchestrator:
         logging.info(f"Duration: {duration_hours} hours")
         logging.info(f"Target Excellence: {self.target_excellence:.1%}")
 
+        validator = SecondaryCopilotValidator()
+
         def _primary_start():
             logging.info("🔍 PRIMARY VALIDATION")
             return primary_validate()
 
         def _secondary_start():
             logging.info("🔍 SECONDARY VALIDATION")
-            return self.secondary_validate()
+            return self.secondary_validate() and validator.validate_corrections([__file__])
 
         run_dual_copilot_validation(_primary_start, _secondary_start)
 

--- a/scripts/enterprise_deployment_orchestrator.py
+++ b/scripts/enterprise_deployment_orchestrator.py
@@ -45,6 +45,7 @@ from typing import Any, Dict, List, Optional
 from enterprise_modules import compliance
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.validation_utils import run_dual_copilot_validation
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 
 # 🚨 CRITICAL: Anti-recursion validation
@@ -198,13 +199,15 @@ class EnterpriseDeploymentOrchestrator:
 
         compliance.validate_enterprise_operation()
 
+        validator = SecondaryCopilotValidator()
+
         def _primary_start():
             logging.info("🔍 PRIMARY VALIDATION")
             return primary_validate()
 
         def _secondary_start():
             logging.info("🔍 SECONDARY VALIDATION")
-            return self.secondary_validate()
+            return self.secondary_validate() and validator.validate_corrections([__file__])
 
         run_dual_copilot_validation(_primary_start, _secondary_start)
 
@@ -291,7 +294,7 @@ class EnterpriseDeploymentOrchestrator:
 
         def _secondary():
             logging.info("🔍 SECONDARY VALIDATION")
-            return self.secondary_validate()
+            return self.secondary_validate() and validator.validate_corrections([__file__])
 
         validation_passed = run_dual_copilot_validation(_primary, _secondary)
         deployment_results["primary_validation"] = validation_passed

--- a/scripts/enterprise_gh_copilot_deployment_orchestrator.py
+++ b/scripts/enterprise_gh_copilot_deployment_orchestrator.py
@@ -17,6 +17,7 @@ from datetime import datetime
 
 from scripts.utilities.production_template_utils import generate_script_from_repository
 from utils.validation_utils import run_dual_copilot_validation
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {"start": "[START]", "success": "[SUCCESS]", "error": "[ERROR]", "info": "[INFO]"}
@@ -37,6 +38,7 @@ class EnterpriseUtility:
         try:
             # Utility implementation
             success = self.perform_utility_function()
+            validator = SecondaryCopilotValidator()
 
             def _primary():
                 self.logger.info("[INFO] PRIMARY VALIDATION")
@@ -44,7 +46,7 @@ class EnterpriseUtility:
 
             def _secondary():
                 self.logger.info("[INFO] SECONDARY VALIDATION")
-                return self.secondary_validate()
+                return self.secondary_validate() and validator.validate_corrections([__file__])
 
             validation_passed = run_dual_copilot_validation(_primary, _secondary)
 

--- a/scripts/enterprise_validation_orchestrator.py
+++ b/scripts/enterprise_validation_orchestrator.py
@@ -62,6 +62,7 @@ from tqdm import tqdm
 
 from enterprise_modules import compliance
 from utils.validation_utils import run_dual_copilot_validation
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 # Configure comprehensive logging
 logging.basicConfig(
@@ -206,13 +207,15 @@ class EnterpriseValidationOrchestrator:
         """Initialize Enterprise Validation Orchestrator with comprehensive capabilities"""
         compliance.validate_enterprise_operation()
 
+        validator = SecondaryCopilotValidator()
+
         def _primary_start():
             logger.info("🔍 PRIMARY VALIDATION")
             return primary_validate()
 
         def _secondary_start():
             logger.info("🔍 SECONDARY VALIDATION")
-            return self.secondary_validate()
+            return self.secondary_validate() and validator.validate_corrections([__file__])
 
         run_dual_copilot_validation(_primary_start, _secondary_start)
         # CRITICAL: Anti-recursion validation
@@ -692,13 +695,15 @@ class EnterpriseValidationOrchestrator:
         logger.info("=" * 80)
 
         # Dual Copilot validation
+        validator = SecondaryCopilotValidator()
+
         def _primary():
             logger.info("🔍 PRIMARY VALIDATION")
             return self.primary_validate()
 
         def _secondary():
             logger.info("🔍 SECONDARY VALIDATION")
-            return self.secondary_validate()
+            return self.secondary_validate() and validator.validate_corrections([__file__])
 
         validation_passed = run_dual_copilot_validation(_primary, _secondary)
         self.validation_metrics.primary_valid = validation_passed

--- a/tests/scripts/test_dual_copilot_invocation.py
+++ b/tests/scripts/test_dual_copilot_invocation.py
@@ -1,0 +1,27 @@
+"""Verify orchestrators include dual-copilot validation hooks."""
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+ORCHESTRATOR_FILES = [
+    "scripts/continuous_operation_orchestrator.py",
+    "scripts/enterprise_deployment_orchestrator.py",
+    "scripts/enterprise_validation_orchestrator.py",
+    "scripts/enterprise_gh_copilot_deployment_orchestrator.py",
+    "scripts/orchestrators/unified_wrapup_orchestrator.py",
+]
+
+
+@pytest.mark.parametrize("rel_path", ORCHESTRATOR_FILES)
+def test_dual_copilot_invocation_present(rel_path: str) -> None:
+    """Ensure each orchestrator references the secondary validator."""
+
+    content = (ROOT / rel_path).read_text()
+    assert "SecondaryCopilotValidator" in content
+    assert "run_dual_copilot_validation" in content
+    assert "validate_corrections" in content
+


### PR DESCRIPTION
## Summary
- ensure orchestrators import SecondaryCopilotValidator and include dual-copilot callbacks
- add tests confirming orchestrators reference the secondary validator

## Testing
- `ruff check scripts/continuous_operation_orchestrator.py scripts/enterprise_deployment_orchestrator.py scripts/enterprise_validation_orchestrator.py scripts/enterprise_gh_copilot_deployment_orchestrator.py scripts/orchestrators/unified_wrapup_orchestrator.py tests/scripts/test_dual_copilot_invocation.py`
- `pytest tests/scripts`


------
https://chatgpt.com/codex/tasks/task_e_6892d135f6108331a2d7cfe742463795