### PR TITLE
feat: add 2025-08-06 whitepaper markdown

### DIFF
--- a/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_(2025-08-06).md
+++ b/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_(2025-08-06).md
@@ -1,0 +1,256 @@
+# gh_COPILOT Project White-Paper Blueprint (2025-08-06)
+1 Repository  Summary  
+Purpose and scope  
+The gh_COPILOT  repository is positioned as an enterprise ‑grade toolkit  for analysing HTTP Archive (HAR) files. It couples database ‑first logic  and a dual‑copilot pattern  (primary execution plus secondary validation) with autonomous operations and compliance 
+enforcement. The README states that the project is under active development ; disaster ‑recovery routines now enforce external backup roots and verified restore tests, while session ‑management enhancements are still being built [1]. The repository aims to deliver 
+learning‑pattern integration and GitHub Copilot collaboration for enterprises.  
+Architecture  
+• Database ‑first architecture  – primary queries always consult production.db  before generating output. The system maintains multiple SQLite databases ( production.db , analytics.db  and monitoring.db ) for separation of concerns [2]. 
+• Dual‑copilot pattern  – requests are executed by a Primary Executor Copilot  (A) that performs the work (with visual indicators, database ‑first queries and anti ‑recursion checks) and then validated by a Secondary Validator Copilot  (B) for quality and 
+compliance [3]. Validation hooks capture runtime metrics into the analytics database.  
+• Visual processing indicators  – progress bars, start ‑time logging, timeout controls and phase indicators are mandated for long ‑running tasks [4]. A unified logging utility writes events into the analytics database [5]. 
+• Autonomous systems  – an autonomous self ‑healing subsystem monitors system health, performs automatic corrections and updates learning patterns; it runs continuously and stores metrics in analytics.db [6]. 
+• Web dashboard  – a Flask dashboard offers endpoints for metrics, database management, backup, migration, deployment and compliance [7]. It uses analytics data to compute composite compliance scores and exposes correction histories [8]. Compliance 
+metrics combine lint warnings, test success and placeholder counts into a single weighted score [9]. 
+• Governance and coding standards  – governance standards emphasise transparency, compliance and peer review. Contributors must follow PEP ‑8 style, type hints and run ruff  and pytest  before submitting changes [10] . 
+Current maturity level  
+The project is actively evolving . Core patterns such as database ‑first logic and the dual ‑copilot framework are implemented and validated [11] . Autonomous operations, visual processing indicators and disaster ‑recovery orchestration are partially complete [12] . 
+Quantum modules exist only as simulation ‑only placeholders [13] ; hardware execution flags are accepted but ignored. Multiple tests still fail and the linting tool ruff  reports numerous issues [14] , indicating that further cleanup is required.  
+2 Current  Implementation  Status  
+Component/Module  Implementation  Status  Notes  
+Asset ingestion  Implemented  – documentation_ingestor.py  and template_asset_ingestor.py  automate parsing, hashing and cataloguing of Markdown and code assets 
+into enterprise_assets.db , computing SHA ‑256 or MD5 to skip duplicates [15] . autonomous_setup_and_audit.py  supports scheduled ingestion runs and 
+compliance hooks [16] . Supports recursive traversal, metadata indexing and integration with 
+analytics pipelines [17] . 
+Dual‑copilot system  Implemented  – The Primary Executor executes tasks with visual indicators and anti ‑recursion validation, while the Secondary Validator checks execution 
+quality, database integration and enterprise compliance [3]. Standardised through run_dual_copilot_validation  and CLI wrappers; considered 100  % 
+implemented [18] . Dual‑copilot enforcement triggers secondary validation via 
+SecondaryCopilotValidator  on ingestion, migration and other scripts [11] . 
+Placeholder auditing  Implemented  – code_placeholder_audit.py  scans for unresolved TODO /FIXME  placeholders; results are logged into analytics.db:code_audit_log [19] . 
+Additional hooks record each audit entry and responsible user [20] . Audit results feed into compliance scores; dashboard displays placeholder 
+metrics [9]. 
+Compliance enforcement  Partially implemented  – Compliance score formula uses lint warnings, test pass rates and placeholder resolution [21] . Anti‑recursion guards block 
+destructive commands and enforce external backup roots [22] . The composite score is surfaced via the dashboard [9]. Governance standards require review 
+and PEP‑8 compliance [10] . However, test failures and incomplete compliance metric calculations (progress ~40  %) remain [23] . Further work is needed on compliance metrics aggregation and enforcement 
+of failing tests [14] . 
+Enterprise dashboard  In progress  – A Flask dashboard with endpoints for metrics, database management, backup, migration, deployment and compliance is available [7]. 
+Composite compliance scores are generated and correction history summarised [9]. dashboard/compliance_metrics_updater.py  populates metrics and 
+writes JSON files [8]. Dashboard progress is tracked under Phase  5 tasks; metrics and rollback 
+logs are accessible but real ‑time alerts and streaming features require further 
+development [24] . 
+Database synchronisation 
+& reconciliation  Started/in progress  – cross_database_reconciler.py  heals drift across production.db , analytics.db  and other stores [25] . A unified synchronization 
+engine is being built; events are logged and conflict resolution is supported [26] . STUB‑modules table marks synchronisation engine tasks as started [27] , and 
+tests for consolidation orchestrator currently fail [28] . 
+Disaster recovery & 
+backup  Implemented  – UnifiedDisasterRecoverySystem  ensures external backup roots and verifies restore operations [29] . point_in_time_backup.py  creates 
+timestamped backups [30]  and backup validation checks have been completed [31] . Anti‑recursion guards enforce that backups cannot reside within the 
+workspace [22] . 
+Session & self ‑healing  Partially implemented  – self‑healing routines for error detection, autonomous correction and anomaly detection exist [6]; however, session management 
+enhancements and comprehensive wrap ‑up validation are still under construction [1]. Continuous operation scheduler and session integrity validators are 
+available; integration with analytics pipelines continues.  
+Quantum integration  Placeholder only  – Quantum modules operate exclusively in simulation; flags for hardware selection are ignored [13] . quantum_placeholders  stubs provide 
+simulation routines and reserve package names [32] . Real hardware integration milestones are defined in the roadmap [33] . The roadmap targets hardware pilots around 2025 –2026; until then, these 
+modules are excluded from production and are for educational use only [34] . 
+Testing & linting  Incomplete  – ruff  and pytest  must be run before commits; current tests have multiple failures [1]. The STUB status report lists numerous failing test 
+modules covering documentation manager, archive scripts, compliance metrics, workspace manager CLI and more [35] . Linting issues and missing type hints are common [36] . Improving test 
+coverage and resolving these failures is a high priority.  
+3 Changelog  & Commit  Insights  
+Recent milestones and notable changes are summarised in the README:  
+• Lessons learned integration  – sessions apply lessons from learning_monitor.db [37] . 
+• Database ‑first architecture  – production database used as the primary reference for generation [38] . 
+• Dual‑copilot pattern & enforcement  – primary/secondary validation framework is available; automation scripts now trigger the secondary validator across ingestion,  archival and migration workflows [39] . 
+• Archive migration executor  – dual‑copilot validation added to log archival workflows [40] . 
+• Analytics consolidation  – database_consolidation_migration.py  performs secondary validation after merging sources [41] . 
+• Full validation coverage  – ingestion, placeholder audits and migration scripts now run the secondary validator by default [42] . 
+• Visual processing indicators and autonomous systems  – progress bar utilities and early self ‑healing scripts were implemented [43] . 
+• Disaster recovery orchestration  – scheduled backups and point ‑in‑time snapshots were added [44] . 
+• Compliance integration and cross ‑database reconciliation  – new orchestrators link session integrity checks with disaster recovery and heal drift across production and analytics databas es[45] . 
+• Placeholder auditing and correction history  – placeholder detection logs findings to analytics.db:code_audit_log [19]  and correction events are recorded in correction_history [46] . 
+• Anti‑recursion guards  – backup and session modules enforce external backup roots [47] . 
+• Quantum integration plan  – quantum modules remain simulation ‑only; hardware integration flagged for future phases [13] . 
+The commit history contains numerous merge commits, suggesting active collaboration and feature integration. The Phase  5 tasks document shows progress on the disaster recovery scheduler, dashboard build, database synchronisation engine, monitor ing and 
+optimisation, session management and script generation [48] . Completed actions include aligning documentation with implementation and clarifying quantum placeholder features [49] [18] . Work on comprehensive compliance metrics is ~40  % complete [23] . 
+4 Implementation  Gaps  
+The project still has several gaps:  
+• Compliance metrics calculation  – Composite compliance scores are defined, but the analytics pipeline that aggregates lint, test and placeholder metrics is onl y ~40  % complete [23] . Additional work is required to finalise formulas and integrate data sources 
+into the dashboard.  
+• Testing and linting  – Many test modules fail, including documentation managers, archive utilities, compliance updaters, workspace managers and sess ion integrity validators [35] . ruff  detects numerous lint issues [36] . Resolving these failures is essential for 
+reliability.  
+• Database synchronisation engine  – Synchronisation between production, analytics and auxiliary databases is started but not fully implemented; conflict resoluti on and event logging are still being developed [26] . 
+• Dashboard enhancements  – The Flask dashboard exists but several features (real ‑time alerts, streaming, interactive metrics) are still under development [24] . Integration of correction logging into the dashboard is underway [50] . 
+• Session management  – Zero‑byte detection and anti ‑recursion safeguards are implemented, but wrap ‑up validation and session metrics tie ‑ins remain under construction [51] . 
+• Quantum integration  – All quantum modules are placeholders; no hardware ‑level execution is available [32] . Roadmap milestones for hardware integration extend into late  2025 and 2026 [33] . 
+• Documentation alignment  – Although a documentation audit has been completed [49] , new modules need updated guides and whitepapers, and the complete technical specifications must be maintained alongside cod e changes.  
+• Governance enforcement  – Governance standards require each change to be peer reviewed and follow PEP ‑8; however, the large number of failing tests suggests that these processes are not consistently applied [14] . 
+5 Compliance Summary  
+Compliance in gh_COPILOT is enforced through multiple routines and scoring systems:  
+• Code quality score  – The dashboard calculates a weighted score based on lint warnings (L), test pass rates (T) and placeholder resolution (P). The  formula score = 0.3 × L + 0.5 × T + 0.2 × P persists to analytics.db [21]  and is displayed on the 
+dashboard [9]. 
+• Placeholder tracking  – code_placeholder_audit.py  scans the repository for unresolved TODO /FIXME  markers and logs them to code_audit_log  and code_audit_history  tables [52] . Auditing results contribute to compliance scores and are accessible through 
+the dashboard.  
+• Forbidden operations guard  – Anti‑recursion guards and the validate_enterprise_operation  wrapper block destructive commands ( rm -rf, mkfs , shutdown , etc.) and enforce that backup operations use external roots [22] . 
+• Correction and rollback logs  – Correction events are recorded in correction_history  with details such as user, session and timestamp [46]. The dashboard’s corrections  endpoint summarises these logs and retains only the most recent entries [53] . 
+• Session and database integrity  – Validators check session integrity and perform anti ‑recursion checks [54] . Database reconciliation scripts log synchronisation events and conflicts [55] . 
+• Governance and peer review  – Governance standards require transparency, compliance with licensing, peer review for every change, PEP ‑8 style and type hints [10] . Contributors must run ruff  and pytest  before committing changes [56] . 
+• Compliance enforcement scripts  – Commands such as enterprise_dual_copilot_validator.py --enterprise -compliance  perform comprehensive validations, while session integrity validators and emergency cleanup scripts offer targeted checks [54] . 
+6 Design  Alignment  and  Documentation  
+A documentation audit in Phase  5 reconciled whitepapers and guides with the actual state of the repository [49] . The README clearly states that quantum modules operate solely in simulation [13]  and highlights active development areas and milestones [11] . Additional 
+documents cover asset ingestion, governance standards, quantum placeholders, and stub module status, providing insight into i ncomplete modules and test coverage [15] [27] . Despite this, failing tests and incomplete compliance metrics show that code and 
+documentation are not always aligned; some modules remain stubs and require accompanying guides. The governance document emph asises peer review and adherence to standards [10] . 
+7 Enterprise  Mission  Objective  
+The gh_COPILOT  project aims to deliver a production ‑ready, enterprise ‑class HAR analysis platform . Its mission in corporate environments is to provide high ‑quality code generation and automation through database ‑first logic , enforce strict governance and 
+compliance  via the dual ‑copilot pattern, and enable reuse and traceability  across operations. By integrating learning ‑pattern feedback loops, self ‑healing protocols and a unified dashboard, the system strives to promote continuous improvement, risk mitigat ion and 
+robust disaster recovery for enterprise clients. The emphasis on compliance scoring and anti ‑recursion safeguards ensures that outputs meet organisational policies and external audit requirements, aligning with the ent erprise’s objective of quality, governance, reuse 
+and traceability . 
+ 
+[1] [2] [3] [4] [5] [6] [7] [8] [9] [11]  [12]  [13]  [19]  [20]  [21]  [22]  [25]  [29]  [30]  [37]  [38]  [39]  [40]  [41]  [42]  [43]  [44]  [45]  [46]  [47]  [52]  [53]  [54]  [55]  [56]  README.md  
+https://github.com/Aries -Serpent/gh_COPILOT/blob/main/README.md  
+[10]  GOVERNANCE_STANDARDS.md  
+https://github.com/Aries -Serpent/gh_COPILOT/blob/main/docs/GOVERNANCE_STANDARDS.md  
+[14]  [27]  [28]  [35]  [36]  STUB_MODULE_STATUS.md  
+https://github.com/Aries -Serpent/gh_COPILOT/blob/main/docs/STUB_MODULE_STATUS.md  
+[15]  [16]  [17]  ASSET_INGESTION.md  
+https://github.com/Aries -Serpent/gh_COPILOT/blob/main/docs/ASSET_INGESTION.md  
+[18]  [23]  [24]  [26]  [31]  [48]  [49]  [50]  [51]  PHASE5_TASKS_STARTED.md  
+https://github.com/Aries -Serpent/gh_COPILOT/blob/main/docs/PHASE5_TASKS_STARTED.md  
+[32]  [33]  [34]  QUANTUM_PLACEHOLDERS.md  
+https://github.com/Aries -Serpent/gh_COPILOT/blob/main/docs/QUANTUM_PLACEHOLDERS.md   
+--- 
+title: "Implement Enterprise Blueprint Findings for gh_COPILOT (2025 -08-07)"  
+repository: "Aries -Serpent/gh_COPILOT"  
+template: "project -blueprint"  
+assignees: [mbaetiong]  
+labels:  
+  - "enhancement"  
+  - "documentation"  
+  - "compliance"  
+  - "refactor"  
+type: "Epic"  
+projects: ["Enterprise Phase 5"]  
+milestone: "Phase 5"  
+tag: "blueprint -2025 -08-07" 
+description: |  
+  # [Issue]: Implement Enterprise Blueprint Findings  
+  > Generated: 2025 -08-07 | Author: Marc  J 
+ 
+  ## Objective  
+  Execute the recommendations from the updated white ‑paper blueprint for `gh_COPILOT`, closing implementation gaps, improving compliance metrics and finishing the enterprise dash board so that the system can operate as a production ‑ready, compliant 
+HAR‑analysis platform.  This epic orchestrates tasks across ingestion, dual ‑copilot validation, placeholder audits, compliance calculations, database synchronisation, dashboard enhancements, session ma nagement and testing.  
+ 
+  ## Context  
+  ### Background  
+  The gh_COPILOT toolkit is an enterprise ‑grade HAR analysis system built around database ‑first logic and a dual ‑copilot pattern.  Recent milestones include implementation of lessons ‑learned integration, dual ‑copilot enforcement, disaster ‑recovery orchestr ation 
+and cross ‑database reconciliation 【468158178394306†L33 -L59】.  However, compliance metrics are only partially implemented 【578536619841329†L84 -L92】, many tests fail 【145792626035967†L52 -L78】 and quantum modules are still 
+placeholders 【875980647522134†L1 -L10】.  A comprehensive white ‑paper identified remaining gaps and prioritised tasks across core modules.  
+ 
+  ### Current Status  
+  - Asset ingestion scripts and placeholder audits are operational 【339746455356943†L2 -L15】. 
+  - Dual‑copilot validation is standardised and used across ingestion, migration and generation flows 【468158178394306†L642 -L660】. 
+  - Compliance scoring formula exists but aggregation and dashboard integration are incomplete 【468158178394306†L69 -L77】【578536619841329†L84 -L92】. 
+ 
+  ## Requirements & Scope  
+ 
+  ### Key Analysis Areas  
+  | Area                                | Method/Approach                                 | Expected Outcome                               | 
+  |------------------------------------ |-------------------------------------------------- |------------------------------------------------ | 
+  | Compliance metrics aggregation      | Implement missing aggregation logic in `dashboard/compliance_metrics_updater.py` and consolidate lint/test/placeholder data into analytics.db | Accurate real ‑time compliance scores reported on dashboard |  
+  | Testing & lint remediation          | Run full pytest suite, prioritise failing modules (documentation manager, archive scr ipts, compliance updater, workspace manager), fix issues and address Ruff warnings | >90  % tests passing, minimal lint errors |  
+  | Dashboard enhancements              | Add real ‑time alerts, streaming endpoints, correction log integration and improved visualization; deploy updated Flask dashboard | Com prehensive enterprise dashboard with interactive metrics and alerting |  
+  | Database synchronisation engine     | Complete cross ‑database reconciliation logic with conflict resolution callbacks and synchronisation event logging | Reliable synchronisation  across production, analytics and monitoring databases |  
+  | Session management & self ‑healing   | Finalise wrap ‑up validation, session metrics tie ‑ins and continuous operation scheduler; integrate anomaly detection and corrections into analytics pipeline | Robust session lifecycle management and autonomous correction |  
+  | Documentation & governance          | Update READMEs and technical guides to reflect implemented features; ensure governanc e standards (PEP ‑8, type hints, peer review) are enforced | Accurate documentation and consistent coding standards |  
+  | Quantum integration roadmap         | Maintain simulation stubs and monitor roadmap; evaluate feasibility of Stage  1 simulator parity | Clear plan for future quantum integration without impacting current production |  
+ 
+  ### Implementation Strategy  
+  | Step                                     | Criteria/Trigger                                       | Action Type                   | Risk Level  |  
+  |----------------------------------------- |-------------------------------------------------------- |------------------------------- |------------- | 
+  | Finalise compliance metric aggregation   | All input data sources (lint logs, pytest results, placeholder audits) identifie d and accessible | Development (code & DB)       | Medium      |  
+  | Resolve failing tests & lint errors      | CI pipeline identifies failing test modules or Ruff violations | Development (bu g fixes, refactoring) | High       |  
+  | Build dashboard real ‑time features       | Compliance metrics available and event streams defined | Development (frontend/backend) | Medium      |  
+  | Complete database synchronisation engine | Schema mapping validated and event logging ready       | Development (backend)         | Medium      |  
+  | Enhance session management               | Zero ‑byte detection integrated; wrap ‑up validator designed | Development (backend)         | Medium      |  
+  | Update documentation & governance        | Major features completed or modified                   | Documentation                 | Low         |  
+  | Assess quantum integration roadmap       | Simulation stubs stable and hardware pilots scheduled | Research & Planning           | Low         |  
+ 
+  ##  Technical & Functional Specifications  
+  - **Target(s):** Achieve enterprise ‑ready HAR analysis platform with compliant dual ‑copilot validation, accurate metrics and operational dashboard.  
+  - **Performance:** Composite compliance score ≥  0.9; database synchronisation latency <  1 minute; dashboard response times <  500  ms.  
+  - **Functionality:** Completed ingestion, dual ‑copilot validation, placeholder audit, compliance metric computation, database synchronisation, backup/restore, self ‑healing routines and interactive dashboard.  
+  - **Availability:** System must support 24/7 operations with scheduled backups and monitoring; downtime must not exceed 1  hour/month.  
+ 
+  ### Safety & Testing Requirements  
+  - **Backup Plan:** Continue using `UnifiedDisasterRecoverySystem` with external backup roots 【468158178394306†L55 -L58】; schedule daily point ‑in‑time backups and weekly full backups.  
+  - **Rollback/Recovery:** Maintain `correction_history` and `code_audit_history` tables for rollback events 【468158178394306†L58 -L60】.  Ensure database migrations are reversible.  
+  - **Testing Protocol:** Run `python scripts/run_checks.py` (ruff + pytest) and `enterprise_dual_copilot_validator.py --enterprise -compliance` before each release 【468158178394306†L10 -L15】【468158178394306†L887 -L904】.  Incorporate regression tests for 
+newly implemented features.  
+  - **Monitoring:** Use `continuous_operation_monitor.py` and related monitoring scripts to record system health and anomaly metr ics【468158178394306†L779 -L789】.  Integrate alerts into the dashboard once streaming is ready.  
+ 
+  ## Deliverables  
+  ### 1 Analysis/Discovery Report  
+  ```markdown  
+  | Item/Name                | Details/Notes                                               | Last Updated |  
+  |------------------------- |------------------------------------------------------------- |-------------- | 
+  | Compliance aggregation   | Data sources identified; formula defined; implementation pending | 2025 ‑08‑07   |  
+  | Failing test modules     | Identified modules: documentation manager, archive scripts, compliance updater, workspace manage r, etc. | 2025 ‑08‑07   |  
+  | Dashboard capabilities   | Endpoints available; streaming and real ‑time alerts unfinished | 2025 ‑08‑07   |  
+  | Synchronisation engine   | Basic reconciler exists; conflict resolution incomplete       | 2025 ‑08‑07   |  
+  | Session management       | Zero ‑byte detection and anti ‑recursion implemented; wrap ‑up pending | 2025 ‑08‑07   |  
+  | Quantum roadmap          | Simulation ‑only stubs; Stage  1 (simulator parity) targeted for late 2025 | 2025 ‑08‑07   |  
+  ```  
+ 
+  ### 2 Implementation/Action Plan  
+  ```markdown  
+  | Source/Origin           | Action                                                     | Target/Result                             | Risk Level   | Method/Notes                                           |  
+  |------------------------ |------------------------------------------------------------ |-------------------------------------------- |------------- |------------------------------------------------------- | 
+  | White‑paper findings   | Implement compliance metric aggregation logic              | Working composite compliance score        | M edium      | Modify `dashboard/compliance_metrics_updater.py`; update analytics schema |  
+  | Test failure report    | Fix failing tests and refactor code                        | >90  % test pass rate                      | High        | Prioritise test modules; engage maintainers for refactoring |  
+  | Dashboard gap analysis | Add real ‑time metrics, streaming and correction log display | Fully interactive dashboard               | Medium      | Extend Flask r outes; integrate SSE/WebSocket; update UI |  
+  | Synchronisation engine docs | Complete cross ‑database synchronisation engine            | Reliable database reconciliation          | Medium      | Finalise `cross_databa se_reconciler.py`; add conflict resolution callbacks |  
+  | Session management audit | Finalise wrap ‑up validators and integrate session metrics   | Comprehensive session lifecycle management | Medium      | Extend `session_ma nagement_consolidation_executor.py`; update analytics logging |  
+  | Governance standards   | Update documentation and enforce PEP ‑8 & type hints        | Consistent coding standards               | Low         | Run `ruff`; add pre ‑commit hooks; update guides |  
+  | Quantum roadmap        | Maintain simulation stubs and review hardware roadmap      | Clear plan for Stage  1 simulator parity   | Low         | Monitor `QUANTUM_PLACEHOLDERS.md`; coordinate with research team |  
+  ```  
+ 
+  ### 3 Timeline & Milestones  
+  ```markdown  
+  | Phase/Stage                 | Duration/Date        | Key Tasks                                                    | Validat ion/Sign‑off                  |  
+  |---------------------------- |---------------------- |------------------------------------------------------------- |-------------------------------------- | 
+  | Planning & Requirements    | Week  1 (Aug  7–Aug  13) | Confirm data sources and schema for compliance metrics; prioritise failing tests; define dashboard enhancements | Produ ct owner review                 |  
+  | Development Sprint  1       | Weeks  2‑3 (Aug  14–Aug  27) | Implement compliance aggregation; fix high ‑priority test failures; start dashboard streaming features | Continuous integration tests & peer review |  
+  | Development Sprint  2       | Weeks  4‑5 (Aug  28–Sep  10) | Finalise database synchronisation engine; integrate session wrap ‑up validator; complete dashboard enhancements | QA acceptance & security audit       |  
+  | Stabilisation & Testing    | Weeks  6‑7 (Sep  11–Sep  24) | Resolve remaining lint issues; run full regression tests; update documentation | Stakeholder sign ‑off                 |  
+  | Review & Pilot Deployment  | Week  8 (Sep  25–Oct  1) | Deploy to staging environment; collect feedback; refine as needed | Executive approval & pilot report    |  
+  ```  
+  ## Success Criteria  
+  ### Quantitative  
+  - [ ] Composite compliance score ≥  0.9 on dashboard  
+  - [ ] ≥  95 % of test suite passes  
+  - [ ] Database synchronisation latency <  1 minute and dashboard latency <  500  ms 
+ 
+  ### Qualitative  
+  - [ ] All major modules documented and aligned with implementation  
+  - [ ] Stakeholder satisfaction with dashboard usability and reporting  
+  - [ ] Governance standards (PEP ‑8, type hints, peer review) consistently followed across new commits  
+ 
+  ## Risk Management  
+  ```markdown  
+  | Risk/Scenario                              | Probability | Impact       | Mitigation Strategy                                                | 
+  |------------------------------------------- |------------- |------------- |-------------------------------------------------------------------- | 
+  | Compliance aggregation remains incomplete | Medium      | High        | Assign dedicated developer; schedule design review;  prioritise in sprint planning |  
+  | Persistent test failures block release    | High        | High        | Triage failures early; pair programming; incrementa l PR reviews    |  
+  | Dashboard performance issues              | Medium      | Medium      | Conduct load testing; optimise queries; use caching ; monitor metrics |  
+  | Synchronisation conflicts cause data loss | Low         | High        | Implement transaction rollback and conflict resolut ion; test thoroughly |  
+  | Quantum roadmap delays resources          | Low         | Low         | Treat quantum integration as separate research stre am; does not block current release |  
+  ```  
+  ##  Notes  
+  ### Prerequisites  
+  - [ ] Environment configured via `setup.sh` and `.env` with secrets  
+  - [ ] External backup root set (`GH_COPILOT_BACKUP_ROOT`)  
+  - [ ] Access to analytics and production databases  
+ 
+  ### Post ‑Implementation Tasks  
+  - [ ] Perform pilot deployment and gather user feedback  
+  - [ ] Update `README.md` and relevant docs to reflect completed features  
+  - [ ] Conduct retrospective meeting to evaluate sprint outcomes  
+ 

