### PR TITLE
test: expand coverage for key modules

### DIFF
--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -10,3 +10,10 @@ def test_deployment_config_has_name() -> None:
     data = json.loads(config_path.read_text())
     assert "deployment_name" in data
 
+
+def test_deployment_config_has_version() -> None:
+    """The deployment configuration should include a version."""
+    config_path = Path("deployment/deployment_config.json")
+    data = json.loads(config_path.read_text())
+    assert "version" in data
+

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -13,3 +13,14 @@ def test_root_endpoint() -> None:
     client = dashboard_actionable_gui.app.test_client()
     assert client.get("/").status_code < 500
 
+
+def test_missing_endpoint_returns_404() -> None:
+    """Unknown endpoints should return 404."""
+    try:
+        from web_gui import dashboard_actionable_gui
+    except Exception:
+        pytest.skip("dashboard_actionable_gui unavailable")
+
+    client = dashboard_actionable_gui.app.test_client()
+    assert client.get("/missing").status_code == 404
+

--- a/tests/integration/test_performance.py
+++ b/tests/integration/test_performance.py
@@ -13,7 +13,16 @@ def test_store_baseline(tmp_path) -> None:
 
     with sqlite3.connect(db_file) as conn:
         value = conn.execute(
-            "SELECT value FROM performance_baseline WHERE metric='metric'"
+            "SELECT value FROM performance_baseline WHERE metric='metric'",
         ).fetchone()[0]
     assert value == 1.0
+
+
+def test_compare_to_baseline(tmp_path) -> None:
+    """Comparisons should reflect differences from baseline."""
+    db_file = tmp_path / "perf.db"
+    framework = PerformanceValidationFramework(db_path=str(db_file))
+    framework.store_baseline({"metric": 1.0})
+    diff = framework.compare_to_baseline({"metric": 2.0})
+    assert diff["metric"] == 1.0
 

--- a/tests/test_database_integration.py
+++ b/tests/test_database_integration.py
@@ -18,3 +18,16 @@ def test_production_db_has_tables() -> None:
         ).fetchall()
     assert tables
 
+
+def test_production_db_has_code_templates_table() -> None:
+    """The production database should include the code_templates table."""
+    db_path = Path("databases/production.db")
+    with sqlite3.connect(db_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    assert "code_templates" in tables
+

--- a/tests/test_flask_apps.py
+++ b/tests/test_flask_apps.py
@@ -2,6 +2,7 @@ from importlib import import_module
 import pytest
 from web_gui.scripts.flask_apps.quantum_enhanced_framework import (
     QuantumEnhancedFramework,
+    quantum_bp,
 )
 
 
@@ -26,4 +27,9 @@ def test_framework_available_algorithms() -> None:
     """QuantumEnhancedFramework should list available algorithms."""
     framework = QuantumEnhancedFramework()
     assert isinstance(framework.available_algorithms(), list)
+
+
+def test_quantum_blueprint_registered() -> None:
+    """Blueprint should expose the expected name."""
+    assert quantum_bp.name == "quantum"
 

--- a/tests/test_quantum_algorithms.py
+++ b/tests/test_quantum_algorithms.py
@@ -12,3 +12,9 @@ def test_execution_summary_is_dict() -> None:
     orchestrator = QuantumIntegrationOrchestrator()
     assert isinstance(orchestrator.execution_summary(), dict)
 
+
+def test_run_plan_empty_returns_list() -> None:
+    """Running an empty plan should return an empty list."""
+    orchestrator = QuantumIntegrationOrchestrator()
+    assert orchestrator.run_plan([]) == []
+

--- a/tests/test_quantum_framework.py
+++ b/tests/test_quantum_framework.py
@@ -16,3 +16,9 @@ def test_execute_with_fallback_uses_classical() -> None:
     result = framework.execute_with_fallback(lambda: "classic")
     assert result == "classic"
 
+
+def test_quantum_enabled_flag_is_boolean() -> None:
+    """quantum_enabled attribute should always be a boolean."""
+    framework = QuantumEnhancedFramework()
+    assert isinstance(framework.quantum_enabled, bool)
+

--- a/tests/test_quantum_performance.py
+++ b/tests/test_quantum_performance.py
@@ -29,3 +29,9 @@ def test_benchmark_physics_engine_runs() -> None:
     else:
         assert isinstance(result, dict)
 
+
+def test_load_metrics_missing_file_raises() -> None:
+    """Missing metrics file should raise FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        benchmarking.load_metrics(Path("does_not_exist.json"))
+

--- a/tests/test_quantum_security.py
+++ b/tests/test_quantum_security.py
@@ -14,3 +14,9 @@ def test_validate_operation_returns_bool() -> None:
     checker = ComplianceChecker()
     assert isinstance(checker.validate_operation(command="echo"), bool)
 
+
+def test_validate_environment_contains_status() -> None:
+    """validate_environment should include a compliance status."""
+    result = ComplianceChecker().validate_environment()
+    assert "compliance_status" in result
+

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -13,3 +13,9 @@ def test_environment_validation_returns_dict() -> None:
     result = checker.validate_environment()
     assert isinstance(result, dict)
 
+
+def test_policy_contains_rules_key() -> None:
+    """Security policy should define security controls."""
+    checker = ComplianceChecker()
+    assert "security_controls" in checker.policy
+


### PR DESCRIPTION
## Summary
- add Flask blueprint and algorithm checks in web GUI tests
- verify database table availability and security policy structure
- extend quantum framework, algorithm, performance, and integration tests

## Testing
- `ruff check tests/test_flask_apps.py tests/test_database_integration.py tests/test_security.py tests/test_quantum_framework.py tests/integration/test_end_to_end.py tests/integration/test_deployment.py tests/integration/test_performance.py tests/test_quantum_algorithms.py tests/test_quantum_performance.py tests/test_quantum_security.py`
- `pytest tests/test_flask_apps.py tests/test_database_integration.py tests/test_security.py tests/test_quantum_framework.py tests/integration/test_end_to_end.py tests/integration/test_deployment.py tests/integration/test_performance.py tests/test_quantum_algorithms.py tests/test_quantum_performance.py tests/test_quantum_security.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ebe6144c8331a14acdf1e0296a10