### PR TITLE
fix: ensure LFS files available before doc conversion

### DIFF
--- a/documentation/generated/README.md
+++ b/documentation/generated/README.md
@@ -60,14 +60,18 @@ For detailed instructions, see the generated documentation files in this directo
 
 ### 🛠 Daily Whitepaper Conversion
 
-After adding new PDFs to `daily_state_update/`, run:
+After adding new PDFs to `daily_state_update/`, ensure Git LFS files are
+materialized and then run the converter:
 
 ```bash
+git lfs fetch --all
+git lfs checkout
 python tools/convert_daily_whitepaper.py
 ```
 
-This generates Markdown copies of each PDF, skips files already converted, and
-refreshes the index linking all available reports.
+This sequence downloads any missing LFS content, generates Markdown copies of
+each PDF, skips files already converted, and refreshes the index linking all
+available reports.
 
 ### 📝 Daily State Generator
 
@@ -92,7 +96,13 @@ validates their creation using the dual-copilot pattern.
      git lfs track "*.pdf"
      git add .gitattributes
      ```
-3. **Convert PDFs to Markdown and update the index**
+3. **Fetch and materialize LFS content**
+   - Ensure PDFs are downloaded before conversion:
+     ```bash
+     git lfs fetch --all
+     git lfs checkout
+     ```
+4. **Convert PDFs to Markdown and update the index**
    - Generate Markdown versions to keep the repository text-friendly and
      automatically rebuild `daily_state_index.md`:
      ```bash

--- a/rename_files_with_spaces.py
+++ b/rename_files_with_spaces.py
@@ -138,9 +138,14 @@ class FileRenamer:
         self.log_summary(summary)
 
         try:
-            from tools.convert_daily_whitepaper import convert_pdfs
+            from tools.convert_daily_whitepaper import (
+                convert_pdfs,
+                fetch_lfs_objects,
+            )
             from scripts.documentation.update_daily_state_index import update_index
 
+            # Ensure Git LFS objects are available before conversion
+            fetch_lfs_objects()
             for message in convert_pdfs(self.target_directory):
                 logger.info(message)
             index_path = self.target_directory.parent / "daily_state_index.md"


### PR DESCRIPTION
## Summary
- fetch and checkout Git LFS files before converting daily whitepapers
- document LFS fetch/checkout steps in generated docs README

## Testing
- `ruff check rename_files_with_spaces.py`
- `pytest` *(fails: tests/quantum/test_interfaces.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894ecd65f5c83319b5fa316a69cb9fb