### PR TITLE
docs: add quantum preparation and certification guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 *This guide is intended for AI contributors (OpenAI Codex/ChatGPT agents) working on the **gh\_COPILOT** repository. It outlines the required environment setup, permitted actions, coding standards, testing procedures, and other protocols that the agent **must** follow to produce acceptable pull requests.*
 Additional instruction modules reside in `.github/instructions/`. These `.instructions.md` files provide focused guidance on specialized workflows and supplement this main guide. Key compliance topics include **DUAL_COPILOT_PATTERN**, **ZERO_TOLERANCE_VISUAL_PROCESSING**, **COMPREHENSIVE_SESSION_INTEGRITY**, **AUTONOMOUS_FILE_MANAGEMENT**, **RESPONSE_CHUNKING**, **WEB_GUI_INTEGRATION**, **QUANTUM_OPTIMIZATION**, **PHASE4_PHASE5_INTEGRATION**, **SESSION_TEMPLATES**, **SESSION_INSTRUCTION**, **ENHANCED_LEARNING_COPILOT**, and **ENHANCED_COGNITIVE_PROCESSING**. Review these modules regularly to ensure your contributions remain in full compliance.
+Supplemental guides for quantum preparation, executive workflows, and certification processes are located under `docs/quantum_preparation`, `docs/executive_guides`, and `docs/certification`.
 
 
 ## Environment Setup

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 > Quantum modules run exclusively in simulation mode; hardware flags are currently ignored. Documentation and guides now clearly mark these components as simulation-only. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Module completion status is tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics_collector.db`.
 > Integration plan: [docs/quantum_integration_plan.md](docs/quantum_integration_plan.md) outlines staged hardware enablement while current builds remain simulator-only.
 > Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards.
-> Documentation: quantum preparation, executive guides, and certification workflows live under [`web_gui/documentation`](web_gui/documentation) — see [web_gui/documentation/quantum_preparation/README.md](web_gui/documentation/quantum_preparation/README.md), [web_gui/documentation/executive_guides/README.md](web_gui/documentation/executive_guides/README.md), and [web_gui/documentation/certification/README.md](web_gui/documentation/certification/README.md).
+> Documentation: quantum preparation, executive guides, and certification workflows live under [`docs`](docs) — see [docs/quantum_preparation/README.md](docs/quantum_preparation/README.md), [docs/executive_guides/README.md](docs/executive_guides/README.md), and [docs/certification/README.md](docs/certification/README.md).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,12 @@ The `template_engine.auto_generator` module clusters stored patterns using KMean
 
 For validation details see [validation/Database_First_Validation.md](validation/Database_First_Validation.md). Copilot-specific notes are available under [.github/docs/Database_First_Copilot.md](../.github/docs/Database_First_Copilot.md).
 
+## Quantum Preparation, Executive Guides, and Certification
+
+- [quantum_preparation/README.md](quantum_preparation/README.md) – steps to prime the toolkit for quantum-enabled features
+- [executive_guides/README.md](executive_guides/README.md) – quick references for leadership teams
+- [certification/README.md](certification/README.md) – procedures for issuing and validating certificates
+
 ## Quantum Template Generation
 
 The `docs/quantum_template_generator.py` script demonstrates the production

--- a/docs/certification/README.md
+++ b/docs/certification/README.md
@@ -1,0 +1,17 @@
+# Certification Workflows
+
+Procedures for issuing and validating certificates used by the web
+interface.
+
+## Key Resources
+
+- [web_gui/certificates/certificate_manager.py](../../web_gui/certificates/certificate_manager.py)
+  – generates and manages certificates
+
+## Workflow
+
+1. Configure certificate settings in `certificate_manager.py`.
+2. Execute the manager to issue or renew certificates.
+3. Distribute the generated certificates to the appropriate deployment
+   targets.
+

--- a/docs/executive_guides/README.md
+++ b/docs/executive_guides/README.md
@@ -1,0 +1,17 @@
+# Executive Guides
+
+Quick references for leadership teams using the enterprise dashboard.
+
+## Key Resources
+
+- [web_gui/scripts/flask_apps/enterprise_dashboard.py](../../web_gui/scripts/flask_apps/enterprise_dashboard.py)
+  – launches the executive dashboard
+- [web_gui/documentation/user_guides/README.md](../../web_gui/documentation/user_guides/README.md)
+  – general user documentation
+
+## Overview
+
+The executive dashboard surfaces compliance summaries, performance
+metrics, and certification status. Run the dashboard script and navigate
+to the highlighted sections to review system health at a glance.
+

--- a/docs/quantum_preparation/README.md
+++ b/docs/quantum_preparation/README.md
@@ -1,0 +1,19 @@
+# Quantum Preparation
+
+Steps to prime the toolkit for quantum-enabled features. All quantum
+operations run in simulation, but databases and routes still require
+preparation.
+
+## Key Resources
+
+- [migration_scripts/quantum_preparation.sql](../../migration_scripts/quantum_preparation.sql)
+  – primes databases for quantum metrics
+- [web_gui/scripts/flask_apps/quantum_enhanced_framework.py](../../web_gui/scripts/flask_apps/quantum_enhanced_framework.py)
+  – exposes simulated quantum endpoints
+
+## Workflow
+
+1. Apply the SQL migration to initialize quantum-related tables.
+2. Launch the `quantum_enhanced_framework` Flask app to enable optional
+   quantum routes.
+

--- a/tests/test_database_integration.py
+++ b/tests/test_database_integration.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import sqlite3
+
+
+def test_production_db_accessible() -> None:
+    """Ensure the production database can be queried."""
+    db_path = Path("databases/production.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("SELECT 1")
+

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,11 @@
+import json
+from pathlib import Path
+
+
+def test_deployment_config_loads() -> None:
+    """Deployment configuration should be valid JSON."""
+    path = Path("deployment/deployment_config.json")
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    assert isinstance(data, dict)
+

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sqlite3
+
+from web_gui.scripts.flask_apps.quantum_enhanced_framework import (
+    QuantumEnhancedFramework,
+)
+
+
+def test_end_to_end_flow() -> None:
+    """Basic end-to-end workflow touches database and quantum layer."""
+    db_path = Path("databases/production.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("SELECT 1")
+    framework = QuantumEnhancedFramework()
+    result = framework.run_algorithm("noop")
+    assert isinstance(result, dict)
+

--- a/tests/test_flask_apps.py
+++ b/tests/test_flask_apps.py
@@ -1,0 +1,20 @@
+from importlib import import_module
+import pytest
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "web_gui.scripts.flask_apps.quantum_enhanced_framework",
+        "web_gui.scripts.flask_apps.enterprise_dashboard",
+    ],
+)
+def test_flask_app_modules_import(name: str) -> None:
+    """Flask app modules should import; skip if environment guards trigger."""
+    try:
+        module = import_module(name)
+    except RuntimeError as exc:  # pragma: no cover - environment guard
+        pytest.skip(str(exc))
+    else:
+        assert module is not None
+

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,8 @@
+from performance_validation_framework import PerformanceValidationFramework
+
+
+def test_performance_framework_instantiation() -> None:
+    """PerformanceValidationFramework should initialize with the database."""
+    framework = PerformanceValidationFramework("databases/production.db")
+    assert framework.db_path.name == "production.db"
+

--- a/tests/test_quantum_algorithms.py
+++ b/tests/test_quantum_algorithms.py
@@ -1,0 +1,8 @@
+from quantum.quantum_integration_orchestrator import QuantumIntegrationOrchestrator
+
+
+def test_orchestrator_lists_algorithms() -> None:
+    """QuantumIntegrationOrchestrator should return a list of algorithms."""
+    orchestrator = QuantumIntegrationOrchestrator()
+    assert isinstance(orchestrator.available_algorithms(), list)
+

--- a/tests/test_quantum_framework.py
+++ b/tests/test_quantum_framework.py
@@ -1,0 +1,11 @@
+from web_gui.scripts.flask_apps.quantum_enhanced_framework import (
+    QuantumEnhancedFramework,
+)
+
+
+def test_quantum_framework_fallback() -> None:
+    """Running an unknown algorithm returns a fallback message."""
+    framework = QuantumEnhancedFramework()
+    result = framework.run_algorithm("noop")
+    assert isinstance(result, dict)
+

--- a/tests/test_quantum_performance.py
+++ b/tests/test_quantum_performance.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+import pytest
+from quantum import benchmarking
+
+
+def test_load_metrics_roundtrip() -> None:
+    """Metrics loader should read JSON metrics files."""
+    path = Path("temp_metrics.json")
+    path.write_text(json.dumps({"value": 1}), encoding="utf-8")
+    try:
+        try:
+            data = benchmarking.load_metrics(path)
+        except NotADirectoryError:  # pragma: no cover - environment guard
+            pytest.skip("path validation failed")
+        else:
+            assert data["value"] == 1
+    finally:
+        path.unlink(missing_ok=True)
+

--- a/tests/test_quantum_security.py
+++ b/tests/test_quantum_security.py
@@ -1,0 +1,10 @@
+from quantum.quantum_compliance_engine import QISKIT_AVAILABLE
+from security.compliance_checker import ComplianceChecker
+
+
+def test_quantum_security_interop() -> None:
+    """Quantum components should coexist with security checks."""
+    checker = ComplianceChecker()
+    assert isinstance(QISKIT_AVAILABLE, bool)
+    assert isinstance(checker.policy, dict)
+

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,8 @@
+from security.compliance_checker import ComplianceChecker
+
+
+def test_compliance_policy_loaded() -> None:
+    """ComplianceChecker should load the security policy."""
+    checker = ComplianceChecker()
+    assert isinstance(checker.policy, dict)
+


### PR DESCRIPTION
## Summary
- document quantum preparation, executive workflows, and certification
- reference new guides in README and agent instructions
- add unit and integration tests for database, security, deployment and quantum modules

## Testing
- `ruff check docs/quantum_preparation docs/executive_guides docs/certification tests/test_flask_apps.py tests/test_database_integration.py tests/test_security.py tests/test_quantum_framework.py tests/test_end_to_end.py tests/test_deployment.py tests/test_performance.py tests/test_quantum_algorithms.py tests/test_quantum_performance.py tests/test_quantum_security.py`
- `pytest tests/test_flask_apps.py tests/test_database_integration.py tests/test_security.py tests/test_quantum_framework.py tests/test_end_to_end.py tests/test_deployment.py tests/test_performance.py tests/test_quantum_algorithms.py tests/test_quantum_performance.py tests/test_quantum_security.py`


------
https://chatgpt.com/codex/tasks/task_e_6894d7e1584083319fc405757750b482