### PR TITLE
feat: log zero-byte files with session metadata

### DIFF
--- a/tests/test_session_integrity.py
+++ b/tests/test_session_integrity.py
@@ -1,0 +1,47 @@
+"""Tests for zero-byte file detection and logging."""
+
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+import unified_session_management_system as usms
+
+
+def _setup_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db = tmp_path / "analytics.db"
+    monkeypatch.setattr(usms, "ANALYTICS_DB", db)
+    return db
+
+
+def _fetch_records(db: Path) -> list[tuple[str, str, str]]:
+    with sqlite3.connect(db) as conn:
+        return list(
+            conn.execute("SELECT path, session_id, phase FROM zero_byte_files")
+        )
+
+
+def test_zero_byte_file_before_block(tmp_path, monkeypatch):
+    db = _setup_db(tmp_path, monkeypatch)
+    zero_file = tmp_path / "empty.txt"
+    zero_file.touch()
+
+    with pytest.raises(RuntimeError):
+        with usms.ensure_no_zero_byte_files(tmp_path, "sess1"):
+            pass
+
+    records = _fetch_records(db)
+    assert (str(zero_file), "sess1", "before") in records
+
+
+def test_zero_byte_file_after_block(tmp_path, monkeypatch):
+    db = _setup_db(tmp_path, monkeypatch)
+    target = tmp_path / "later.txt"
+
+    with pytest.raises(RuntimeError):
+        with usms.ensure_no_zero_byte_files(tmp_path, "sess2"):
+            target.touch()
+
+    records = _fetch_records(db)
+    assert (str(target), "sess2", "after") in records
+


### PR DESCRIPTION
## Summary
- track zero-byte files with session IDs and wrap both start and end stages
- capture zero-byte scan counts in WLC session analytics
- test zero-byte file detection and logging

## Testing
- `ruff check unified_session_management_system.py scripts/wlc_session_manager.py tests/test_session_integrity.py`
- `pytest tests/test_session_integrity.py`

------
https://chatgpt.com/codex/tasks/task_e_689401a566ec8331a01f9ba6e073d275