### PR TITLE
feat: expand compliance metrics with violation and rollback data

### DIFF
--- a/tests/dashboard/test_compliance_metrics_updater.py
+++ b/tests/dashboard/test_compliance_metrics_updater.py
@@ -1,0 +1,66 @@
+import logging
+import sqlite3
+from datetime import datetime
+
+import pytest
+
+from dashboard import compliance_metrics_updater as cmu
+from utils.log_utils import ensure_tables
+
+
+def _prepare_db(path: str) -> None:
+    """Initialize required tables for analytics DB."""
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE IF NOT EXISTS todo_fixme_tracking (status TEXT)")
+        conn.execute(
+            "INSERT INTO violation_logs (timestamp, details) VALUES (?, ?)",
+            (datetime.utcnow().isoformat(), "violation"),
+        )
+        conn.execute(
+            "INSERT INTO rollback_logs (target, timestamp) VALUES (?, ?)",
+            ("target", datetime.utcnow().isoformat()),
+        )
+        conn.execute("INSERT INTO todo_fixme_tracking (status) VALUES ('resolved')")
+        conn.execute("INSERT INTO todo_fixme_tracking (status) VALUES ('open')")
+
+
+def test_violation_and_rollback_counts_affect_composite(tmp_path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dash"
+    monkeypatch.setattr(cmu, "ANALYTICS_DB", db)
+    monkeypatch.setattr(cmu, "DASHBOARD_DIR", dash_dir)
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    ensure_tables(db, ["violation_logs", "rollback_logs", "correction_logs", "event_log"], test_mode=False)
+    updater = cmu.ComplianceMetricsUpdater(dash_dir, test_mode=True)
+    _prepare_db(str(db))
+
+    metrics = updater._fetch_compliance_metrics(test_mode=True)
+    assert metrics["violation_count"] == 1
+    assert metrics["rollback_count"] == 1
+    assert metrics["score_breakdown"]["violation_penalty"] == 10
+    assert metrics["score_breakdown"]["rollback_penalty"] == 5
+    assert metrics["composite_score"] == pytest.approx(83.0, rel=1e-3)
+
+
+def test_warn_when_tables_empty(tmp_path, monkeypatch, caplog):
+    db = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dash"
+    monkeypatch.setattr(cmu, "ANALYTICS_DB", db)
+    monkeypatch.setattr(cmu, "DASHBOARD_DIR", dash_dir)
+    monkeypatch.setattr(cmu, "validate_no_recursive_folders", lambda: None)
+    monkeypatch.setattr(cmu, "validate_environment_root", lambda: None)
+    ensure_tables(db, ["violation_logs", "rollback_logs", "correction_logs", "event_log"], test_mode=False)
+    updater = cmu.ComplianceMetricsUpdater(dash_dir, test_mode=True)
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE IF NOT EXISTS todo_fixme_tracking (status TEXT)")
+
+    with caplog.at_level(logging.WARNING):
+        metrics = updater._fetch_compliance_metrics(test_mode=True)
+
+    assert metrics["violation_count"] == 0
+    assert metrics["rollback_count"] == 0
+    warnings = [r.message for r in caplog.records]
+    assert any("violation_logs table has no entries" in m for m in warnings)
+    assert any("rollback_logs table has no entries" in m for m in warnings)
+


### PR DESCRIPTION
## Summary
- warn when `violation_logs` or `rollback_logs` tables are empty and include their counts in compliance calculations
- apply violation and rollback penalties to composite compliance scores
- test compliance metrics updater with violation and rollback scenarios

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/dashboard/test_compliance_metrics_updater.py`
- `pytest tests/dashboard/test_compliance_metrics_updater.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892dd8ce0748331988f9d6987505a40