### PR TITLE
feat: add quantum framework abstractions with simulator fallback

### DIFF
--- a/quantum/README.md
+++ b/quantum/README.md
@@ -9,6 +9,14 @@ gh_COPILOT toolkit.
 > `IBM_BACKEND` are accepted for future compatibility but are treated as
 > no-ops. Hardware execution is not yet supported.
 
+## Framework and Models
+
+- `framework` – core abstractions for backend management. The
+  `QuantumExecutor` automatically falls back to a lightweight simulator when
+  no quantum hardware is available.
+- `models` – base interfaces for quantum-enabled models that build circuits and
+  execute them through the framework.
+
 ## Optimizers
 - `optimizers.quantum_optimizer.QuantumOptimizer` – classical/quantum hybrid
   optimizer with progress logging. Events are recorded using

--- a/quantum/framework/__init__.py
+++ b/quantum/framework/__init__.py
@@ -1,0 +1,11 @@
+"""Core abstractions for quantum backend management."""
+
+from .backend import QuantumBackend, SimulatorBackend, get_backend
+from .executor import QuantumExecutor
+
+__all__ = [
+    "QuantumBackend",
+    "SimulatorBackend",
+    "get_backend",
+    "QuantumExecutor",
+]

--- a/quantum/framework/backend.py
+++ b/quantum/framework/backend.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Tuple
+
+from quantum.ibm_backend import init_ibm_backend
+
+
+class QuantumBackend(ABC):
+    """Abstract interface for executing quantum circuits."""
+
+    @abstractmethod
+    def run(self, circuit: Any, **kwargs: Any) -> Any:  # pragma: no cover - interface
+        """Execute a circuit and return provider specific result."""
+
+
+class SimulatorBackend(QuantumBackend):
+    """Fallback backend that simulates circuit execution."""
+
+    def run(self, circuit: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"simulated": True, "circuit": str(circuit)}
+
+
+def get_backend(token: str | None = None) -> Tuple[QuantumBackend, bool]:
+    """Return best available backend with hardware detection.
+
+    Parameters
+    ----------
+    token:
+        Optional IBM token passed through to :func:`init_ibm_backend`.
+
+    Returns
+    -------
+    tuple
+        ``(backend, use_hardware)`` where ``backend`` implements
+        :class:`QuantumBackend` and ``use_hardware`` indicates whether a real
+        device will be used.
+    """
+    backend, use_hardware = init_ibm_backend(token=token)
+    if backend is None:
+        return SimulatorBackend(), False
+    if hasattr(backend, "run"):
+        # Wrap existing provider object in an adapter so `run` can be called.
+        class _Adapter(QuantumBackend):  # pragma: no cover - thin wrapper
+            def run(self, circuit: Any, **kwargs: Any) -> Any:
+                job = backend.run(circuit, **kwargs)
+                return job.result() if hasattr(job, "result") else job
+
+        return _Adapter(), use_hardware
+    return SimulatorBackend(), False

--- a/quantum/framework/executor.py
+++ b/quantum/framework/executor.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .backend import QuantumBackend, SimulatorBackend, get_backend
+
+
+class QuantumExecutor:
+    """Lightweight executor that delegates to a quantum backend.
+
+    The executor automatically falls back to :class:`SimulatorBackend` when a
+    hardware backend is unavailable or raises an error during execution.
+    """
+
+    def __init__(self, backend: QuantumBackend | None = None, *, token: str | None = None) -> None:
+        if backend is None:
+            self.backend, self.use_hardware = get_backend(token)
+        else:
+            self.backend = backend
+            self.use_hardware = not isinstance(backend, SimulatorBackend)
+
+    def run(self, circuit: Any, **kwargs: Any) -> Any:
+        """Execute ``circuit`` using the configured backend."""
+        try:
+            return self.backend.run(circuit, **kwargs)
+        except Exception:
+            self.backend = SimulatorBackend()
+            self.use_hardware = False
+            return self.backend.run(circuit, **kwargs)

--- a/quantum/models/__init__.py
+++ b/quantum/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model interfaces built atop the quantum framework."""
+
+from .base import QuantumModel
+
+__all__ = ["QuantumModel"]

--- a/quantum/models/base.py
+++ b/quantum/models/base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from quantum.framework import QuantumExecutor
+
+
+class QuantumModel(ABC):
+    """Base class for quantum-enabled models."""
+
+    def __init__(self, executor: QuantumExecutor | None = None) -> None:
+        self.executor = executor or QuantumExecutor()
+
+    @abstractmethod
+    def build_circuit(self) -> Any:  # pragma: no cover - interface
+        """Construct a circuit representation."""
+
+    def run(self, **kwargs: Any) -> Any:
+        """Build and execute the model's circuit."""
+        circuit = self.build_circuit()
+        return self.executor.run(circuit, **kwargs)

--- a/tests/quantum/test_framework_models.py
+++ b/tests/quantum/test_framework_models.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from quantum.framework import QuantumExecutor, SimulatorBackend, backend as fw_backend
+from quantum.models import QuantumModel
+
+
+def test_executor_falls_back_to_simulator(monkeypatch):
+    monkeypatch.setattr(fw_backend, "init_ibm_backend", lambda token=None: (None, False))
+    executor = QuantumExecutor()
+    assert isinstance(executor.backend, SimulatorBackend)
+    assert executor.use_hardware is False
+
+
+class _DummyModel(QuantumModel):
+    def build_circuit(self):
+        return "test-circuit"
+
+
+def test_model_run_uses_simulator(monkeypatch):
+    monkeypatch.setattr(fw_backend, "init_ibm_backend", lambda token=None: (None, False))
+    model = _DummyModel()
+    result = model.run()
+    assert result == {"simulated": True, "circuit": "test-circuit"}


### PR DESCRIPTION
## Summary
- add backend abstraction with automatic simulation fallback
- introduce lightweight executor and model base class
- document quantum framework and add tests for fallback behavior

## Testing
- `ruff check quantum/framework quantum/models tests/quantum/test_framework_models.py`
- `pytest tests/quantum/test_framework_models.py`


------
https://chatgpt.com/codex/tasks/task_e_6894c839d6b48331a09b734cc84e9f72