### PR TITLE
fix: clean up utilities and add base64 decoder test

### DIFF
--- a/analytics_db_decoder.py
+++ b/analytics_db_decoder.py
@@ -5,12 +5,10 @@ Decodes the analytics_db_zip_base64.txt file
 """
 
 import base64
-import zipfile
 import io
-import os
 import struct
 import tempfile
-from pathlib import Path
+import zipfile
 
 def read_base64_file():
     """Read the base64 content from the analytics file"""
@@ -159,7 +157,7 @@ def analyze_raw_content(data):
         if readable_chars:
             print(f"\nReadable content preview:")
             print(readable_chars[:500])
-    except:
+    except Exception:
         pass
     
     return data

--- a/analytics_db_inspector.py
+++ b/analytics_db_inspector.py
@@ -5,7 +5,6 @@ Provides a comprehensive overview of the analytics.db database
 """
 
 import sqlite3
-import json
 from pathlib import Path
 
 def inspect_database():
@@ -76,7 +75,7 @@ def inspect_database():
                     sample_data = cursor.fetchall()
                     if sample_data:
                         print(f"      Sample: {len(sample_data)} rows")
-                except:
+                except Exception:
                     pass
         
         # Check for recent activity
@@ -97,7 +96,7 @@ def inspect_database():
                         latest = cursor.fetchone()[0]
                         if latest:
                             print(f"   • {table_name}: Latest entry at {latest}")
-                except:
+                except Exception:
                     pass
         
         # Enterprise features

--- a/clean_git_state.py
+++ b/clean_git_state.py
@@ -5,11 +5,9 @@ Ensures git repository is in a completely clean state for VS Code
 Generated: 2025-08-06 | Enterprise Standards Compliance
 """
 
-import os
 import subprocess
-import shutil
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 def clean_git_state():
     """Ensure git repository is in completely clean state"""

--- a/deep_base64_analyzer.py
+++ b/deep_base64_analyzer.py
@@ -5,12 +5,9 @@ Performs deep analysis of base64 content including hex dump and structure analys
 """
 
 import base64
-import zipfile
-import os
-import tempfile
-from pathlib import Path
-from datetime import datetime
 import struct
+from datetime import datetime
+from pathlib import Path
 
 def hex_dump(data: bytes, start_offset: int = 0, max_lines: int = 20) -> str:
     """Create a hex dump of binary data"""
@@ -114,8 +111,8 @@ def extract_files_manually(data: bytes, analysis: dict) -> dict:
                     try:
                         decompressed = zlib.decompress(compressed_data, -15)  # Raw deflate
                         print(f"   ✅ Decompressed {len(compressed_data)} -> {len(decompressed)} bytes")
-                    except:
-                        print(f"   ⚠️ Decompression failed, saving raw data")
+                    except Exception:
+                        print("   ⚠️ Decompression failed, saving raw data")
                         decompressed = compressed_data
                 elif entry['method'] == 0:  # STORED (no compression)
                     decompressed = compressed_data

--- a/fix_git_lfs_and_merge_conflicts.py
+++ b/fix_git_lfs_and_merge_conflicts.py
@@ -7,7 +7,7 @@ Generated: 2025-08-06 | Enterprise Standards Compliance
 
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, Optional
 import os
 import subprocess
 import shutil

--- a/git_lfs_recovery_orchestrator.py
+++ b/git_lfs_recovery_orchestrator.py
@@ -7,7 +7,7 @@ Generated: 2025-08-06 | Enterprise Standards Compliance
 
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, Optional
 import os
 import subprocess
 import shutil

--- a/partial_data_recovery.py
+++ b/partial_data_recovery.py
@@ -4,7 +4,6 @@
 Attempts to recover readable content from partial/corrupted data
 """
 
-import re
 from pathlib import Path
 
 def analyze_raw_data(file_path: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ extend-exclude = [
     "quantum_optimizer.py",
     "databases/*.db",
     "*.log",
+    "recovered_files_*",
 ]
 
 [tool.ruff.lint]

--- a/rename_files_with_spaces.py
+++ b/rename_files_with_spaces.py
@@ -4,8 +4,6 @@
 Systematically rename all files in a directory to replace spaces with underscores
 """
 
-import os
-import shutil
 from pathlib import Path
 from datetime import datetime
 import logging

