### PR TITLE
build: add PyPDF2 to test requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,3 +15,4 @@ dill>=0.3.7
 py7zr
 schedule
 ruff
+PyPDF2==3.0.1


### PR DESCRIPTION
## Summary
- include PyPDF2 in test requirements to match core dependencies
- verify PyPDF2 installation and import

## Testing
- `ruff check .`
- `pytest -q` *(fails: tests/web_gui/test_database_web_connector.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894bed032a48331b5680d964d087ab5