### PR TITLE
feat: add real-time database sync watcher

### DIFF
--- a/docs/DATABASE_SYNC_GUIDE.md
+++ b/docs/DATABASE_SYNC_GUIDE.md
@@ -15,6 +15,24 @@ This guide outlines recovery procedures and common failure modes for the
 5. **Resume synchronization** – once issues are resolved, run the engine again
    to bring databases back into consistency.
 
+## Real-Time Synchronization
+`SyncManager` can operate in real time through the `SyncWatcher` utility. The
+watcher observes one or more database pairs and triggers a synchronization when
+either side changes:
+
+```python
+from database_first_synchronization_engine import SyncManager, SyncWatcher
+
+manager = SyncManager()
+watcher = SyncWatcher(manager)
+watcher.watch_pairs([(db_a, db_b), (db_c, db_d)], policy="last-write-wins")
+```
+
+## Conflict Policies
+The synchronization engine supports pluggable conflict resolution. Use the
+`"last-write-wins"` policy for timestamp-based merges or supply a custom merge
+function via `ResolverPolicy` when domain-specific logic is required.
+
 ## Failure Modes
 - **Schema mismatch** – target databases missing required tables or columns.
   Update the schema mapping or migrate the databases before retrying.

--- a/tests/dashboard/test_sync_events.py
+++ b/tests/dashboard/test_sync_events.py
@@ -11,10 +11,11 @@ import dashboard.enterprise_dashboard as ed
 def _setup_analytics_db(path: Path) -> None:
     with sqlite3.connect(path) as conn:
         conn.execute(
-            "CREATE TABLE synchronization_events (timestamp INTEGER, source_db TEXT, target_db TEXT, action TEXT)"
+            "CREATE TABLE synchronization_events (timestamp INTEGER, source_db TEXT, target_db TEXT, action TEXT, status TEXT)"
         )
         conn.execute(
-            "INSERT INTO synchronization_events (timestamp, source_db, target_db, action) VALUES (1, 'a.db', 'b.db', 'sync')"
+            "INSERT INTO synchronization_events (timestamp, source_db, target_db, action, status)"
+            " VALUES (1, 'a.db', 'b.db', 'sync', 'success')"
         )
         conn.commit()
 

--- a/tests/test_database_first_synchronization_engine.py
+++ b/tests/test_database_first_synchronization_engine.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from database_first_synchronization_engine import (
     SchemaMapper,
     SyncManager,
+    SyncWatcher,
+    ResolverPolicy,
     list_events,
 )
 
@@ -39,13 +41,7 @@ def test_bidirectional_sync_and_logging(tmp_path: Path) -> None:
     mapper = SchemaMapper()
     manager = SyncManager(mapper, analytics_db=analytics)
 
-    calls: list[tuple[str, int]] = []
-
-    def resolver(table: str, row_a: dict, row_b: dict) -> dict:
-        calls.append((table, row_a["id"]))
-        return row_a if row_a["updated_at"] >= row_b["updated_at"] else row_b
-
-    manager.sync(db_a, db_b, resolver=resolver)
+    manager.sync(db_a, db_b, policy="last-write-wins")
 
     assert _read_rows(db_a) == [
         (1, "b", 3),
@@ -57,7 +53,6 @@ def test_bidirectional_sync_and_logging(tmp_path: Path) -> None:
         (2, "from_a", 2),
         (3, "from_b", 3),
     ]
-    assert calls  # conflict resolver invoked
 
     with sqlite3.connect(analytics) as conn:
         rows = conn.execute(
@@ -100,3 +95,66 @@ def test_watch_triggers_sync_on_change(tmp_path: Path) -> None:
     assert _read_rows(db_b) == [(1, "new", 3)]
     events = list_events(analytics, limit=1)
     assert events and events[0]["status"] == "success"
+
+
+def test_custom_merge_policy(tmp_path: Path) -> None:
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+
+    _create_db(db_a, [(1, "a", 1)])
+    _create_db(db_b, [(1, "b", 2)])
+
+    mapper = SchemaMapper()
+    manager = SyncManager(mapper)
+
+    calls: list[str] = []
+
+    def merge(table: str, row_a: dict, row_b: dict) -> dict:
+        calls.append(table)
+        return {**row_a, "data": row_a["data"] + row_b["data"], "updated_at": row_b["updated_at"]}
+
+    manager.sync(db_a, db_b, policy=ResolverPolicy(merge))
+
+    assert calls == ["items"]
+    assert _read_rows(db_a) == [(1, "ab", 2)]
+    assert _read_rows(db_b) == [(1, "ab", 2)]
+
+
+def test_watch_pairs_syncs_multiple_pairs(tmp_path: Path) -> None:
+    db1_a = tmp_path / "a1.db"
+    db1_b = tmp_path / "b1.db"
+    db2_a = tmp_path / "a2.db"
+    db2_b = tmp_path / "b2.db"
+    analytics = tmp_path / "analytics.db"
+
+    _create_db(db1_a, [(1, "a", 1)])
+    _create_db(db1_b, [(1, "b", 2)])
+    _create_db(db2_a, [(1, "x", 1)])
+    _create_db(db2_b, [(1, "y", 2)])
+
+    manager = SyncManager(SchemaMapper(), analytics_db=analytics)
+    watcher = SyncWatcher(manager)
+
+    stop = threading.Event()
+    t = threading.Thread(
+        target=watcher.watch_pairs,
+        args=([(db1_a, db1_b), (db2_a, db2_b)],),
+        kwargs={"interval": 0.1, "stop_event": stop, "policy": "last-write-wins"},
+    )
+    t.start()
+    try:
+        with sqlite3.connect(db1_a) as conn:
+            conn.execute("UPDATE items SET data='new1', updated_at=3 WHERE id=1")
+            conn.commit()
+        with sqlite3.connect(db2_b) as conn:
+            conn.execute("UPDATE items SET data='new2', updated_at=3 WHERE id=1")
+            conn.commit()
+        time.sleep(0.5)
+    finally:
+        stop.set()
+        t.join()
+
+    assert _read_rows(db1_a) == [(1, "new1", 3)]
+    assert _read_rows(db1_b) == [(1, "new1", 3)]
+    assert _read_rows(db2_a) == [(1, "new2", 3)]
+    assert _read_rows(db2_b) == [(1, "new2", 3)]


### PR DESCRIPTION
## Summary
- add LastWriteWinsPolicy and policy selection in SyncManager
- add SyncWatcher for real-time sync across multiple database pairs
- document real-time sync and conflict policies

## Testing
- `ruff check database_first_synchronization_engine.py tests/test_database_first_synchronization_engine.py`
- `ruff check tests/dashboard/test_sync_events.py`
- `pytest tests/test_database_first_synchronization_engine.py tests/dashboard/test_sync_events.py`

------
https://chatgpt.com/codex/tasks/task_e_6893f97739488331b33926439b1dbfc1