### PR TITLE
fix: add sync watcher and isolate monitoring stubs

### DIFF
--- a/tests/monitoring/test_anomaly_pipeline.py
+++ b/tests/monitoring/test_anomaly_pipeline.py
@@ -2,6 +2,7 @@ import json
 import sqlite3
 import sys
 from types import SimpleNamespace
+import pytest
 
 
 def _stub_score(values):
@@ -9,9 +10,16 @@ def _stub_score(values):
     return sum(vals) / len(vals)
 
 
-sys.modules["quantum_algorithm_library_expansion"] = SimpleNamespace(
-    quantum_score_stub=_stub_score
-)
+
+
+@pytest.fixture(autouse=True)
+def _stub_quantum_module(monkeypatch):
+    """Provide a temporary quantum scoring stub."""
+    monkeypatch.setitem(
+        sys.modules,
+        "quantum_algorithm_library_expansion",
+        SimpleNamespace(quantum_score_stub=_stub_score),
+    )
 
 from unified_monitoring_optimization_system import anomaly_detection_loop
 from dashboard.enterprise_dashboard import anomaly_metrics

--- a/tests/test_unified_monitoring_optimization_system.py
+++ b/tests/test_unified_monitoring_optimization_system.py
@@ -16,9 +16,21 @@ def _stub_score(values):
     return sum(vals) / len(vals)
 
 
-sys.modules["quantum_algorithm_library_expansion"] = SimpleNamespace(
-    quantum_score_stub=_stub_score
-)
+@pytest.fixture(autouse=True)
+def _stub_quantum_module(monkeypatch):
+    """Provide a quantum score stub for tests."""
+    monkeypatch.setitem(
+        sys.modules,
+        "quantum_algorithm_library_expansion",
+        SimpleNamespace(quantum_score_stub=_stub_score),
+    )
+    monkeypatch.setattr(
+        sys.modules["quantum_algorithm_library_expansion"],
+        "quantum_score_stub",
+        _stub_score,
+    )
+
+
 quantum_score_stub = _stub_score
 
 from unified_monitoring_optimization_system import (


### PR DESCRIPTION
## Summary
- implement SyncWatcher to monitor multiple DB pairs
- stub quantum scoring modules with pytest fixtures to avoid global side effects

## Testing
- `ruff check database_first_synchronization_engine.py tests/monitoring/test_anomaly_pipeline.py tests/test_unified_monitoring_optimization_system.py`
- `pytest tests/test_database_first_synchronization_engine.py::test_watch_pairs_syncs_multiple_pairs -vv`
- `pytest` *(fails: tests/dashboard/test_actionable_endpoints.py::test_corrections_endpoint - TypeError)*


------
https://chatgpt.com/codex/tasks/task_e_68941f5ac9948331973c9cb80c9055de