### PR TITLE
feat: add sync watcher and conflict logging

### DIFF
--- a/database_first_synchronization_engine.py
+++ b/database_first_synchronization_engine.py
@@ -7,16 +7,19 @@ This module provides two main classes:
 
 ``SyncManager``
     Performs bidirectional synchronization using explicit transactions and
-    pluggable conflict-resolution callbacks.  Each call to :meth:`SyncManager.sync`
-    records an event in ``analytics.db`` under the ``synchronization_events``
-    table.
+    pluggable conflict-resolution policies.  Synchronization results and
+    conflicts are recorded in ``analytics.db`` with success or failure
+    statuses.  A background :meth:`SyncManager.watch` helper can trigger
+    synchronization automatically when the source databases change.
 """
 
 from __future__ import annotations
 
 import sqlite3
+import threading
+import time
 from pathlib import Path
-from typing import Callable, Dict, Any, List
+from typing import Any, Callable, Dict, List
 
 
 class SchemaMapper:
@@ -32,6 +35,32 @@ class SchemaMapper:
             ).fetchone()
             if not exists:
                 target.execute(sql)
+
+
+class ConflictPolicy:
+    """Base class for conflict resolution policies."""
+
+    def resolve(self, table: str, row_a: Dict[str, Any], row_b: Dict[str, Any]) -> Dict[str, Any]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class ResolverPolicy(ConflictPolicy):
+    """Wrap a simple resolver callable into a :class:`ConflictPolicy`."""
+
+    def __init__(self, resolver: Callable[[str, Dict[str, Any], Dict[str, Any]], Dict[str, Any]]) -> None:
+        self._resolver = resolver
+
+    def resolve(self, table: str, row_a: Dict[str, Any], row_b: Dict[str, Any]) -> Dict[str, Any]:
+        return self._resolver(table, row_a, row_b)
+
+
+class TimestampConflictPolicy(ConflictPolicy):
+    """Choose the row with the newest timestamp."""
+
+    def resolve(self, table: str, row_a: Dict[str, Any], row_b: Dict[str, Any]) -> Dict[str, Any]:
+        ts_a = row_a.get("updated_at") or row_a.get("modified_at") or 0
+        ts_b = row_b.get("updated_at") or row_b.get("modified_at") or 0
+        return row_a if ts_a >= ts_b else row_b
 
 
 class SyncManager:
@@ -50,18 +79,21 @@ class SyncManager:
         self,
         db_a: Path | str,
         db_b: Path | str,
+        *,
         resolver: Callable[[str, Dict[str, Any], Dict[str, Any]], Dict[str, Any]] | None = None,
+        policy: ConflictPolicy | None = None,
     ) -> None:
         """Bidirectionally synchronize ``db_a`` and ``db_b``.
 
