### PR TITLE
feat: add compliance score aggregation

### DIFF
--- a/scripts/compliance_aggregator.py
+++ b/scripts/compliance_aggregator.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Compliance aggregator for composite score calculations.
+
+This utility combines lint, test, and placeholder metrics into a
+weighted composite score and records the results for dashboard use.
+"""
+
+from pathlib import Path
+import argparse
+from typing import Any, Dict
+
+from utils.validation_utils import calculate_composite_compliance_score
+from enterprise_modules.compliance import record_code_quality_metrics
+
+
+def aggregate_metrics(
+    ruff_issues: int,
+    tests_passed: int,
+    tests_failed: int,
+    placeholders_open: int,
+    placeholders_resolved: int = 0,
+    *,
+    db_path: Path | None = None,
+    test_mode: bool = False,
+) -> Dict[str, Any]:
+    """Return composite compliance metrics and optionally persist them."""
+    scores = calculate_composite_compliance_score(
+        ruff_issues, tests_passed, tests_failed, placeholders_open
+    )
+    record_code_quality_metrics(
+        ruff_issues,
+        tests_passed,
+        tests_failed,
+        placeholders_open,
+        placeholders_resolved,
+        scores["composite"],
+        db_path,
+        test_mode=test_mode,
+    )
+    result: Dict[str, Any] = {
+        "ruff_issues": ruff_issues,
+        "tests_passed": tests_passed,
+        "tests_failed": tests_failed,
+        "placeholders_open": placeholders_open,
+        "placeholders_resolved": placeholders_resolved,
+        "composite_score": scores["composite"],
+        "breakdown": scores,
+    }
+    return result
+
+
+def main() -> None:  # pragma: no cover - CLI wrapper
+    parser = argparse.ArgumentParser(description="Compute composite compliance score")
+    parser.add_argument("--ruff-issues", type=int, required=True)
+    parser.add_argument("--tests-passed", type=int, required=True)
+    parser.add_argument("--tests-failed", type=int, required=True)
+    parser.add_argument("--placeholders-open", type=int, required=True)
+    parser.add_argument("--placeholders-resolved", type=int, default=0)
+    parser.add_argument("--db-path", type=Path)
+    args = parser.parse_args()
+    metrics = aggregate_metrics(
+        args.ruff_issues,
+        args.tests_passed,
+        args.tests_failed,
+        args.placeholders_open,
+        args.placeholders_resolved,
+        db_path=args.db_path,
+    )
+    print(metrics)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI execution
+    main()

--- a/tests/compliance/test_compliance_aggregator.py
+++ b/tests/compliance/test_compliance_aggregator.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from scripts.compliance_aggregator import aggregate_metrics
+from utils.validation_utils import calculate_composite_compliance_score
+
+
+def test_aggregate_metrics_persist(tmp_path: Path) -> None:
+    db = tmp_path / "analytics.db"
+    result = aggregate_metrics(
+        ruff_issues=5,
+        tests_passed=8,
+        tests_failed=2,
+        placeholders_open=1,
+        db_path=db,
+    )
+    expected = calculate_composite_compliance_score(5, 8, 2, 1)["composite"]
+    assert result["composite_score"] == expected
+    with sqlite3.connect(db) as conn:
+        row = conn.execute(
+            "SELECT ruff_issues, tests_passed, tests_failed, placeholders_open, composite_score FROM code_quality_metrics"
+        ).fetchone()
+        assert row == (5, 8, 2, 1, expected)
+
+
+def test_composite_score_in_dashboard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "databases" / "analytics.db"
+    db.parent.mkdir(parents=True)
+    aggregate_metrics(1, 3, 1, 2, db_path=db)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS todo_fixme_tracking (placeholder_type TEXT, status TEXT)"
+        )
+        conn.commit()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    from web_gui.scripts.flask_apps import enterprise_dashboard as ed
+
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+    monkeypatch.setattr(ed, "COMPLIANCE_DIR", tmp_path / "dashboard" / "compliance")
+    from dashboard.compliance_metrics_updater import ComplianceMetricsUpdater
+
+    ed.metrics_updater = ComplianceMetricsUpdater(ed.COMPLIANCE_DIR, test_mode=True)
+    ed.metrics_updater._fetch_compliance_metrics = lambda **_: {}
+    client = ed.app.test_client()
+    data = client.get("/metrics").get_json()
+    expected = calculate_composite_compliance_score(1, 3, 1, 2)["composite"]
+    assert data["composite_score"] == expected

--- a/web_gui/scripts/flask_apps/enterprise_dashboard.py
+++ b/web_gui/scripts/flask_apps/enterprise_dashboard.py
@@ -333,6 +333,12 @@ def metrics_table() -> Any:
     return render_template("metrics_table.html", metrics=metrics)
 
 
+@app.get("/compliance_metrics")
+def compliance_metrics_page() -> Any:
+    metrics = _fetch_metrics()
+    return render_template("html/compliance_metrics.html", metrics=metrics)
+
+
 @app.get("/health")
 def health() -> Any:
     start = time.time()

--- a/web_gui/templates/html/compliance_metrics.html
+++ b/web_gui/templates/html/compliance_metrics.html
@@ -4,15 +4,17 @@
 
 {% block enterprise_content %}
 <h1 class="mb-4">Compliance Metrics</h1>
+<div id="progress"></div>
 <table class="table table-striped">
     <thead>
         <tr><th>Metric</th><th>Value</th></tr>
     </thead>
     <tbody>
-        <tr><td>Score</td><td>{{ metrics.score }}</td></tr>
+        <tr><td>Compliance Score</td><td>{{ metrics.compliance_score }}</td></tr>
+        <tr><td>Composite Score</td><td id="composite_score">{{ metrics.composite_score }}</td></tr>
         <tr><td>Last Audit Date</td><td>{{ metrics.last_audit_date }}</td></tr>
         {% for key, value in metrics.items() %}
-            {% if key not in ['compliance_trend', 'recent_rollbacks', 'score', 'last_audit_date'] %}
+            {% if key not in ['compliance_trend', 'recent_rollbacks', 'compliance_score', 'composite_score', 'last_audit_date'] %}
             <tr><td>{{ key }}</td><td>{{ value }}</td></tr>
             {% endif %}
         {% endfor %}
@@ -25,4 +27,19 @@
     <li class="list-group-item">{{ score }}</li>
     {% endfor %}
 </ul>
+{% endblock %}
+
+{% block scripts %}
+<script>
+if (window.EventSource) {
+  const es = new EventSource("/metrics_stream");
+  es.onmessage = function(evt) {
+    const data = JSON.parse(evt.data);
+    const el = document.getElementById("composite_score");
+    if (el && data.composite_score !== undefined) {
+      el.textContent = data.composite_score.toFixed(2);
+    }
+  };
+}
+</script>
 {% endblock %}

--- a/web_gui/templates/html/mobile/compliance_metrics.html
+++ b/web_gui/templates/html/mobile/compliance_metrics.html
@@ -6,10 +6,11 @@
   <div id="progress"></div>
   <table class="table table-sm">
     <tr><th>Metric</th><th>Value</th></tr>
-    <tr><td>Score</td><td>{{ metrics.score }}</td></tr>
+    <tr><td>Compliance Score</td><td>{{ metrics.compliance_score }}</td></tr>
+    <tr><td>Composite Score</td><td id="composite_score">{{ metrics.composite_score }}</td></tr>
     <tr><td>Last Audit Date</td><td>{{ metrics.last_audit_date }}</td></tr>
     {% for key, value in metrics.items() %}
-      {% if key not in ['compliance_trend', 'recent_rollbacks', 'score', 'last_audit_date'] %}
+      {% if key not in ['compliance_trend', 'recent_rollbacks', 'compliance_score', 'composite_score', 'last_audit_date'] %}
       <tr><td>{{ key }}</td><td>{{ value }}</td></tr>
       {% endif %}
     {% endfor %}
@@ -19,4 +20,19 @@
     <a class="btn btn-primary btn-sm" href="/dashboard/compliance">Compliance Metrics</a>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+if (window.EventSource) {
+  const es = new EventSource("/metrics_stream");
+  es.onmessage = function(evt) {
+    const data = JSON.parse(evt.data);
+    const el = document.getElementById("composite_score");
+    if (el && data.composite_score !== undefined) {
+      el.textContent = data.composite_score.toFixed(2);
+    }
+  };
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `compliance_aggregator` script to compute composite compliance scores
- surface composite score on compliance metrics templates and endpoint
- test aggregation logic and dashboard metric exposure

## Testing
- `ruff check scripts/compliance_aggregator.py web_gui/scripts/flask_apps/enterprise_dashboard.py tests/compliance/test_compliance_aggregator.py`
- `pytest tests/compliance/test_compliance_aggregator.py`


------
https://chatgpt.com/codex/tasks/task_e_68950f4f5ba08331bdd326589c4727e8