### PR TITLE
feat: automate daily state index updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,8 @@ Thank you for considering a contribution to gh_COPILOT. Please follow these guid
 
 For daily white-paper updates, ensure the following:
 
-- [ ] PDF named `gh_COPILOT Project White‑Paper Blueprint (YYYY‑MM‑DD).pdf` placed in `documentation/generated/daily state update/`
+- [ ] PDF named `gh_COPILOT Project White‑Paper Blueprint (YYYY‑MM‑DD).pdf` placed in `documentation/generated/daily_state_update/`
 - [ ] `git lfs install` and `git lfs track "*.pdf"` executed; `.gitattributes` committed
-- [ ] `python tools/convert_daily_whitepaper.py` run to create Markdown copy
-- [ ] `documentation/generated/daily_state_index.md` updated with links to PDF and Markdown
+- [ ] `python tools/convert_daily_whitepaper.py` run to create Markdown copy and update the index
 
 See `documentation/generated/README.md` for detailed instructions.

--- a/documentation/generated/README.md
+++ b/documentation/generated/README.md
@@ -60,13 +60,14 @@ For detailed instructions, see the generated documentation files in this directo
 
 ### 🛠 Daily Whitepaper Conversion
 
-After adding new PDFs to `daily state update/`, run:
+After adding new PDFs to `daily_state_update/`, run:
 
 ```bash
 python tools/convert_daily_whitepaper.py
 ```
 
-This generates Markdown copies of each PDF and skips files already converted.
+This generates Markdown copies of each PDF, skips files already converted, and
+refreshes the index linking all available reports.
 
 ### 📝 Daily State Generator
 
@@ -82,7 +83,7 @@ validates their creation using the dual-copilot pattern.
 ### 📚 Step-by-Step Document Workflow
 
 1. **Name the file**
-   - Place new PDFs in `documentation/generated/daily state update/`.
+   - Place new PDFs in `documentation/generated/daily_state_update/`.
    - Use the format `gh_COPILOT Project White‑Paper Blueprint (YYYY‑MM‑DD).pdf`.
 2. **Track large files with Git LFS**
    - Ensure Git LFS is installed and tracking PDFs:
