### PR TITLE
feat: add daily compliance reporting script

### DIFF
--- a/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
+++ b/docs/COMPLETE_TECHNICAL_SPECIFICATIONS_WHITEPAPER.md
@@ -14,6 +14,8 @@ Compliance and audit metrics are logged to `analytics.db` via the
 `EnterpriseComplianceValidator`, and compliance scores combine lint, test, and
 placeholder metrics before being computed by the `WLC_SESSION_MANAGER` during
 session wrap-up.
+Daily compliance and test summaries are written to
+`documentation/generated/daily_state_update/`.
 
 *All quantum modules run exclusively in simulation mode; any hardware configuration is currently ignored until future integration lands. Hardware flags and tokens are retained for interface parity but have no effect.*
 *Phase&nbsp;5 advanced AI features are partially integrated and not yet production ready.*

--- a/documentation/generated/daily_state_update/daily_state_2025-08-06.json
+++ b/documentation/generated/daily_state_update/daily_state_2025-08-06.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2025-08-06",
+  "compliance": {
+    "placeholders": 0,
+    "forbidden_commands": 0,
+    "anti_recursions": 0
+  },
+  "tests": {
+    "exit_code": 1,
+    "summary": "2 skipped, 40 warnings, 1 error in 9.22s"
+  },
+  "lint": {
+    "exit_code": 0,
+    "errors": 0
+  }
+}

--- a/documentation/generated/daily_state_update/daily_state_2025-08-06.md
+++ b/documentation/generated/daily_state_update/daily_state_2025-08-06.md
@@ -1,0 +1,12 @@
+# Daily State Update (2025-08-06)
+
+## Compliance Findings
+- Placeholder removals: 0
+- Forbidden command violations: 0
+- Anti-recursion violations: 0
+
+## Test Results
+- pytest: 2 skipped, 40 warnings, 1 error in 9.22s (exit code 1)
+
+## Lint Results
+- ruff: passed (exit code 0)

--- a/scripts/reporting/generate_compliance_and_test_reports.py
+++ b/scripts/reporting/generate_compliance_and_test_reports.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Generate compliance, test, and lint reports."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DB_PATH = ROOT / "databases" / "analytics.db"
+OUTPUT_DIR = ROOT / "documentation" / "generated" / "daily_state_update"
+
+
+def _query_counts(db: Path) -> dict[str, int]:
+    """Return counts of placeholder, forbidden-command, and anti-recursion findings."""
+    queries = {
+        "placeholders": "SELECT COUNT(*) FROM placeholder_removals",
+        "forbidden_commands": "SELECT COUNT(*) FROM violation_logs WHERE details LIKE '%forbidden%'",
+        "anti_recursions": "SELECT COUNT(*) FROM violation_logs WHERE details LIKE '%anti-recursion%'",
+    }
+    counts = {}
+    with sqlite3.connect(db) as conn:
+        cur = conn.cursor()
+        for key, sql in queries.items():
+            try:
+                counts[key] = cur.execute(sql).fetchone()[0]
+            except sqlite3.Error:
+                counts[key] = 0
+    return counts
+
+
+def _run(cmd: list[str]) -> tuple[int, str]:
+    """Run a command and return its exit code and combined output."""
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    output = proc.stdout.strip()
+    return proc.returncode, output
+
+
+def generate_reports() -> dict:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    counts = _query_counts(DB_PATH)
+
+    pytest_rc, pytest_out = _run(["pytest", "-q"])
+    pytest_summary = pytest_out.splitlines()[-1] if pytest_out else ""
+
+    ruff_rc, ruff_out = _run(["ruff", "check", ".", "--quiet"])
+    lint_errors = len(ruff_out.splitlines()) if ruff_rc else 0
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    data = {
+        "timestamp": timestamp,
+        "compliance": counts,
+        "tests": {"exit_code": pytest_rc, "summary": pytest_summary},
+        "lint": {"exit_code": ruff_rc, "errors": lint_errors},
+    }
+
+    md_lines = [
+        f"# Daily State Update ({timestamp})",
+        "",
+        "## Compliance Findings",
+        f"- Placeholder removals: {counts['placeholders']}",
+        f"- Forbidden command violations: {counts['forbidden_commands']}",
+        f"- Anti-recursion violations: {counts['anti_recursions']}",
+        "",
+        "## Test Results",
+        f"- pytest: {pytest_summary or 'no output'} (exit code {pytest_rc})",
+        "",
+        "## Lint Results",
+        f"- ruff: {'passed' if ruff_rc == 0 else f'{lint_errors} issues'} (exit code {ruff_rc})",
+        "",
+    ]
+    md_path = OUTPUT_DIR / f"daily_state_{timestamp}.md"
+    json_path = OUTPUT_DIR / f"daily_state_{timestamp}.json"
+    md_path.write_text("\n".join(md_lines))
+    json_path.write_text(json.dumps(data, indent=2))
+    return data
+
+
+def main() -> None:
+    generate_reports()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_compliance_and_test_reports.py` to aggregate analytics, run tests/lint, and emit daily reports
- document location of generated compliance and test summaries in whitepaper
- include sample daily state report under `documentation/generated/daily_state_update`

## Testing
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6892e51140208331932337545e12307d