### PR TITLE
feat: integrate quantum deployment and recovery

### DIFF
--- a/deployment/scripts/backup_manager.py
+++ b/deployment/scripts/backup_manager.py
@@ -25,6 +25,8 @@ def create_backup(name: str, backup_root: Path | None = None) -> Path:
     if path is None:
         raise ValueError(f"Unsupported database: {name}")
 
+    validate_database_file(path)
+
     if backup_root is None:
         backup_root = Path(os.environ["GH_COPILOT_BACKUP_ROOT"]) / "backups"
     else:

--- a/deployment/scripts/deploy_to_production.py
+++ b/deployment/scripts/deploy_to_production.py
@@ -12,6 +12,7 @@ import os
 from .environment_migration import migrate_environment
 from .backup_manager import create_backup
 from .data_migration import migrate_data
+from .quantum_deployment import deploy_quantum_modules
 
 WORKSPACE = Path(os.environ.get("GH_COPILOT_WORKSPACE", Path(__file__).resolve().parents[2]))
 WEB_GUI_PATH = WORKSPACE / "web_gui"
@@ -22,7 +23,11 @@ def deploy_to_production() -> None:
     migrate_environment(["production"])
     migrate_data("analytics", "production")
     create_backup("production")
-    print(f"Deploying web GUI from {WEB_GUI_PATH} to production environment")
+    deploy_quantum_modules()
+    print(
+        f"Deploying web GUI from {WEB_GUI_PATH} "
+        f"to production environment with quantum modules"
+    )
 
 
 if __name__ == "__main__":

--- a/deployment/scripts/deploy_to_staging.py
+++ b/deployment/scripts/deploy_to_staging.py
@@ -12,6 +12,7 @@ import os
 from .environment_migration import migrate_environment
 from .backup_manager import create_backup
 from .data_migration import migrate_data
+from .quantum_deployment import deploy_quantum_modules
 
 WORKSPACE = Path(os.environ.get("GH_COPILOT_WORKSPACE", Path(__file__).resolve().parents[2]))
 WEB_GUI_PATH = WORKSPACE / "web_gui"
@@ -22,7 +23,11 @@ def deploy_to_staging() -> None:
     migrate_environment(["production"])
     migrate_data("analytics", "production")
     create_backup("production")
-    print(f"Deploying web GUI from {WEB_GUI_PATH} to staging environment")
+    deploy_quantum_modules()
+    print(
+        f"Deploying web GUI from {WEB_GUI_PATH} "
+        f"to staging environment with quantum modules"
+    )
 
 
 if __name__ == "__main__":

--- a/deployment/scripts/environment_migration.py
+++ b/deployment/scripts/environment_migration.py
@@ -35,6 +35,23 @@ def validate_database_file(path: Path) -> None:
     sqlite3.connect(path).close()
 
 
+def register_database(name: str, path: Path) -> None:
+    """Register an additional database for migrations.
+
+    Parameters
+    ----------
+    name:
+        Unique identifier for the database.
+    path:
+        Location of the SQLite database file.
+    """
+
+    if name in SUPPORTED_DATABASES:
+        raise ValueError(f"Database already registered: {name}")
+    validate_database_file(path)
+    SUPPORTED_DATABASES[name] = path
+
+
 def migrate_environment(names: Iterable[str]) -> List[str]:
     """Validate databases and simulate migration.
 
@@ -62,4 +79,9 @@ def migrate_environment(names: Iterable[str]) -> List[str]:
     return processed
 
 
-__all__ = ["migrate_environment", "SUPPORTED_DATABASES", "validate_database_file"]
+__all__ = [
+    "migrate_environment",
+    "SUPPORTED_DATABASES",
+    "validate_database_file",
+    "register_database",
+]

--- a/deployment/scripts/restoration_engine.py
+++ b/deployment/scripts/restoration_engine.py
@@ -7,7 +7,7 @@ import os
 import shutil
 from pathlib import Path
 
-from .environment_migration import SUPPORTED_DATABASES
+from .environment_migration import SUPPORTED_DATABASES, validate_database_file
 
 
 def restore_backup(name: str, backup_root: Path | None = None) -> Path:
@@ -26,6 +26,7 @@ def restore_backup(name: str, backup_root: Path | None = None) -> Path:
         raise FileNotFoundError(f"Backup not found for {name}")
 
     shutil.copy2(source, path)
+    validate_database_file(path)
     return path
 
 

--- a/deployment/scripts/rollback_procedures.py
+++ b/deployment/scripts/rollback_procedures.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-"""Rollback utilities for the web GUI deployment.
+"""Rollback utilities for the web GUI and quantum modules.
 
-Adjusted to use the new ``web_gui`` directory location at the repository root.
+Adjusted to use the new ``web_gui`` directory location at the repository root
+and restore both production and quantum databases.
 """
 
 from pathlib import Path
@@ -16,8 +17,9 @@ WEB_GUI_PATH = WORKSPACE / "web_gui"
 
 
 def rollback() -> None:
-    """Simulate rolling back the web GUI deployment."""
+    """Simulate rolling back the web GUI and quantum modules."""
     restore_backup("production")
+    restore_backup("quantum")
     migrate_quantum()
     print(f"Rolling back web GUI using artifacts in {WEB_GUI_PATH}")
 


### PR DESCRIPTION
## Summary
- deploy quantum modules alongside web GUI in staging and production
- support rollback of both production and quantum databases
- add database registration, stricter backup and restore validation

## Testing
- `ruff check deployment/scripts/deploy_to_staging.py deployment/scripts/deploy_to_production.py deployment/scripts/rollback_procedures.py deployment/scripts/environment_migration.py deployment/scripts/backup_manager.py deployment/scripts/restoration_engine.py`
- `pytest --override-ini addopts=''` *(fails: ModuleNotFoundError: No module named 'scripts.utilities')*

------
https://chatgpt.com/codex/tasks/task_e_6894d2427eb48331870203806faa9a65