### PR TITLE
test: cover multi-db ingestion duplicate handling

### DIFF
--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -15,6 +15,12 @@ def _create_duplicate_files(directory: Path) -> None:
     (directory / "second.md").write_text("duplicate", encoding="utf-8")
 
 
+def _create_unique_files(directory: Path) -> None:
+    """Create two markdown files with distinct content."""
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "alpha.md").write_text("alpha", encoding="utf-8")
+    (directory / "beta.md").write_text("beta", encoding="utf-8")
+
 def test_ingestion_pipeline(tmp_path, monkeypatch):
     workspace = tmp_path
     db_dir = workspace / "databases"
@@ -148,6 +154,146 @@ def test_cross_db_duplicate_detection(tmp_path: Path, monkeypatch) -> None:
     db_path = db_dir / "enterprise_assets.db"
     with sqlite3.connect(db_path) as conn:
         doc_count = conn.execute("SELECT COUNT(*) FROM documentation_assets").fetchone()[0]
+        dup_count = conn.execute(
+            "SELECT COUNT(*) FROM cross_database_sync_operations WHERE operation='documentation_ingestion' AND status='DUPLICATE'"
+        ).fetchone()[0]
+
+    assert doc_count == 0
+    assert dup_count == 2
+
+    rel_doc1 = str((docs_dir / "first.md").relative_to(workspace))
+    rel_doc2 = str((docs_dir / "second.md").relative_to(workspace))
+    with sqlite3.connect(analytics_db) as conn:
+        rows = conn.execute(
+            "SELECT doc_path, sha256 FROM event_log WHERE status='DUPLICATE' AND module='documentation_ingestor'"
+        ).fetchall()
+    assert set(rows) == {(rel_doc1, digest), (rel_doc2, digest)}
+
+
+def test_multi_db_distinct_records_ingested_once(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path
+    db_dir = workspace / "databases"
+    docs_dir = workspace / "documentation"
+    _create_unique_files(docs_dir)
+
+    analytics_db = db_dir / "analytics.db"
+    db_dir.mkdir()
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE event_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                module TEXT,
+                level TEXT,
+                doc_path TEXT,
+                status TEXT,
+                sha256 TEXT,
+                md5 TEXT
+            )
+            """
+        )
+
+    now = datetime.now(timezone.utc).isoformat()
+    prod_db = db_dir / "production.db"
+    legacy_db = db_dir / "legacy.db"
+    digests = [
+        hashlib.sha256("existing1".encode()).hexdigest(),
+        hashlib.sha256("existing2".encode()).hexdigest(),
+    ]
+    for db, digest in zip((prod_db, legacy_db), digests):
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "CREATE TABLE documentation_assets (id INTEGER PRIMARY KEY, doc_path TEXT NOT NULL, content_hash TEXT NOT NULL UNIQUE, created_at TEXT NOT NULL, modified_at TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO documentation_assets (doc_path, content_hash, created_at, modified_at) VALUES (?, ?, ?, ?)",
+                ("existing.md", digest, now, now),
+            )
+
+    monkeypatch.setenv("ANALYTICS_DB", str(analytics_db))
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+
+    ingest_documentation(workspace, docs_dir)
+
+    db_path = db_dir / "enterprise_assets.db"
+    with sqlite3.connect(db_path) as conn:
+        doc_count = conn.execute(
+            "SELECT COUNT(*) FROM documentation_assets"
+        ).fetchone()[0]
+        dup_count = conn.execute(
+            "SELECT COUNT(*) FROM cross_database_sync_operations WHERE operation='documentation_ingestion' AND status='DUPLICATE'"
+        ).fetchone()[0]
+
+    assert doc_count == 2
+    assert dup_count == 0
+
+    rel_alpha = str((docs_dir / "alpha.md").relative_to(workspace))
+    rel_beta = str((docs_dir / "beta.md").relative_to(workspace))
+    digest_alpha = hashlib.sha256("alpha".encode()).hexdigest()
+    digest_beta = hashlib.sha256("beta".encode()).hexdigest()
+    with sqlite3.connect(analytics_db) as conn:
+        rows = conn.execute(
+            "SELECT doc_path, sha256, status FROM event_log WHERE module='documentation_ingestor'"
+        ).fetchall()
+    assert set(rows) == {
+        (rel_alpha, digest_alpha, "SUCCESS"),
+        (rel_beta, digest_beta, "SUCCESS"),
+    }
+
+
+def test_multi_db_overlapping_records_detect_duplicates(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path
+    db_dir = workspace / "databases"
+    docs_dir = workspace / "documentation"
+    _create_duplicate_files(docs_dir)
+
+    analytics_db = db_dir / "analytics.db"
+    db_dir.mkdir()
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE event_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                module TEXT,
+                level TEXT,
+                doc_path TEXT,
+                status TEXT,
+                sha256 TEXT,
+                md5 TEXT
+            )
+            """
+        )
+
+    digest = hashlib.sha256("duplicate".encode()).hexdigest()
+    now = datetime.now(timezone.utc).isoformat()
+    prod_db = db_dir / "production.db"
+    legacy_db = db_dir / "legacy.db"
+    for db in (prod_db, legacy_db):
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "CREATE TABLE documentation_assets (id INTEGER PRIMARY KEY, doc_path TEXT NOT NULL, content_hash TEXT NOT NULL UNIQUE, created_at TEXT NOT NULL, modified_at TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO documentation_assets (doc_path, content_hash, created_at, modified_at) VALUES (?, ?, ?, ?)",
+                ("existing.md", digest, now, now),
+            )
+
+    monkeypatch.setenv("ANALYTICS_DB", str(analytics_db))
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+
+    ingest_documentation(workspace, docs_dir)
+
+    db_path = db_dir / "enterprise_assets.db"
+    with sqlite3.connect(db_path) as conn:
+        doc_count = conn.execute(
+            "SELECT COUNT(*) FROM documentation_assets"
+        ).fetchone()[0]
         dup_count = conn.execute(
             "SELECT COUNT(*) FROM cross_database_sync_operations WHERE operation='documentation_ingestion' AND status='DUPLICATE'"
         ).fetchone()[0]


### PR DESCRIPTION
## Summary
- add helper to create unique markdown files for ingestion tests
- test ingestion handles overlapping records across multiple databases with duplicate logging
- ensure distinct records across databases are ingested exactly once

## Testing
- `ruff check tests/test_ingestion_pipeline.py`
- `pytest tests/test_ingestion_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68938b118ce483318a981aa5510a5294