### PR TITLE
docs: correct daily blueprint date format

### DIFF
--- a/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_(2025-08-04).md
+++ b/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_(2025-08-04).md
@@ -1,4 +1,4 @@
-# gh_COPILOT Project White-Paper Blueprint Summary (2025-08-04)
+# gh_COPILOT Project White-Paper Blueprint Summary (2025‑08‑04)
 
 ## Objectives
 - Update the enterprise whitepaper to reflect current architecture and feature maturity, clarifying that all quantum components are simulation-only.


### PR DESCRIPTION
## Summary
- normalize the date formatting on the 2025-08-04 daily white-paper blueprint, using non-breaking hyphens

## Testing
- `ruff check .` (fails: unused imports)
- `pytest` (fails: tests/test_analytics_modules.py)


------
https://chatgpt.com/codex/tasks/task_e_6894d3bf2a4c8331b60ed080e8079676