### PR TITLE
chore: add PDF validation log

### DIFF
--- a/reports/pdf_validation.log
+++ b/reports/pdf_validation.log
@@ -1,0 +1,24 @@
+documentation/generated/daily_state_update/gh_COPILOT_Project_White‑Paper_Blueprint_(2025-08-05).pdf: PDF document, version 1.7, 9 page(s)
+PyPDF2: header valid, pages=9
+
+documentation/generated/daily_state_update/gh_COPILOT_Project_White‑Paper_Blueprint_(2025-08-06).pdf: PDF document, version 1.7, 5 page(s)
+PyPDF2: header valid, pages=5
+
+documentation/generated/daily_state_update/gh_COPILOT_Project_White‑Paper_Blueprint_(2025‑07‑30).pdf: PDF document, version 1.7
+PyPDF2: header valid, pages=18
+
+documentation/generated/daily_state_update/gh_COPILOT_Project_White‑Paper_Blueprint_(2025‑07‑31).pdf: PDF document, version 1.7
+PyPDF2: header valid, pages=6
+
+documentation/generated/daily_state_update/gh_COPILOT_Project_White‑Paper_Blueprint_(2025‑08‑01).pdf: PDF document, version 1.7, 6 page(s)
+PyPDF2: header valid, pages=6
+
+documentation/generated/daily_state_update/gh_COPILOT_Project_White‑Paper_Blueprint_(2025‑08‑02).pdf: PDF document, version 1.7, 6 page(s)
+PyPDF2: header valid, pages=6
+
+documentation/generated/daily_state_update/gh_COPILOT_Project_White‑Paper_Blueprint_(2025‑08‑03).pdf: PDF document, version 1.7, 12 page(s)
+PyPDF2: header valid, pages=12
+
+documentation/generated/daily_state_update/gh_COPILOT_Project_White‑Paper_Blueprint_(2025‑08‑04).pdf: PDF document, version 1.7, 11 page(s)
+PyPDF2: header valid, pages=11
+


### PR DESCRIPTION
## Summary
- log PDF header validation results for daily state update reports

## Testing
- `ruff check .` (fails: F821, F401)
- `pytest` (fails: tests/quantum/test_interfaces.py)


------
https://chatgpt.com/codex/tasks/task_e_6894e09ddbb883318876dbd93f49dc79