### PR TITLE
feat: centralize zero-byte file detection

### DIFF
--- a/scripts/session/COMPREHENSIVE_WORKSPACE_MANAGER.py
+++ b/scripts/session/COMPREHENSIVE_WORKSPACE_MANAGER.py
@@ -20,6 +20,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Iterable, List
 
+from utils.validation_utils import detect_zero_byte_files
+
 from tqdm import tqdm
 
 from scripts.monitoring.unified_monitoring_optimization_system import (
@@ -67,11 +69,8 @@ class ComprehensiveWorkspaceManager:
         Path(backup_root).mkdir(parents=True, exist_ok=True)
 
     def _scan_zero_byte_files(self) -> List[Path]:
-        files: List[Path] = []
-        for path in self.workspace.rglob("*"):
-            if path.is_file() and path.stat().st_size == 0:
-                files.append(path)
-        return files
+        """Return zero-byte files under the workspace using shared util."""
+        return detect_zero_byte_files(self.workspace)
 
     def _scan_recursive_folders(self) -> List[Path]:
         folders: List[Path] = []

--- a/tests/test_comprehensive_workspace_manager.py
+++ b/tests/test_comprehensive_workspace_manager.py
@@ -50,3 +50,22 @@ def test_start_end_session_records_wrapup(tmp_path, monkeypatch):
     assert status == "COMPLETED"
     assert end_time is not None
     assert not manager.session_file.exists()
+
+
+def test_scan_zero_byte_files_uses_shared_util(monkeypatch, tmp_path):
+    """Ensure manager delegates zero-byte detection to shared utility."""
+    temp_db = copy_db(tmp_path)
+    manager = ComprehensiveWorkspaceManager(db_path=temp_db)
+
+    expected = [tmp_path / "a.txt"]
+
+    def fake_detect(path):
+        assert path == manager.workspace
+        return expected
+
+    monkeypatch.setattr(
+        "scripts.session.COMPREHENSIVE_WORKSPACE_MANAGER.detect_zero_byte_files",
+        fake_detect,
+    )
+
+    assert manager._scan_zero_byte_files() == expected


### PR DESCRIPTION
## Summary
- reuse shared utility for zero-byte file scanning in ComprehensiveWorkspaceManager
- add regression test ensuring session manager delegates detection to utils

## Testing
- `ruff check scripts/session/COMPREHENSIVE_WORKSPACE_MANAGER.py tests/test_comprehensive_workspace_manager.py`
- `pytest tests/test_comprehensive_workspace_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6893f2f07df88331881095ee66e28354