### PR TITLE
build: update PyPDF2 requirement

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,4 +15,4 @@ dill>=0.3.7
 py7zr
 schedule
 ruff
-PyPDF2==3.0.1
+PyPDF2>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ tqdm==4.67.1                # Progress bar for CLI and batch tasks
 PyYAML==6.0.2               # YAML config parsing
 toml==0.10.2                # TOML config parsing
 Jinja2==3.1.6               # Template generation for configs
-PyPDF2==3.0.1              # PDF processing
+PyPDF2>=3.0                # PDF processing
 
 # --- Optional platform support (install only on Windows) ---
 wmi==1.5.1; sys_platform == "win32"    # Hardware info on Windows


### PR DESCRIPTION
## Summary
- loosen PyPDF2 constraint for PDF converter
- sync testing requirements with new PyPDF2 version

## Testing
- `ruff check tests/test_convert_daily_whitepaper.py`
- `pytest tests/test_convert_daily_whitepaper.py`


------
https://chatgpt.com/codex/tasks/task_e_6894c2cc11d8833197020dc189066209