### PR TITLE
docs: add quantum preparation and certification guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 > Quantum modules run exclusively in simulation mode; hardware flags are currently ignored. Documentation and guides now clearly mark these components as simulation-only. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Module completion status is tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics_collector.db`.
 > Integration plan: [docs/quantum_integration_plan.md](docs/quantum_integration_plan.md) outlines staged hardware enablement while current builds remain simulator-only.
 > Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards.
+> Documentation: quantum preparation, executive guides, and certification workflows live under [`web_gui/documentation`](web_gui/documentation) — see [web_gui/documentation/quantum_preparation/README.md](web_gui/documentation/quantum_preparation/README.md), [web_gui/documentation/executive_guides/README.md](web_gui/documentation/executive_guides/README.md), and [web_gui/documentation/certification/README.md](web_gui/documentation/certification/README.md).
 
 ---
 

--- a/web_gui/documentation/README.md
+++ b/web_gui/documentation/README.md
@@ -6,7 +6,7 @@ Generated: 2025-01-06T04:53:00Z
 
 ## 📚 Complete Documentation Suite
 
-This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit web GUI system, addressing critical enterprise compliance requirements.
+This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit web GUI system, addressing critical enterprise compliance requirements, quantum preparation steps, executive usage, and certification workflows.
 
 ### 🎯 Core Documentation Areas
 
@@ -16,6 +16,9 @@ This comprehensive documentation covers all aspects of the gh_COPILOT Toolkit we
 4. **[User Guides](user_guides/README.md)** - End-user documentation and tutorials
 5. **[API Documentation](api_docs/README.md)** - REST API reference and integration guides
 6. **[Error Recovery](error_recovery/README.md)** - Troubleshooting and error handling
+7. **[Quantum Preparation](quantum_preparation/README.md)** - Preparing databases and services for simulated quantum features
+8. **[Executive Guides](executive_guides/README.md)** - High-level dashboard usage for leadership teams
+9. **[Certification Workflows](certification/README.md)** - Managing and validating web interface certificates
 
 ### 🌐 Web GUI Components
 

--- a/web_gui/documentation/certification/README.md
+++ b/web_gui/documentation/certification/README.md
@@ -1,0 +1,14 @@
+# Certification Workflows - gh_COPILOT Web GUI
+
+Procedures for issuing and validating certificates used by the web interface.
+
+## Key Resources
+
+- [web_gui/certificates/certificate_manager.py](../../certificates/certificate_manager.py) – generates and manages certificates
+
+## Workflow
+
+1. Configure certificate settings in `certificate_manager.py`.
+2. Execute the manager to issue or renew certificates.
+3. Distribute the generated certificates to the appropriate deployment targets.
+

--- a/web_gui/documentation/executive_guides/README.md
+++ b/web_gui/documentation/executive_guides/README.md
@@ -1,0 +1,13 @@
+# Executive Guides - gh_COPILOT Web GUI
+
+Quick references for leadership teams using the enterprise dashboard.
+
+## Key Resources
+
+- [web_gui/scripts/flask_apps/enterprise_dashboard.py](../../scripts/flask_apps/enterprise_dashboard.py) – launches the executive dashboard
+- [../user_guides/README.md](../user_guides/README.md) – general user documentation
+
+## Overview
+
+The executive dashboard surfaces compliance summaries, performance metrics, and certification status. Run the dashboard script and navigate to the highlighted sections to review system health at a glance.
+

--- a/web_gui/documentation/quantum_preparation/README.md
+++ b/web_gui/documentation/quantum_preparation/README.md
@@ -1,0 +1,14 @@
+# Quantum Preparation - gh_COPILOT Web GUI
+
+Steps to prime the web interface for quantum-enabled features. All quantum operations run in simulation, but databases and routes still require preparation.
+
+## Key Resources
+
+- [migration_scripts/quantum_preparation.sql](../../../migration_scripts/quantum_preparation.sql) – primes databases for quantum metrics
+- [web_gui/scripts/flask_apps/quantum_enhanced_framework.py](../../scripts/flask_apps/quantum_enhanced_framework.py) – exposes simulated quantum endpoints
+
+## Workflow
+
+1. Apply the SQL migration to initialize quantum-related tables.
+2. Launch the `quantum_enhanced_framework` Flask app to enable optional quantum routes.
+


### PR DESCRIPTION
## Summary
- link root docs to new quantum preparation, executive guide, and certification workflow references
- expand Web GUI documentation index with quantum, executive, and certificate sections
- add dedicated guides for quantum preparation, executive usage, and certificate workflows

## Testing
- `ruff check .` *(fails: F821 undefined name `quantum_crypto`, F822 undefined name `init_app`)*
- `pytest -q` *(fails: NameError: name 'logging' is not defined in tests/dashboard/test_actionable_endpoints.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894cbdf2fc88331a0219f00147bb650