### PR TITLE
feat: guard script entry points

### DIFF
--- a/scripts/cleanup.py
+++ b/scripts/cleanup.py
@@ -8,6 +8,8 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from utils.validation_utils import anti_recursion_guard
+
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -44,6 +46,7 @@ def cleanup_legacy_assets(cluster_file: Path, dry_run: bool = True) -> list[Path
     return removed
 
 
+@anti_recursion_guard
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Cleanup legacy assets using clusters")
     parser.add_argument("--clusters", type=Path, default=Path("cluster_output.json"))

--- a/scripts/placeholder_cleanup.py
+++ b/scripts/placeholder_cleanup.py
@@ -7,11 +7,18 @@ Use ``scripts/code_placeholder_audit.py --cleanup`` which now provides
 from __future__ import annotations
 
 import sys
+
+from utils.validation_utils import anti_recursion_guard
 from scripts import code_placeholder_audit
 
-if __name__ == "__main__":
+@anti_recursion_guard
+def main() -> None:
     print(
         "DEPRECATED: use 'python scripts/code_placeholder_audit.py --apply-fixes'",
         file=sys.stderr,
     )
     code_placeholder_audit.main(*sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Iterable
 import logging
 
+from utils.validation_utils import anti_recursion_guard
+
 # When executed directly, ensure the repository root is on ``sys.path`` so that
 # imports from the ``scripts`` package resolve correctly.
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -92,6 +94,7 @@ def verify_migrations() -> None:
     print("Migrations verified")
 
 
+@anti_recursion_guard
 def main() -> None:
     """Bootstrap environment and install test requirements."""
     ensure_env()

--- a/scripts/validate_docs_metrics.py
+++ b/scripts/validate_docs_metrics.py
@@ -9,6 +9,8 @@ import sqlite3
 import sys
 from pathlib import Path
 
+from utils.validation_utils import anti_recursion_guard
+
 ROOT = Path(__file__).resolve().parents[1]
 # Default to the production database stored under the ``databases`` directory.
 # A previous path pointed to ``ROOT / 'production.db'``, which created an empty
@@ -99,7 +101,8 @@ def validate(db_path: Path = DB_PATH) -> bool:
     return success
 
 
-if __name__ == "__main__":
+@anti_recursion_guard
+def main() -> int:
     parser = argparse.ArgumentParser(description="Validate documentation metrics against the database.")
     parser.add_argument(
         "--db-path",
@@ -108,4 +111,8 @@ if __name__ == "__main__":
         help="Path to the production database",
     )
     args = parser.parse_args()
-    sys.exit(0 if validate(args.db_path) else 1)
+    return 0 if validate(args.db_path) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_anti_recursion_guard_imports.py
+++ b/tests/test_anti_recursion_guard_imports.py
@@ -6,6 +6,10 @@ MODULES = [
     ("scripts.automation.autonomous_database_health_optimizer", "main"),
     ("scripts.database.maintenance_scheduler", "main"),
     ("scripts.database.unified_database_initializer", "main"),
+    ("scripts.setup_environment", "main"),
+    ("scripts.placeholder_cleanup", "main"),
+    ("scripts.cleanup", "main"),
+    ("scripts.validate_docs_metrics", "main"),
 ]
 
 def test_required_modules_are_decorated():


### PR DESCRIPTION
## Summary
- add anti_recursion_guard to several script entry points
- extend anti_recursion_guard decorator tests to new scripts

## Testing
- `ruff check scripts/cleanup.py scripts/placeholder_cleanup.py scripts/setup_environment.py scripts/validate_docs_metrics.py tests/test_anti_recursion_guard_imports.py`
- `pytest tests/test_anti_recursion_guard_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68937ccdf3088331992b48e00d412911