### PR TITLE
feat: add basic email templates

### DIFF
--- a/web_gui/templates/email/alert_notifications.html
+++ b/web_gui/templates/email/alert_notifications.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body style="margin:0;padding:0;font-family:Arial,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td>
+          <h1>{{ subject }}</h1>
+          <p>{{ message }}</p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/web_gui/templates/email/compliance_reports.html
+++ b/web_gui/templates/email/compliance_reports.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body style="margin:0;padding:0;font-family:Arial,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td>
+          <h1>Compliance Report</h1>
+          <p>{{ report }}</p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/web_gui/templates/email/deployment_reports.html
+++ b/web_gui/templates/email/deployment_reports.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body style="margin:0;padding:0;font-family:Arial,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td>
+          <h1>Deployment Report</h1>
+          <p>{{ report }}</p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add alert, deployment, and compliance email templates under web_gui/templates/email

## Testing
- `ruff check .`
- `pytest` *(fails: import file mismatch for tests/web_gui/test_database_web_connector.py)*
- `python scripts/wlc_session_manager.py` *(fails: NotADirectoryError: '/workspace/gh_COPILOT/databases/production.db')*

------
https://chatgpt.com/codex/tasks/task_e_68949338b05883318abab6350128f4ec