### PR TITLE
feat(web_gui): add quantum dashboard

### DIFF
--- a/dashboard/integrated_dashboard.py
+++ b/dashboard/integrated_dashboard.py
@@ -27,6 +27,7 @@ from enterprise_modules.compliance import (
 from utils.validation_utils import calculate_composite_compliance_score
 from web_gui import middleware, security
 from web_gui.certificates import init_app as init_certificates
+from web_gui.dashboards.quantum_dashboard import get_metrics as get_quantum_metrics
 
 # Paths and database locations
 METRICS_FILE = Path(__file__).with_name("metrics.json")
@@ -328,6 +329,11 @@ def audit_results_view() -> str:
 @_dashboard.get("/sync-events/view")
 def sync_events_view() -> str:
     return render_template("sync_events.html", events=_load_sync_events())
+
+
+@_dashboard.get("/quantum-dashboard")
+def quantum_dashboard_view() -> str:
+    return render_template("html/quantum_dashboard.html", metrics=get_quantum_metrics())
 
 
 @_dashboard.get("/dashboard/compliance")

--- a/tests/dashboard/test_actionable_endpoints.py
+++ b/tests/dashboard/test_actionable_endpoints.py
@@ -99,3 +99,19 @@ def test_metrics_include_anomaly_and_quantum(gui_app):
     assert data["latest_anomaly_score"] == 0.4
     assert data["latest_anomaly_composite"] == 0.5
     assert data["latest_quantum_score"] == 0.9
+
+
+def test_quantum_dashboard_view(gui_app, monkeypatch):
+    import scripts.validation.secondary_copilot_validator as scv
+
+    monkeypatch.setattr(
+        scv.SecondaryCopilotValidator,
+        "validate_corrections",
+        lambda self, files, primary_success=None: True,
+    )
+    monkeypatch.setattr(gui, "get_quantum_metrics", lambda: {"quantum_score": 0.1})
+    monkeypatch.setattr(gui, "render_template", lambda template, **ctx: str(ctx))
+    client = gui_app.test_client()
+    resp = client.get("/quantum-dashboard")
+    assert resp.status_code == 200
+    assert "quantum_score" in resp.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- integrate quantum dashboard view into integrated dashboard
- test quantum dashboard view rendering and metrics

## Testing
- `ruff check dashboard/integrated_dashboard.py tests/dashboard/test_actionable_endpoints.py`
- `pytest tests/dashboard/test_actionable_endpoints.py`

## Follow-up
- expand quantum dashboard with additional metrics

cc @maintainers

------
https://chatgpt.com/codex/tasks/task_e_6894f9007530833191a0d6b881e5ada6