@@ -91,13 +92,12 @@ validates their creation using the dual-copilot pattern.
      git lfs track "*.pdf"
      git add .gitattributes
      ```
-3. **Convert PDFs to Markdown**
-   - Generate Markdown versions to keep the repository text-friendly:
+3. **Convert PDFs to Markdown and update the index**
+   - Generate Markdown versions to keep the repository text-friendly and
+     automatically rebuild `daily_state_index.md`:
      ```bash
      python tools/convert_daily_whitepaper.py
      ```
-4. **Update the index**
-   - Add a new row to `documentation/generated/daily_state_index.md` linking to both the PDF and Markdown files.
 
 Following these steps ensures documentation stays consistent and searchable.
 

--- a/documentation/generated/daily_state_index.md
+++ b/documentation/generated/daily_state_index.md
@@ -2,11 +2,11 @@
 
 | Date | Summary | PDF | Markdown |
 |------|---------|-----|----------|
-| 2025‑07‑30 | Snapshot of gh_COPILOT project state for 2025‑07‑30 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9107%E2%80%9130%29.pdf>) | - |
-| 2025‑07‑31 | Snapshot of gh_COPILOT project state for 2025‑07‑31 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9107%E2%80%9131%29.pdf>) | - |
-| 2025‑08‑01 | Snapshot of gh_COPILOT project state for 2025‑08‑01 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9101%29.pdf>) | - |
-| 2025‑08‑02 | Snapshot of gh_COPILOT project state for 2025‑08‑02 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9102%29.pdf>) | - |
-| 2025‑08‑03 | Snapshot of gh_COPILOT project state for 2025‑08‑03 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9103%29.pdf>) | - |
-| 2025‑08‑04 | Snapshot of gh_COPILOT project state for 2025‑08‑04 | [PDF](<daily%20state%20update/gh_COPILOT%20Project%20White%E2%80%91Paper%20Blueprint%20%282025%E2%80%9108%E2%80%9104%29.pdf>) | [Markdown](<daily%20state%20update/gh_COPILOT_Project_White-Paper_Blueprint_2025-08-04.md>) |
-| 2025‑08‑05 | Snapshot of gh_COPILOT project state for 2025‑08‑05 | [PDF](<daily%20state%20update/gh_copilot_project_white_paper_blueprint_2025-08-05.pdf>) | [Markdown](<daily%20state%20update/gh_copilot_project_white_paper_blueprint_2025-08-05.md>) |
-| 2025‑08‑06 | Snapshot of gh_COPILOT project state for 2025‑08‑06 | [PDF](<daily%20state%20update/gh_copilot_project_white_paper_blueprint_2025-08-06.pdf>) | [Markdown](<daily%20state%20update/gh_copilot_project_white_paper_blueprint_2025-08-06.md>) |
+| 2025-07-30 | Snapshot of gh_COPILOT project state for 2025-07-30 | [PDF](<daily_state_update/gh_COPILOT_Project_White%E2%80%91Paper_Blueprint_%282025%E2%80%9107%E2%80%9130%29.pdf>) | - |
+| 2025-07-31 | Snapshot of gh_COPILOT project state for 2025-07-31 | [PDF](<daily_state_update/gh_COPILOT_Project_White%E2%80%91Paper_Blueprint_%282025%E2%80%9107%E2%80%9131%29.pdf>) | - |
+| 2025-08-01 | Snapshot of gh_COPILOT project state for 2025-08-01 | [PDF](<daily_state_update/gh_COPILOT_Project_White%E2%80%91Paper_Blueprint_%282025%E2%80%9108%E2%80%9101%29.pdf>) | - |
+| 2025-08-02 | Snapshot of gh_COPILOT project state for 2025-08-02 | [PDF](<daily_state_update/gh_COPILOT_Project_White%E2%80%91Paper_Blueprint_%282025%E2%80%9108%E2%80%9102%29.pdf>) | - |
+| 2025-08-03 | Snapshot of gh_COPILOT project state for 2025-08-03 | [PDF](<daily_state_update/gh_COPILOT_Project_White%E2%80%91Paper_Blueprint_%282025%E2%80%9108%E2%80%9103%29.pdf>) | - |
+| 2025-08-04 | Snapshot of gh_COPILOT project state for 2025-08-04 | [PDF](<daily_state_update/gh_COPILOT_Project_White%E2%80%91Paper_Blueprint_%282025%E2%80%9108%E2%80%9104%29.pdf>) | [Markdown](<daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_%282025-08-04%29.md>) |
+| 2025-08-05 | Snapshot of gh_COPILOT project state for 2025-08-05 | [PDF](<daily_state_update/gh_COPILOT_Project_White%E2%80%91Paper_Blueprint_%282025-08-05%29.pdf>) | [Markdown](<daily_state_update/gh_COPILOT_Project_White%E2%80%91Paper_Blueprint_%282025-08-05%29.md>) |
+| 2025-08-06 | Snapshot of gh_COPILOT project state for 2025-08-06 | [PDF](<daily_state_update/gh_COPILOT_Project_White%E2%80%91Paper_Blueprint_%282025-08-06%29.pdf>) | [Markdown](<daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_%282025-08-06%29.md>) |

--- a/scripts/documentation/update_daily_state_index.py
+++ b/scripts/documentation/update_daily_state_index.py
@@ -1,0 +1,102 @@
+"""Rebuild ``daily_state_index.md`` from available daily white‑paper files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import urllib.parse
+from pathlib import Path
+from typing import Dict, Tuple
+
+DEFAULT_SOURCE_DIR = Path("documentation") / "generated" / "daily_state_update"
+INDEX_PATH = Path("documentation") / "generated" / "daily_state_index.md"
+
+DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
+NON_ASCII_HYPHENS = "\u2010\u2011\u2012\u2013\u2014\u2015"
+
+
+def _scan(source_dir: Path) -> Dict[str, Dict[str, Path]]:
+    """Return mapping of dates to available PDF/Markdown paths."""
+
+    results: Dict[str, Dict[str, Path]] = {}
+    for path in source_dir.iterdir():
+        if not path.is_file():
+            continue
+        sanitized = path.name
+        for ch in NON_ASCII_HYPHENS:
+            sanitized = sanitized.replace(ch, "-")
+        match = DATE_RE.search(sanitized)
+        if not match:
+            continue
+        date = match.group(1)
+        record = results.setdefault(date, {"pdf": None, "md": None})
+        suffix = path.suffix.lower()
+        if suffix == ".pdf":
+            record["pdf"] = path
+        elif suffix == ".md" and path.name.lower() != "readme.md":
+            record["md"] = path
+    return results
+
+
+def _format_link(path: Path, index_dir: Path) -> str:
+    """Return Markdown link for ``path`` relative to ``index_dir``."""
+
+    rel = path.relative_to(index_dir).as_posix()
+    return f"<{urllib.parse.quote(rel, safe='/')}>"
+
+
+def update_index(
+    source_dir: Path = DEFAULT_SOURCE_DIR, index_path: Path = INDEX_PATH
+) -> Path:
+    """Write ``daily_state_index.md`` linking to all daily reports."""
+
+    index_dir = index_path.parent
+    data = _scan(source_dir)
+    lines = [
+        "# Daily State White‑Paper Index",
+        "",
+        "| Date | Summary | PDF | Markdown |",
+        "|------|---------|-----|----------|",
+    ]
+
+    for date in sorted(data):
+        record = data[date]
+        pdf = (
+            f"[PDF]({_format_link(record['pdf'], index_dir)})" if record["pdf"] else "-"
+        )
+        md = (
+            f"[Markdown]({_format_link(record['md'], index_dir)})"
+            if record["md"]
+            else "-"
+        )
+        summary = f"Snapshot of gh_COPILOT project state for {date}"
+        lines.append(f"| {date} | {summary} | {pdf} | {md} |")
+
+    index_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return index_path
+
+
+def main(argv: Tuple[str, ...] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Update daily_state_index.md with links to available reports"
+    )
+    parser.add_argument(
+        "--source-dir",
+        default=DEFAULT_SOURCE_DIR,
+        type=Path,
+        help="Directory containing daily state PDF/Markdown files",
+    )
+    parser.add_argument(
+        "--index-path",
+        default=INDEX_PATH,
+        type=Path,
+        help="Path to write the generated index",
+    )
+    args = parser.parse_args(argv)
+
+    update_index(source_dir=args.source_dir, index_path=args.index_path)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/tests/test_update_daily_state_index.py
+++ b/tests/test_update_daily_state_index.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from scripts.documentation.update_daily_state_index import update_index
+
+
+def test_update_index_writes_links(tmp_path):
+    source = tmp_path / "daily_state_update"
+    source.mkdir()
+    (source / "report_2025-08-07.pdf").write_text("pdf")
+    (source / "report_2025-08-07.md").write_text("md")
+
+    index = tmp_path / "daily_state_index.md"
+    update_index(source_dir=source, index_path=index)
+
+    content = index.read_text()
+    assert "2025-08-07" in content
+    assert "report_2025-08-07.pdf" in content
+    assert "report_2025-08-07.md" in content
+

--- a/tools/convert_daily_whitepaper.py
+++ b/tools/convert_daily_whitepaper.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -28,6 +29,12 @@ def _sanitize_name(name: str) -> str:
 
 import PyPDF2  # noqa: F401
 from PyPDF2 import PdfReader
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.documentation.update_daily_state_index import update_index
 
 
 def convert_pdfs(pdf_dir: Path) -> Iterable[str]:
@@ -78,6 +85,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     for message in convert_pdfs(args.pdf_dir):
         logging.info(message)
+    update_index(source_dir=args.pdf_dir)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- add script to rebuild daily_state_index.md from generated reports
- wire script into daily whitepaper conversion tool
- document automated index refresh workflow

## Testing
- `bash tools/pre-commit-lfs.sh`
- `python scripts/run_checks.py` *(fails: F401/F821 in web_gui/security)*
- `pytest` *(fails: NameError in web_gui/security)*

------
https://chatgpt.com/codex/tasks/task_e_6894c97f68d883318fc8adfc14104ca5