### PR TITLE
feat: push detailed compliance breakdown metrics

### DIFF
--- a/tests/test_violation_rollback_dashboard_output.py
+++ b/tests/test_violation_rollback_dashboard_output.py
@@ -5,7 +5,6 @@ import sys
 import types
 
 
-from enterprise_modules import compliance
 import enterprise_modules.compliance as compliance_module
 
 
@@ -31,7 +30,7 @@ def test_violation_rollback_dashboard_output(tmp_path, monkeypatch):
             "INSERT INTO rollback_logs (target, backup, timestamp) VALUES ('t', 'b', 'ts')"
         )
         conn.execute(
-            "CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT, removal_id INTEGER)"
+            "CREATE TABLE todo_fixme_tracking (resolved INTEGER, status TEXT, removal_id INTEGER, placeholder_type TEXT)"
         )
         conn.execute(
             "CREATE TABLE correction_logs (compliance_score REAL)"


### PR DESCRIPTION
## Summary
- guard the compliance metrics entry point with `@pid_recursion_guard`
- emit per-component compliance breakdown metrics via `push_metrics`
- extend dashboard tests for breakdown metric emission

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/test_compliance_metrics_updater.py tests/test_violation_rollback_dashboard_output.py tests/dashboard/test_compliance_metrics_updater.py`
- `pytest tests/test_compliance_metrics_updater.py tests/test_violation_rollback_dashboard_output.py tests/dashboard/test_compliance_metrics_updater.py`
- `python - <<'PY'
from dashboard import compliance_metrics_updater as cmu
cmu.validate_no_recursive_folders=lambda: None
cmu.validate_environment_root=lambda: None
cmu.validate_enterprise_operation=lambda *a, **k: None
class DummyCorrectionLoggerRollback:
    def __init__(self, *a, **k):
        pass
    def log_violation(self, *a, **k):
        pass
    def log_change(self, *a, **k):
        pass
cmu.CorrectionLoggerRollback = DummyCorrectionLoggerRollback
cmu.main(test_mode=True)
PY`
- `sqlite3 databases/analytics.db "SELECT metrics_json FROM enterprise_metrics ORDER BY id DESC LIMIT 1;"`
- `sqlite3 databases/analytics.db "SELECT metrics_json FROM compliance_score_breakdown ORDER BY id DESC;"`

------
https://chatgpt.com/codex/tasks/task_e_68938b132a348331a80b4bb287bc0098