### PR TITLE
feat: add certificate utilities with quantum-safe helpers

### DIFF
--- a/tests/web_gui/test_certificates.py
+++ b/tests/web_gui/test_certificates.py
@@ -1,0 +1,37 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from web_gui.certificates import certificate_manager as cm
+from web_gui.certificates import quantum_crypto as qc
+from web_gui.certificates import ssl_config
+from hashlib import sha3_256
+
+
+def test_load_certificate_and_key_roundtrip():
+    with tempfile.TemporaryDirectory() as tmp:
+        cert_path = Path(tmp) / "cert.pem"
+        key_path = Path(tmp) / "key.pem"
+        cert_path.write_text("cert")
+        key_path.write_text("key")
+        assert cm.load_certificate(str(cert_path)) == b"cert"
+        assert cm.load_private_key(str(key_path)) == b"key"
+
+
+def test_load_certificate_missing():
+    with pytest.raises(FileNotFoundError):
+        cm.load_certificate("missing.pem")
+
+
+def test_create_ssl_context_missing_files():
+    with pytest.raises(FileNotFoundError):
+        ssl_config.create_ssl_context("missing.crt", "missing.key")
+
+
+def test_quantum_safe_hash_and_key_generation():
+    data = b"hello"
+    assert qc.quantum_safe_hash(data) == sha3_256(data).hexdigest()
+    key = qc.generate_quantum_safe_key(16)
+    assert isinstance(key, bytes)
+    assert len(key) == 16

--- a/web_gui/certificates/__init__.py
+++ b/web_gui/certificates/__init__.py
@@ -1,0 +1,1 @@
+"""Certificate utilities for the web GUI."""

--- a/web_gui/certificates/certificate_manager.py
+++ b/web_gui/certificates/certificate_manager.py
@@ -1,0 +1,38 @@
+"""Utilities for managing certificate files."""
+from pathlib import Path
+
+
+def load_certificate(path: str) -> bytes:
+    """Read a certificate file from disk.
+
+    Args:
+        path: Path to the certificate file.
+
+    Returns:
+        Contents of the certificate file as bytes.
+
+    Raises:
+        FileNotFoundError: If the certificate file does not exist.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Certificate not found: {path}")
+    return file_path.read_bytes()
+
+
+def load_private_key(path: str) -> bytes:
+    """Read a private key file from disk.
+
+    Args:
+        path: Path to the private key file.
+
+    Returns:
+        Contents of the key file as bytes.
+
+    Raises:
+        FileNotFoundError: If the key file does not exist.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Private key not found: {path}")
+    return file_path.read_bytes()

--- a/web_gui/certificates/quantum_crypto.py
+++ b/web_gui/certificates/quantum_crypto.py
@@ -1,0 +1,28 @@
+"""Quantum-safe cryptographic helpers."""
+
+from hashlib import sha3_256
+import secrets
+
+
+def generate_quantum_safe_key(length: int = 32) -> bytes:
+    """Generate a random key for quantum-safe algorithms.
+
+    Args:
+        length: Size of the key in bytes. Defaults to 32 bytes.
+
+    Returns:
+        Random bytes suitable for use as a symmetric key.
+    """
+    return secrets.token_bytes(length)
+
+
+def quantum_safe_hash(data: bytes) -> str:
+    """Compute a SHA3-256 hash of *data*.
+
+    Args:
+        data: Input data to hash.
+
+    Returns:
+        Hexadecimal string representation of the digest.
+    """
+    return sha3_256(data).hexdigest()

--- a/web_gui/certificates/ssl_config.py
+++ b/web_gui/certificates/ssl_config.py
@@ -1,0 +1,33 @@
+"""SSL context configuration helpers."""
+
+from pathlib import Path
+import ssl
+
+
+def create_ssl_context(cert_file: str, key_file: str, ca_file: str | None = None) -> ssl.SSLContext:
+    """Create an SSL context using certificate and key files.
+
+    Args:
+        cert_file: Path to the server certificate file.
+        key_file: Path to the private key file.
+        ca_file: Optional path to a CA bundle file.
+
+    Returns:
+        An initialized :class:`ssl.SSLContext` instance.
+
+    Raises:
+        FileNotFoundError: If any supplied file does not exist.
+    """
+    for path in (cert_file, key_file):
+        if not Path(path).exists():
+            raise FileNotFoundError(f"File not found: {path}")
+
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.load_cert_chain(certfile=cert_file, keyfile=key_file)
+
+    if ca_file:
+        if not Path(ca_file).exists():
+            raise FileNotFoundError(f"File not found: {ca_file}")
+        context.load_verify_locations(cafile=ca_file)
+
+    return context


### PR DESCRIPTION
## Summary
- add certificate manager utilities for loading certificate and key files
- configure SSL contexts with optional CA support
- introduce quantum-safe helpers and tests for web GUI certificates

## Testing
- `ruff check web_gui/certificates tests/web_gui/test_certificates.py`
- `pytest tests/web_gui/test_certificates.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ba9c481c833194ed1f9f0bc97d40