### PR TITLE
feat: add daily state generator

### DIFF
--- a/documentation/generated/README.md
+++ b/documentation/generated/README.md
@@ -68,6 +68,17 @@ python tools/convert_daily_whitepaper.py
 
 This generates Markdown copies of each PDF and skips files already converted.
 
+### 📝 Daily State Generator
+
+Generate a daily summary in both Markdown and PDF formats:
+
+```bash
+python scripts/documentation/daily_state_generator.py
+```
+
+The script writes both files to `documentation/generated/daily state update/` and
+validates their creation using the dual-copilot pattern.
+
 ### 📚 Step-by-Step Document Workflow
 
 1. **Name the file**

--- a/scripts/documentation/daily_state_generator.py
+++ b/scripts/documentation/daily_state_generator.py
@@ -1,0 +1,61 @@
+"""Generate daily state report in Markdown and PDF formats."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple
+
+from PyPDF2 import PdfWriter
+from PyPDF2.generic import AnnotationBuilder
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from utils.validation_utils import run_dual_copilot_validation
+OUTPUT_DIR = ROOT / "documentation" / "generated" / "daily state update"
+
+
+def _write_markdown(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_pdf(path: Path, content: str) -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+    annot = AnnotationBuilder.free_text(content, rect=(50, 700, 562, 780))
+    writer.add_annotation(page_number=0, annotation=annot)
+    with path.open("wb") as handle:
+        writer.write(handle)
+
+
+def generate_daily_state(output_dir: Path | None = None) -> Tuple[Path, Path]:
+    """Generate daily state report and return paths to created files."""
+    out_dir = output_dir or OUTPUT_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%d")
+    content = f"# Daily State Report\n\nGenerated on {timestamp}\n"
+    md_path = out_dir / f"daily_state_{timestamp}.md"
+    pdf_path = out_dir / f"daily_state_{timestamp}.pdf"
+    _write_markdown(md_path, content)
+    _write_pdf(pdf_path, content)
+
+    def _primary() -> bool:
+        return md_path.exists()
+
+    def _secondary() -> bool:
+        return pdf_path.exists()
+
+    run_dual_copilot_validation(_primary, _secondary)
+    return md_path, pdf_path
+
+
+def main() -> None:
+    generate_daily_state()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_daily_state_generator.py
+++ b/tests/test_daily_state_generator.py
@@ -1,0 +1,21 @@
+"""Tests for daily_state_generator."""
+
+from __future__ import annotations
+
+from scripts.documentation import daily_state_generator as dsg
+
+
+def test_generate_daily_state_creates_md_and_pdf(tmp_path, monkeypatch):
+    called: dict[str, object] = {}
+
+    def fake_run(primary, secondary):
+        called["primary"] = primary
+        called["secondary"] = secondary
+        return primary() and secondary()
+
+    monkeypatch.setattr(dsg, "run_dual_copilot_validation", fake_run)
+
+    md_path, pdf_path = dsg.generate_daily_state(output_dir=tmp_path)
+
+    assert md_path.exists() and pdf_path.exists()
+    assert "primary" in called and "secondary" in called


### PR DESCRIPTION
## Summary
- add daily_state_generator script to output markdown and PDF reports with dual-copilot validation
- document daily state generator usage
- test daily_state_generator creation and validation

## Testing
- `ruff check .`
- `pytest tests/test_daily_state_generator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894bb3c34548331a9fd38a24e9bf628