### PR TITLE
chore: add asset placeholders and LFS rules for web GUI

### DIFF
--- a/.codex_lfs_policy.yaml
+++ b/.codex_lfs_policy.yaml
@@ -13,6 +13,10 @@ binary_extensions:
   - .dot
   - .sqlite
   - .exe
+  - .ttf
+  - .otf
+  - .woff
+  - .woff2
 # Template used when generating .gitattributes automatically
 gitattributes_template: |
   codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text
@@ -23,3 +27,7 @@ gitattributes_template: |
   *.sqlite filter=lfs diff=lfs merge=lfs -text
   *.exe filter=lfs diff=lfs merge=lfs -text
   *.dot filter=lfs diff=lfs merge=lfs -text
+  # Web GUI asset binaries
+  web_gui/assets/icons/** filter=lfs diff=lfs merge=lfs -text
+  web_gui/assets/images/** filter=lfs diff=lfs merge=lfs -text
+  web_gui/assets/fonts/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,4 +10,8 @@ codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text
 # Web GUI documentation assets
 web_gui/documentation/deployment/screenshots/*.png filter=lfs diff=lfs merge=lfs -text
 *.pdf filter=lfs diff=lfs merge=lfs -text
+# Web GUI asset binaries
+web_gui/assets/icons/** filter=lfs diff=lfs merge=lfs -text
+web_gui/assets/images/** filter=lfs diff=lfs merge=lfs -text
+web_gui/assets/fonts/** filter=lfs diff=lfs merge=lfs -text
 # End of LFS patterns

--- a/web_gui/assets/fonts/README.md
+++ b/web_gui/assets/fonts/README.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:187a3dff9e530b39ac198e2465894d2887a3f97fc12bcd8d64ed6fb202cd3930
+size 246

--- a/web_gui/assets/icons/README.md
+++ b/web_gui/assets/icons/README.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2b2f726a1e7f64b09e63e4fd21b29e4423fab36b9a2fcaeabc65ebba50c2492
+size 282

--- a/web_gui/assets/images/README.md
+++ b/web_gui/assets/images/README.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afcc3abac5d6616247adbd6c755e51c6f767314d712e91e41d41b9c4001d9047
+size 279


### PR DESCRIPTION
## Summary
- add README placeholders for icons, images, and fonts
- track web GUI asset binaries via Git LFS
- extend LFS policy with asset directories and font extensions

## Testing
- `ruff check .`
- `pytest` *(fails: tests/web_gui/test_database_web_connector.py)*
- `python scripts/wlc_session_manager.py` *(fails: NotADirectoryError: '/workspace/gh_COPILOT/databases/production.db')*

------
https://chatgpt.com/codex/tasks/task_e_6894c76f45088331ada10ca8ba99ef3d