### PR TITLE
feat: add sync and audit endpoints to dashboard

### DIFF
--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -1,8 +1,18 @@
+"""Enterprise dashboard routes and utilities."""
+
 from pathlib import Path
 import sqlite3
-from typing import Dict
+from typing import Any, Dict
 
-from .integrated_dashboard import app, _dashboard as dashboard_bp, create_app
+from flask import jsonify
+
+from .integrated_dashboard import (
+    app,
+    _dashboard as dashboard_bp,
+    _load_audit_results,
+    _load_sync_events,
+    create_app,
+)
 
 ANALYTICS_DB = Path("databases/analytics.db")
 
@@ -14,7 +24,7 @@ def anomaly_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, float]:
     if db_path.exists():
         with sqlite3.connect(db_path) as conn:
             cur = conn.execute(
-                "SELECT COUNT(*), AVG(anomaly_score) FROM anomaly_results"
+                "SELECT COUNT(*), AVG(anomaly_score) FROM anomaly_results",
             )
             count, avg = cur.fetchone()
             metrics["count"] = int(count or 0)
@@ -22,4 +32,17 @@ def anomaly_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, float]:
     return metrics
 
 
+@app.get("/sync_events")
+def sync_events() -> Any:
+    """Return recent synchronization events."""
+    return jsonify(_load_sync_events())
+
+
+@app.get("/audit_results")
+def audit_results() -> Any:
+    """Return placeholder audit aggregation results."""
+    return jsonify(_load_audit_results())
+
+
 __all__ = ["app", "dashboard_bp", "create_app", "anomaly_metrics"]
+

--- a/dashboard/integrated_dashboard.py
+++ b/dashboard/integrated_dashboard.py
@@ -204,6 +204,8 @@ def index() -> str:
         "dashboard.html",
         metrics=_load_metrics(),
         rollbacks=get_rollback_logs(),
+        sync_events=_load_sync_events(),
+        audit_results=_load_audit_results(),
     )
 
 

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -78,8 +78,8 @@
             fetch('/dashboard/compliance').then(r=>r.json()).then(updateCompliance);
         }
         function pollExtras(){
-            fetch('/sync-events').then(r=>r.json()).then(updateSyncEvents);
-            fetch('/audit-results').then(r=>r.json()).then(updateAuditResults);
+            fetch('/sync_events').then(r=>r.json()).then(updateSyncEvents);
+            fetch('/audit_results').then(r=>r.json()).then(updateAuditResults);
         }
         window.onload = function(){
             if(!!window.EventSource){


### PR DESCRIPTION
## Summary
- add JSON endpoints `/sync_events` and `/audit_results`
- include sync and audit data on dashboard index
- poll new endpoints on dashboard page and test coverage

## Testing
- `ruff check dashboard/enterprise_dashboard.py dashboard/integrated_dashboard.py tests/test_dashboard.py`
- `pytest tests/test_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68940c8dfc9483318285c5940fe96469