### PR TITLE
feat: add dynamic template components for web GUI

### DIFF
--- a/web_gui/documentation/README.md
+++ b/web_gui/documentation/README.md
@@ -30,6 +30,11 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 - **Backup/Restore**: Data protection tools
 - **Migration**: Environment migration tools
 - **Deployment**: Deployment pipeline management
+- **Components** (in `templates/components/`):
+  - `navigation.html` – renders navigation links from `links`
+  - `metrics_widgets.html` – displays metric widgets via `widgets`
+  - `security_indicators.html` – shows security statuses from `indicators`
+  - `quantum_indicators.html` – visualizes quantum metrics from `indicators`
 
 #### Quantum Enhanced Framework
 - **File**: `web_gui/scripts/flask_apps/quantum_enhanced_framework.py`

--- a/web_gui/templates/components/metrics_widgets.html
+++ b/web_gui/templates/components/metrics_widgets.html
@@ -1,0 +1,8 @@
+<div class="metrics-widgets">
+  {% for widget in widgets %}
+    <div class="widget">
+      <h3>{{ widget.title }}</h3>
+      <p>{{ widget.value }}</p>
+    </div>
+  {% endfor %}
+</div>

--- a/web_gui/templates/components/navigation.html
+++ b/web_gui/templates/components/navigation.html
@@ -1,0 +1,7 @@
+<nav>
+  <ul>
+    {% for item in links %}
+      <li><a href="{{ item.href }}">{{ item.title }}</a></li>
+    {% endfor %}
+  </ul>
+</nav>

--- a/web_gui/templates/components/quantum_indicators.html
+++ b/web_gui/templates/components/quantum_indicators.html
@@ -1,0 +1,8 @@
+<div class="quantum-indicators">
+  {% for indicator in indicators %}
+    <div class="indicator">
+      <span class="name">{{ indicator.name }}</span>
+      <span class="value">{{ indicator.value }}</span>
+    </div>
+  {% endfor %}
+</div>

--- a/web_gui/templates/components/security_indicators.html
+++ b/web_gui/templates/components/security_indicators.html
@@ -1,0 +1,8 @@
+<div class="security-indicators">
+  {% for indicator in indicators %}
+    <div class="indicator">
+      <span class="name">{{ indicator.name }}</span>:
+      <span class="status">{{ indicator.status }}</span>
+    </div>
+  {% endfor %}
+</div>


### PR DESCRIPTION
## Summary
- add navigation, metrics, security, and quantum indicator templates for dynamic rendering
- document new components in Web GUI docs

## Testing
- `ruff check .`
- `pytest` *(fails: AttributeError in tests/web_gui/test_database_web_connector.py)*

------
https://chatgpt.com/codex/tasks/task_e_68949337b0708331898493a3739df21d