### PR TITLE
feat(web-gui): add enterprise base and mobile templates

### DIFF
--- a/web_gui/templates/html/base_enterprise.html
+++ b/web_gui/templates/html/base_enterprise.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    {% block head_extra %}{% endblock %}
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="#">Enterprise Dashboard</a>
+      </div>
+    </nav>
+    <main class="container py-4">
+      {% block enterprise_content %}{% endblock %}
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/web_gui/templates/html/mobile/backup_restore.html
+++ b/web_gui/templates/html/mobile/backup_restore.html
@@ -1,0 +1,9 @@
+{% extends "html/base_enterprise.html" %}
+{% block title %}Backup Restore{% endblock %}
+{% block enterprise_content %}
+<div class="container-fluid">
+  <h1 class="h4">Backup Restore</h1>
+  <div id="progress"></div>
+  <a class="btn btn-primary btn-sm" href="/dashboard/compliance">Compliance Metrics</a>
+</div>
+{% endblock %}

--- a/web_gui/templates/html/mobile/dashboard.html
+++ b/web_gui/templates/html/mobile/dashboard.html
@@ -1,0 +1,22 @@
+{% extends "html/base_enterprise.html" %}
+{% block title %}Dashboard{% endblock %}
+{% block enterprise_content %}
+<div class="container-fluid">
+  <h1 class="h4">Dashboard</h1>
+  <div id="progress"></div>
+  <ul class="list-unstyled">
+    <li>Placeholder Removals: {{ metrics.get('placeholder_removal', 0) }}</li>
+    <li>Compliance Score: {{ '%.3f'|format(metrics.get('compliance_score', 0)) }}</li>
+    <li>Violations: {{ metrics.get('violation_count', 0) }}</li>
+    <li>Rollbacks: {{ metrics.get('rollback_count', 0) }}</li>
+  </ul>
+  <div class="mt-3">
+    <a class="btn btn-primary btn-sm" href="/dashboard/compliance">Compliance Metrics</a>
+    <a class="btn btn-secondary btn-sm" href="/dashboard/rollback">Rollback Logs</a>
+    <a class="btn btn-secondary btn-sm" href="/dashboard/corrections">Correction History</a>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script type="module" src="{{ url_for('static', filename='js/dashboard_intelligence.js') }}"></script>
+{% endblock %}

--- a/web_gui/templates/html/mobile/database.html
+++ b/web_gui/templates/html/mobile/database.html
@@ -1,0 +1,9 @@
+{% extends "html/base_enterprise.html" %}
+{% block title %}Database{% endblock %}
+{% block enterprise_content %}
+<div class="container-fluid">
+  <h1 class="h4">Database</h1>
+  <div id="progress"></div>
+  <a class="btn btn-primary btn-sm" href="/dashboard/compliance">Compliance Metrics</a>
+</div>
+{% endblock %}

--- a/web_gui/templates/html/mobile/deployment.html
+++ b/web_gui/templates/html/mobile/deployment.html
@@ -1,0 +1,9 @@
+{% extends "html/base_enterprise.html" %}
+{% block title %}Deployment{% endblock %}
+{% block enterprise_content %}
+<div class="container-fluid">
+  <h1 class="h4">Deployment</h1>
+  <div id="progress"></div>
+  <a class="btn btn-primary btn-sm" href="/dashboard/compliance">Compliance Metrics</a>
+</div>
+{% endblock %}

--- a/web_gui/templates/html/mobile/migration.html
+++ b/web_gui/templates/html/mobile/migration.html
@@ -1,0 +1,9 @@
+{% extends "html/base_enterprise.html" %}
+{% block title %}Migration{% endblock %}
+{% block enterprise_content %}
+<div class="container-fluid">
+  <h1 class="h4">Migration</h1>
+  <div id="progress"></div>
+  <a class="btn btn-primary btn-sm" href="/dashboard/compliance">Compliance Metrics</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Bootstrap 5 `base_enterprise.html`
- introduce mobile templates for dashboard, database, backup/restore, migration, and deployment

## Testing
- `ruff check web_gui`
- `pytest` *(fails: tests/web_gui/test_database_web_connector.py)*

------
https://chatgpt.com/codex/tasks/task_e_68949335ddfc8331b35062888fe389cc