### PR TITLE
docs: update quantum placeholder roadmap

### DIFF
--- a/docs/QUANTUM_PLACEHOLDERS.md
+++ b/docs/QUANTUM_PLACEHOLDERS.md
@@ -6,7 +6,9 @@ and are intentionally excluded from production import paths. They reference
 the planned features outlined in the
 [technical whitepaper](COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md)
 around line 587 and later. The placeholders reserve package structure for
-upcoming development without affecting production builds.
+upcoming development without affecting production builds. The core
+`quantum/` package also includes several simulation-oriented modules that
+act as early placeholders for hardware backends.
 
 Refer to [README.md](../README.md) for a high-level overview of how these placeholders fit into the current system.
 
@@ -24,6 +26,29 @@ Refer to [README.md](../README.md) for a high-level overview of how these placeh
 - Hardware-related flags are accepted by some interfaces but are currently
   ignored.
 - Placeholder modules are excluded from production builds.
+
+## `quantum/` Package Placeholders
+
+The primary `quantum/` package contains additional stubs and simulator-only
+implementations:
+
+- `algorithms/base.py` – abstract interface with unimplemented execution and
+  naming hooks.
+- `algorithms/functional.py` – runs Grover search, KMeans clustering, and a
+  simple QNN on `AerSimulator`; no direct hardware mapping yet.
+- `algorithms/hardware_aware.py` – demo algorithm that selects IBM hardware
+  when available and falls back to simulation otherwise.
+- `integration/secure_channel.py` – encrypts and decrypts locally to mimic a
+  quantum-secure channel; true QKD integration is pending.
+- `ibm_backend.py` – initializes IBM Quantum backends but defaults to the
+  local simulator when credentials or providers are missing.
+- `orchestration/executor.py` – manages algorithm execution and defaults to
+  simulators when hardware backends are unavailable.
+- `optimizers/quantum_optimizer.py` – offers simulated annealing and QAOA/VQE
+  stubs; hardware execution milestones are tracked separately.
+
+Progress toward hardware integration for these modules is monitored in
+[`documentation/generated/daily state update/quantum_feature_status.md`](../documentation/generated/daily%20state%20update/quantum_feature_status.md).
 
 ## Roadmap
 

--- a/documentation/generated/daily state update/quantum_feature_status.md
+++ b/documentation/generated/daily state update/quantum_feature_status.md
@@ -7,4 +7,6 @@
 | Annealing routine | Planned | Target D-Wave Advantage integration |
 | Entanglement correction utilities | Planned | Rigetti and IBM Quantum prototypes scheduled |
 | Superposition search | Planned | IonQ and IBM backends under evaluation |
+| Hardware-aware demo algorithm | Simulation | Selects IBM hardware when available; falls back to simulator |
+| Quantum secure channel | Simulation | Encrypt/decrypt loop; quantum communication APIs TBD |
 


### PR DESCRIPTION
## Summary
- document simulator stubs inside the `quantum/` package and link to progress tracker
- track hardware-aware algorithm and secure channel placeholders in daily status report

## Testing
- `ruff check docs 'documentation/generated/daily state update/quantum_feature_status.md'`
- `pytest` *(fails: tests/test_compliance_decorators.py)*

------
https://chatgpt.com/codex/tasks/task_e_6892e56c2bf083319f9ee30fc7956719