### PR TITLE
feat: add backup restoration utilities and tests

### DIFF
--- a/deployment/scripts/backup_manager.py
+++ b/deployment/scripts/backup_manager.py
@@ -8,6 +8,7 @@ import shutil
 from pathlib import Path
 
 from .environment_migration import SUPPORTED_DATABASES, WORKSPACE, validate_database_file
+from .restoration_engine import restore_backup
 
 
 def create_backup(name: str, backup_root: Path | None = None) -> Path:
@@ -42,4 +43,4 @@ def create_backup(name: str, backup_root: Path | None = None) -> Path:
     return destination
 
 
-__all__ = ["create_backup"]
+__all__ = ["create_backup", "restore_backup"]

--- a/deployment/scripts/environment_migration.py
+++ b/deployment/scripts/environment_migration.py
@@ -52,6 +52,12 @@ def register_database(name: str, path: Path) -> None:
     SUPPORTED_DATABASES[name] = path
 
 
+def get_registered_databases() -> List[str]:
+    """Return a sorted list of registered database identifiers."""
+
+    return sorted(SUPPORTED_DATABASES)
+
+
 def migrate_environment(names: Iterable[str]) -> List[str]:
     """Validate databases and simulate migration.
 
@@ -84,4 +90,5 @@ __all__ = [
     "SUPPORTED_DATABASES",
     "validate_database_file",
     "register_database",
+    "get_registered_databases",
 ]

--- a/tests/test_backup_restore_engine.py
+++ b/tests/test_backup_restore_engine.py
@@ -1,0 +1,44 @@
+"""Tests for backup and restoration utilities."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from deployment.scripts.environment_migration import (
+    SUPPORTED_DATABASES,
+    get_registered_databases,
+    register_database,
+    validate_database_file,
+)
+from deployment.scripts.backup_manager import create_backup, restore_backup
+
+
+def test_backup_and_restore_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Database can be backed up and restored successfully."""
+
+    db_path = tmp_path / "sample.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE t(x INTEGER);")
+    conn.commit()
+    conn.close()
+
+    register_database("sample", db_path)
+    assert "sample" in get_registered_databases()
+
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path))
+
+    backup_file = create_backup("sample")
+    assert backup_file.exists()
+
+    db_path.unlink()
+    assert not db_path.exists()
+
+    restore_backup("sample")
+    assert db_path.exists()
+    validate_database_file(db_path)
+
+    SUPPORTED_DATABASES.pop("sample", None)
+


### PR DESCRIPTION
## Summary
- expose registered database listing in environment migration utilities
- re-export restore helper through backup manager
- test backup and restoration round-trip

## Testing
- `ruff check deployment/scripts/environment_migration.py deployment/scripts/backup_manager.py deployment/scripts/restoration_engine.py tests/test_backup_restore_engine.py`
- `pytest tests/test_backup_restore_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6894dd017df88331ac0a0df21d0a0540