### PR TITLE
feat: validate database migrations

### DIFF
--- a/scripts/database/add_violation_logs.py
+++ b/scripts/database/add_violation_logs.py
@@ -37,7 +37,10 @@ def add_table(db_path: Path) -> None:
     start_time = datetime.now()
     logger.info("[START] add_table for %s", db_path)
     logger.info("Process ID: %s", os.getpid())
+    from enterprise_modules.compliance import validate_enterprise_operation
 
+    if not validate_enterprise_operation(str(db_path)):
+        return
     db_path.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(db_path, timeout=5) as conn, tqdm(total=1, desc="create-table", unit="step") as bar:
         conn.executescript(SCHEMA_SQL)
@@ -46,6 +49,9 @@ def add_table(db_path: Path) -> None:
     logger.info("violation_logs ensured in %s", db_path)
     check_database_sizes(db_path.parent)
     _log_event({"event": "violation_logs_ready", "db": str(db_path)})
+    from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
+
+    DualCopilotOrchestrator(logger).validator.validate_corrections([str(db_path)])
 
     elapsed = datetime.now() - start_time
     logger.info("[SUCCESS] Completed in %s", str(elapsed))

--- a/tests/database/test_violation_and_rollback_validators.py
+++ b/tests/database/test_violation_and_rollback_validators.py
@@ -1,0 +1,49 @@
+"""Tests ensuring migration validators are invoked."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import scripts.database.add_violation_logs as av
+import scripts.database.add_rollback_logs as ar
+
+
+def _setup_mocks(module, monkeypatch, calls):
+    def fake_validate(path: str) -> bool:
+        calls["validate"] = path
+        return True
+
+    class DummyValidator:
+        def validate_corrections(self, targets):  # pragma: no cover - simple collector
+            calls["dual"] = list(targets)
+
+    class DummyOrchestrator:
+        def __init__(self, *_, **__):
+            self.validator = DummyValidator()
+
+    monkeypatch.setattr(
+        "enterprise_modules.compliance.validate_enterprise_operation", fake_validate
+    )
+    monkeypatch.setattr(
+        "scripts.validation.dual_copilot_orchestrator.DualCopilotOrchestrator",
+        DummyOrchestrator,
+    )
+
+
+def test_violation_logs_validators(monkeypatch, tmp_path: Path) -> None:
+    calls: dict[str, object] = {}
+    _setup_mocks(av, monkeypatch, calls)
+    db = tmp_path / "analytics.db"
+    av.add_table(db)
+    assert calls["validate"] == str(db)
+    assert calls["dual"] == [str(db)]
+
+
+def test_rollback_logs_validators(monkeypatch, tmp_path: Path) -> None:
+    calls: dict[str, object] = {}
+    _setup_mocks(ar, monkeypatch, calls)
+    db = tmp_path / "analytics.db"
+    ar.add_table(db)
+    assert calls["validate"] == str(db)
+    assert calls["dual"] == [str(db)]
+


### PR DESCRIPTION
## Summary
- validate violation and rollback migration scripts with enterprise path checks
- run DualCopilotOrchestrator validation after DB migrations
- test that both validators execute for violation and rollback log migrations

## Testing
- `ruff check scripts/database/add_violation_logs.py scripts/database/add_rollback_logs.py tests/database/test_violation_and_rollback_validators.py`
- `pytest tests/database/test_violation_and_rollback_validators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892e5160b0483319749d1e7ab17a429