### PR TITLE
fix: simplify table header in daily state update

### DIFF
--- a/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_(2025-08-07).md
+++ b/documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_(2025-08-07).md
@@ -37,8 +37,8 @@ Key architectural patterns are validated (e.g., database‑first and dual‑copi
 
 The table below summarises major components and their implementation status based on the README and the Phase 5 task list:
 
-| Component                         | Implementation Status       | Notes                                                                                                    |
-| ---------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Component | Implementation Status | Notes |
+| --- | --- | --- |
 | Asset Ingestion & Script Generation| Partial                    | The database‑first code generator, auto‑generator and pattern mining engines are implemented; however, some tests for template generation, archive scripts and cross‑database logging still fail[[11]]. KMeans clustering for template selection has been completed and validated[[12]]. |
 | Dual‑Copilot System                | Complete for core functions| The dual‑copilot pattern (primary executor & secondary validator) is implemented with progress indicators and anti‑recursion guards[[3]]. `SecondaryCopilotValidator` runs automatically after primary execution and logs metrics[[13]]. |
 | Placeholder Auditing               | Operational                | `scripts/code_placeholder_audit.py` scans the codebase and logs unresolved TODO/FIXME placeholders to `analytics.db`. This task is marked complete in the stub status document[[14]]. |


### PR DESCRIPTION
## Summary
- normalize the daily status table header to three columns

## Testing
- `ruff check .` *(fails: unused imports, undefined names)*
- `pytest` *(fails: tests/quantum/test_interfaces.py)*

------
https://chatgpt.com/codex/tasks/task_e_68950dd433dc83319e79dad2f3dab784