### PR TITLE
feat: log forbidden temp path violations

### DIFF
--- a/quantum/optimizers/quantum_optimizer.py
+++ b/quantum/optimizers/quantum_optimizer.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import os
 
 import numpy as np
+from enterprise_modules.compliance import _log_violation
 
 try:  # pragma: no cover - import check
     from qiskit import Aer
@@ -102,13 +103,25 @@ def validate_no_recursive_folders() -> None:
 
 
 def detect_c_temp_violations() -> Optional[str]:
+    """Detect forbidden Windows ``E:/temp`` paths.
+
+    The legacy ``E:/temp`` directory is disallowed for both the workspace
+    and the backup root.  When either path begins with this location the
+    offending path is returned and the incident is recorded via
+    :func:`_log_violation`.
+
+    Returns ``None`` when no violation is present.
+    """
+
     forbidden = ["E:/temp/", "E:\\temp\\"]
     workspace = str(CrossPlatformPathManager.get_workspace_path())
     backup_root = str(CrossPlatformPathManager.get_backup_root())
     for forbidden_path in forbidden:
         if workspace.startswith(forbidden_path):
+            _log_violation(workspace)
             return workspace
         if backup_root.startswith(forbidden_path):
+            _log_violation(backup_root)
             return backup_root
     return None
 

--- a/tests/test_detect_c_temp_violations.py
+++ b/tests/test_detect_c_temp_violations.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+class _DummyTqdm:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def update(self, *args, **kwargs):
+        pass
+
+sys.modules.setdefault("tqdm", types.SimpleNamespace(tqdm=_DummyTqdm))
+sys.modules.setdefault("scripts.docs_metrics_validator", types.ModuleType("docs_metrics_validator"))
+sys.modules.setdefault("scripts.validate_docs_metrics", types.ModuleType("validate_docs_metrics"))
+numpy_stub = types.ModuleType("numpy")
+numpy_stub.ndarray = object
+sys.modules.setdefault("numpy", numpy_stub)
+sys.modules.setdefault("psutil", types.ModuleType("psutil"))
+
+quantum_pkg = types.ModuleType("quantum")
+quantum_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "quantum")]
+sys.modules["quantum"] = quantum_pkg
+quantum_utils_pkg = types.ModuleType("quantum.utils")
+quantum_utils_pkg.__path__ = []
+sys.modules["quantum.utils"] = quantum_utils_pkg
+backend_provider_stub = types.ModuleType("quantum.utils.backend_provider")
+backend_provider_stub.get_backend = lambda *args, **kwargs: None
+sys.modules["quantum.utils.backend_provider"] = backend_provider_stub
+qo = importlib.import_module("quantum.optimizers.quantum_optimizer")
+
+
+def test_detect_c_temp_violations_docstring():
+    doc = qo.detect_c_temp_violations.__doc__
+    assert doc and "E:/temp" in doc
+
+
+def test_detect_c_temp_violations_logs_when_forbidden(tmp_path):
+    ws = Path("E:/temp/project")
+    bk = tmp_path
+    with mock.patch.object(qo.CrossPlatformPathManager, "get_workspace_path", return_value=ws), \
+         mock.patch.object(qo.CrossPlatformPathManager, "get_backup_root", return_value=bk), \
+         mock.patch.object(qo, "_log_violation") as log:
+        assert qo.detect_c_temp_violations() == str(ws)
+        log.assert_called_once_with(str(ws))


### PR DESCRIPTION
## Summary
- document and log Windows `E:/temp` workspace or backup violations in the quantum optimizer
- test detection logic and docstring coverage for forbidden temp paths

## Testing
- `ruff check quantum/optimizers/quantum_optimizer.py tests/test_detect_c_temp_violations.py`
- `pytest tests/test_detect_c_temp_violations.py -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68952b76f6008331913b225a661353f4