### PR TITLE
fix: use relative path for daily state update

### DIFF
--- a/rename_files_with_spaces.py
+++ b/rename_files_with_spaces.py
@@ -6,6 +6,7 @@ Systematically rename all files in a directory to replace spaces with underscore
 
 from pathlib import Path
 from datetime import datetime
+from typing import Union
 import logging
 
 # Configure logging
@@ -17,8 +18,9 @@ logger = logging.getLogger(__name__)
 
 class FileRenamer:
     """🔧 Professional file renaming with space-to-underscore conversion"""
-    
-    def __init__(self, target_directory: str):
+
+    def __init__(self, target_directory: Union[str, Path]):
+        """Initialize renamer with directory to process."""
         self.target_directory = Path(target_directory)
         self.renamed_files = []
         self.skipped_files = []
@@ -179,15 +181,17 @@ class FileRenamer:
         
         logger.info("="*60)
 
-def main():
+def main() -> dict:
     """🎯 Main execution function"""
-    # Target directory
-    target_directory = r"E:\gh_COPILOT\documentation\generated\daily_state_update"
-    
+    # Target directory derived relative to this script for portability
+    target_directory = (
+        Path(__file__).resolve().parent / "documentation/generated/daily_state_update"
+    )
+
     # Create renamer and execute
     renamer = FileRenamer(target_directory)
     summary = renamer.rename_all_files()
-    
+
     # Return summary for potential further processing
     return summary
 

--- a/tests/test_rename_files_with_spaces.py
+++ b/tests/test_rename_files_with_spaces.py
@@ -1,0 +1,25 @@
+from pathlib import PurePosixPath, PureWindowsPath
+
+from rename_files_with_spaces import FileRenamer
+
+
+def test_target_directory_path():
+    posix_path = PurePosixPath("/workspace/gh_COPILOT/rename_files_with_spaces.py")
+    windows_path = PureWindowsPath("C:/workspace/gh_COPILOT/rename_files_with_spaces.py")
+
+    expected_posix = posix_path.parent / "documentation/generated/daily_state_update"
+    expected_windows = windows_path.parent / "documentation/generated/daily_state_update"
+
+    assert str(expected_posix).endswith("documentation/generated/daily_state_update")
+    assert str(expected_windows).endswith("documentation\\generated\\daily_state_update")
+
+
+def test_file_renamer(tmp_path):
+    file_with_spaces = tmp_path / "file with space.txt"
+    file_with_spaces.write_text("sample")
+
+    renamer = FileRenamer(tmp_path)
+    summary = renamer.rename_all_files()
+
+    assert summary["files_renamed"] == 1
+    assert (tmp_path / "file_with_space.txt").exists()


### PR DESCRIPTION
## Summary
- replace hardcoded Windows path with relative Path operations
- add unit tests for cross-platform path handling and file renaming

## Testing
- `ruff check rename_files_with_spaces.py tests/test_rename_files_with_spaces.py`
- `pytest tests/test_rename_files_with_spaces.py`


------
https://chatgpt.com/codex/tasks/task_e_68947fffba9c8331b9a755fc7e2697b6