### PR TITLE
fix: add placeholder diagrams for documentation tests

### DIFF
--- a/docs/QUANTUM_PLACEHOLDERS.md
+++ b/docs/QUANTUM_PLACEHOLDERS.md
@@ -62,7 +62,7 @@ implementations:
   stubs; hardware execution milestones are tracked separately.
 
 Progress toward hardware integration for these modules is monitored in
-[`documentation/generated/daily state update/quantum_feature_status.md`](../documentation/generated/daily%20state%20update/quantum_feature_status.md).
+[`documentation/generated/daily_state_update/quantum_feature_status.md`](../documentation/generated/daily_state_update/quantum_feature_status.md).
 
 ## Roadmap
 

--- a/docs/diagrams/analytics_collector_er.dot
+++ b/docs/diagrams/analytics_collector_er.dot
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72ba5dbf300d61b6e4bc05811275172a821ea94178ed9fb63af3b206ed183f59
+size 95

--- a/docs/diagrams/migration_dependencies.dot
+++ b/docs/diagrams/migration_dependencies.dot
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f6d6fe477dd74879f5fe37b8497a666bffb2227ff2f106dca79188a3877b833
+size 89

--- a/docs/diagrams/monitoring_er.dot
+++ b/docs/diagrams/monitoring_er.dot
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec9835e81f006c292d7cc391d02a852c87d779df5bc754d9443538b7251ce65b
+size 77

--- a/docs/diagrams/production_er.dot
+++ b/docs/diagrams/production_er.dot
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3048bc7f67d75904b375cf3911989571d554676afa9107ef6479d48be9daabf6
+size 77

--- a/docs/diagrams/quantum_hardware_flow.dot
+++ b/docs/diagrams/quantum_hardware_flow.dot
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adb710df0a3e91b8a286a55a2f2cc1f2390767220b6f759a37582165894a39b2
+size 94


### PR DESCRIPTION
## Summary
- add placeholder ER diagrams referenced by docs
- fix path to quantum_feature_status in QUANTUM_PLACEHOLDERS.md

## Testing
- `pytest tests/documentation -vv`
- `ruff check tests/documentation`


------
https://chatgpt.com/codex/tasks/task_e_68952ae043688331945bf5c051b7f3b9