### PR TITLE
fix: detect zero-byte files in subdirectories

### DIFF
--- a/tests/test_session_management_consolidation_executor.py
+++ b/tests/test_session_management_consolidation_executor.py
@@ -31,3 +31,20 @@ def test_consolidation_executor_fails_on_zero_byte(tmp_path, monkeypatch):
     (tmp_path / "empty.txt").write_text("")
     util = EnterpriseUtility(str(tmp_path))
     assert util.perform_utility_function() is False
+
+
+def test_consolidation_executor_fails_on_subdir_zero_byte(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "utils.cross_platform_paths.CrossPlatformPathManager.get_workspace_path",
+        lambda: tmp_path,
+    )
+    backup_root = tmp_path.parent / "backups"
+    backup_root.mkdir(exist_ok=True)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+    monkeypatch.chdir(tmp_path)
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "empty.txt").write_text("")
+    util = EnterpriseUtility(str(tmp_path))
+    assert util.perform_utility_function() is False


### PR DESCRIPTION
## Summary
- refactor session utility to use `detect_zero_byte_files` for comprehensive zero-byte file detection
- log and return failure when zero-byte files appear anywhere in workspace
- add tests for detecting zero-byte files inside subdirectories

## Testing
- `ruff check session_management_consolidation_executor.py tests/test_session_management_consolidation_executor.py`
- `pytest tests/test_session_management_consolidation_executor.py`
- `pytest` *(fails: tests/documentation/test_link_and_schema.py::test_markdown_links_exist)*

------
https://chatgpt.com/codex/tasks/task_e_6893f3fd5df0833181c534681953fb04