### PR TITLE
fix: restore DocumentationManager after dual validation

### DIFF
--- a/archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py
+++ b/archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py
@@ -147,10 +147,21 @@ class DocumentationManager:
         return count
 
 
+# Keep reference to the original class so tests that temporarily replace
+# ``DocumentationManager`` do not leak those changes to subsequent tests.
+_ORIGINAL_DOCUMENTATION_MANAGER = DocumentationManager
+
+
 def dual_validate() -> bool:
-    manager = DocumentationManager()
-    processed = manager.render()
-    return processed > 0
+    cls = DocumentationManager
+    try:
+        manager = cls()
+        processed = manager.render()
+        return processed > 0
+    finally:
+        # Restore the original class to avoid cross-test contamination when
+        # ``DocumentationManager`` is patched in a test.
+        globals()["DocumentationManager"] = _ORIGINAL_DOCUMENTATION_MANAGER
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `DocumentationManager` class is restored after `dual_validate`

## Testing
- `pytest tests/test_documentation_manager.py tests/test_documentation_manager_validator.py tests/test_enterprise_documentation_manager.py tests/test_enterprise_database_driven_documentation_manager.py tests/test_enterprise_documentation_manager_module.py tests/test_enterprise_documentation_manager_new.py tests/documentation/test_documentation_manager_templates.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68952ae043688331945bf5c051b7f3b9