### PR TITLE
feat: add compliance metrics dashboard

### DIFF
--- a/docs/COMPLIANCE_LOGGING_GUIDE.md
+++ b/docs/COMPLIANCE_LOGGING_GUIDE.md
@@ -16,13 +16,19 @@ dashboard.
 
 - `dashboard/compliance_metrics_updater.py` loads the correction summary and
   merges the data with other compliance metrics.
-- The updater exposes a list of correction logs and an average compliance score
-  alongside placeholder and violation statistics.
+- Each compliance run records a **composite score** and its component
+  contributions (lint, tests, and placeholder resolution) into
+  `databases/analytics.db` under the `compliance_scores` table.
+- The updater exposes a list of correction logs, the latest composite score and
+  a trend of recent scores alongside placeholder and violation statistics.
 
 ## Dashboard Display
 
 - `dashboard/templates/metrics.html` presents the aggregated compliance score
   and renders each correction log with its individual score and rationale.
+- `dashboard/enterprise_dashboard.py` provides a `/compliance-metrics` route
+  returning the most recent composite score, its component breakdown, and a
+  history of prior scores for trend visualizations.
 
 Running `compliance_metrics_updater.py` after executing the correction logger
 keeps the dashboard synchronized with the latest corrections and compliance

--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -417,21 +417,43 @@ def calculate_composite_score(
     placeholders_open: int,
     placeholders_resolved: int,
 ) -> tuple[float, dict]:
-    """Return composite score and weighted component breakdown on a 0–100 scale."""
+    """Return composite score and weighted component breakdown on a 0–100 scale.
+
+    All inputs are coerced to non-negative integers. ``lint_score`` is bounded to
+    ``0..100`` and the remaining scores gracefully handle ``0`` denominators.
+    """
+
+    ruff_issues = max(0, int(ruff_issues))
+    tests_passed = max(0, int(tests_passed))
+    tests_failed = max(0, int(tests_failed))
+    placeholders_open = max(0, int(placeholders_open))
+    placeholders_resolved = max(0, int(placeholders_resolved))
 
     total_tests = tests_passed + tests_failed
     total_placeholders = placeholders_open + placeholders_resolved
-    lint_score = max(0.0, 100 - ruff_issues)
-    test_score = (tests_passed / total_tests * 100) if total_tests else 0.0
+
+    lint_score = max(0.0, 100.0 - float(ruff_issues))
+    test_score = (tests_passed / total_tests * 100.0) if total_tests else 0.0
     placeholder_score = (
-        placeholders_resolved / total_placeholders * 100
+        placeholders_resolved / total_placeholders * 100.0
         if total_placeholders
         else 100.0
     )