-        ``resolver`` is invoked when a row exists in both databases with the same
-        primary key but differing content.  It receives ``(table, row_a, row_b)``
-        and must return the row that should be kept.
+        ``resolver`` is deprecated; pass ``policy`` instead.  The conflict policy
+        resolves differing rows deterministically and triggers conflict logging.
         """
 
         db_a = Path(db_a)
         db_b = Path(db_b)
-        resolver = resolver or self._default_resolver
+        if policy is None:
+            resolver = resolver or self._default_resolver
+            policy = ResolverPolicy(resolver)
 
         with sqlite3.connect(db_a) as conn_a, sqlite3.connect(db_b) as conn_b:
             conn_a.row_factory = sqlite3.Row
@@ -87,7 +119,9 @@ class SyncManager:
                             row = rows_a[pk]
                             other = rows_b[pk]
                             if row != other:
-                                merged = resolver(table, row, other)
+                                merged = policy.resolve(table, row, other)
+                                decision = "a" if merged == row else "b"
+                                self._log_conflict(db_a, db_b, table, pk, decision)
                                 self._upsert(conn_a, table, merged)
                                 self._upsert(conn_b, table, merged)
                         elif in_a:
@@ -100,10 +134,40 @@ class SyncManager:
             except Exception:
                 conn_a.rollback()
                 conn_b.rollback()
-                self._log_event(db_a, db_b, "sync_failed")
+                self._log_event(db_a, db_b, "sync", "failure")
                 raise
             else:
-                self._log_event(db_a, db_b, "sync")
+                self._log_event(db_a, db_b, "sync", "success")
+
+    def watch(
+        self,
+        db_a: Path | str,
+        db_b: Path | str,
+        *,
+        interval: float = 1.0,
+        stop_event: threading.Event | None = None,
+        resolver: Callable[[str, Dict[str, Any], Dict[str, Any]], Dict[str, Any]] | None = None,
+        policy: ConflictPolicy | None = None,
+    ) -> None:
+        """Watch databases for changes and synchronize on modification."""
+
+        db_a = Path(db_a)
+        db_b = Path(db_b)
+        stop_event = stop_event or threading.Event()
+        last_a = db_a.stat().st_mtime if db_a.exists() else 0
+        last_b = db_b.stat().st_mtime if db_b.exists() else 0
+
+        while not stop_event.is_set():
+            try:
+                mt_a = db_a.stat().st_mtime if db_a.exists() else 0
+                mt_b = db_b.stat().st_mtime if db_b.exists() else 0
+                if mt_a != last_a or mt_b != last_b:
+                    self.sync(db_a, db_b, resolver=resolver, policy=policy)
+                    last_a, last_b = mt_a, mt_b
+            except Exception:
+                # Errors logged in :meth:`sync` ensure monitoring.
+                pass
+            time.sleep(interval)
 
     @staticmethod
     def _upsert(conn: sqlite3.Connection, table: str, row: Dict[str, Any]) -> None:
@@ -120,7 +184,8 @@ class SyncManager:
         ts_b = row_b.get("updated_at") or row_b.get("modified_at") or 0
         return row_a if ts_a >= ts_b else row_b
 
-    def _log_event(self, db_a: Path, db_b: Path, action: str) -> None:
+    
+    def _log_event(self, db_a: Path, db_b: Path, action: str, status: str) -> None:
         self.analytics_db.parent.mkdir(parents=True, exist_ok=True)
         with sqlite3.connect(self.analytics_db) as conn:
             conn.execute(
@@ -130,17 +195,40 @@ class SyncManager:
                     source_db TEXT NOT NULL,
                     target_db TEXT NOT NULL,
                     action TEXT NOT NULL,
+                    status TEXT NOT NULL,
                     timestamp INTEGER NOT NULL
                 )
-                """
+                """,
             )
             conn.execute(
-                "INSERT INTO synchronization_events (source_db, target_db, action, timestamp)"
-                " VALUES (?, ?, ?, strftime('%s','now'))",
-                (str(db_a), str(db_b), action),
+                "INSERT INTO synchronization_events (source_db, target_db, action, status, timestamp)"
+                " VALUES (?, ?, ?, ?, strftime('%s','now'))",
+                (str(db_a), str(db_b), action, status),
             )
             conn.commit()
 
+    def _log_conflict(self, db_a: Path, db_b: Path, table: str, row_id: Any, decision: str) -> None:
+        self.analytics_db.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.analytics_db) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS synchronization_conflicts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_db TEXT NOT NULL,
+                    target_db TEXT NOT NULL,
+                    table_name TEXT NOT NULL,
+                    row_id INTEGER NOT NULL,
+                    decision TEXT NOT NULL,
+                    timestamp INTEGER NOT NULL
+                )
+                """,
+            )
+            conn.execute(
+                "INSERT INTO synchronization_conflicts (source_db, target_db, table_name, row_id, decision, timestamp)"
+                " VALUES (?, ?, ?, ?, ?, strftime('%s','now'))",
+                (str(db_a), str(db_b), table, int(row_id), decision),
+            )
+            conn.commit()
 
 def list_events(analytics_db: Path | str, limit: int = 10) -> List[Dict[str, Any]]:
     """Return recent synchronization events from ``analytics.db``."""
