### PR TITLE
feat: extend compliance and rollback templates with quantum dashboard

### DIFF
--- a/web_gui/templates/compliance_metrics.html
+++ b/web_gui/templates/compliance_metrics.html
@@ -1,5 +1,6 @@
-<!doctype html>
-<title>Compliance Metrics</title>
+{% extends "base_enterprise.html" %}
+
+{% block enterprise_content %}
 <h1>Compliance Metrics</h1>
 <table border="1">
     <tr><th>Metric</th><th>Value</th></tr>
@@ -18,3 +19,4 @@
     <li>{{ score }}</li>
     {% endfor %}
 </ul>
+{% endblock %}

--- a/web_gui/templates/html/quantum_dashboard.html
+++ b/web_gui/templates/html/quantum_dashboard.html
@@ -1,0 +1,11 @@
+{% extends "base_enterprise.html" %}
+
+{% block enterprise_content %}
+<h1>Quantum Metrics Dashboard</h1>
+<ul>
+    <li>Quantum Efficiency: {{ metrics.quantum_efficiency }}</li>
+    <li>Qubit Utilization: {{ metrics.qubit_utilization }}</li>
+    <li>Entanglement Fidelity: {{ metrics.entanglement_fidelity }}</li>
+</ul>
+{% endblock %}
+

--- a/web_gui/templates/rollback_logs.html
+++ b/web_gui/templates/rollback_logs.html
@@ -1,8 +1,10 @@
-<!doctype html>
-<title>Rollback Logs</title>
+{% extends "base_enterprise.html" %}
+
+{% block enterprise_content %}
 <h1>Rollback Logs</h1>
 <ul>
     {% for log in logs %}
     <li>{{ log.timestamp }} - {{ log.event }}</li>
     {% endfor %}
 </ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend compliance and rollback templates from `base_enterprise.html`
- add quantum metrics dashboard template

## Testing
- `ruff check web_gui/templates`
- `pytest` *(fails: import file mismatch in tests/web_gui/test_database_web_connector.py)*
- `pytest tests/dashboard/test_database_web_connector.py`


------
https://chatgpt.com/codex/tasks/task_e_68949336b7088331810135218187d241