### PR TITLE
feat: add PyPDF2 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ version = "0.1.0"
 description = "Reusable modules and orchestrators for gh_COPILOT"
 authors = [{name = "gh_COPILOT Team"}]
 requires-python = ">=3.8"
+dependencies = [
+    "PyPDF2==3.0.1",
+]
 
 [project.scripts]
 final-enterprise-orchestrator = "copilot.orchestrators.final_enterprise_orchestrator:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ tqdm==4.67.1                # Progress bar for CLI and batch tasks
 PyYAML==6.0.2               # YAML config parsing
 toml==0.10.2                # TOML config parsing
 Jinja2==3.1.6               # Template generation for configs
-PyPDF2>=3.0                # PDF processing
+PyPDF2==3.0.1               # PDF processing
 
 # --- Optional platform support (install only on Windows) ---
 wmi==1.5.1; sys_platform == "win32"    # Hardware info on Windows


### PR DESCRIPTION
## Summary
- add PyPDF2 to core runtime dependencies
- declare PyPDF2 in pyproject metadata

## Testing
- `pip install --no-cache-dir -r requirements.txt`
- `python -c "import PyPDF2"`
- `ruff check .` *(fails: F401 unused imports in web_gui/security, F821 undefined names in web_gui/security, F822 undefined names in web_gui/security)*
- `pytest` *(fails: NameError: name 'logging' is not defined in tests/dashboard/test_actionable_endpoints.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894c9bf58c48331ab435502b8d3486e