### PR TITLE
feat: convert daily PDFs to markdown

### DIFF
--- a/documentation/generated/daily_state_update/README.md
+++ b/documentation/generated/daily_state_update/README.md
@@ -10,3 +10,13 @@ The following steps were performed to ensure the latest artifacts are available:
 2. `git lfs checkout documentation/generated/daily_state_update`
 3. Confirmed `gh_COPILOT_Project_White‑Paper_Blueprint_(2025-08-06).pdf` is a PDF via `file`.
 
+## Generating new reports
+
+Run `python rename_files_with_spaces.py` after adding a new daily PDF. The script:
+
+1. Renames any files with spaces to use underscores.
+2. Converts each PDF to a Markdown file using `tools/convert_daily_whitepaper.py`.
+3. Updates `documentation/generated/daily_state_index.md` so both formats are linked.
+
+CI includes a regression check to ensure the most recent date has both `.pdf` and `.md` files.
+

--- a/rename_files_with_spaces.py
+++ b/rename_files_with_spaces.py
@@ -136,7 +136,19 @@ class FileRenamer:
         # Generate and return summary
         summary = self.generate_summary()
         self.log_summary(summary)
-        
+
+        try:
+            from tools.convert_daily_whitepaper import convert_pdfs
+            from scripts.documentation.update_daily_state_index import update_index
+
+            for message in convert_pdfs(self.target_directory):
+                logger.info(message)
+            index_path = self.target_directory.parent / "daily_state_index.md"
+            update_index(source_dir=self.target_directory, index_path=index_path)
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"❌ Conversion step failed: {e}")
+            self.errors.append(f"Conversion error: {e}")
+
         return summary
     
     def generate_summary(self) -> dict:

--- a/tests/test_rename_files_with_spaces.py
+++ b/tests/test_rename_files_with_spaces.py
@@ -1,5 +1,9 @@
 from pathlib import Path, PureWindowsPath
 import rename_files_with_spaces as rfs
+import shutil
+
+from tools.convert_daily_whitepaper import PdfReader
+import pytest
 
 def test_relative_path_unix():
     expected = Path(rfs.__file__).resolve().parent / 'documentation/generated/daily_state_update'
@@ -10,3 +14,13 @@ def test_relative_path_windows():
     base = PureWindowsPath('C:/gh_COPILOT')
     target = base / 'documentation/generated/daily_state_update'
     assert str(target).endswith('documentation\\generated\\daily_state_update')
+
+
+@pytest.mark.skipif(PdfReader is None, reason="PyPDF2 not installed")
+def test_renamer_converts_pdf(tmp_path):
+    source_pdf = next((Path('documentation') / 'generated' / 'daily_state_update').glob('*.pdf'))
+    shutil.copy(source_pdf, tmp_path / 'sample report.pdf')
+    renamer = rfs.FileRenamer(tmp_path)
+    renamer.rename_all_files()
+    assert (tmp_path / 'sample_report.pdf').exists()
+    assert (tmp_path / 'sample_report.md').exists()

--- a/tests/test_update_daily_state_index.py
+++ b/tests/test_update_daily_state_index.py
@@ -1,6 +1,8 @@
-from pathlib import Path
-
-from scripts.documentation.update_daily_state_index import update_index
+from scripts.documentation.update_daily_state_index import (
+    DEFAULT_SOURCE_DIR,
+    _scan,
+    update_index,
+)
 
 
 def test_update_index_writes_links(tmp_path):
@@ -16,4 +18,12 @@ def test_update_index_writes_links(tmp_path):
     assert "2025-08-07" in content
     assert "report_2025-08-07.pdf" in content
     assert "report_2025-08-07.md" in content
+
+
+def test_latest_entry_has_pdf_and_md():
+    data = _scan(DEFAULT_SOURCE_DIR)
+    assert data, "no daily state reports found"
+    latest = max(data)
+    record = data[latest]
+    assert record["pdf"] and record["md"], f"Missing formats for {latest}"
 


### PR DESCRIPTION
## Summary
- update renaming workflow to also convert daily PDFs to Markdown and refresh the index
- document how to generate daily reports and add regression check for missing formats
- add tests ensuring rename workflow and daily index cover both pdf and md outputs

## Testing
- `ruff check rename_files_with_spaces.py tests/test_rename_files_with_spaces.py tests/test_update_daily_state_index.py`
- `pytest tests/test_rename_files_with_spaces.py tests/test_update_daily_state_index.py tests/test_convert_daily_whitepaper.py`

------
https://chatgpt.com/codex/tasks/task_e_6894e08143c883319eb1ba7e4c15a889