### PR TITLE
fix: handle optional dependencies in archive scripts tests

### DIFF
--- a/docs/testing/failing_modules.md
+++ b/docs/testing/failing_modules.md
@@ -4,4 +4,6 @@ The following modules failed during the latest test run:
 
 - `tests/quantum/test_interfaces.py` – SyntaxError in `quantum/interfaces/quantum_templates.py`: unterminated triple-quoted string.
 
+Archive script test failures have been resolved and removed from this list.
+
 Source: `failing_tests.log`

--- a/scripts/run_migrations.py
+++ b/scripts/run_migrations.py
@@ -13,7 +13,18 @@ import os
 import sqlite3
 from pathlib import Path
 
-from tqdm import tqdm
+try:  # pragma: no cover - optional dependency
+    from tqdm import tqdm
+except ModuleNotFoundError:  # pragma: no cover
+    from contextlib import contextmanager
+
+    @contextmanager
+    def tqdm(*args, **kwargs):  # type: ignore[override]
+        class _Bar:
+            def update(self, *_, **__):  # pragma: no cover - no-op fallback
+                return None
+
+        yield _Bar()
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -18,7 +18,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
-from tqdm import tqdm
+# ``tqdm`` is optional; provide a no-op fallback if unavailable.
+try:  # pragma: no cover - import guard for optional dependency
+    from tqdm import tqdm
+except ModuleNotFoundError:  # pragma: no cover
+    def tqdm(iterable=None, **kwargs):  # type: ignore[override]
+        return iterable if iterable is not None else []
 
 # Default analytics DB path (test-only, never created here)
 DEFAULT_ANALYTICS_DB = Path(os.environ.get("ANALYTICS_DB", "databases/analytics.db"))

--- a/utils/validation_utils.py
+++ b/utils/validation_utils.py
@@ -7,7 +7,10 @@ from typing import Any, Dict, Iterable, List, Tuple, Callable
 from functools import wraps
 import tempfile
 import os
-import psutil
+try:  # pragma: no cover - optional dependency
+    import psutil
+except ModuleNotFoundError:  # pragma: no cover
+    psutil = None  # type: ignore[assignment]
 
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.lessons_learned_integrator import store_lesson
@@ -232,7 +235,7 @@ def anti_recursion_guard(func: Callable) -> Callable:
                 existing = int(pid_file.read_text().strip())
             except ValueError:
                 existing = None
-            if existing and psutil.pid_exists(existing):
+            if existing and (psutil and psutil.pid_exists(existing)):
                 raise RuntimeError("PID guard triggered")
         try:
             lock_file.touch()


### PR DESCRIPTION
## Summary
- handle missing `tqdm` in logging and migration utilities
- guard PID checks when `psutil` isn't installed
- update failing test module list after resolving archive script failures

## Testing
- `ruff check utils/log_utils.py utils/validation_utils.py`
- `pytest tests/test_archive_scripts.py -vv -o addopts='' -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_68952e473d9083318c6816ad01166f0a