### PR TITLE
feat: cleanup redundant template clusters

### DIFF
--- a/docs/TEMPLATE_ENGINE_GUIDE.md
+++ b/docs/TEMPLATE_ENGINE_GUIDE.md
@@ -1,0 +1,17 @@
+# Template Engine Guide
+
+## Clustering Strategy
+
+`EnterpriseUtility.cluster_templates` groups template files by counting
+their placeholder markers and applying ``KMeans``. The resulting
+``cluster_output.json`` maps cluster labels to template paths for further
+analysis.
+
+## Cleanup Flow
+
+After clustering, the utility invokes
+``UnifiedLegacyCleanupSystem.remove_redundant_templates``. The cleanup
+routine hashes each template's contents and removes duplicates within a
+cluster, ensuring only unique templates remain on disk and in the
+returned mapping.
+

--- a/scripts/utilities/unified_script_generation_system.py
+++ b/scripts/utilities/unified_script_generation_system.py
@@ -136,6 +136,10 @@ class EnterpriseUtility:
         for label, path in zip(labels, valid_paths):
             clusters[int(label)].append(path)
 
+        # remove redundant templates via cleanup system
+        cleanup = UnifiedLegacyCleanupSystem(self.workspace_path)
+        clusters = cleanup.remove_redundant_templates(clusters)
+
         cluster_file = self.workspace_path / "cluster_output.json"
         cluster_file.write_text(
             json.dumps({k: [str(p) for p in v] for k, v in clusters.items()}, indent=2),

--- a/tests/script_generation/test_template_clustering.py
+++ b/tests/script_generation/test_template_clustering.py
@@ -1,0 +1,23 @@
+"""Tests for template clustering and cleanup."""
+
+from pathlib import Path
+
+from unified_script_generation_system import EnterpriseUtility
+
+
+def test_cluster_templates_removes_duplicates(tmp_path: Path) -> None:
+    """Duplicates in a cluster are removed by cleanup routine."""
+
+    t1 = tmp_path / "template1.txt"
+    t2 = tmp_path / "template2.txt"
+    content = "Hello {name}\n"
+    t1.write_text(content)
+    t2.write_text(content)
+
+    utility = EnterpriseUtility(workspace_path=str(tmp_path))
+    clusters = utility.cluster_templates([t1, t2], n_clusters=1)
+
+    assert 0 in clusters
+    assert len(clusters[0]) == 1
+    assert not t2.exists()
+


### PR DESCRIPTION
## Summary
- deduplicate clustered templates via legacy cleanup system
- add regression test for template clustering cleanup
- document clustering and cleanup flow

## Testing
- `ruff check scripts/utilities/unified_script_generation_system.py unified_legacy_cleanup_system.py tests/script_generation/test_template_clustering.py`
- `pytest tests/script_generation/test_template_clustering.py`


------
https://chatgpt.com/codex/tasks/task_e_6894043055a08331801d1570eba10cc2