### PR TITLE
feat: add consolidated lint and test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
         if: steps.changed.outputs.added_modified != ''
         run: pyright ${{ steps.changed.outputs.added_modified }}
 
+      - name: Run combined checks
+        env:
+          GH_COPILOT_WORKSPACE: ${{ github.workspace }}
+          GH_COPILOT_BACKUP_ROOT: /tmp/gh_copilot_backup
+        run: python scripts/run_checks.py
+
       - name: Import template_engine modules
         run: |
           python - <<'PY'

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 **Status:** Active development with incremental improvements. Disaster recovery now enforces external backup roots and has verified restore tests, while session-management enhancements remain under construction.
 
+> Combined checks: run `python scripts/run_checks.py` to execute `ruff` and `pytest` sequentially.
 > Tests: run `pytest` before committing. Current repository tests report multiple failures.
 > Lint: run `ruff check .` before committing.
 > Compliance: run `python secondary_copilot_validator.py --validate` after critical changes to enforce dual-copilot and EnterpriseComplianceValidator checks.

--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -1,0 +1,38 @@
+"""Run linting and tests sequentially."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils.validation_utils import anti_recursion_guard
+
+
+@anti_recursion_guard
+def main() -> int:
+    """Run ``ruff`` and ``pytest`` sequentially.
+
+    Returns the exit code of the first failing command, or ``0`` if both
+    commands succeed.
+    """
+
+    commands = [
+        ["ruff", "check", "."],
+        ["pytest"],
+    ]
+
+    for cmd in commands:
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            return result.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add scripts/run_checks.py to run Ruff and pytest with an anti-recursion guard
- document combined check script in README
- call run_checks.py from CI workflow

## Testing
- `python scripts/run_checks.py` *(fails: tests/test_violation_rollback_dashboard_output.py: F401 unused import)*
- `pytest -q` *(fails: tests/dashboard/test_compliance_metrics_updater.py::test_violation_and_rollback_counts_affect_composite - assert 0 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_68938b1036d4833198582c9248ba4ea8