--- a/tests/test_convert_daily_whitepaper.py
+++ b/tests/test_convert_daily_whitepaper.py
@@ -3,7 +3,7 @@ import shutil
 
 import pytest
 
-from tools.convert_daily_whitepaper import PdfReader, convert_pdfs
+from tools.convert_daily_whitepaper import PdfReader, convert_pdfs, _sanitize_name
 
 pytestmark = pytest.mark.skipif(
     PdfReader is None, reason="PyPDF2 not installed"
@@ -11,21 +11,20 @@ pytestmark = pytest.mark.skipif(
 
 
 def test_convert_creates_markdown(tmp_path):
-    source_pdf = next(
-        Path("documentation/generated/daily state update").glob("*.pdf")
-    )
+    source_dir = Path("documentation/generated/daily_state_update")
+    source_pdf = next(source_dir.glob("*.pdf"))
     shutil.copy(source_pdf, tmp_path / source_pdf.name)
     logs = list(convert_pdfs(tmp_path))
-    md_file = (tmp_path / source_pdf.name).with_suffix(".md")
+    md_name = _sanitize_name(source_pdf.stem) + ".md"
+    md_file = tmp_path / md_name
     assert md_file.exists()
     assert any("Converted" in msg for msg in logs)
     assert md_file.read_text().strip()
 
 
 def test_skip_existing_markdown(tmp_path):
-    source_pdf = next(
-        Path("documentation/generated/daily state update").glob("*.pdf")
-    )
+    source_dir = Path("documentation/generated/daily_state_update")
+    source_pdf = next(source_dir.glob("*.pdf"))
     target_pdf = tmp_path / source_pdf.name
     shutil.copy(source_pdf, target_pdf)
     md_file = target_pdf.with_suffix(".md")

--- a/tools/convert_daily_whitepaper.py
+++ b/tools/convert_daily_whitepaper.py
@@ -1,6 +1,6 @@
 """Convert daily whitepaper PDFs to Markdown.
 
-This utility scans the ``documentation/generated/daily state update``
+This utility scans the ``documentation/generated/daily_state_update``
 folder for PDF files and converts each one to a Markdown file with the
 same base name. Files that already have a corresponding ``.md`` file are
 skipped. Conversion activity is logged to stdout.
@@ -11,6 +11,18 @@ import argparse
 import logging
 from pathlib import Path
 from typing import Iterable
+
+# Some PDFs were produced with non-breaking hyphens in the filename.  The
+# Markdown files should use plain ASCII hyphens so downstream tooling can
+# reference them consistently.
+NON_ASCII_HYPHENS = "\u2010\u2011\u2012\u2013\u2014\u2015"
+
+
+def _sanitize_name(name: str) -> str:
+    """Replace any non-ASCII hyphen characters with a standard hyphen."""
+    for ch in NON_ASCII_HYPHENS:
+        name = name.replace(ch, "-")
+    return name
 
 import PyPDF2  # noqa: F401
 from PyPDF2 import PdfReader
@@ -31,15 +43,20 @@ def convert_pdfs(pdf_dir: Path) -> Iterable[str]:
     """
     messages: list[str] = []
     for pdf_path in pdf_dir.glob("*.pdf"):
-        md_path = pdf_path.with_suffix(".md")
-        if md_path.exists():
+        sanitized_md = pdf_path.with_name(_sanitize_name(pdf_path.stem) + ".md")
+        original_md = pdf_path.with_suffix(".md")
+
+        if original_md.exists() or sanitized_md.exists():
             messages.append(f"Skipping {pdf_path.name}: already converted")
             continue
 
         reader = PdfReader(str(pdf_path))
         text = "\n".join(page.extract_text() or "" for page in reader.pages)
-        md_path.write_text(text)
-        messages.append(f"Converted {pdf_path.name} -> {md_path.name}")
+        lines = text.splitlines()
+        if lines:
+            lines[0] = "# " + _sanitize_name(lines[0].strip())
+        sanitized_md.write_text("\n".join(lines))
+        messages.append(f"Converted {pdf_path.name} -> {sanitized_md.name}")
     return messages
 
 
@@ -48,9 +65,7 @@ def main() -> None:
         description="Convert daily whitepaper PDFs to Markdown"
     )
     default_dir = (
-        Path("documentation")
-        / "generated"
-        / "daily state update"
+        Path("documentation") / "generated" / "daily_state_update"
     )
     parser.add_argument(
         "--pdf-dir",


### PR DESCRIPTION
## Summary
- extract August 6 2025 whitepaper to Markdown and store alongside other daily documents
- make PDF converter handle unicode hyphens and insert top-level headings
- update daily whitepaper conversion tests

## Testing
- `ruff check .`
- `pytest` *(fails: tests/web_gui/test_database_web_connector.py)*


------
https://chatgpt.com/codex/tasks/task_e_689493510fd88331b25bb55189887ae6