### PR TITLE
docs: add git LFS recovery guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Ensure the development environment is correctly configured **before** making any
   * **TEST_MODE** – Set to "1" in test environments to disable side effects (e.g., database writes) in scripts like `scripts/wlc_session_manager.py`.
   * *Optional variables:* **WORKSPACE\_ROOT** (alias for `GH_COPILOT_WORKSPACE`), **FLASK\_SECRET\_KEY** (for the optional Flask web UI, default `'your_secret_key'` – replace in production), **FLASK\_RUN\_PORT** (Flask dev server port, default 5000), **CONFIG\_PATH** (path to a custom config file if not using the default `config/enterprise.json`), **WEB\_DASHBOARD\_ENABLED** (`"1"` or `"0"` to toggle logging of performance metrics with `[DASHBOARD]` tags). Configure these as needed if using those features.
 * After installing dependencies and setting variables, **run the test suite** (see [Testing and Validation](#testing-and-validation)) to verify the environment is correctly set up.
+* For procedures on restoring Git LFS-managed files, consult [docs/git_lfs_recovery.md](docs/git_lfs_recovery.md).
 
 ## Output Safety and `clw`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for considering a contribution to gh_COPILOT. Please follow these guid
 - Review and follow the [Governance Standards](docs/GOVERNANCE_STANDARDS.md).
 - Run `bash setup.sh`, activate the virtual environment, and execute `ruff` and `pytest` before committing.
 - Use conventional commit messages and reference these standards in your pull requests.
+- Follow the [Git LFS recovery guide](docs/git_lfs_recovery.md) when restoring large binary files.
 
 ## Documentation Workflow Checklist
 

--- a/docs/git_lfs_recovery.md
+++ b/docs/git_lfs_recovery.md
@@ -1,0 +1,57 @@
+# Git LFS Recovery Guide
+
+This guide defines the standardized procedure for restoring Git LFS managed artifacts in gh_COPILOT.
+
+## 1. Verify the Environment
+
+1. Run `bash setup.sh` and activate the virtual environment.
+2. Ensure Git LFS is available:
+   ```bash
+   git lfs install
+   ```
+3. Review `.gitattributes` to confirm tracked patterns such as:
+   - `codex_sessions/*.zip`
+   - `*.db`, `*.7z`, `*.zip`, `*.bak`, `*.sqlite`, `*.exe`, `*.dot`
+   - `web_gui/documentation/deployment/screenshots/*.png`
+
+These patterns are defined in the repository's [`.gitattributes`](../.gitattributes).
+
+## 2. Retrieve LFS Objects
+
+Fetch and check out LFS pointers to restore missing files:
+
+```bash
+git lfs fetch --all
+git lfs checkout
+```
+
+Use `git lfs ls-files` to verify that all required files are tracked.
+
+## 3. Recover Session Artifacts
+
+For session archives stored under `codex_sessions/`, use the artifact manager's recovery mode:
+
+```bash
+python artifact_manager.py --recover <archive>
+```
+
+See [ARTIFACT_RECOVERY_WORKFLOW.md](../ARTIFACT_RECOVERY_WORKFLOW.md) for a detailed explanation of packaging, committing, and verifying artifacts.
+
+## 4. Re-track Missing Files
+
+If a binary file is missing from LFS:
+
+1. Track the extension and update pointers:
+   ```bash
+   git lfs track "*.ext"
+   git add .gitattributes <file>
+   ```
+2. Re-run `git lfs ls-files` to confirm.
+
+## 5. Commit the Recovery
+
+After restoring files, commit the changes using the standard commit workflow. Set `ALLOW_AUTOLFS=1` to allow automatic LFS tracking if new binary types were added.
+
+---
+
+Following this procedure ensures the repository's binary artifacts stay consistent and recoverable.


### PR DESCRIPTION
## Summary
- document standard procedure for restoring Git LFS artifacts
- reference existing LFS patterns and artifact recovery workflow
- surface recovery guide in AGENTS and CONTRIBUTING docs

## Testing
- `ruff check .`
- `pytest` *(fails: tests/test_compliance_decorators.py)*


------
https://chatgpt.com/codex/tasks/task_e_6892dfd4fcc48331b6151620dba12cfc