### PR TITLE
feat: add quantum interface utilities and AI enhancements

### DIFF
--- a/quantum/ai_enhancement/__init__.py
+++ b/quantum/ai_enhancement/__init__.py
@@ -1,0 +1,14 @@
+"""Supplemental AI utilities for the quantum package.
+
+This subpackage groups small, self contained helpers that simulate
+additional AI capabilities.  The modules are intentionally lightweight so
+that they can be exercised easily in unit tests.
+"""
+
+__all__ = [
+    "cognitive_computing",
+    "nlp",
+    "maintenance",
+    "ecosystem_integration",
+]
+

--- a/quantum/ai_enhancement/cognitive_computing.py
+++ b/quantum/ai_enhancement/cognitive_computing.py
@@ -1,0 +1,16 @@
+"""Simplified cognitive computing helpers.
+
+The functions defined here are intentionally small and deterministic.  They
+serve as stand‑ins for more advanced cognitive systems that might analyse
+patterns or optimise decision making in the real platform.
+"""
+
+
+def simulate_cognition(data: str) -> str:
+    """Return ``data`` reversed to mimic a transformation step."""
+
+    return data[::-1]
+
+
+__all__ = ["simulate_cognition"]
+

--- a/quantum/ai_enhancement/ecosystem_integration.py
+++ b/quantum/ai_enhancement/ecosystem_integration.py
@@ -1,0 +1,15 @@
+"""Helpers for integrating with external services."""
+
+from typing import Any, Dict
+
+
+def integrate_service(service: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Combine ``service`` name and ``payload`` into a single dictionary."""
+
+    result = {"service": service}
+    result.update(payload)
+    return result
+
+
+__all__ = ["integrate_service"]
+

--- a/quantum/ai_enhancement/maintenance.py
+++ b/quantum/ai_enhancement/maintenance.py
@@ -1,0 +1,22 @@
+"""Predictive maintenance helpers."""
+
+from typing import Iterable
+
+
+def predict_failure(metrics: Iterable[float]) -> float:
+    """Return the average of *metrics* as a simple risk indicator.
+
+    Raises
+    ------
+    ValueError
+        If ``metrics`` is empty.
+    """
+
+    values = list(metrics)
+    if not values:
+        raise ValueError("metrics must not be empty")
+    return sum(values) / len(values)
+
+
+__all__ = ["predict_failure"]
+

--- a/quantum/ai_enhancement/nlp.py
+++ b/quantum/ai_enhancement/nlp.py
@@ -1,0 +1,11 @@
+"""Natural language processing utilities."""
+
+
+def count_tokens(text: str) -> int:
+    """Very small tokenizer counting whitespace separated tokens."""
+
+    return 0 if not text else len(text.split())
+
+
+__all__ = ["count_tokens"]
+

--- a/quantum/interfaces/quantum_api.py
+++ b/quantum/interfaces/quantum_api.py
@@ -1,12 +1,54 @@
-"""High-level API for interacting with quantum services."""
+"""High-level API for interacting with quantum services.
+
+This module exposes a very small facade used throughout the tests to
+simulate execution of quantum tasks.  The real project integrates with
+various backends, but for unit testing we only need a deterministic and
+side‑effect free implementation.  The :func:`execute_quantum_task` function
+therefore wires together the template and websocket helpers defined in the
+same package and returns a simple dictionary describing the result of the
+operation.
+"""
 
 from typing import Any, Dict
 
+from . import quantum_templates, quantum_websocket
+
 
 def execute_quantum_task(task: Dict[str, Any]) -> Dict[str, Any]:
-    """Execute a quantum task and return the result.
+    """Execute a quantum task described by ``task``.
 
-    Currently a placeholder that should be implemented with actual
-    quantum execution logic.
+    Parameters
+    ----------
+    task:
+        A dictionary describing the work to perform.  It must contain a
+        ``"template"`` key referencing a registered template and may
+        optionally include ``"input"`` and ``"url"`` entries.  ``"input"``
+        is passed to the template callable and ``"url"`` – when provided –
+        will be used to open a simulated websocket connection.
+
+    Returns
+    -------
+    Dict[str, Any]
+        A dictionary containing the ``"result"`` from the template
+        execution.  If a ``"url"`` was supplied the returned mapping also
+        includes a ``"socket"`` entry describing the opened connection.
     """
-    raise NotImplementedError("Quantum task execution is not implemented yet")
+
+    template_name = task.get("template")
+    if not template_name:
+        raise ValueError("task must include a 'template' field")
+
+    template = quantum_templates.get_template(template_name)
+    input_data = task.get("input")
+    result = template(input_data)
+
+    socket_info = None
+    url = task.get("url")
+    if url:
+        socket = quantum_websocket.open_quantum_socket(url)
+        socket_info = {"url": socket.url}
+
+    response: Dict[str, Any] = {"result": result}
+    if socket_info:
+        response["socket"] = socket_info
+    return response

--- a/quantum/interfaces/quantum_templates.py
+++ b/quantum/interfaces/quantum_templates.py
@@ -1,8 +1,41 @@
-"""Template management for quantum operations."""
+"""Template management for quantum operations.
 
-from typing import Any
+The real project stores templates in a database but for testing we keep a
+very small in-memory registry.  Templates are simple callables that accept a
+single argument and return a processed value.  Additional templates can be
+registered at runtime using :func:`register_template`.
+"""
+
+from typing import Any, Callable, Dict
+
+_TEMPLATES: Dict[str, Callable[[Any], Any]] = {
+    "identity": lambda x: x,
+    "increment": lambda x: x + 1 if x is not None else 1,
+    "double": lambda x: (x or 0) * 2,
+}
 
 
-def get_template(name: str) -> Any:
-    """Retrieve a quantum template by name."""
-    raise NotImplementedError("Template retrieval is not implemented yet")
+def register_template(name: str, template: Callable[[Any], Any]) -> None:
+    """Register ``template`` under ``name``.
+
+    Overwrites any existing template with the same name.
+    """
+
+    _TEMPLATES[name] = template
+
+
+def get_template(name: str) -> Callable[[Any], Any]:
+    """Retrieve a quantum template by ``name``.
+
+    Raises
+    ------
+    KeyError
+        If no template with ``name`` exists.
+    """
+
+    if name not in _TEMPLATES:
+        raise KeyError(f"Unknown template: {name}")
+    return _TEMPLATES[name]
+
+
+__all__ = ["get_template", "register_template"]

--- a/quantum/interfaces/quantum_websocket.py
+++ b/quantum/interfaces/quantum_websocket.py
@@ -1,8 +1,43 @@
-"""WebSocket interface for quantum communication channels."""
+"""WebSocket interface for quantum communication channels.
 
-from typing import Any
+The production system exposes websocket endpoints for streaming quantum
+results.  For testing purposes we emulate a very small portion of that
+behaviour with an in-memory object that mimics the necessary attributes.
+"""
+
+from dataclasses import dataclass
 
 
-def open_quantum_socket(url: str) -> Any:
-    """Open a WebSocket connection to a quantum service."""
-    raise NotImplementedError("Quantum WebSocket connection is not implemented yet")
+@dataclass
+class QuantumWebSocket:
+    """Minimal representation of an opened websocket connection."""
+
+    url: str
+    messages: list[str] = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        if self.messages is None:
+            self.messages = []
+
+    def send(self, message: str) -> None:
+        """Store ``message`` in the internal buffer."""
+
+        self.messages.append(message)
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        """Close the websocket (no-op for the stub)."""
+
+
+def open_quantum_socket(url: str) -> QuantumWebSocket:
+    """Open a websocket connection to ``url``.
+
+    The function performs basic validation to ensure a websocket URL is
+    provided and returns a :class:`QuantumWebSocket` instance.
+    """
+
+    if not url.startswith("ws://") and not url.startswith("wss://"):
+        raise ValueError("url must start with 'ws://' or 'wss://'")
+    return QuantumWebSocket(url)
+
+
+__all__ = ["QuantumWebSocket", "open_quantum_socket"]

--- a/tests/quantum/test_ai_enhancement_utils.py
+++ b/tests/quantum/test_ai_enhancement_utils.py
@@ -1,0 +1,27 @@
+"""Tests for the quantum.ai_enhancement subpackage."""
+
+from quantum.ai_enhancement import (
+    cognitive_computing,
+    ecosystem_integration,
+    maintenance,
+    nlp,
+)
+
+
+def test_simulate_cognition() -> None:
+    assert cognitive_computing.simulate_cognition("abc") == "cba"
+
+
+def test_count_tokens() -> None:
+    assert nlp.count_tokens("hello world") == 2
+
+
+def test_predict_failure() -> None:
+    assert maintenance.predict_failure([1.0, 2.0, 3.0]) == 2.0
+
+
+def test_integrate_service() -> None:
+    payload = {"value": 42}
+    result = ecosystem_integration.integrate_service("demo", payload)
+    assert result == {"service": "demo", "value": 42}
+

--- a/tests/quantum/test_interfaces.py
+++ b/tests/quantum/test_interfaces.py
@@ -1,20 +1,18 @@
-"""Tests for quantum interface placeholders."""
-
-import pytest
+"""Tests for the quantum interface layer."""
 
 from quantum.interfaces import quantum_api, quantum_templates, quantum_websocket
 
 
-def test_quantum_api_placeholder() -> None:
-    with pytest.raises(NotImplementedError):
-        quantum_api.execute_quantum_task({})
+def test_execute_quantum_task() -> None:
+    result = quantum_api.execute_quantum_task({"template": "increment", "input": 3})
+    assert result["result"] == 4
 
 
-def test_quantum_templates_placeholder() -> None:
-    with pytest.raises(NotImplementedError):
-        quantum_templates.get_template("example")
+def test_get_template_and_apply() -> None:
+    tmpl = quantum_templates.get_template("double")
+    assert tmpl(5) == 10
 
 
-def test_quantum_websocket_placeholder() -> None:
-    with pytest.raises(NotImplementedError):
-        quantum_websocket.open_quantum_socket("ws://example")
+def test_open_quantum_socket() -> None:
+    socket = quantum_websocket.open_quantum_socket("ws://example")
+    assert socket.url == "ws://example"


### PR DESCRIPTION
## Summary
- implement quantum API wrapper executing templates and optional websocket connections
- add in-memory template registry and websocket stub
- introduce cognitive computing, NLP, maintenance, and ecosystem integration helpers
- test quantum interfaces and AI enhancement utilities

## Testing
- `ruff check quantum/interfaces/quantum_api.py quantum/interfaces/quantum_templates.py quantum/interfaces/quantum_websocket.py quantum/ai_enhancement tests/quantum/test_interfaces.py tests/quantum/test_ai_enhancement_utils.py`
- `pytest tests/quantum/test_interfaces.py tests/quantum/test_ai_enhancement_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6894d32b55448331b91c742abdd0d214