### PR TITLE
feat: add certificate management placeholders

### DIFF
--- a/web_gui/certificates/certificate_manager.py
+++ b/web_gui/certificates/certificate_manager.py
@@ -1,4 +1,10 @@
-"""Utilities for managing certificate files."""
+"""Utilities for managing certificate files.
+
+Steps:
+1. Load certificate and private key material from disk.
+2. Validate file presence before returning bytes.
+3. Provide a placeholder for certificate rotation.
+"""
 from pathlib import Path
 
 from secondary_copilot_validator import SecondaryCopilotValidator
@@ -46,3 +52,19 @@ def load_private_key(
     data = file_path.read_bytes()
     (validator or SecondaryCopilotValidator()).validate_corrections([path])
     return data
+
+
+def rotate_certificate(
+    current_cert: str,
+    new_cert: str,
+    validator: SecondaryCopilotValidator | None = None,
+) -> None:
+    """Placeholder for rotating certificate files.
+
+    Steps:
+        1. Load the new certificate from *new_cert*.
+        2. Replace the file at *current_cert* with the new data.
+        3. Trigger any service reload required to apply the change.
+    """
+    (validator or SecondaryCopilotValidator()).validate_corrections([current_cert, new_cert])
+    # Placeholder: real implementation would ensure atomic swap and backups.

--- a/web_gui/certificates/quantum_crypto.py
+++ b/web_gui/certificates/quantum_crypto.py
@@ -1,4 +1,10 @@
-"""Quantum-safe cryptographic helpers."""
+"""Quantum-safe cryptographic helpers.
+
+Steps:
+1. Generate random keys suitable for symmetric encryption.
+2. Hash data with SHA3-256 as a stand-in for post-quantum hashing.
+3. Serve as placeholders until full quantum-resistant algorithms are integrated.
+"""
 
 from hashlib import sha3_256
 import secrets

--- a/web_gui/certificates/ssl_config.py
+++ b/web_gui/certificates/ssl_config.py
@@ -1,4 +1,13 @@
-"""SSL context configuration helpers."""
+"""SSL context configuration helpers.
+
+Steps:
+1. Verify certificate and key files exist on disk.
+2. Build an :class:`ssl.SSLContext` and load the certificate chain.
+3. Optionally load a CA bundle for client verification.
+
+These helpers provide placeholder logic; production code would include
+robust error handling and automatic rotation hooks.
+"""
 
 from pathlib import Path
 import ssl


### PR DESCRIPTION
## Summary
- expand certificate helper docstrings
- outline certificate rotation logic
- document quantum-safe crypto helpers

## Testing
- `ruff check web_gui/certificates/ssl_config.py web_gui/certificates/certificate_manager.py web_gui/certificates/quantum_crypto.py`
- `pytest tests/web_gui/test_certificates.py`


------
https://chatgpt.com/codex/tasks/task_e_6894cc18ab508331b35cd4defa026140