### PR TITLE
ci: ensure git lfs files available before conversions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
         python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
+      - name: Fetch Git LFS content
+        run: |
+          git lfs fetch --all
+          git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/tests/test_convert_daily_whitepaper.py
+++ b/tests/test_convert_daily_whitepaper.py
@@ -3,7 +3,12 @@ import shutil
 
 import pytest
 
-from tools.convert_daily_whitepaper import PdfReader, convert_pdfs, _sanitize_name
+from tools.convert_daily_whitepaper import (
+    PdfReader,
+    convert_pdfs,
+    _sanitize_name,
+    verify_lfs_pdfs,
+)
 
 pytestmark = pytest.mark.skipif(
     PdfReader is None, reason="PyPDF2 not installed"
@@ -32,3 +37,10 @@ def test_skip_existing_markdown(tmp_path):
     logs = list(convert_pdfs(tmp_path))
     assert any("already converted" in msg for msg in logs)
     assert md_file.read_text() == "already here"
+
+
+def test_verify_lfs_pdfs_detects_pointer(tmp_path):
+    pointer = tmp_path / "fake.pdf"
+    pointer.write_text("version https://git-lfs.github.com/spec/v1\n")
+    with pytest.raises(FileNotFoundError):
+        verify_lfs_pdfs(tmp_path)


### PR DESCRIPTION
## Summary
- run `git lfs fetch --all` and `git lfs checkout` in CI to ensure LFS files are present
- verify and fetch LFS PDFs before converting whitepapers, aborting with guidance when missing
- cover LFS pointer detection with unit tests

## Testing
- `ruff check tools/convert_daily_whitepaper.py tests/test_convert_daily_whitepaper.py`
- `pytest tests/test_convert_daily_whitepaper.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6894e082cd1c83319e2eb347a21a4d13