### PR TITLE
feat: add middleware integration and tests

### DIFF
--- a/scripts/bot/webhook_server.py
+++ b/scripts/bot/webhook_server.py
@@ -16,6 +16,7 @@ from utils.cross_platform_paths import (
     CrossPlatformPathManager,
     verify_environment_variables,
 )
+from web_gui import middleware
 
 TEXT_INDICATORS = {
     "start": "[START]",
@@ -29,6 +30,7 @@ def create_app() -> Flask:
     """Create configured Flask app."""
     verify_environment_variables()
     app = Flask(__name__)
+    middleware.init_app(app)
     secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
 
     backup_root = CrossPlatformPathManager.get_backup_root()

--- a/scripts/enterprise/enterprise_api_infrastructure_framework.py
+++ b/scripts/enterprise/enterprise_api_infrastructure_framework.py
@@ -22,22 +22,19 @@ import os
 import sys
 import json
 import time
-import sqlite3
-import asyncio
 import logging
 import hashlib
 import threading
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional
 from dataclasses import dataclass, field
-from concurrent.futures import ThreadPoolExecutor
 from collections import defaultdict
 import uuid
 
 # Essential imports for API framework
-import numpy as np
 from tqdm import tqdm
+from web_gui import middleware
 from utils.log_utils import log_message
 
 # Flask imports for web API
@@ -53,7 +50,7 @@ except ImportError:
 
 # Additional API framework imports
 try:
-    import jwt
+    import jwt  # noqa: F401
 
     JWT_AVAILABLE = True
 except ImportError:
@@ -367,6 +364,7 @@ class EnterpriseAPIServer:
         if FLASK_AVAILABLE:
             self.app = Flask(__name__)
             CORS(self.app, resources={r"/api/*": {"origins": self.allowed_origins}})
+            middleware.init_app(self.app)
             self._setup_flask_routes()
         else:
             self.app = None

--- a/tests/web_gui/test_middleware.py
+++ b/tests/web_gui/test_middleware.py
@@ -10,6 +10,7 @@ from web_gui.middleware import (
     security_headers,
     session_management,
 )
+from web_gui import middleware
 
 
 def create_app() -> Flask:
@@ -69,4 +70,15 @@ def test_middleware_dual_copilot(monkeypatch) -> None:
     client = app.test_client()
     client.get("/")
     assert calls
+
+
+def test_init_app_applies_middlewares() -> None:
+    app = create_app()
+    app.config.update({"ENABLE_RATE_LIMITING": False})
+    middleware.init_app(app)
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert client.get("/?q=<script>").status_code == 400
 

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -25,6 +25,7 @@ from dashboard.compliance_metrics_updater import ComplianceMetricsUpdater
 from config.secret_manager import get_secret
 from utils.cross_platform_paths import CrossPlatformPathManager
 from enterprise_modules.compliance import get_latest_compliance_score
+from web_gui import middleware
 
 workspace_root = CrossPlatformPathManager.get_workspace_path()
 ANALYTICS_DB = Path(os.getenv("ANALYTICS_DB", workspace_root / "databases" / "analytics.db"))
@@ -34,6 +35,7 @@ TEMPLATES = Path(__file__).resolve().parents[2] / "templates"
 STATIC = Path(__file__).resolve().parents[2] / "static"
 app = Flask(__name__, template_folder=str(TEMPLATES), static_folder=str(STATIC))
 app.secret_key = get_secret("FLASK_SECRET_KEY", "dev_key")
+middleware.init_app(app)
 LOG_FILE = Path("artifacts/logs/dashboard") / "dashboard.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler(LOG_FILE), logging.StreamHandler()])


### PR DESCRIPTION
## Summary
- integrate web_gui middleware into Flask entry points
- add integration tests covering header injection and input validation

## Testing
- `ruff check web_gui/scripts/flask_apps/enterprise_dashboard.py scripts/bot/webhook_server.py tests/web_gui/test_middleware.py`
- `ruff check scripts/enterprise/enterprise_api_infrastructure_framework.py`
- `pytest tests/web_gui/test_middleware.py`

------
https://chatgpt.com/codex/tasks/task_e_6894cc164ed48331965b615955e13f0b