### PR TITLE
fix: ensure setup script imports utils after path setup

### DIFF
--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -11,14 +11,13 @@ from pathlib import Path
 from typing import Iterable
 import logging
 
-from utils.validation_utils import anti_recursion_guard
-
 # When executed directly, ensure the repository root is on ``sys.path`` so that
 # imports from the ``scripts`` package resolve correctly.
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from utils.validation_utils import anti_recursion_guard
 from scripts import run_migrations
 
 

--- a/tests/test_setup_environment_import.py
+++ b/tests/test_setup_environment_import.py
@@ -1,0 +1,23 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def test_setup_environment_imports_utils(tmp_path, monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.chdir(tmp_path)
+    # remove repo_root from sys.path to simulate execution outside workspace
+    cleaned_paths = []
+    for p in list(sys.path):
+        try:
+            if Path(p).resolve() != repo_root:
+                cleaned_paths.append(p)
+        except Exception:
+            continue
+    monkeypatch.setattr(sys, "path", cleaned_paths)
+
+    spec = importlib.util.spec_from_file_location("setup_environment", repo_root / "scripts" / "setup_environment.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert "utils.validation_utils" in sys.modules


### PR DESCRIPTION
## Summary
- fix setup_environment import order so utils can be resolved when run directly
- add regression test verifying setup script can be executed outside workspace

## Testing
- `ruff check scripts/setup_environment.py tests/test_setup_environment_import.py`
- `pytest tests/test_setup_environment_import.py`
- `python scripts/wlc_session_manager.py --steps 0`


------
https://chatgpt.com/codex/tasks/task_e_6893f2f07df88331881095ee66e28354