### PR TITLE
feat(web_gui): add middleware utilities

### DIFF
--- a/tests/web_gui/test_middleware.py
+++ b/tests/web_gui/test_middleware.py
@@ -1,0 +1,57 @@
+"""Tests for web GUI middleware modules."""
+
+from flask import Flask, session
+
+from web_gui.middleware import (
+    input_validation,
+    rate_limiting,
+    security_headers,
+    session_management,
+)
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.secret_key = "test"
+
+    @app.route("/")
+    def index():
+        session["foo"] = "bar"
+        return "OK"
+
+    return app
+
+
+def test_security_headers() -> None:
+    app = create_app()
+    app.wsgi_app = security_headers.security_headers_middleware(app.wsgi_app)
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_rate_limiting() -> None:
+    app = create_app()
+    app.wsgi_app = rate_limiting.rate_limiting_middleware(app.wsgi_app, limit=1, window=60)
+    client = app.test_client()
+    assert client.get("/").status_code == 200
+    assert client.get("/").status_code == 429
+
+
+def test_input_validation() -> None:
+    app = create_app()
+    app.wsgi_app = input_validation.input_validation_middleware(app.wsgi_app)
+    client = app.test_client()
+    assert client.get("/?q=test").status_code == 200
+    assert client.get("/?q=<script>").status_code == 400
+
+
+def test_session_management() -> None:
+    app = create_app()
+    app.wsgi_app = session_management.session_management_middleware(app.wsgi_app)
+    client = app.test_client()
+    resp = client.get("/")
+    cookie = resp.headers["Set-Cookie"]
+    assert "Secure" in cookie and "HttpOnly" in cookie
+

--- a/web_gui/middleware/input_validation.py
+++ b/web_gui/middleware/input_validation.py
@@ -1,0 +1,26 @@
+"""Basic input validation middleware."""
+
+from __future__ import annotations
+
+import re
+from typing import Callable, Iterable
+
+WSGIApp = Callable[[dict, Callable], Iterable[bytes]]
+SCRIPT_RE = re.compile(r"<script", re.IGNORECASE)
+
+
+def input_validation_middleware(app: WSGIApp) -> WSGIApp:
+    """Reject requests containing obvious script tags in the query string."""
+
+    def middleware(environ: dict, start_response: Callable):  # type: ignore[override]
+        query = environ.get("QUERY_STRING", "")
+        if SCRIPT_RE.search(query):
+            start_response("400 Bad Request", [("Content-Type", "text/plain")])
+            return [b"Invalid input"]
+        return app(environ, start_response)
+
+    return middleware
+
+
+__all__ = ["input_validation_middleware"]
+

--- a/web_gui/middleware/rate_limiting.py
+++ b/web_gui/middleware/rate_limiting.py
@@ -1,0 +1,31 @@
+"""Simple in-memory rate limiting WSGI middleware."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Dict, Iterable
+
+WSGIApp = Callable[[dict, Callable], Iterable[bytes]]
+
+
+def rate_limiting_middleware(app: WSGIApp, limit: int = 60, window: int = 60) -> WSGIApp:
+    """Wrap ``app`` with a naive IP-based rate limiter."""
+
+    hits: Dict[str, list[float]] = {}
+
+    def middleware(environ: dict, start_response: Callable):  # type: ignore[override]
+        addr = environ.get("REMOTE_ADDR", "unknown")
+        now = time.time()
+        records = [t for t in hits.get(addr, []) if now - t < window]
+        if len(records) >= limit:
+            start_response("429 Too Many Requests", [("Content-Type", "text/plain")])
+            return [b"Rate limit exceeded"]
+        records.append(now)
+        hits[addr] = records
+        return app(environ, start_response)
+
+    return middleware
+
+
+__all__ = ["rate_limiting_middleware"]
+

--- a/web_gui/middleware/security_headers.py
+++ b/web_gui/middleware/security_headers.py
@@ -1,0 +1,36 @@
+"""WSGI middleware for adding common security headers.
+
+This module exposes :func:`security_headers_middleware` which can be used to
+wrap a WSGI application (such as ``Flask.wsgi_app``) to inject security
+headers into every response.
+"""
+
+from typing import Callable, Iterable, Tuple
+
+WSGIApp = Callable[[dict, Callable], Iterable[bytes]]
+
+
+def security_headers_middleware(app: WSGIApp) -> WSGIApp:
+    """Wrap ``app`` to add security headers to each response."""
+
+    def middleware(environ: dict, start_response: Callable):  # type: ignore[override]
+        def custom_start_response(
+            status: str, headers: list[Tuple[str, str]], exc_info=None
+        ) -> Callable:
+            headers = list(headers)
+            headers.extend(
+                [
+                    ("X-Content-Type-Options", "nosniff"),
+                    ("X-Frame-Options", "DENY"),
+                    ("Content-Security-Policy", "default-src 'self'"),
+                ]
+            )
+            return start_response(status, headers, exc_info)
+
+        return app(environ, custom_start_response)
+
+    return middleware
+
+
+__all__ = ["security_headers_middleware"]
+

--- a/web_gui/middleware/session_management.py
+++ b/web_gui/middleware/session_management.py
@@ -1,0 +1,33 @@
+"""Session management middleware."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Tuple
+
+WSGIApp = Callable[[dict, Callable], Iterable[bytes]]
+
+
+def session_management_middleware(app: WSGIApp) -> WSGIApp:
+    """Ensure session cookies are marked secure and HTTP only."""
+
+    def middleware(environ: dict, start_response: Callable):  # type: ignore[override]
+        def custom_start_response(
+            status: str, headers: list[Tuple[str, str]], exc_info=None
+        ) -> Callable:
+            new_headers: list[Tuple[str, str]] = []
+            for header, value in headers:
+                if header.lower() == "set-cookie" and "session=" in value.lower():
+                    if "httponly" not in value.lower():
+                        value += "; HttpOnly"
+                    if "secure" not in value.lower():
+                        value += "; Secure"
+                new_headers.append((header, value))
+            return start_response(status, new_headers, exc_info)
+
+        return app(environ, custom_start_response)
+
+    return middleware
+
+
+__all__ = ["session_management_middleware"]
+


### PR DESCRIPTION
## Summary
- add WSGI security headers middleware
- add in-memory rate limiting middleware
- add simple input validation and session cookie hardening

## Testing
- `ruff check web_gui/middleware tests/web_gui/test_middleware.py`
- `pytest tests/web_gui/test_middleware.py`

------
https://chatgpt.com/codex/tasks/task_e_6894ba9a501c83318c6f17dc214a3e58