### PR TITLE
feat: initialize core SQLite databases

### DIFF
--- a/databases/enterprise_auth.db
+++ b/databases/enterprise_auth.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9aa9fbd47eab5be6449a56a1417c5feabf57fb7edf058ad767cb71feebd9961a
-size 4096
+oid sha256:efee02fa6af333fc71f20152406999449a18813992ec645e85a63208fd80f0da
+size 20480

--- a/databases/migration_scripts/v1_to_v2_migration.sql
+++ b/databases/migration_scripts/v1_to_v2_migration.sql
@@ -1,10 +1,10 @@
 -- Migration script upgrading schema from v1 to v2
 
--- Add last_login column to web_users if it does not exist
-ALTER TABLE web_users ADD COLUMN IF NOT EXISTS last_login TEXT;
+-- SQLite does not support the "IF NOT EXISTS" clause for ADD COLUMN.
+-- The following statements assume the columns do not yet exist.
+ALTER TABLE web_users ADD COLUMN last_login TEXT;
 
--- Add is_active column to web_pages if it does not exist and default to active
-ALTER TABLE web_pages ADD COLUMN IF NOT EXISTS is_active INTEGER DEFAULT 1;
+ALTER TABLE web_pages ADD COLUMN is_active INTEGER DEFAULT 1;
 
 -- Ensure existing pages are marked active
 UPDATE web_pages SET is_active = 1 WHERE is_active IS NULL;

--- a/databases/quantum_learning.db
+++ b/databases/quantum_learning.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9aa9fbd47eab5be6449a56a1417c5feabf57fb7edf058ad767cb71feebd9961a
-size 4096
+oid sha256:905da07140c2239af70cf58cff438932706c00fbea85b99b44438f3601650140
+size 20480

--- a/databases/web_gui_data.db
+++ b/databases/web_gui_data.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9aa9fbd47eab5be6449a56a1417c5feabf57fb7edf058ad767cb71feebd9961a
-size 4096
+oid sha256:61781aa862f340f6ab2404c3eee7f42ac0c66b0c4823de62fe6cb4ecfb94e525
+size 20480


### PR DESCRIPTION
## Summary
- initialize SQLite databases for web GUI, enterprise authentication, and quantum learning
- fix v1 to v2 migration script for SQLite compatibility

## Testing
- `ruff check .`
- `pytest -c /dev/null` *(fails: 293 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6894baad259083319b45a296284cbd8b