### PR TITLE
docs: highlight LFS and security checks

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -199,6 +199,7 @@ print(f"Zero-byte Protection: {validation['zero_byte_protection']}")
 - **Zero-Byte Validation:** Real-time file integrity monitoring
 - **Enterprise Protocols:** Comprehensive compliance framework
 - **Emergency Prevention:** Automatic violation detection and correction
+- **Binary Asset Enforcement:** Verify new databases and other binary files are tracked with Git LFS using `git lfs ls-files`.
 
 ### Compliance Standards
 - **Data Integrity:** SHA-256 validation and backup protection
@@ -206,6 +207,7 @@ print(f"Zero-byte Protection: {validation['zero_byte_protection']}")
 - **Process Monitoring:** Real-time system health and performance tracking
 - **Error Prevention:** Graceful failure handling and recovery protocols
 - **Quality Assurance:** Enterprise-grade validation and testing frameworks
+- **Mandatory Checks:** Run `ruff` and `pytest` before committing to ensure lint and tests pass.
 
 ## 📚 Enterprise API Reference
 


### PR DESCRIPTION
## Summary
- clarify security docs to verify Git LFS tracking and require lint/test checks

## Testing
- `git lfs ls-files | head -n 20`
- `ruff check .` *(fails: F821, F401)*
- `pytest` *(fails: tests/quantum/test_interfaces.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894ec152e988331a1a0d48deabed976