### PR TITLE
feat: add web GUI analytics modules

### DIFF
--- a/tests/web_gui/test_analytics_modules.py
+++ b/tests/web_gui/test_analytics_modules.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from web_gui.analytics.user_behavior import log_user_action
+from web_gui.analytics.performance_analysis import summarize_performance
+from web_gui.analytics.pattern_recognition import find_repeated
+from web_gui.analytics.predictive_models import predict_next
+
+def test_log_user_action(monkeypatch) -> None:
+    def fake_metrics() -> dict[str, float]:
+        return {"cpu_percent": 1.0, "memory_percent": 2.0}
+
+    monkeypatch.setattr(
+        "web_gui.analytics.user_behavior.collect_performance_metrics",
+        fake_metrics,
+    )
+    store, metrics = log_user_action("click")
+    assert store["click"] == 1
+    assert metrics["cpu_percent"] == 1.0
+
+def test_summarize_performance(monkeypatch) -> None:
+    def fake_metrics() -> dict[str, float]:
+        return {"cpu_percent": 1.0, "memory_percent": 3.0}
+
+    monkeypatch.setattr(
+        "web_gui.analytics.performance_analysis.collect_performance_metrics",
+        fake_metrics,
+    )
+    assert summarize_performance() == 2.0
+
+def test_find_repeated() -> None:
+    assert find_repeated([1, 2, 3, 1, 2, 4]) == [1, 2]
+
+def test_predict_next(monkeypatch) -> None:
+    def fake_metrics() -> dict[str, float]:
+        return {"cpu_percent": 5.0, "memory_percent": 6.0}
+
+    monkeypatch.setattr(
+        "web_gui.analytics.predictive_models.collect_performance_metrics",
+        fake_metrics,
+    )
+    assert predict_next() == 5.0
+    assert predict_next([1.0, 2.0, 3.0]) == 4.0

--- a/web_gui/analytics/__init__.py
+++ b/web_gui/analytics/__init__.py
@@ -1,0 +1,8 @@
+"""Analytics utilities for the web GUI."""
+
+__all__ = [
+    "user_behavior",
+    "performance_analysis",
+    "pattern_recognition",
+    "predictive_models",
+]

--- a/web_gui/analytics/pattern_recognition.py
+++ b/web_gui/analytics/pattern_recognition.py
@@ -1,0 +1,33 @@
+"""Pattern recognition utilities for the web GUI."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Sequence
+
+from web_gui.monitoring.performance_metrics import collect_performance_metrics
+
+__all__ = ["find_repeated", "PatternRecognizer"]
+
+
+def find_repeated(values: Iterable[int]) -> List[int]:
+    """Return sorted values that appear more than once in ``values``."""
+    seen: set[int] = set()
+    repeated: set[int] = set()
+    for value in values:
+        if value in seen:
+            repeated.add(value)
+        else:
+            seen.add(value)
+    return sorted(repeated)
+
+
+class PatternRecognizer:
+    """Stub recognizer using current performance metrics as features."""
+
+    def current_metrics(self) -> Dict[str, float]:
+        """Expose current performance metrics for downstream analysis."""
+        return collect_performance_metrics()
+
+    def detect(self, values: Sequence[int]) -> List[int]:
+        """Identify repeated values using :func:`find_repeated`."""
+        return find_repeated(values)

--- a/web_gui/analytics/performance_analysis.py
+++ b/web_gui/analytics/performance_analysis.py
@@ -1,0 +1,21 @@
+"""Performance analysis helpers for the web GUI."""
+
+from __future__ import annotations
+
+from web_gui.monitoring.performance_metrics import collect_performance_metrics
+
+__all__ = ["summarize_performance", "PerformanceAnalyzer"]
+
+
+def summarize_performance() -> float:
+    """Return the average of collected performance metrics."""
+    metrics = collect_performance_metrics()
+    return sum(metrics.values()) / len(metrics) if metrics else 0.0
+
+
+class PerformanceAnalyzer:
+    """Stub analyzer that delegates to :func:`summarize_performance`."""
+
+    def summarize(self) -> float:
+        """Return summary statistics for current performance metrics."""
+        return summarize_performance()

--- a/web_gui/analytics/predictive_models.py
+++ b/web_gui/analytics/predictive_models.py
@@ -1,0 +1,27 @@
+"""Predictive model stubs for web GUI analytics."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from web_gui.monitoring.performance_metrics import collect_performance_metrics
+
+__all__ = ["predict_next", "PerformancePredictor"]
+
+
+def predict_next(values: Sequence[float] | None = None) -> float:
+    """Predict next value from ``values`` or current CPU usage."""
+    if values:
+        if len(values) < 2:
+            return float(values[-1])
+        return float(values[-1] + (values[-1] - values[-2]))
+    metrics = collect_performance_metrics()
+    return metrics.get("cpu_percent", 0.0)
+
+
+class PerformancePredictor:
+    """Stub predictive model."""
+
+    def predict(self, history: Sequence[float] | None = None) -> float:
+        """Delegate to :func:`predict_next` for prediction."""
+        return predict_next(history)

--- a/web_gui/analytics/user_behavior.py
+++ b/web_gui/analytics/user_behavior.py
@@ -1,0 +1,25 @@
+"""User behavior analytics for the web GUI."""
+
+from __future__ import annotations
+
+from typing import Dict, Sequence, Tuple
+
+from web_gui.monitoring.performance_metrics import collect_performance_metrics
+
+__all__ = ["log_user_action", "UserBehaviorModel"]
+
+
+def log_user_action(action: str, storage: Dict[str, int] | None = None) -> Tuple[Dict[str, int], Dict[str, float]]:
+    """Record an ``action`` and capture current performance metrics."""
+    store = storage if storage is not None else {}
+    store[action] = store.get(action, 0) + 1
+    metrics = collect_performance_metrics()
+    return store, metrics
+
+
+class UserBehaviorModel:
+    """Stub model for user behavior prediction."""
+
+    def predict(self, actions: Sequence[str]) -> str:
+        """Return the most recent action or an empty string."""
+        return actions[-1] if actions else ""


### PR DESCRIPTION
## Summary
- add analytics modules for web GUI (user behavior tracking, performance summarization, pattern recognition, predictive models)
- leverage monitoring metrics for analytics and add stub models
- add unit tests for new analytics helpers

## Testing
- `ruff check web_gui/analytics tests/web_gui/test_analytics_modules.py`
- `pytest tests/web_gui/test_analytics_modules.py`


------
https://chatgpt.com/codex/tasks/task_e_6894d7c2cb04833186d7772818497649