### PR TITLE
feat: add monitoring metric collectors

### DIFF
--- a/tests/web_gui/test_metric_collectors.py
+++ b/tests/web_gui/test_metric_collectors.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from web_gui.monitoring.performance_metrics import PerformanceMetricsCollector, DictExporter as PerfExporter
+from web_gui.monitoring.compliance_monitoring import collect_compliance_metrics
+from web_gui.monitoring.quantum_metrics import collect_quantum_metrics
+
+
+def test_performance_metrics_collector_and_exporter() -> None:
+    collector = PerformanceMetricsCollector()
+    exporter = PerfExporter()
+    metrics = exporter.export(collector.collect())
+    assert 0.0 <= metrics["cpu_percent"] <= 100.0
+    assert 0.0 <= metrics["memory_percent"] <= 100.0
+
+
+def test_compliance_metrics_success() -> None:
+    metrics = collect_compliance_metrics({"policy": "p", "status": "ok"})
+    assert metrics == {"is_compliant": True, "missing": []}
+
+
+def test_compliance_metrics_missing() -> None:
+    metrics = collect_compliance_metrics({})
+    assert metrics == {"is_compliant": False, "missing": ["policy", "status"]}
+
+
+def test_quantum_metrics_average_fallback() -> None:
+    metrics = collect_quantum_metrics([1.0, 3.0])
+    assert metrics == {"quantum_score": 2.0}

--- a/web_gui/monitoring/compliance_monitoring.py
+++ b/web_gui/monitoring/compliance_monitoring.py
@@ -2,14 +2,41 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List
 
-__all__ = ["check_compliance"]
+__all__ = [
+    "ComplianceMetricsCollector",
+    "DictExporter",
+    "collect_compliance_metrics",
+    "check_compliance",
+]
 
 
 REQUIRED_KEYS = {"policy", "status"}
 
 
+class ComplianceMetricsCollector:
+    """Collect basic compliance information from provided data."""
+
+    def collect(self, data: Dict[str, str]) -> Dict[str, object]:
+        missing: List[str] = sorted(REQUIRED_KEYS - data.keys())
+        return {"is_compliant": not missing, "missing": missing}
+
+
+class DictExporter:
+    """Return compliance metrics as a dictionary."""
+
+    def export(self, metrics: Dict[str, object]) -> Dict[str, object]:
+        return metrics
+
+
+def collect_compliance_metrics(data: Dict[str, str]) -> Dict[str, object]:
+    """Collect and export compliance information for *data*."""
+    collector = ComplianceMetricsCollector()
+    exporter = DictExporter()
+    return exporter.export(collector.collect(data))
+
+
 def check_compliance(data: Dict[str, str]) -> bool:
-    """Naive compliance check ensuring required fields are present."""
-    return REQUIRED_KEYS.issubset(data.keys())
+    """Return ``True`` if required compliance keys are present."""
+    return collect_compliance_metrics(data)["is_compliant"]

--- a/web_gui/monitoring/performance_metrics.py
+++ b/web_gui/monitoring/performance_metrics.py
@@ -2,15 +2,58 @@
 
 from __future__ import annotations
 
+import json
 import psutil
-from typing import Dict
+from typing import Dict, Protocol
 
-__all__ = ["collect_performance_metrics"]
+__all__ = [
+    "PerformanceMetricsCollector",
+    "DictExporter",
+    "JsonExporter",
+    "collect_performance_metrics",
+]
+
+
+class MetricCollector(Protocol):
+    """Protocol for metric collectors."""
+
+    def collect(self) -> Dict[str, float]:
+        """Collect metrics and return a mapping."""
+
+
+class MetricExporter(Protocol):
+    """Protocol for metric exporters."""
+
+    def export(self, metrics: Dict[str, float]):
+        """Export metrics in a desired format."""
+
+
+class PerformanceMetricsCollector:
+    """Gather basic system performance metrics using :mod:`psutil`."""
+
+    def collect(self) -> Dict[str, float]:
+        return {
+            "cpu_percent": psutil.cpu_percent(interval=0.1),
+            "memory_percent": psutil.virtual_memory().percent,
+        }
+
+
+class DictExporter:
+    """Return metrics unchanged as a dictionary."""
+
+    def export(self, metrics: Dict[str, float]) -> Dict[str, float]:
+        return metrics
+
+
+class JsonExporter:
+    """Serialize metrics as a JSON string."""
+
+    def export(self, metrics: Dict[str, float]) -> str:
+        return json.dumps(metrics)
 
 
 def collect_performance_metrics() -> Dict[str, float]:
-    """Return basic system performance metrics."""
-    return {
-        "cpu_percent": psutil.cpu_percent(interval=0.1),
-        "memory_percent": psutil.virtual_memory().percent,
-    }
+    """Return basic system performance metrics as a dictionary."""
+    collector = PerformanceMetricsCollector()
+    exporter = DictExporter()
+    return exporter.export(collector.collect())

--- a/web_gui/monitoring/quantum_metrics.py
+++ b/web_gui/monitoring/quantum_metrics.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Dict, Iterable
 
-__all__ = ["quantum_metric"]
+__all__ = [
+    "quantum_metric",
+    "QuantumMetricsCollector",
+    "DictExporter",
+    "collect_quantum_metrics",
+]
 
 
 def quantum_metric(values: Iterable[float]) -> float:
@@ -19,3 +24,24 @@ def quantum_metric(values: Iterable[float]) -> float:
     except Exception:
         data = list(values)
         return float(sum(data) / len(data)) if data else 0.0
+
+
+class QuantumMetricsCollector:
+    """Collect quantum-related metrics for a series of values."""
+
+    def collect(self, values: Iterable[float]) -> Dict[str, float]:
+        return {"quantum_score": quantum_metric(values)}
+
+
+class DictExporter:
+    """Return quantum metrics as a dictionary."""
+
+    def export(self, metrics: Dict[str, float]) -> Dict[str, float]:
+        return metrics
+
+
+def collect_quantum_metrics(values: Iterable[float]) -> Dict[str, float]:
+    """Collect and export quantum metrics for *values*."""
+    collector = QuantumMetricsCollector()
+    exporter = DictExporter()
+    return exporter.export(collector.collect(values))


### PR DESCRIPTION
## Summary
- implement collector/exporter interfaces for performance, compliance, and quantum metrics
- add tests covering metric calculations

## Testing
- `ruff check web_gui/monitoring/performance_metrics.py web_gui/monitoring/compliance_monitoring.py web_gui/monitoring/quantum_metrics.py tests/web_gui/test_metric_collectors.py`
- `pytest --override-ini addopts='' tests/web_gui/test_metric_collectors.py`


------
https://chatgpt.com/codex/tasks/task_e_6894d7c140ec8331b433d0f1da6389bb