### PR TITLE
feat(alerting): add severity-based alert pipelines

### DIFF
--- a/tests/web_gui/test_alert_pipelines.py
+++ b/tests/web_gui/test_alert_pipelines.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from web_gui.monitoring.alerting import NOTIFICATION_LOG, ROUTE_LOG, trigger_alert
+
+
+def test_critical_pipeline_routes_to_dashboard() -> None:
+    NOTIFICATION_LOG.clear()
+    ROUTE_LOG.clear()
+    trigger_alert("system failure", "critical")
+    assert NOTIFICATION_LOG == ["[HIGH] system failure"]
+    assert ROUTE_LOG == [("high", "system failure")]
+
+
+def test_warning_pipeline_no_dashboard_route() -> None:
+    NOTIFICATION_LOG.clear()
+    ROUTE_LOG.clear()
+    trigger_alert("minor issue", "warning")
+    assert NOTIFICATION_LOG == ["[MEDIUM] minor issue"]
+    assert ROUTE_LOG == []

--- a/web_gui/monitoring/alerting/__init__.py
+++ b/web_gui/monitoring/alerting/__init__.py
@@ -1,6 +1,6 @@
 """Alerting utilities for web GUI monitoring."""
 
 from .alert_manager import trigger_alert
-from .notification_engine import NOTIFICATION_LOG
+from .notification_engine import NOTIFICATION_LOG, ROUTE_LOG
 
-__all__ = ["trigger_alert", "NOTIFICATION_LOG"]
+__all__ = ["trigger_alert", "NOTIFICATION_LOG", "ROUTE_LOG"]

--- a/web_gui/monitoring/alerting/escalation_rules.py
+++ b/web_gui/monitoring/alerting/escalation_rules.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Callable, Dict, List
 
-__all__ = ["get_escalation_level"]
+from .notification_engine import route_to_dashboard, send_notification
+
+__all__ = ["get_escalation_level", "get_pipeline"]
 
 
 ESCALATION_MAP: Dict[str, str] = {
@@ -13,7 +15,18 @@ ESCALATION_MAP: Dict[str, str] = {
     "info": "low",
 }
 
+PIPELINES: Dict[str, List[Callable[[str, str], None]]] = {
+    "critical": [send_notification, route_to_dashboard],
+    "warning": [send_notification],
+    "info": [send_notification],
+}
+
 
 def get_escalation_level(alert_type: str) -> str:
     """Return the escalation level for ``alert_type``."""
     return ESCALATION_MAP.get(alert_type, "low")
+
+
+def get_pipeline(alert_type: str) -> List[Callable[[str, str], None]]:
+    """Return the handler pipeline for ``alert_type``."""
+    return PIPELINES.get(alert_type, [send_notification])

--- a/web_gui/monitoring/alerting/notification_engine.py
+++ b/web_gui/monitoring/alerting/notification_engine.py
@@ -1,16 +1,36 @@
-"""Notification engine for alerts."""
+"""Notification engine for alerts.
+
+This module provides simple notification handlers used by the alerting
+pipeline. Handlers share a common signature of ``(level, message)`` and
+append information to in-memory logs so tests can assert on side effects.
+"""
 
 from __future__ import annotations
 
-__all__ = ["send_notification", "route_to_dashboard"]
+from typing import List, Tuple
+
+__all__ = [
+    "send_notification",
+    "route_to_dashboard",
+    "NOTIFICATION_LOG",
+    "ROUTE_LOG",
+]
 
 
-def send_notification(message: str) -> None:
-    """Record ``message`` and emit it to stdout."""
-    NOTIFICATION_LOG.append(message)
-    print(message)
+# In-memory logs used for test assertions
+NOTIFICATION_LOG: List[str] = []
+ROUTE_LOG: List[Tuple[str, str]] = []
+
+
+def send_notification(level: str, message: str) -> None:
+    """Record ``message`` with ``level`` and emit it to stdout."""
+    formatted = f"[{level.upper()}] {message}"
+    NOTIFICATION_LOG.append(formatted)
+    print(formatted)
 
 
 def route_to_dashboard(level: str, message: str) -> None:
     """Placeholder router forwarding alerts to dashboards."""
+    ROUTE_LOG.append((level, message))
     print(f"ROUTE[{level.upper()}] {message}")
+

--- a/web_gui/monitoring/health_checks.py
+++ b/web_gui/monitoring/health_checks.py
@@ -86,8 +86,7 @@ def run_all_checks(
     quantum_values: Optional[Iterable[float]] = None,
     quantum_threshold: float = 0.0,
     alert: bool = False,
-    notifier: Optional[Callable[[str], None]] = None,
-    dashboard_router: Optional[Callable[[str, str], None]] = None,
+    pipeline: Optional[Iterable[Callable[[str, str], None]]] = None,
 ) -> Dict[str, bool]:
     """Run available health checks and optionally trigger alerts.
 
@@ -102,11 +101,9 @@ def run_all_checks(
     alert:
         When ``True`` an alert is emitted for any failing check using
         :func:`alerting.alert_manager.trigger_alert`.
-    notifier:
-        Optional callback used by :func:`trigger_alert` to deliver messages.
-    dashboard_router:
-        Optional callback used by :func:`trigger_alert` to route messages
-        to dashboards.
+    pipeline:
+        Optional iterable of alert handlers forwarded to
+        :func:`~web_gui.monitoring.alerting.alert_manager.trigger_alert`.
     """
 
     results = {
@@ -122,13 +119,6 @@ def run_all_checks(
     if alert:
         for name, passed in results.items():
             if not passed:
-                if notifier is not None:
-                    trigger_alert(
-                        f"{name} check failed", "critical", notifier, dashboard_router
-                    )
-                else:
-                    trigger_alert(
-                        f"{name} check failed", "critical", dashboard_router=dashboard_router
-                    )
+                trigger_alert(f"{name} check failed", "critical", pipeline=pipeline)
 
     return results


### PR DESCRIPTION
## Summary
- create modular notification handlers with in-memory logs
- map escalation levels to handler pipelines
- run alerts through severity-specific pipelines and update health check integration
- add unit tests for alert routing and pipeline integration

## Testing
- `ruff check web_gui/monitoring/alerting web_gui/monitoring/health_checks.py tests/web_gui/test_web_gui_monitoring_health_checks.py tests/web_gui/test_alert_pipelines.py`
- `pytest tests/web_gui/test_alert_pipelines.py tests/web_gui/test_web_gui_monitoring_health_checks.py`


------
https://chatgpt.com/codex/tasks/task_e_6894d7c213a4833188bbf20acc125b75