### PR TITLE
feat: add development and staging configs with tests

### DIFF
--- a/tests/web_gui/test_config_security.py
+++ b/tests/web_gui/test_config_security.py
@@ -1,4 +1,6 @@
+from web_gui.scripts.config.development_config import DevelopmentConfig
 from web_gui.scripts.config.production_config import ProductionConfig
+from web_gui.scripts.config.staging_config import StagingConfig
 
 
 def test_production_config_defaults_secure() -> None:
@@ -6,3 +8,17 @@ def test_production_config_defaults_secure() -> None:
     assert not cfg.DEBUG
     assert cfg.SESSION_COOKIE_SECURE
     assert cfg.WTF_CSRF_ENABLED
+
+
+def test_development_config_defaults_relaxed() -> None:
+    cfg = DevelopmentConfig()
+    assert cfg.DEBUG
+    assert not cfg.SESSION_COOKIE_SECURE
+    assert not cfg.WTF_CSRF_ENABLED
+
+
+def test_staging_config_defaults_balanced() -> None:
+    cfg = StagingConfig()
+    assert not cfg.DEBUG
+    assert cfg.WTF_CSRF_ENABLED
+    assert not cfg.SESSION_COOKIE_SECURE

--- a/web_gui/scripts/config/development_config.py
+++ b/web_gui/scripts/config/development_config.py
@@ -1,20 +1,32 @@
-"""Development configuration for web GUI scripts.
+"""Development configuration for the Web GUI.
 
-Mirrors the structure of the production configuration with
-settings tailored for local development.
-"""
+Mirrors the production structure but with development-friendly defaults."""
 
+from __future__ import annotations
+
+import os
 from dataclasses import dataclass
 from pathlib import Path
+
+__all__ = ["DevelopmentConfig"]
 
 BASE_DIR = Path(__file__).resolve().parents[2]
 DATABASE_DIR = BASE_DIR / "databases"
 
 
-@dataclass
+@dataclass(frozen=True)
 class DevelopmentConfig:
     """Configuration values for development environment."""
 
-    DEBUG: bool = True
+    DEBUG: bool = True  # Enable verbose error pages.
     TESTING: bool = True
     DATABASE_PATH: str = str(DATABASE_DIR / "development.db")
+    SECRET_KEY: str = os.getenv("FLASK_SECRET_KEY", "dev_secret_key")
+    SESSION_COOKIE_SECURE: bool = False  # Allow HTTP during local dev.
+    SESSION_COOKIE_HTTPONLY: bool = True
+    SESSION_COOKIE_SAMESITE: str = "Lax"
+    PREFERRED_URL_SCHEME: str = "http"
+    WTF_CSRF_ENABLED: bool = False  # Simplify form testing.
+    REMEMBER_COOKIE_SECURE: bool = False
+    REMEMBER_COOKIE_HTTPONLY: bool = True
+    REMEMBER_COOKIE_SAMESITE: str = "Lax"

--- a/web_gui/scripts/config/staging_config.py
+++ b/web_gui/scripts/config/staging_config.py
@@ -1,20 +1,32 @@
-"""Staging configuration for web GUI scripts.
+"""Staging configuration for the Web GUI.
 
-Follows the pattern of the production configuration with
-settings suited for the staging environment.
-"""
+Mirrors the production structure but with staging defaults."""
 
+from __future__ import annotations
+
+import os
 from dataclasses import dataclass
 from pathlib import Path
+
+__all__ = ["StagingConfig"]
 
 BASE_DIR = Path(__file__).resolve().parents[2]
 DATABASE_DIR = BASE_DIR / "databases"
 
 
-@dataclass
+@dataclass(frozen=True)
 class StagingConfig:
     """Configuration values for staging environment."""
 
     DEBUG: bool = False
     TESTING: bool = False
     DATABASE_PATH: str = str(DATABASE_DIR / "staging.db")
+    SECRET_KEY: str = os.getenv("FLASK_SECRET_KEY", "staging_secret_key")
+    SESSION_COOKIE_SECURE: bool = False  # Staging may run over HTTP.
+    SESSION_COOKIE_HTTPONLY: bool = True
+    SESSION_COOKIE_SAMESITE: str = "Lax"
+    PREFERRED_URL_SCHEME: str = "https"
+    WTF_CSRF_ENABLED: bool = True
+    REMEMBER_COOKIE_SECURE: bool = False
+    REMEMBER_COOKIE_HTTPONLY: bool = True
+    REMEMBER_COOKIE_SAMESITE: str = "Lax"


### PR DESCRIPTION
## Summary
- add development and staging configuration modules mirroring production settings
- add tests validating configuration defaults

## Testing
- `ruff check web_gui/scripts/config tests/web_gui/test_config_security.py`
- `pytest tests/web_gui/test_config_security.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c76cd42c8331a13e4e90b75b41b1