### PR TITLE
feat: add zero-byte scan helper

### DIFF
--- a/scripts/utilities/unified_session_management_system.py
+++ b/scripts/utilities/unified_session_management_system.py
@@ -78,6 +78,10 @@ class UnifiedSessionManagementSystem:
         except Exception:
             self.logger.exception("Rollback failed: %s", message)
 
+    def _scan_zero_byte_files(self) -> list[Path]:
+        """Detect and remove any zero-byte files before session start."""
+        return self._cleanup_zero_byte_files()
+
     def _cleanup_zero_byte_files(self) -> list[Path]:
         from utils.validation_utils import detect_zero_byte_files
         zero_files = detect_zero_byte_files(self.workspace_root)

--- a/tests/test_session_management_system.py
+++ b/tests/test_session_management_system.py
@@ -80,6 +80,15 @@ def test_zero_byte_file_cleanup(monkeypatch, tmp_path):
     assert not zero.exists()
 
 
+def test_scan_zero_byte_files(monkeypatch, tmp_path):
+    harness = USMSTestHarness(monkeypatch, tmp_path)
+    zero = tmp_path / "empty.txt"
+    zero.touch()
+    removed = harness.system._scan_zero_byte_files()
+    assert zero not in removed or not zero.exists()
+    assert removed and removed[0].name == "empty.txt"
+
+
 def test_prevent_double_start(monkeypatch, tmp_path):
     harness = USMSTestHarness(monkeypatch, tmp_path)
     assert harness.system.start_session()


### PR DESCRIPTION
## Summary
- add `_scan_zero_byte_files` to remove empty files before session start
- test zero-byte scanning in session management system

## Testing
- `ruff check scripts/utilities/unified_session_management_system.py tests/test_session_management_system.py`
- `pytest tests/test_session_management_system.py`
- `python scripts/wlc_session_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6893f2f07df88331881095ee66e28354