### PR TITLE
feat: add quantum interfaces and AI enhancement modules

### DIFF
--- a/ai_enhancement/__init__.py
+++ b/ai_enhancement/__init__.py
@@ -1,0 +1,8 @@
+"""AI enhancement modules for advanced features."""
+
+__all__ = [
+    "cognitive_computing",
+    "nlp",
+    "maintenance",
+    "ecosystem_integration",
+]

--- a/ai_enhancement/cognitive_computing.py
+++ b/ai_enhancement/cognitive_computing.py
@@ -1,0 +1,8 @@
+"""Cognitive computing utilities."""
+
+from typing import Any
+
+
+def analyze_cognition(data: Any) -> Any:
+    """Analyze cognitive data."""
+    raise NotImplementedError("Cognitive analysis not implemented")

--- a/ai_enhancement/ecosystem_integration.py
+++ b/ai_enhancement/ecosystem_integration.py
@@ -1,0 +1,8 @@
+"""Ecosystem integration utilities."""
+
+from typing import Any
+
+
+def integrate_with_ecosystem(component: str) -> Any:
+    """Integrate AI component with external ecosystem."""
+    raise NotImplementedError("Ecosystem integration not implemented")

--- a/ai_enhancement/maintenance.py
+++ b/ai_enhancement/maintenance.py
@@ -1,0 +1,8 @@
+"""Maintenance utilities for AI systems."""
+
+from typing import Any
+
+
+def perform_maintenance(task: str) -> Any:
+    """Perform maintenance task."""
+    raise NotImplementedError("Maintenance operations not implemented")

--- a/ai_enhancement/nlp.py
+++ b/ai_enhancement/nlp.py
@@ -1,0 +1,8 @@
+"""Natural language processing utilities."""
+
+from typing import Any
+
+
+def process_text(text: str) -> Any:
+    """Process text input using NLP techniques."""
+    raise NotImplementedError("NLP processing not implemented")

--- a/quantum/interfaces/__init__.py
+++ b/quantum/interfaces/__init__.py
@@ -1,0 +1,3 @@
+"""Interface layer for quantum modules."""
+
+__all__ = ["quantum_api", "quantum_templates", "quantum_websocket"]

--- a/quantum/interfaces/quantum_api.py
+++ b/quantum/interfaces/quantum_api.py
@@ -1,0 +1,12 @@
+"""High-level API for interacting with quantum services."""
+
+from typing import Any, Dict
+
+
+def execute_quantum_task(task: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute a quantum task and return the result.
+
+    Currently a placeholder that should be implemented with actual
+    quantum execution logic.
+    """
+    raise NotImplementedError("Quantum task execution is not implemented yet")

--- a/quantum/interfaces/quantum_templates.py
+++ b/quantum/interfaces/quantum_templates.py
@@ -1,0 +1,8 @@
+"""Template management for quantum operations."""
+
+from typing import Any
+
+
+def get_template(name: str) -> Any:
+    """Retrieve a quantum template by name."""
+    raise NotImplementedError("Template retrieval is not implemented yet")

--- a/quantum/interfaces/quantum_websocket.py
+++ b/quantum/interfaces/quantum_websocket.py
@@ -1,0 +1,8 @@
+"""WebSocket interface for quantum communication channels."""
+
+from typing import Any
+
+
+def open_quantum_socket(url: str) -> Any:
+    """Open a WebSocket connection to a quantum service."""
+    raise NotImplementedError("Quantum WebSocket connection is not implemented yet")

--- a/tests/ai_enhancement/test_ai_enhancement_modules.py
+++ b/tests/ai_enhancement/test_ai_enhancement_modules.py
@@ -1,0 +1,30 @@
+"""Tests for AI enhancement placeholder modules."""
+
+import pytest
+
+from ai_enhancement import (
+    cognitive_computing,
+    ecosystem_integration,
+    maintenance,
+    nlp,
+)
+
+
+def test_cognitive_computing_placeholder() -> None:
+    with pytest.raises(NotImplementedError):
+        cognitive_computing.analyze_cognition(None)
+
+
+def test_nlp_placeholder() -> None:
+    with pytest.raises(NotImplementedError):
+        nlp.process_text("")
+
+
+def test_maintenance_placeholder() -> None:
+    with pytest.raises(NotImplementedError):
+        maintenance.perform_maintenance("task")
+
+
+def test_ecosystem_integration_placeholder() -> None:
+    with pytest.raises(NotImplementedError):
+        ecosystem_integration.integrate_with_ecosystem("component")

--- a/tests/quantum/test_interfaces.py
+++ b/tests/quantum/test_interfaces.py
@@ -1,0 +1,20 @@
+"""Tests for quantum interface placeholders."""
+
+import pytest
+
+from quantum.interfaces import quantum_api, quantum_templates, quantum_websocket
+
+
+def test_quantum_api_placeholder() -> None:
+    with pytest.raises(NotImplementedError):
+        quantum_api.execute_quantum_task({})
+
+
+def test_quantum_templates_placeholder() -> None:
+    with pytest.raises(NotImplementedError):
+        quantum_templates.get_template("example")
+
+
+def test_quantum_websocket_placeholder() -> None:
+    with pytest.raises(NotImplementedError):
+        quantum_websocket.open_quantum_socket("ws://example")


### PR DESCRIPTION
## Summary
- add quantum interfaces package with API, template and websocket stubs
- introduce ai_enhancement package for cognitive computing, NLP, maintenance and ecosystem integration
- cover new modules with placeholder tests

## Testing
- `ruff check .`
- `pytest` *(interrupted: KeyboardInterrupt)*
- `pytest tests/ai_enhancement/test_ai_enhancement_modules.py tests/quantum/test_interfaces.py`

------
https://chatgpt.com/codex/tasks/task_e_6894c83ab22c8331a8031320b2c2b79b