### PR TITLE
feat: add PyPDF2 dependency and import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ tqdm==4.67.1                # Progress bar for CLI and batch tasks
 PyYAML==6.0.2               # YAML config parsing
 toml==0.10.2                # TOML config parsing
 Jinja2==3.1.6               # Template generation for configs
+PyPDF2==3.0.1              # PDF processing
 
 # --- Optional platform support (install only on Windows) ---
 wmi==1.5.1; sys_platform == "win32"    # Hardware info on Windows

--- a/tools/convert_daily_whitepaper.py
+++ b/tools/convert_daily_whitepaper.py
@@ -12,10 +12,8 @@ import logging
 from pathlib import Path
 from typing import Iterable
 
-try:  # pragma: no cover - optional dependency
-    from PyPDF2 import PdfReader
-except Exception:  # pragma: no cover - import guarding
-    PdfReader = None  # type: ignore
+import PyPDF2  # noqa: F401
+from PyPDF2 import PdfReader
 
 
 def convert_pdfs(pdf_dir: Path) -> Iterable[str]:
@@ -38,18 +36,10 @@ def convert_pdfs(pdf_dir: Path) -> Iterable[str]:
             messages.append(f"Skipping {pdf_path.name}: already converted")
             continue
 
-        if PdfReader is None:
-            messages.append(
-                f"Cannot convert {pdf_path.name}: PyPDF2 not installed"
-            )
-            continue
-
         reader = PdfReader(str(pdf_path))
         text = "\n".join(page.extract_text() or "" for page in reader.pages)
         md_path.write_text(text)
-        messages.append(
-            f"Converted {pdf_path.name} -> {md_path.name}"
-        )
+        messages.append(f"Converted {pdf_path.name} -> {md_path.name}")
     return messages
 
 


### PR DESCRIPTION
## Summary
- add PyPDF2 to core dependencies
- use PyPDF2 in daily whitepaper conversion script

## Testing
- `pip install -r requirements.txt`
- `ruff check tools/convert_daily_whitepaper.py`
- `pytest` *(fails: tests/dashboard/test_actionable_endpoints.py::test_corrections_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68947f6bd1088331b23a9b722ba9f82d