### PR TITLE
feat: expand enterprise dashboard insights

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -97,10 +97,11 @@ Example screenshot:
 
 1. Start the dashboard: `python dashboard/enterprise_dashboard.py`.
 2. Visit [http://localhost:5000/](http://localhost:5000/) and verify the dashboard renders.
-3. Open `/metrics/view` to confirm metrics are displayed.
-4. Open `/rollback-logs/view` to confirm rollback entries are shown.
-5. Open `/sync-events/view` to confirm synchronization events are shown.
-6. Ensure styling from `dashboard/static/style.css` is applied.
+3. Open `/overview` to view metrics, rollback logs, sync events, and audit results together.
+4. Open `/metrics/view` to confirm metrics are displayed.
+5. Open `/rollback-logs/view` to confirm rollback entries are shown.
+6. Open `/sync-events/view` to confirm synchronization events are shown.
+7. Ensure styling from `dashboard/static/style.css` is applied.
 
 ### Live Metrics
 
@@ -124,9 +125,9 @@ compliance issues immediately.
 | `/deployment`             | Deployment status and controls                                                   |
 | `/api/scripts`            | Run and monitor scripts via API                                                  |
 | `/api/health`             | System health check API                                                          |
-
-| `/metrics_stream`         | Server-Sent Events stream of live metrics             |
+| `/metrics_stream`         | Server-Sent Events stream of live metrics                                       |
 | `/dashboard/compliance`   | Returns compliance metrics, rollback and audit trail as JSON                     |
+| `/overview`               | Consolidated dashboard with metrics, rollbacks, sync events, and audit results   |
 #### Example `/dashboard/compliance` Response
 
 The `/dashboard/compliance` endpoint returns compliance information as JSON, combining live metrics from `analytics.db` and correction/rollback summaries from `dashboard/compliance/correction_summary.json`.

--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -1,3 +1,30 @@
-from .integrated_dashboard import app, _dashboard as dashboard_bp, create_app
+"""Enterprise dashboard entrypoint with consolidated views."""
 
-__all__ = ["app", "dashboard_bp", "create_app"]
+from flask import render_template
+
+from .integrated_dashboard import (
+    _load_audit_results,
+    _load_metrics,
+    _load_sync_events,
+    app,
+    get_rollback_logs,
+    _dashboard as dashboard_bp,
+    create_app,
+)
+
+
+# Register view directly on the Flask app because the blueprint is already
+# attached during app creation.
+@app.get("/overview")
+def overview() -> str:
+    """Render a unified view of metrics, rollbacks, sync events, and audits."""
+    return render_template(
+        "dashboard.html",
+        metrics=_load_metrics(),
+        rollbacks=get_rollback_logs(),
+        sync_events=_load_sync_events(),
+        audit_results=_load_audit_results(),
+    )
+
+
+__all__ = ["app", "dashboard_bp", "create_app", "overview"]

--- a/dashboard/templates/audit_results.html
+++ b/dashboard/templates/audit_results.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Audit Results</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body>
     <h1>Audit Results</h1>

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -48,6 +48,24 @@
                 list.appendChild(li);
             });
         }
+        function updateSyncEvents(events){
+            const list = document.getElementById('sync_events');
+            list.innerHTML = '';
+            events.forEach(e => {
+                const li = document.createElement('li');
+                li.textContent = e.timestamp + ' - ' + e.source_db + ' -> ' + e.target_db + ' (' + e.action + ')';
+                list.appendChild(li);
+            });
+        }
+        function updateAuditResults(rows){
+            const list = document.getElementById('audit_results');
+            list.innerHTML = '';
+            rows.forEach(r => {
+                const li = document.createElement('li');
+                li.textContent = r.placeholder_type + ': ' + r.count;
+                list.appendChild(li);
+            });
+        }
         function updateCompliance(payload){
             if(payload.metrics){
                 updateMetrics(payload.metrics);
@@ -58,6 +76,10 @@
         }
         function pollCompliance(){
             fetch('/dashboard/compliance').then(r=>r.json()).then(updateCompliance);
+        }
+        function pollExtras(){
+            fetch('/sync-events').then(r=>r.json()).then(updateSyncEvents);
+            fetch('/audit-results').then(r=>r.json()).then(updateAuditResults);
         }
         window.onload = function(){
             if(!!window.EventSource){
@@ -71,7 +93,9 @@
                 },5000);
             }
             pollCompliance();
+            pollExtras();
             setInterval(pollCompliance,5000);
+            setInterval(pollExtras,5000);
         };
     </script>
 </head>
@@ -99,6 +123,20 @@
 <ul id="rollbacks">
 {% for log in rollbacks %}
     <li>{{ log.timestamp }} - {{ log.target }}{% if log.backup %} ({{ log.backup }}){% endif %}</li>
+{% endfor %}
+</ul>
+
+<h2>Recent Sync Events</h2>
+<ul id="sync_events">
+{% for event in sync_events %}
+    <li>{{ event.timestamp }} - {{ event.source_db }} -> {{ event.target_db }} ({{ event.action }})</li>
+{% endfor %}
+</ul>
+
+<h2>Audit Results</h2>
+<ul id="audit_results">
+{% for row in audit_results %}
+    <li>{{ row.placeholder_type }}: {{ row.count }}</li>
 {% endfor %}
 </ul>
 </body>

--- a/dashboard/templates/sync_events.html
+++ b/dashboard/templates/sync_events.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Synchronization Events</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
 <h1>Synchronization Events</h1>

--- a/web_gui_integration_system.py
+++ b/web_gui_integration_system.py
@@ -1,21 +1,28 @@
-"""Web GUI Integration System launcher.
-
-This module re-exports :class:`WebGUIIntegrationSystem` from
-``scripts.utilities.web_gui_integration_system`` and exposes the ``main``
-function so the dashboard can be started via ``python web_gui_integration_system.py``.
-"""
+"""Web GUI Integration System launcher with dashboard routes."""
 
 from scripts.utilities.web_gui_integration_system import (
-    WebGUIIntegrationSystem,
-    main as _main,
+    WebGUIIntegrationSystem as _BaseSystem,
 )
+from dashboard.enterprise_dashboard import app as dashboard_app
 
 __all__ = ["WebGUIIntegrationSystem", "main"]
 
 
+class WebGUIIntegrationSystem(_BaseSystem):
+    """Extend base system to expose enterprise dashboard views."""
+
+    def start(self, port: int = 5000) -> None:  # pragma: no cover - thin wrapper
+        self.integrator.register_endpoints(dashboard_app)
+        self.integrator.initialize()
+        self.logger.info("Starting dashboard on port %s", port)
+        dashboard_app.run(port=port)
+
+
 def main() -> int:
     """Run the Web GUI Integration System."""
-    return _main()
+    system = WebGUIIntegrationSystem()
+    system.start()
+    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- expose consolidated overview route surfacing metrics, rollbacks, sync events and audit results
- extend dashboard template and auxiliary views for sync events and audits
- wire enterprise dashboard into web GUI launcher

## Testing
- `ruff check dashboard web_gui_integration_system.py`
- `pytest` *(fails: ImportError: cannot import name 'SyncWatcher' from 'database_first_synchronization_engine')*


------
https://chatgpt.com/codex/tasks/task_e_6894041f1cf48331b5217bda3b583c33