### PR TITLE
fix: remove indentation before deliverable headings

### DIFF
--- a/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_(2025-08-07).md
+++ b/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_(2025-08-07).md
@@ -220,9 +220,9 @@ description: |
   - **Testing Protocol:** Run `pytest`, `ruff`, and `EnterpriseComplianceValidator` before merging changes.  Achieve >95 % test coverage and zero unresolved placeholders.
   - **Monitoring:** Deploy continuous operation monitors (`enterprise_compliance_monitor.py`, `continuous_operation_monitor.py`) and set alert thresholds.  Implement anomaly detection models using IsolationForest or similar algorithms.
 
-  ## Deliverables
+## Deliverables
 
-  ### 1 Analysis/Discovery Report
+### 1 Analysis/Discovery Report
   ```markdown
   | Item/Name                         | Details/Notes                                                   | Last Updated  |
   | -------------------------------- | ---------------------------------------------------------------- | ------------- |
@@ -234,7 +234,7 @@ description: |
   | Quantum integration roadmap      | Summary of simulation stubs and future hardware milestones      | 2025‑08‑07    |
   ```
 
-  ### 2 Implementation/Action Plan
+### 2 Implementation/Action Plan
   ```markdown
   | Source/Origin                    | Action                                          | Target/Result                                 | Risk Level | Method/Notes                                       |
   | ------------------------------- | ----------------------------------------------- | --------------------------------------------- | ---------- | -------------------------------------------------- |
@@ -247,7 +247,7 @@ description: |
   | Quantum roadmap                 | Draft hardware integration guidelines           | Preparedness for IBM/D‑Wave/IonQ pilots       | Low        | Document API changes; maintain simulation stubs    |
   ```
 
-  ### 3 Timeline & Milestones
+### 3 Timeline & Milestones
   ```markdown
   | Phase/Stage              | Duration/Date        | Key Tasks                                            | Validation/Sign‑off                |
   | ------------------------ | -------------------- | ---------------------------------------------------- | ---------------------------------- |
@@ -258,19 +258,19 @@ description: |
   | Review & Pilot Deployment| Sep 25 – Oct 1       | Deploy to staging, gather feedback, refine as needed | Executive sponsor & pilot users    |
   ```
 
-  ## Success Criteria
+## Success Criteria
 
-  ### Quantitative
-  - [ ] Composite compliance score ≥ 0.9 (90 %) across lint, tests and placeholders.
-  - [ ] >95 % of pytest tests passing; <5 unresolved placeholders across codebase.
-  - [ ] Dashboard latency ≤ 1 minute with real‑time metrics refresh ≤ 30 seconds.
+### Quantitative
+- [ ] Composite compliance score ≥ 0.9 (90 %) across lint, tests and placeholders.
+- [ ] >95 % of pytest tests passing; <5 unresolved placeholders across codebase.
+- [ ] Dashboard latency ≤ 1 minute with real‑time metrics refresh ≤ 30 seconds.
 
-  ### Qualitative
-  - [ ] Documentation and whitepapers accurately reflect implementation state.
-  - [ ] Dashboard provides actionable insights with streaming metrics and correction logs.
-  - [ ] Self‑healing systems proactively detect and remediate anomalies without human intervention.
+### Qualitative
+- [ ] Documentation and whitepapers accurately reflect implementation state.
+- [ ] Dashboard provides actionable insights with streaming metrics and correction logs.
+- [ ] Self‑healing systems proactively detect and remediate anomalies without human intervention.
 
-  ## Risk Management
+## Risk Management
   ```markdown
   | Risk/Scenario                          | Probability | Impact   | Mitigation Strategy                                           |
   | ------------------------------------- | ----------- | -------- | -------------------------------------------------------------- |
@@ -282,16 +282,16 @@ description: |
   | Quantum integration delays             | Low         | Low      | Maintain simulation fallback; adjust roadmap as needed         |
   ```
 
-  ## Notes
+## Notes
 
-  ### Prerequisites
-  - [ ] Set `GH_COPILOT_BACKUP_ROOT` to an external directory and run `setup.sh` to install dependencies.
-  - [ ] Initialize databases with `scripts/database/unified_database_initializer.py` and run migrations.
-  - [ ] Configure `.env` with `FLASK_SECRET_KEY`, `API_SECRET_KEY` and optional `OPENAI_API_KEY`.
+### Prerequisites
+- [ ] Set `GH_COPILOT_BACKUP_ROOT` to an external directory and run `setup.sh` to install dependencies.
+- [ ] Initialize databases with `scripts/database/unified_database_initializer.py` and run migrations.
+- [ ] Configure `.env` with `FLASK_SECRET_KEY`, `API_SECRET_KEY` and optional `OPENAI_API_KEY`.
 
-  ### Post‑Implementation Tasks
-  - [ ] Update documentation, README and whitepapers to reflect completed work.
-  - [ ] Generate a new daily whitepaper summary after each milestone.
-  - [ ] Conduct a pilot deployment review and capture feedback for continuous improvement.
+### Post‑Implementation Tasks
+- [ ] Update documentation, README and whitepapers to reflect completed work.
+- [ ] Generate a new daily whitepaper summary after each milestone.
+- [ ] Conduct a pilot deployment review and capture feedback for continuous improvement.
 ---
 ````


### PR DESCRIPTION
## Summary
- ensure headings and checklists in daily white-paper markdown file start at column 1

## Testing
- `ruff check documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_(2025-08-07).md`
- `pytest`
- `python scripts/wlc_session_manager.py --steps 1 --db-path databases/production.db --orchestrate`

------
https://chatgpt.com/codex/tasks/task_e_68950768c610833192d8bcda17b26616