### PR TITLE
feat(web): add correction history dashboard view

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,7 +823,7 @@ class SelfHealingSelfLearningSystem:
 
 ## 🌐 ENTERPRISE WEB DASHBOARD
 
-### **Flask Dashboard (7 Endpoints)**
+### **Flask Dashboard (8 Endpoints)**
 - **`/`** - Executive dashboard with real-time metrics
 - **`/database`** - Database management interface
 - **`/backup`** - Backup and restore operations
@@ -833,6 +833,7 @@ class SelfHealingSelfLearningSystem:
 - **`/api/health`** - System health check
 - **`/dashboard/compliance`** - Compliance metrics and rollback history
 - **`/summary`** - JSON summary of metrics and alerts
+- **`/corrections`** - Correction history overview
 
 ### **Access Dashboard**
 ```bash

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -371,6 +371,19 @@ def correction_history() -> Any:
     return jsonify(_fetch_correction_history())
 
 
+@app.get("/corrections")
+def corrections() -> Any:
+    """Render correction history using an HTML template."""
+    history = _fetch_correction_history()
+    return render_template("corrections.html", corrections=history)
+
+
+@app.get("/dashboard/corrections")
+def dashboard_corrections() -> Any:
+    """Alias route for the corrections page."""
+    return corrections()
+
+
 def calculate_etc(start_time: float, current_progress: int, total_work: int) -> str:
     elapsed = time.time() - start_time
     if current_progress > 0:

--- a/web_gui/templates/corrections.html
+++ b/web_gui/templates/corrections.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>Correction History</title>
+<h1>Correction History</h1>
+<ul>
+    {% for item in corrections %}
+    <li>{{ item.timestamp }} - {{ item.file_path }} (score {{ '%.3f'|format(item.compliance_score) }})</li>
+    {% endfor %}
+</ul>
+

--- a/web_gui/templates/dashboard.html
+++ b/web_gui/templates/dashboard.html
@@ -10,3 +10,4 @@
 </ul>
 <p><a href="/dashboard/compliance">Compliance Metrics</a></p>
 <p><a href="/dashboard/rollback">Rollback Logs</a></p>
+<p><a href="/dashboard/corrections">Correction History</a></p>


### PR DESCRIPTION
## Summary
- add corrections.html template to display correction log
- expose /corrections route and dashboard alias
- link correction history from main dashboard and README

## Testing
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py`
- `pytest` *(fails: unrecognized arguments --cov=. --cov-report=term)*

------
https://chatgpt.com/codex/tasks/task_e_689403f200dc8331a6d435afa1c6f6e9