### PR TITLE
feat: convert daily PDFs via workflow

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - 'docs/**'
+      - 'documentation/generated/daily_state_update/**'
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:
@@ -34,3 +35,29 @@ jobs:
           else
             python -m scripts.docs_metrics_validator
           fi
+  daily-whitepaper:
+    runs-on: ubuntu-latest
+    env:
+      GH_COPILOT_WORKSPACE: ${{ github.workspace }}
+      GH_COPILOT_BACKUP_ROOT: /tmp/gh_copilot_backup
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Convert daily whitepaper PDFs
+        run: |
+          python tools/convert_daily_whitepaper.py
+          git diff --exit-code
+      - name: Secondary copilot validation
+        run: |
+          python - <<'PY'
+          from secondary_copilot_validator import run_flake8
+          run_flake8(['tools/convert_daily_whitepaper.py'])
+          PY

--- a/documentation/generated/README.md
+++ b/documentation/generated/README.md
@@ -64,6 +64,8 @@ After adding new PDFs to `daily_state_update/`, run:
 
 ```bash
 python tools/convert_daily_whitepaper.py
+# or convert a single file
+python tools/convert_daily_whitepaper.py --pdf-file path/to/report.pdf
 ```
 
 This generates Markdown copies of each PDF, skips files already converted, and

--- a/documentation/generated/daily_state_update/README.md
+++ b/documentation/generated/daily_state_update/README.md
@@ -15,7 +15,7 @@ The following steps were performed to ensure the latest artifacts are available:
 Run `python rename_files_with_spaces.py` after adding a new daily PDF. The script:
 
 1. Renames any files with spaces to use underscores.
-2. Converts each PDF to a Markdown file using `tools/convert_daily_whitepaper.py`.
+2. Converts each PDF to a Markdown file using `tools/convert_daily_whitepaper.py` (or pass `--pdf-file` for a single report).
 3. Updates `documentation/generated/daily_state_index.md` so both formats are linked.
 
 CI includes a regression check to ensure the most recent date has both `.pdf` and `.md` files.

--- a/tests/test_convert_daily_whitepaper.py
+++ b/tests/test_convert_daily_whitepaper.py
@@ -6,6 +6,7 @@ import pytest
 from tools.convert_daily_whitepaper import (
     PdfReader,
     convert_pdfs,
+    convert_pdf,
     _sanitize_name,
     verify_lfs_pdfs,
 )
@@ -44,3 +45,15 @@ def test_verify_lfs_pdfs_detects_pointer(tmp_path):
     pointer.write_text("version https://git-lfs.github.com/spec/v1\n")
     with pytest.raises(FileNotFoundError):
         verify_lfs_pdfs(tmp_path)
+
+
+def test_convert_pdf_single_file(tmp_path):
+    source_dir = Path("documentation") / "generated" / "daily_state_update"
+    source_pdf = next(source_dir.glob("*.pdf"))
+    target_pdf = tmp_path / source_pdf.name
+    shutil.copy(source_pdf, target_pdf)
+    message = convert_pdf(target_pdf)
+    md_name = _sanitize_name(source_pdf.stem) + ".md"
+    md_file = tmp_path / md_name
+    assert md_file.exists()
+    assert "Converted" in message


### PR DESCRIPTION
## Summary
- extend daily whitepaper converter with single PDF option
- add workflow job to convert new daily PDFs and run secondary validation
- document new usage and cover with tests

## Testing
- `ruff check .` *(fails: imported but unused, undefined name)*
- `pytest tests/test_convert_daily_whitepaper.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ecd42a608331addbdf5af0049186