### PR TITLE
feat: add analytics dashboards

### DIFF
--- a/tests/dashboard/test_executive_dashboard.py
+++ b/tests/dashboard/test_executive_dashboard.py
@@ -1,0 +1,12 @@
+"""Tests for the executive dashboard analytics collection."""
+
+from web_gui.dashboards.executive_dashboard import collect_analytics
+
+
+def test_collect_analytics_keys() -> None:
+    """Ensure analytics dictionary contains expected keys."""
+    data = collect_analytics()
+    assert set(data.keys()) == {"technical", "security", "quantum"}
+    for section in data.values():
+        assert isinstance(section, dict)
+

--- a/web_gui/dashboards/executive_dashboard.py
+++ b/web_gui/dashboards/executive_dashboard.py
@@ -1,0 +1,20 @@
+"""Executive dashboard aggregating analytics."""
+
+from typing import Dict
+
+from .technical_dashboard import get_metrics as get_technical_metrics
+from .security_dashboard import get_metrics as get_security_metrics
+from .quantum_dashboard import get_metrics as get_quantum_metrics
+
+
+def collect_analytics() -> Dict[str, Dict]:
+    """Collect analytics from all sub dashboards."""
+    return {
+        "technical": get_technical_metrics(),
+        "security": get_security_metrics(),
+        "quantum": get_quantum_metrics(),
+    }
+
+
+__all__ = ["collect_analytics"]
+

--- a/web_gui/dashboards/quantum_dashboard.py
+++ b/web_gui/dashboards/quantum_dashboard.py
@@ -1,0 +1,27 @@
+"""Quantum dashboard analytics integration."""
+
+from pathlib import Path
+import sqlite3
+from typing import Dict
+
+ANALYTICS_DB = Path("databases/analytics.db")
+
+
+def get_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, float]:
+    """Return quantum related analytics."""
+    metrics = {"avg_importance": 0.0}
+    if db_path.exists():
+        try:
+            with sqlite3.connect(db_path) as conn:
+                cur = conn.execute(
+                    "SELECT AVG(importance_score) FROM quantum_template_tracking",
+                )
+                (avg,) = cur.fetchone()
+                metrics["avg_importance"] = float(avg or 0.0)
+        except sqlite3.Error:
+            pass
+    return metrics
+
+
+__all__ = ["get_metrics"]
+

--- a/web_gui/dashboards/security_dashboard.py
+++ b/web_gui/dashboards/security_dashboard.py
@@ -1,0 +1,27 @@
+"""Security dashboard analytics integration."""
+
+from pathlib import Path
+import sqlite3
+from typing import Dict
+
+ANALYTICS_DB = Path("databases/analytics.db")
+
+
+def get_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, int]:
+    """Return basic security analytics."""
+    metrics = {"open_issues": 0}
+    if db_path.exists():
+        try:
+            with sqlite3.connect(db_path) as conn:
+                cur = conn.execute(
+                    "SELECT COUNT(*) FROM violation_logs WHERE status='open'",
+                )
+                (count,) = cur.fetchone()
+                metrics["open_issues"] = int(count or 0)
+        except sqlite3.Error:
+            pass
+    return metrics
+
+
+__all__ = ["get_metrics"]
+

--- a/web_gui/dashboards/technical_dashboard.py
+++ b/web_gui/dashboards/technical_dashboard.py
@@ -1,0 +1,27 @@
+"""Technical dashboard analytics integration."""
+
+from pathlib import Path
+import sqlite3
+from typing import Dict
+
+ANALYTICS_DB = Path("databases/analytics.db")
+
+
+def get_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, int]:
+    """Return basic technical analytics."""
+    metrics = {"scripts": 0}
+    if db_path.exists():
+        try:
+            with sqlite3.connect(db_path) as conn:
+                cur = conn.execute(
+                    "SELECT COUNT(*) FROM enhanced_script_tracking",
+                )
+                (count,) = cur.fetchone()
+                metrics["scripts"] = int(count or 0)
+        except sqlite3.Error:
+            pass
+    return metrics
+
+
+__all__ = ["get_metrics"]
+


### PR DESCRIPTION
## Summary
- add technical, security, and quantum analytics dashboards
- aggregate metrics through new executive dashboard collector
- test executive dashboard analytics hook

## Testing
- `ruff check web_gui/dashboards tests/dashboard/test_executive_dashboard.py`
- `pytest tests/dashboard/test_executive_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_6894bfb942b0833193a33e9b1e6b6335