@@ -150,7 +238,7 @@ def list_events(analytics_db: Path | str, limit: int = 10) -> List[Dict[str, Any
         return events
     with sqlite3.connect(db_path) as conn:
         cur = conn.execute(
-            "SELECT timestamp, source_db, target_db, action FROM synchronization_events ORDER BY timestamp DESC LIMIT ?",
+            "SELECT timestamp, source_db, target_db, action, status FROM synchronization_events ORDER BY timestamp DESC LIMIT ?",
             (limit,),
         )
         events = [
@@ -159,6 +247,7 @@ def list_events(analytics_db: Path | str, limit: int = 10) -> List[Dict[str, Any
                 "source_db": row[1],
                 "target_db": row[2],
                 "action": row[3],
+                "status": row[4],
             }
             for row in cur.fetchall()
         ]

--- a/tests/test_database_first_synchronization_engine.py
+++ b/tests/test_database_first_synchronization_engine.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
+import time
 from pathlib import Path
 
 from database_first_synchronization_engine import (
@@ -43,7 +45,7 @@ def test_bidirectional_sync_and_logging(tmp_path: Path) -> None:
         calls.append((table, row_a["id"]))
         return row_a if row_a["updated_at"] >= row_b["updated_at"] else row_b
 
-    manager.sync(db_a, db_b, resolver)
+    manager.sync(db_a, db_b, resolver=resolver)
 
     assert _read_rows(db_a) == [
         (1, "b", 3),
@@ -58,8 +60,43 @@ def test_bidirectional_sync_and_logging(tmp_path: Path) -> None:
     assert calls  # conflict resolver invoked
 
     with sqlite3.connect(analytics) as conn:
-        rows = conn.execute("SELECT source_db, target_db, action FROM synchronization_events").fetchall()
-        assert rows[0][2] == "sync"
+        rows = conn.execute(
+            "SELECT source_db, target_db, action, status FROM synchronization_events"
+        ).fetchall()
+        assert rows[0][2] == "sync" and rows[0][3] == "success"
+        conflicts = conn.execute(
+            "SELECT table_name, row_id, decision FROM synchronization_conflicts"
+        ).fetchall()
+        assert conflicts
 
     events = list_events(analytics, limit=1)
-    assert events and events[0]["action"] == "sync"
+    assert events and events[0]["action"] == "sync" and events[0]["status"] == "success"
+
+
+def test_watch_triggers_sync_on_change(tmp_path: Path) -> None:
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+    analytics = tmp_path / "analytics.db"
+
+    _create_db(db_a, [(1, "a", 1)])
+    _create_db(db_b, [(1, "b", 2)])
+
+    mapper = SchemaMapper()
+    manager = SyncManager(mapper, analytics_db=analytics)
+
+    stop = threading.Event()
+    t = threading.Thread(target=manager.watch, args=(db_a, db_b), kwargs={"interval": 0.1, "stop_event": stop})
+    t.start()
+    try:
+        with sqlite3.connect(db_a) as conn:
+            conn.execute("UPDATE items SET data='new', updated_at=3 WHERE id=1")
+            conn.commit()
+        time.sleep(0.3)
+    finally:
+        stop.set()
+        t.join()
+
+    assert _read_rows(db_a) == [(1, "new", 3)]
+    assert _read_rows(db_b) == [(1, "new", 3)]
+    events = list_events(analytics, limit=1)
+    assert events and events[0]["status"] == "success"


### PR DESCRIPTION
## Summary
- add pluggable conflict policy and watcher loop to SyncManager
- log sync outcomes and conflict resolutions to analytics.db
- cover new synchronization features with tests

## Testing
- `ruff check database_first_synchronization_engine.py tests/test_database_first_synchronization_engine.py`
- `pytest tests/test_database_first_synchronization_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_6893f3f0a8548331aa7998d51a3b5715