--- a/tests/test_universal_base64_decoder.py
+++ b/tests/test_universal_base64_decoder.py
@@ -1,0 +1,20 @@
+import base64
+import io
+from pathlib import Path
+import zipfile
+
+from universal_base64_decoder import analyze_base64_content
+
+def test_analyze_base64_detects_zip(tmp_path, monkeypatch):
+    """`analyze_base64_content` should classify ZIP archives correctly."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("hello.txt", "hello")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+
+    monkeypatch.chdir(tmp_path)
+    result = analyze_base64_content(b64)
+
+    assert result["success"] is True
+    assert result["file_type"] == "ZIP Archive"
+    assert Path(result["output_file"]).exists()

--- a/universal_base64_decoder.py
+++ b/universal_base64_decoder.py
@@ -6,10 +6,8 @@ Decodes base64 content and analyzes what type of file it is
 
 import base64
 import zipfile
-import os
-import tempfile
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 def analyze_base64_content(base64_string: str) -> dict:
     """
@@ -43,20 +41,19 @@ def analyze_base64_content(base64_string: str) -> dict:
         
         # Common file signatures
         file_signatures = {
-            b'PK\x03\x04': 'ZIP Archive',
-            b'PK\x05\x06': 'ZIP Archive (empty)',
-            b'PK\x07\x08': 'ZIP Archive (spanned)',
-            b'\x50\x4B\x03\x04': 'ZIP Archive',
-            b'\x1f\x8b': 'GZIP Archive',
-            b'\x42\x5a\x68': 'BZIP2 Archive',
-            b'\x37\x7a\xbc\xaf\x27\x1c': '7Z Archive',
-            b'Rar!': 'RAR Archive',
-            b'\x89PNG': 'PNG Image',
-            b'\xff\xd8\xff': 'JPEG Image',
-            b'GIF8': 'GIF Image',
-            b'\x00\x00\x00\x20\x66\x74\x79\x70': 'MP4 Video',
-            b'%PDF': 'PDF Document',
-            b'\xd0\xcf\x11\xe0': 'Microsoft Office Document',
+            b"PK\x03\x04": "ZIP Archive",
+            b"PK\x05\x06": "ZIP Archive (empty)",
+            b"PK\x07\x08": "ZIP Archive (spanned)",
+            b"\x1f\x8b": "GZIP Archive",
+            b"\x42\x5a\x68": "BZIP2 Archive",
+            b"\x37\x7a\xbc\xaf\x27\x1c": "7Z Archive",
+            b"Rar!": "RAR Archive",
+            b"\x89PNG": "PNG Image",
+            b"\xff\xd8\xff": "JPEG Image",
+            b"GIF8": "GIF Image",
+            b"\x00\x00\x00\x20\x66\x74\x79\x70": "MP4 Video",
+            b"%PDF": "PDF Document",
+            b"\xd0\xcf\x11\xe0": "Microsoft Office Document",
         }
         
         detected_type = "Unknown Binary File"
@@ -78,7 +75,7 @@ def analyze_base64_content(base64_string: str) -> dict:
             try:
                 text_content = decoded_bytes.decode('latin-1')
                 print("📄 Content might be Latin-1 encoded text")
-            except:
+            except Exception:
                 print("📄 Content is binary data")
         
         # Step 4: Create output file

--- a/zip_recovery_tool.py
+++ b/zip_recovery_tool.py
@@ -98,7 +98,7 @@ def manual_zip_extraction(data: bytes) -> dict:
                             try:
                                 decompressed = zlib.decompress(compressed_data, -15)
                                 print(f"   ✅ Decompressed using standard deflate: {len(decompressed)} bytes")
-                            except:
+                            except Exception:
                                 pass
                             
                             # Method 2: Raw deflate
@@ -106,7 +106,7 @@ def manual_zip_extraction(data: bytes) -> dict:
                                 try:
                                     decompressed = zlib.decompress(compressed_data)
                                     print(f"   ✅ Decompressed using raw deflate: {len(decompressed)} bytes")
-                                except:
+                                except Exception:
                                     pass
                             
                             # Method 3: Inflate
@@ -115,7 +115,7 @@ def manual_zip_extraction(data: bytes) -> dict:
                                     inflater = zlib.decompressobj()
                                     decompressed = inflater.decompress(compressed_data)
                                     print(f"   ✅ Decompressed using inflater: {len(decompressed)} bytes")
-                                except:
+                                except Exception:
                                     pass
                             
                             if decompressed is None:


### PR DESCRIPTION
## Summary
- fix universal_base64_decoder file signature table and clarify exception handling
- remove unused imports and bare `except` usages across recovery utilities
- exclude recovered file snapshots from linting and add regression test for ZIP detection

## Testing
- `ruff check .`
- `PYTEST_ADDOPTS="-k universal_base64_decoder" python scripts/run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_68940135e88883318d1802f572bf5c43