### PR TITLE
feat: add enterprise base template with reusable header and footer

### DIFF
--- a/web_gui/templates/compliance_metrics.html
+++ b/web_gui/templates/compliance_metrics.html
@@ -1,4 +1,4 @@
-{% extends "base_enterprise.html" %}
+{% extends "html/base_enterprise.html" %}
 
 {% block enterprise_content %}
 <h1>Compliance Metrics</h1>

--- a/web_gui/templates/html/base_enterprise.html
+++ b/web_gui/templates/html/base_enterprise.html
@@ -8,14 +8,15 @@
     {% block head_extra %}{% endblock %}
   </head>
   <body>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <div class="container-fluid">
-        <a class="navbar-brand" href="#">Enterprise Dashboard</a>
-      </div>
-    </nav>
+    {% block header %}
+      {% include "components/navigation.html" %}
+    {% endblock %}
     <main class="container py-4">
       {% block enterprise_content %}{% endblock %}
     </main>
+    {% block footer %}
+      <footer class="text-center py-3">&copy; 2024 Enterprise Dashboard</footer>
+    {% endblock %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     {% block scripts %}{% endblock %}
   </body>

--- a/web_gui/templates/rollback_logs.html
+++ b/web_gui/templates/rollback_logs.html
@@ -1,4 +1,4 @@
-{% extends "base_enterprise.html" %}
+{% extends "html/base_enterprise.html" %}
 
 {% block enterprise_content %}
 <h1>Rollback Logs</h1>


### PR DESCRIPTION
## Summary
- add shared `base_enterprise.html` with navigation header and footer blocks
- point `compliance_metrics.html` and `rollback_logs.html` to the enterprise base template

## Testing
- `ruff check .`
- `pytest` *(fails: ERROR tests/web_gui/test_database_web_connector.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894be194dc88331853f4727bb511c63