### PR TITLE
feat: add security modules with role-based checks

### DIFF
--- a/tests/web_gui/test_security_modules.py
+++ b/tests/web_gui/test_security_modules.py
@@ -1,0 +1,44 @@
+import logging
+
+import pytest
+
+from web_gui.security import (
+    audit_logging,
+    authentication,
+    authorization,
+    encryption,
+    quantum_security,
+)
+
+
+def test_authentication_and_authorization():
+    user_db = {"alice": {"password": "secret", "roles": ["admin"]}}
+    assert authentication.authenticate_user("alice", "secret", user_db, "admin")
+    assert not authentication.authenticate_user("alice", "secret", user_db, "user")
+    assert authorization.has_role(["admin"], "admin")
+    assert not authorization.has_role(["user"], "admin")
+
+
+def test_encryption_roundtrip():
+    data = b"hello"
+    key = 42
+    roles = ["crypto"]
+    enc = encryption.xor_encrypt(data, key, roles)
+    assert enc != data
+    dec = encryption.xor_decrypt(enc, key, roles)
+    assert dec == data
+    with pytest.raises(PermissionError):
+        encryption.xor_encrypt(data, key, roles=[])
+
+
+def test_audit_and_quantum_security(caplog):
+    caplog.set_level(logging.INFO)
+    audit_logging.log_event("alice", "login", ["auditor"])
+    assert "AUDIT" in caplog.text
+    with pytest.raises(PermissionError):
+        audit_logging.log_event("alice", "login", [])
+    token = quantum_security.generate_quantum_token(["quantum"])
+    assert isinstance(token, str) and len(token) == 32
+    with pytest.raises(PermissionError):
+        quantum_security.generate_quantum_token([])
+

--- a/web_gui/security/audit_logging.py
+++ b/web_gui/security/audit_logging.py
@@ -1,0 +1,21 @@
+"""Audit logging utilities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+def log_event(user: str, action: str, roles: Iterable[str]) -> None:
+    """Log ``action`` performed by ``user`` if ``roles`` include ``"auditor"``."""
+
+    if "auditor" not in set(roles):
+        logger.warning("Audit log denied for user %s", user)
+        raise PermissionError("missing auditor role")
+    logger.info("AUDIT %s: %s", user, action)
+
+
+__all__ = ["log_event"]
+

--- a/web_gui/security/authentication.py
+++ b/web_gui/security/authentication.py
@@ -1,0 +1,34 @@
+"""Simple role-aware authentication helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable
+
+logger = logging.getLogger(__name__)
+
+UserDB = Dict[str, Dict[str, Iterable[str]]]
+
+
+def authenticate_user(
+    username: str,
+    password: str,
+    user_db: UserDB,
+    required_role: str | None = None,
+) -> bool:
+    """Authenticate ``username`` and optionally enforce ``required_role``."""
+
+    record = user_db.get(username)
+    if not record or record.get("password") != password:
+        logger.warning("Authentication failed for user %s", username)
+        return False
+    roles = set(record.get("roles", []))
+    if required_role and required_role not in roles:
+        logger.warning("User %s lacks role %s", username, required_role)
+        return False
+    logger.info("User %s authenticated", username)
+    return True
+
+
+__all__ = ["authenticate_user"]
+

--- a/web_gui/security/authorization.py
+++ b/web_gui/security/authorization.py
@@ -1,0 +1,21 @@
+"""Authorization helpers with role checks."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+def has_role(user_roles: Iterable[str], required_role: str) -> bool:
+    """Return ``True`` if ``required_role`` is present in ``user_roles``."""
+
+    allowed = required_role in set(user_roles)
+    if not allowed:
+        logger.warning("Missing required role: %s", required_role)
+    return allowed
+
+
+__all__ = ["has_role"]
+

--- a/web_gui/security/encryption.py
+++ b/web_gui/security/encryption.py
@@ -1,0 +1,28 @@
+"""Minimal encryption utilities with role enforcement."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+def xor_encrypt(data: bytes, key: int, roles: Iterable[str]) -> bytes:
+    """XOR ``data`` with ``key`` if ``roles`` contain ``"crypto"``."""
+
+    if "crypto" not in set(roles):
+        logger.warning("Encryption denied, missing 'crypto' role")
+        raise PermissionError("missing crypto role")
+    logger.info("Data encrypted with XOR")
+    return bytes(b ^ key for b in data)
+
+
+def xor_decrypt(data: bytes, key: int, roles: Iterable[str]) -> bytes:
+    """Decrypt ``data`` using the same XOR operation."""
+
+    return xor_encrypt(data, key, roles)
+
+
+__all__ = ["xor_encrypt", "xor_decrypt"]
+

--- a/web_gui/security/quantum_security.py
+++ b/web_gui/security/quantum_security.py
@@ -1,0 +1,24 @@
+"""Quantum-inspired security helpers."""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+def generate_quantum_token(roles: Iterable[str]) -> str:
+    """Return a random token if ``roles`` contain ``"quantum"``."""
+
+    if "quantum" not in set(roles):
+        logger.warning("Quantum token generation denied")
+        raise PermissionError("missing quantum role")
+    token = secrets.token_hex(16)
+    logger.info("Quantum token generated")
+    return token
+
+
+__all__ = ["generate_quantum_token"]
+


### PR DESCRIPTION
## Summary
- add security package with authentication, authorization, encryption, audit logging, and quantum token helpers
- implement role-based checks and logging hooks for each security helper
- test security helpers for expected behavior and permission enforcement

## Testing
- `ruff check web_gui/security tests/web_gui/test_security_modules.py`
- `pytest tests/web_gui/test_security_modules.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ba9868ec833188df405aefb87f97