### PR TITLE
feat: add anomaly and quantum metrics

### DIFF
--- a/tests/dashboard/test_actionable_endpoints.py
+++ b/tests/dashboard/test_actionable_endpoints.py
@@ -56,3 +56,46 @@ def test_violations_endpoint_no_recursion_warning(gui_app, caplog):
         data = client.get("/violations").get_json()
     assert data["violations"][0]["details"] == "violation"
     assert "recurs" not in caplog.text.lower()
+
+
+def test_metrics_include_anomaly_and_quantum(gui_app):
+    db = Path(gui.ANALYTICS_DB)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE anomaly_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                metrics_json TEXT,
+                anomaly_score REAL,
+                quantum_score REAL,
+                composite_score REAL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO anomaly_results (metrics_json, anomaly_score, quantum_score, composite_score)
+            VALUES ('{}', 0.4, 0.6, 0.5)
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE quantum_scores (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                metrics_json TEXT,
+                score REAL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO quantum_scores (metrics_json, score) VALUES ('{}', 0.9)"
+        )
+        conn.commit()
+
+    client = gui_app.test_client()
+    data = client.get("/metrics").get_json()
+    assert data["latest_anomaly_score"] == 0.4
+    assert data["latest_anomaly_composite"] == 0.5
+    assert data["latest_quantum_score"] == 0.9


### PR DESCRIPTION
## Summary
- persist IsolationForest models while pushing metrics and emit scores to dashboard
- expose anomaly and quantum data on integrated dashboard
- test model persistence and dashboard metric exposure

## Testing
- `ruff check unified_monitoring_optimization_system.py dashboard/integrated_dashboard.py tests/test_unified_monitoring_optimization_system.py tests/dashboard/test_actionable_endpoints.py`
- `pytest --override-ini addopts="" -p no:cov tests/test_unified_monitoring_optimization_system.py tests/dashboard/test_actionable_endpoints.py`

------
https://chatgpt.com/codex/tasks/task_e_68940135ceac83319a267adbca323001