### PR TITLE
fix: correct header date for 2025-08-04 summary

### DIFF
--- a/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_Summary_(2025-08-06).md
+++ b/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_Summary_(2025-08-06).md
@@ -1,6 +1,6 @@
-# gh_COPILOT Project White-Paper Blueprint Summary (2025-08-06)
+# gh_COPILOT Project White-Paper Blueprint Summary (2025-08-04)
 
-Derived from `gh_COPILOT_Project_White‑Paper_Blueprint_(2025-08-06).pdf`.
+Derived from `gh_COPILOT_Project_White‑Paper_Blueprint_(2025-08-04).pdf`.
 
 ## Objectives
 - Execute recommendations from the updated white-paper blueprint to close implementation gaps, enhance compliance metrics, and finalize the enterprise dashboard for a production-ready HAR analysis platform.


### PR DESCRIPTION
## Summary
- fix header date and source reference in 2025-08-04 white-paper blueprint summary

## Testing
- `ruff check documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_Summary_(2025-08-06).md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894e0a083348331b2eb23c3bc0ffe0b