### PR TITLE
feat: integrate alert logging with dashboards

### DIFF
--- a/web_gui/dashboards/executive_dashboard.py
+++ b/web_gui/dashboards/executive_dashboard.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional
 from .technical_dashboard import get_metrics as get_technical_metrics
 from .security_dashboard import get_metrics as get_security_metrics
 from .quantum_dashboard import get_metrics as get_quantum_metrics
+from web_gui.monitoring.alerting import NOTIFICATION_LOG
 
 
 def collect_analytics(db_path: Optional[Path] = None) -> Dict[str, Dict]:
@@ -13,11 +14,14 @@ def collect_analytics(db_path: Optional[Path] = None) -> Dict[str, Dict]:
 
     ``db_path`` allows overriding the analytics database used by sub dashboards.
     """
-    return {
+    data = {
         "technical": get_technical_metrics(db_path) if db_path else get_technical_metrics(),
         "security": get_security_metrics(db_path) if db_path else get_security_metrics(),
         "quantum": get_quantum_metrics(db_path) if db_path else get_quantum_metrics(),
     }
+    if NOTIFICATION_LOG:
+        data["alerts"] = list(NOTIFICATION_LOG)
+    return data
 
 
 __all__ = ["collect_analytics"]

--- a/web_gui/dashboards/quantum_dashboard.py
+++ b/web_gui/dashboards/quantum_dashboard.py
@@ -4,12 +4,14 @@ from pathlib import Path
 import sqlite3
 from typing import Dict
 
+from analytics.predictive_models import predict_next
+
 ANALYTICS_DB = Path("databases/analytics.db")
 
 
 def get_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, float]:
     """Return quantum related analytics."""
-    metrics = {"avg_importance": 0.0}
+    metrics = {"avg_importance": 0.0, "predicted_importance": 0.0}
     if db_path.exists():
         try:
             with sqlite3.connect(db_path) as conn:
@@ -18,6 +20,7 @@ def get_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, float]:
                 )
                 (avg,) = cur.fetchone()
                 metrics["avg_importance"] = float(avg or 0.0)
+                metrics["predicted_importance"] = predict_next([metrics["avg_importance"]])
         except sqlite3.Error:
             pass
     return metrics

--- a/web_gui/dashboards/security_dashboard.py
+++ b/web_gui/dashboards/security_dashboard.py
@@ -4,12 +4,17 @@ from pathlib import Path
 import sqlite3
 from typing import Dict
 
+from analytics.user_behavior import log_user_action
+
 ANALYTICS_DB = Path("databases/analytics.db")
+
+
+ACTION_LOG: Dict[str, int] = {}
 
 
 def get_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, int]:
     """Return basic security analytics."""
-    metrics = {"open_issues": 0}
+    metrics = {"open_issues": 0, "views": 0}
     if db_path.exists():
         try:
             with sqlite3.connect(db_path) as conn:
@@ -20,6 +25,7 @@ def get_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, int]:
                 metrics["open_issues"] = int(count or 0)
         except sqlite3.Error:
             pass
+    metrics["views"] = log_user_action("security_dashboard", ACTION_LOG)["security_dashboard"]
     return metrics
 
 

--- a/web_gui/dashboards/technical_dashboard.py
+++ b/web_gui/dashboards/technical_dashboard.py
@@ -4,12 +4,14 @@ from pathlib import Path
 import sqlite3
 from typing import Dict
 
+from analytics.performance_analysis import summarize_performance
+
 ANALYTICS_DB = Path("databases/analytics.db")
 
 
 def get_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, int]:
     """Return basic technical analytics."""
-    metrics = {"scripts": 0}
+    metrics = {"scripts": 0, "avg_scripts": 0.0}
     if db_path.exists():
         try:
             with sqlite3.connect(db_path) as conn:
@@ -18,6 +20,7 @@ def get_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, int]:
                 )
                 (count,) = cur.fetchone()
                 metrics["scripts"] = int(count or 0)
+                metrics["avg_scripts"] = summarize_performance({"scripts": metrics["scripts"]})
         except sqlite3.Error:
             pass
     return metrics

--- a/web_gui/monitoring/alerting/__init__.py
+++ b/web_gui/monitoring/alerting/__init__.py
@@ -1,1 +1,6 @@
 """Alerting utilities for web GUI monitoring."""
+
+from .alert_manager import trigger_alert
+from .notification_engine import NOTIFICATION_LOG
+
+__all__ = ["trigger_alert", "NOTIFICATION_LOG"]

--- a/web_gui/monitoring/alerting/notification_engine.py
+++ b/web_gui/monitoring/alerting/notification_engine.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-__all__ = ["send_notification"]
+from typing import List
+
+__all__ = ["send_notification", "NOTIFICATION_LOG"]
+
+NOTIFICATION_LOG: List[str] = []
 
 
 def send_notification(message: str) -> None:
-    """Placeholder notification sender."""
+    """Record ``message`` and emit it to stdout."""
+    NOTIFICATION_LOG.append(message)
     print(message)


### PR DESCRIPTION
## Summary
- add run_all_checks helper with alerting for failed checks
- log notifications for dashboard consumption
- surface alert and analytic metrics in dashboards

## Testing
- `ruff check web_gui/monitoring/health_checks.py web_gui/monitoring/alerting/notification_engine.py web_gui/monitoring/alerting/__init__.py web_gui/dashboards/executive_dashboard.py web_gui/dashboards/technical_dashboard.py web_gui/dashboards/security_dashboard.py web_gui/dashboards/quantum_dashboard.py tests/web_gui/test_web_gui_monitoring_health_checks.py`
- `pytest tests/web_gui/test_web_gui_monitoring_health_checks.py`


------
https://chatgpt.com/codex/tasks/task_e_6894cf36d4548331a275013da03094de