### PR TITLE
feat: add navigation blocks for enterprise templates

### DIFF
--- a/templates/html/base_enterprise.html
+++ b/templates/html/base_enterprise.html
@@ -7,7 +7,9 @@
     {% block head %}{% endblock %}
 </head>
 <body>
-    {% include 'components/navigation.html' %}
+    {% block navigation %}
+        {% include 'components/navigation.html' %}
+    {% endblock %}
     <main>
         {% block content %}{% endblock %}
     </main>

--- a/templates/html/mobile/base_enterprise.html
+++ b/templates/html/mobile/base_enterprise.html
@@ -7,6 +7,7 @@
     {% block head %}{% endblock %}
 </head>
 <body>
+    {% block navigation %}{% endblock %}
     <main>
         {% block content %}{% endblock %}
     </main>


### PR DESCRIPTION
## Summary
- add overridable navigation block in enterprise base template
- expose navigation block in mobile base layout for parity

## Testing
- `ruff check .`
- `pytest` *(fails: import file mismatch in tests/web_gui/test_database_web_connector.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894baa8b7c48331b43c4d1ed5d676dc