### PR TITLE
feat: add enterprise template layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Phase 5 scoring guidelines.
 ### **Enterprise Systems**
 - **Multiple SQLite Databases:** `databases/production.db`, `databases/analytics.db`, `databases/monitoring.db`
 - [ER Diagrams](docs/ER_DIAGRAMS.md) for key databases
- - **Flask Enterprise Dashboard:** run `python web_gui_integration_system.py` to launch the metrics and compliance dashboard
- - **Template Intelligence Platform:** tracks generated scripts
+- **Flask Enterprise Dashboard:** run `python web_gui_integration_system.py` to launch the metrics and compliance dashboard
+- **Template Intelligence Platform:** tracks generated scripts
+- **Enterprise HTML Templates:** reusable base layouts, components, mobile views, and email templates under `templates/`
 - **Documentation logs:** rendered templates saved under `logs/template_rendering/`
 - **Script Validation**: automated checks available
 - **Self-Healing Systems:** correction scripts

--- a/templates/components/metrics_widgets.html
+++ b/templates/components/metrics_widgets.html
@@ -1,0 +1,9 @@
+<section id="metrics-widgets">
+    <div class="widget">
+        <strong>Compliance Score:</strong> {{ metrics.compliance_score | default(0) }}
+    </div>
+    <div class="widget">
+        <strong>Open Placeholders:</strong> {{ metrics.open_placeholders | default(0) }}
+    </div>
+</section>
+

--- a/templates/components/navigation.html
+++ b/templates/components/navigation.html
@@ -1,0 +1,8 @@
+<nav>
+    <ul>
+        <li><a href="/metrics">Metrics</a></li>
+        <li><a href="/rollback">Rollback Logs</a></li>
+        <li><a href="/quantum">Quantum</a></li>
+    </ul>
+</nav>
+

--- a/templates/components/quantum_indicators.html
+++ b/templates/components/quantum_indicators.html
@@ -1,0 +1,6 @@
+<section id="quantum-indicators">
+    <div class="indicator">
+        <strong>Qubit Utilization:</strong> {{ quantum.qubits | default(0) }}
+    </div>
+</section>
+

--- a/templates/components/security_indicators.html
+++ b/templates/components/security_indicators.html
@@ -1,0 +1,6 @@
+<section id="security-indicators">
+    <div class="indicator">
+        <strong>Security Status:</strong> {{ security.status | default('unknown') }}
+    </div>
+</section>
+

--- a/templates/email/alert_notifications.html
+++ b/templates/email/alert_notifications.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <title>Alert Notification</title>
+</head>
+<body>
+    <p>{{ message }}</p>
+</body>
+</html>
+

--- a/templates/email/compliance_reports.html
+++ b/templates/email/compliance_reports.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <title>Compliance Report</title>
+</head>
+<body>
+    <h1>Compliance Report</h1>
+    <p>Score: {{ score }}</p>
+</body>
+</html>
+

--- a/templates/email/deployment_reports.html
+++ b/templates/email/deployment_reports.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <title>Deployment Report</title>
+</head>
+<body>
+    <h1>Deployment Report</h1>
+    <p>Status: {{ status }}</p>
+</body>
+</html>
+

--- a/templates/html/base_enterprise.html
+++ b/templates/html/base_enterprise.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% block title %}Enterprise Dashboard{% endblock %}</title>
+    {% block head %}{% endblock %}
+</head>
+<body>
+    {% include 'components/navigation.html' %}
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+    {% block scripts %}{% endblock %}
+</body>
+</html>
+

--- a/templates/html/compliance_metrics.html
+++ b/templates/html/compliance_metrics.html
@@ -1,0 +1,10 @@
+{% extends 'html/base_enterprise.html' %}
+
+{% block title %}Compliance Metrics{% endblock %}
+
+{% block content %}
+<h1>Compliance Metrics</h1>
+{% include 'components/metrics_widgets.html' %}
+{% include 'components/security_indicators.html' %}
+{% endblock %}
+

--- a/templates/html/mobile/base_enterprise.html
+++ b/templates/html/mobile/base_enterprise.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% block title %}Enterprise Mobile{% endblock %}</title>
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+    {% block scripts %}{% endblock %}
+</body>
+</html>
+

--- a/templates/html/mobile/compliance_metrics.html
+++ b/templates/html/mobile/compliance_metrics.html
@@ -1,0 +1,9 @@
+{% extends 'html/mobile/base_enterprise.html' %}
+
+{% block title %}Compliance Metrics{% endblock %}
+
+{% block content %}
+<h1>Compliance Metrics</h1>
+{% include 'components/metrics_widgets.html' %}
+{% endblock %}
+

--- a/templates/html/mobile/quantum_dashboard.html
+++ b/templates/html/mobile/quantum_dashboard.html
@@ -1,0 +1,9 @@
+{% extends 'html/mobile/base_enterprise.html' %}
+
+{% block title %}Quantum Dashboard{% endblock %}
+
+{% block content %}
+<h1>Quantum Dashboard</h1>
+{% include 'components/quantum_indicators.html' %}
+{% endblock %}
+

--- a/templates/html/mobile/rollback_logs.html
+++ b/templates/html/mobile/rollback_logs.html
@@ -1,0 +1,13 @@
+{% extends 'html/mobile/base_enterprise.html' %}
+
+{% block title %}Rollback Logs{% endblock %}
+
+{% block content %}
+<h1>Rollback Logs</h1>
+<ul>
+    {% for log in logs %}
+    <li>{{ log }}</li>
+    {% endfor %}
+</ul>
+{% endblock %}
+

--- a/templates/html/quantum_dashboard.html
+++ b/templates/html/quantum_dashboard.html
@@ -1,0 +1,9 @@
+{% extends 'html/base_enterprise.html' %}
+
+{% block title %}Quantum Dashboard{% endblock %}
+
+{% block content %}
+<h1>Quantum Dashboard</h1>
+{% include 'components/quantum_indicators.html' %}
+{% endblock %}
+

--- a/templates/html/rollback_logs.html
+++ b/templates/html/rollback_logs.html
@@ -1,0 +1,13 @@
+{% extends 'html/base_enterprise.html' %}
+
+{% block title %}Rollback Logs{% endblock %}
+
+{% block content %}
+<h1>Rollback Logs</h1>
+<ul>
+    {% for log in logs %}
+    <li>{{ log }}</li>
+    {% endfor %}
+</ul>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- implement base enterprise HTML layout with navigation component
- add compliance metrics, rollback logs, and quantum dashboard templates including mobile variants
- provide reusable components and email templates for alerts, deployments, and compliance reports
- document new template system in README

## Testing
- `ruff check .`
- `pytest --override-ini addopts=` (fails: 281 errors during collection)
- `python secondary_copilot_validator.py` (fails: No module named 'tqdm')
- `python scripts/wlc_session_manager.py --action log --message "template update"` (fails: No module named 'tqdm')

------
https://chatgpt.com/codex/tasks/task_e_68949668758c8331afc0f24a913a70e3