### PR TITLE
fix: verify LFS objects in daily whitepaper workflow

### DIFF
--- a/.github/workflows/daily-whitepaper.yml
+++ b/.github/workflows/daily-whitepaper.yml
@@ -14,6 +14,21 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
+      - name: Fetch LFS objects
+        run: |
+          git lfs fetch --all
+          git lfs checkout
+      - name: Verify LFS objects
+        run: |
+          missing=$(git lfs ls-files -n | while read -r file; do
+            if grep -q "oid sha256" "$file"; then
+              echo "$file"
+            fi
+          done)
+          if [ -n "$missing" ]; then
+            echo "Missing LFS objects:\n$missing" >&2
+            exit 1
+          fi
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/documentation/generated/daily_state_update/README.md
+++ b/documentation/generated/daily_state_update/README.md
@@ -9,6 +9,7 @@ The following steps were performed to ensure the latest artifacts are available:
 1. `git lfs fetch -I documentation/generated/daily_state_update`
 2. `git lfs checkout documentation/generated/daily_state_update`
 3. Confirmed `gh_COPILOT_Project_White‑Paper_Blueprint_(2025-08-06).pdf` is a PDF via `file`.
+4. The conversion workflow fails if any tracked file remains a pointer after checkout.
 
 ## Generating new reports
 


### PR DESCRIPTION
## Summary
- fetch and checkout Git LFS files before converting daily whitepaper
- fail conversion job when any Git LFS object is missing
- document LFS fetch and checkout requirement for daily state updates

## Testing
- `ruff check .github/workflows/daily-whitepaper.yml` *(fails: SyntaxError: Simple statements must be separated by newlines or semicolons)*
- `pytest` *(fails: tests/quantum/test_interfaces.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894f1dbdc4c83319e325f6937893748