+
+    total_weight = LINT_WEIGHT + TEST_WEIGHT + PLACEHOLDER_WEIGHT
+    if total_weight != 1.0:
+        norm_lint = LINT_WEIGHT / total_weight
+        norm_test = TEST_WEIGHT / total_weight
+        norm_placeholder = PLACEHOLDER_WEIGHT / total_weight
+    else:
+        norm_lint = LINT_WEIGHT
+        norm_test = TEST_WEIGHT
+        norm_placeholder = PLACEHOLDER_WEIGHT
+
     score = (
-        LINT_WEIGHT * lint_score
-        + TEST_WEIGHT * test_score
-        + PLACEHOLDER_WEIGHT * placeholder_score
+        norm_lint * lint_score
+        + norm_test * test_score
+        + norm_placeholder * placeholder_score
     )
     breakdown = {
         "ruff_issues": ruff_issues,
@@ -442,9 +464,9 @@ def calculate_composite_score(
         "lint_score": round(lint_score, 2),
         "test_score": round(test_score, 2),
         "placeholder_score": round(placeholder_score, 2),
-        "lint_weighted": round(LINT_WEIGHT * lint_score, 2),
-        "test_weighted": round(TEST_WEIGHT * test_score, 2),
-        "placeholder_weighted": round(PLACEHOLDER_WEIGHT * placeholder_score, 2),
+        "lint_weighted": round(norm_lint * lint_score, 2),
+        "test_weighted": round(norm_test * test_score, 2),
+        "placeholder_weighted": round(norm_placeholder * placeholder_score, 2),
     }
     return round(score, 2), breakdown
 
@@ -493,18 +515,43 @@ def calculate_code_quality_score(
     }
 
 
-def persist_compliance_score(score: float, db_path: Path | None = None) -> None:
-    """Persist ``score`` to the ``compliance_scores`` table in analytics.db."""
+def persist_compliance_score(
+    score: float,
+    breakdown: dict | None = None,
+    db_path: Path | None = None,
+) -> None:
+    """Persist composite and component scores to ``analytics.db``."""
+
     workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
     db = db_path or (workspace / "databases" / "analytics.db")
     db.parent.mkdir(parents=True, exist_ok=True)
+    breakdown = breakdown or {}
     with sqlite3.connect(db) as conn:
         conn.execute(
-            "CREATE TABLE IF NOT EXISTS compliance_scores (timestamp TEXT, score REAL)"
+            """CREATE TABLE IF NOT EXISTS compliance_scores (
+                timestamp TEXT,
+                composite_score REAL,
+                lint_score REAL,
+                test_score REAL,
+                placeholder_score REAL
+            )"""
         )
+        for column in ("lint_score", "test_score", "placeholder_score"):
+            try:
+                conn.execute(f"ALTER TABLE compliance_scores ADD COLUMN {column} REAL")
+            except sqlite3.OperationalError:
+                pass
         conn.execute(
-            "INSERT INTO compliance_scores (timestamp, score) VALUES (?, ?)",
-            (datetime.now().isoformat(), float(score)),
+            """INSERT INTO compliance_scores (
+                timestamp, composite_score, lint_score, test_score, placeholder_score
+            ) VALUES (?, ?, ?, ?, ?)""",
+            (
+                datetime.now().isoformat(),
+                float(score),
+                float(breakdown.get("lint_score", 0.0)),
+                float(breakdown.get("test_score", 0.0)),
+                float(breakdown.get("placeholder_score", 0.0)),
+            ),
         )
         conn.commit()
 
@@ -572,14 +619,14 @@ def record_code_quality_metrics(
         conn.commit()
 
 def get_latest_compliance_score(db_path: Path | None = None) -> float:
-    """Return the most recent compliance score from analytics.db."""
+    """Return the most recent composite compliance score from analytics.db."""
     workspace = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
     db = db_path or (workspace / "databases" / "analytics.db")
     if not db.exists():
         return 0.0
     with sqlite3.connect(db) as conn:
         cur = conn.execute(
-            "SELECT score FROM compliance_scores ORDER BY timestamp DESC LIMIT 1"
+            "SELECT composite_score FROM compliance_scores ORDER BY timestamp DESC LIMIT 1"
         )
         row = cur.fetchone()
         return float(row[0]) if row else 0.0
@@ -590,10 +637,10 @@ def calculate_and_persist_compliance_score() -> float:
     issues = _run_ruff()
     passed, failed = _run_pytest()
     placeholders_open = _count_placeholders()
-    score, _ = calculate_composite_score(
+    score, breakdown = calculate_composite_score(
         issues, passed, failed, placeholders_open, 0
     )
-    persist_compliance_score(score)
+    persist_compliance_score(score, breakdown)
     record_code_quality_metrics(
         issues,
         passed,

--- a/tests/dashboard/test_composite_score_persistence.py
+++ b/tests/dashboard/test_composite_score_persistence.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 import dashboard.enterprise_dashboard as ed
+import dashboard.integrated_dashboard as gui
 from enterprise_modules.compliance import (
     calculate_composite_score,
     persist_compliance_score,
@@ -13,11 +14,12 @@ def test_composite_score_persisted_and_served(tmp_path, monkeypatch):
     metrics_file = tmp_path / "metrics.json"
     metrics_file.write_text(json.dumps({"metrics": {}}), encoding="utf-8")
     db = tmp_path / "analytics.db"
-    monkeypatch.setattr(ed, "METRICS_FILE", metrics_file)
+    monkeypatch.setattr(gui, "METRICS_FILE", metrics_file)
+    monkeypatch.setattr(gui, "ANALYTICS_DB", db)
     monkeypatch.setattr(ed, "ANALYTICS_DB", db)
 
     score, breakdown = calculate_composite_score(5, 8, 2, 1, 4)
-    persist_compliance_score(score, db_path=db)
+    persist_compliance_score(score, breakdown, db_path=db)
     record_code_quality_metrics(5, 8, 2, 1, 4, score, db_path=db)
 
     client = ed.app.test_client()

--- a/tests/test_compliance_score.py
+++ b/tests/test_compliance_score.py
@@ -8,7 +8,8 @@ from enterprise_modules import compliance
 def test_score_persistence_and_fetch(tmp_path: Path) -> None:
     db = tmp_path / "analytics.db"
     score = compliance.calculate_compliance_score(1, 2, 0, 0, 0)
-    compliance.persist_compliance_score(score, db_path=db)
+    _, breakdown = compliance.calculate_composite_score(1, 2, 0, 0, 0)
+    compliance.persist_compliance_score(score, breakdown, db_path=db)
     assert compliance.get_latest_compliance_score(db_path=db) == score
 
 


### PR DESCRIPTION
## Summary
- compute composite compliance score with edge case handling and store component weights
- expose compliance score trend via `/compliance-metrics` dashboard endpoint
- document updated compliance metrics workflow

## Testing
- `ruff check enterprise_modules/compliance.py dashboard/enterprise_dashboard.py tests/dashboard/test_compliance_metrics.py tests/dashboard/test_composite_score_persistence.py tests/test_compliance_score.py docs/COMPLIANCE_LOGGING_GUIDE.md`
- `pytest tests/dashboard/test_compliance_metrics.py tests/dashboard/test_composite_score_persistence.py tests/test_compliance_score.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68941536bb548331934acb18ceb8a7de