### PR TITLE
ci: add LFS pre-commit hook and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Ensure the development environment is correctly configured **before** making any
   ```
 * **Python & Tools**: Use **Python 3.8+** (already provided in Codex). The setup will install necessary system packages (development headers, build tools, SQLite, etc.) and Python packages as specified by the project. Do **not** install additional packages beyond those listed in `requirements.txt` (and optional `requirements-web.txt`, `requirements-ml.txt`, etc.). **Only use** the dependencies declared by the project. If you believe a new package is required, **do not install it yourself** – instead, mention the need in the PR description for maintainers.
 * **Virtual Environment**: Always activate the Python virtual environment after running setup. For example, use `source .venv/bin/activate` to ensure you’re using the project’s isolated environment and packages.
+* **Git LFS Pre-commit Hook**: Install `tools/pre-commit-lfs.sh` as a local pre-commit hook (e.g., `cp tools/pre-commit-lfs.sh .git/hooks/pre-commit-lfs && chmod +x .git/hooks/pre-commit-lfs`) and run it before committing to verify all `.db` files are tracked by Git LFS.
 * **Environment Variables**: Certain environment variables must be set for the toolkit to function correctly. In particular:
 
   * **GH\_COPILOT\_WORKSPACE** – Absolute path to the repository’s root workspace. This should point to the project root (in the Codex container it defaults to `/app`, but set it explicitly). Many scripts use this to locate files and databases.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for considering a contribution to gh_COPILOT. Please follow these guidelines:
 
 - Review and follow the [Governance Standards](docs/GOVERNANCE_STANDARDS.md).
-- Run `bash setup.sh`, activate the virtual environment, and execute `ruff` and `pytest` before committing.
+- Run `bash setup.sh`, activate the virtual environment, and execute `ruff`, `pytest`, and `tools/pre-commit-lfs.sh` before committing.
 - Use conventional commit messages and reference these standards in your pull requests.
 
 ## Documentation Workflow Checklist

--- a/tools/pre-commit-lfs.sh
+++ b/tools/pre-commit-lfs.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure Git LFS pointers are valid. Some git-lfs versions do not support
+# `--strict`; fall back to a plain listing if the flag is unavailable.
+if ! git lfs ls-files --strict >/tmp/lfs_check.log 2>&1; then
+  if grep -q "unknown flag" /tmp/lfs_check.log; then
+    git lfs ls-files >/dev/null 2>&1 || {
+      cat /tmp/lfs_check.log >&2
+      exit 1
+    }
+  else
+    cat /tmp/lfs_check.log >&2
+    exit 1
+  fi
+fi
+
+# Collect staged .db files
+staged_db_files=$(git diff --cached --name-only -- '*.db')
+
+# Verify each staged .db file is managed by Git LFS
+for f in $staged_db_files; do
+  if ! git lfs ls-files "$f" >/dev/null 2>&1; then
+    echo "Error: $f is a .db file not tracked by Git LFS" >&2
+    echo "Run 'git lfs track \"*.db\"' and re-add the file." >&2
+    exit 1
+  fi
+done
+
+# Check for untracked .db files in working tree
+untracked_db_files=$(git ls-files --others --exclude-standard '*.db')
+if [ -n "$untracked_db_files" ]; then
+  echo "Error: Untracked .db file(s) found:" >&2
+  echo "$untracked_db_files" >&2
+  echo "Ensure they are added and tracked by Git LFS." >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add `tools/pre-commit-lfs.sh` to ensure `.db` files are tracked by Git LFS
- document the LFS hook in `AGENTS.md` and `CONTRIBUTING.md`

## Testing
- `tools/pre-commit-lfs.sh`
- `ruff check .`
- `pytest` *(fails: tests/test_compliance_decorators.py)*

------
https://chatgpt.com/codex/tasks/task_e_6892dfd8d1ac83318d67919e2baba9fa