### PR TITLE
feat: add email templates and tests

### DIFF
--- a/tests/web_gui/test_email_templates.py
+++ b/tests/web_gui/test_email_templates.py
@@ -1,0 +1,34 @@
+import pytest
+from flask import render_template
+
+
+@pytest.mark.parametrize(
+    "template, context, expected",
+    [
+        (
+            "email/alert_notifications.html",
+            {"subject": "Alert", "message": "Attention"},
+            ["Alert", "Attention"],
+        ),
+        (
+            "email/deployment_reports.html",
+            {"subject": "Deployment", "report": "Success"},
+            ["Deployment", "Success"],
+        ),
+        (
+            "email/compliance_reports.html",
+            {"subject": "Compliance", "report": "Pass"},
+            ["Compliance", "Pass"],
+        ),
+    ],
+)
+def test_email_templates_render(template, context, expected, monkeypatch, tmp_path):
+    """Ensure email templates render dynamic content."""
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    from web_gui.scripts.flask_apps.enterprise_dashboard import app
+
+    with app.test_request_context('/'):
+        html = render_template(template, **context)
+    for item in expected:
+        assert item in html
+

--- a/web_gui/templates/email/compliance_reports.html
+++ b/web_gui/templates/email/compliance_reports.html
@@ -4,7 +4,7 @@
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td>
-          <h1>Compliance Report</h1>
+          <h1>{{ subject }}</h1>
           <p>{{ report }}</p>
         </td>
       </tr>

--- a/web_gui/templates/email/deployment_reports.html
+++ b/web_gui/templates/email/deployment_reports.html
@@ -4,7 +4,7 @@
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td>
-          <h1>Deployment Report</h1>
+          <h1>{{ subject }}</h1>
           <p>{{ report }}</p>
         </td>
       </tr>


### PR DESCRIPTION
## Summary
- allow dynamic subjects in deployment and compliance email templates
- test rendering for alert, deployment, and compliance emails

## Testing
- `ruff check tests/web_gui/test_email_templates.py`
- `pytest tests/web_gui/test_email_templates.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ca31bc208331a171e58257e4920f