### PR TITLE
feat: guard orchestrator entry points

### DIFF
--- a/disaster_recovery_orchestrator.py
+++ b/disaster_recovery_orchestrator.py
@@ -14,12 +14,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from enterprise_modules.compliance import pid_recursion_guard
 from unified_disaster_recovery_system import UnifiedDisasterRecoverySystem
 
 
 class DisasterRecoveryOrchestrator:
     """Coordinate backup scheduling and recovery execution."""
 
+    @pid_recursion_guard
     def __init__(self, workspace_root: str | None = None) -> None:
         self._system = UnifiedDisasterRecoverySystem(workspace_root)
 

--- a/quantum_integration_orchestrator.py
+++ b/quantum_integration_orchestrator.py
@@ -6,9 +6,11 @@ import argparse
 import os
 import sys
 
+from enterprise_modules.compliance import pid_recursion_guard
 from scripts.automation.quantum_integration_orchestrator import EnterpriseUtility
 
 
+@pid_recursion_guard
 def main(argv: list[str] | None = None) -> int:
     """Run the orchestrator with optional hardware support."""
     parser = argparse.ArgumentParser(description="Quantum Integration Orchestrator")

--- a/scripts/continuous_operation_orchestrator.py
+++ b/scripts/continuous_operation_orchestrator.py
@@ -45,6 +45,7 @@ from tqdm import tqdm
 
 from utils.cross_platform_paths import CrossPlatformPathManager
 from enterprise_modules import compliance
+from enterprise_modules.compliance import pid_recursion_guard
 from utils.validation_utils import run_dual_copilot_validation
 from secondary_copilot_validator import SecondaryCopilotValidator
 
@@ -610,6 +611,7 @@ class EnterpriseSystemMonitor:
         logging.info("🏢 Enterprise System Monitor initialized")
 
 
+@pid_recursion_guard
 def main() -> int:
     """🚀 Main execution function"""
     parser = argparse.ArgumentParser(description="Continuous operation orchestrator")

--- a/scripts/enterprise_deployment_orchestrator.py
+++ b/scripts/enterprise_deployment_orchestrator.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from enterprise_modules import compliance
+from enterprise_modules.compliance import pid_recursion_guard
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.validation_utils import run_dual_copilot_validation
 from secondary_copilot_validator import SecondaryCopilotValidator
@@ -608,6 +609,7 @@ class EnterpriseDeploymentOrchestrator:
         return {"score": 99.5, "status": "SECURE"}
 
 
+@pid_recursion_guard
 def main():
     """🚀 Main enterprise deployment function"""
 

--- a/scripts/enterprise_gh_copilot_deployment_orchestrator.py
+++ b/scripts/enterprise_gh_copilot_deployment_orchestrator.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from scripts.utilities.production_template_utils import generate_script_from_repository
 from utils.validation_utils import run_dual_copilot_validation
 from secondary_copilot_validator import SecondaryCopilotValidator
+from enterprise_modules.compliance import pid_recursion_guard
 
 # Text-based indicators (NO Unicode emojis)
 TEXT_INDICATORS = {"start": "[START]", "success": "[SUCCESS]", "error": "[ERROR]", "info": "[INFO]"}
@@ -78,6 +79,7 @@ class EnterpriseUtility:
         return self.primary_validate()
 
 
+@pid_recursion_guard
 def main():
     """Main execution function"""
     utility = EnterpriseUtility()

--- a/scripts/enterprise_validation_orchestrator.py
+++ b/scripts/enterprise_validation_orchestrator.py
@@ -61,6 +61,7 @@ import psutil
 from tqdm import tqdm
 
 from enterprise_modules import compliance
+from enterprise_modules.compliance import pid_recursion_guard
 from utils.validation_utils import run_dual_copilot_validation
 from secondary_copilot_validator import SecondaryCopilotValidator
 
@@ -1147,6 +1148,7 @@ class EnterpriseValidationOrchestrator:
         return self.validation_metrics.overall_score >= 80.0
 
 
+@pid_recursion_guard
 def main():
     """Main execution function with comprehensive command line interface"""
     parser = argparse.ArgumentParser(description="Enterprise Validation Orchestrator - Comprehensive Script Validation")

--- a/simplified_quantum_integration_orchestrator.py
+++ b/simplified_quantum_integration_orchestrator.py
@@ -2,10 +2,12 @@
 
 from session_management_consolidation_executor import EnterpriseUtility
 from utils.log_utils import _log_plain
+from enterprise_modules.compliance import pid_recursion_guard
 
 __all__ = ["EnterpriseUtility", "hello_world"]
 
 
+@pid_recursion_guard
 def hello_world() -> None:
     """Print a friendly greeting."""
 


### PR DESCRIPTION
## Summary
- add `pid_recursion_guard` to disaster recovery orchestrator initialization
- protect orchestrator scripts with `pid_recursion_guard`

## Testing
- `ruff check disaster_recovery_orchestrator.py quantum_integration_orchestrator.py simplified_quantum_integration_orchestrator.py scripts/enterprise_deployment_orchestrator.py scripts/enterprise_validation_orchestrator.py scripts/continuous_operation_orchestrator.py scripts/enterprise_gh_copilot_deployment_orchestrator.py`
- `pytest` *(fails: tests/dashboard/test_compliance_metrics_updater.py::test_violation_and_rollback_counts_affect_composite)*

------
https://chatgpt.com/codex/tasks/task_e_68937ccc16108331860541f3f5a1ebf8