### PR TITLE
feat: add codex log cursor and convenience helpers

### DIFF
--- a/tests/stubs/scripts/__init__.py
+++ b/tests/stubs/scripts/__init__.py
@@ -1,0 +1,1 @@
+# stub package for tests

--- a/tests/stubs/scripts/run_migrations.py
+++ b/tests/stubs/scripts/run_migrations.py
@@ -1,0 +1,3 @@
+def ensure_migrations_applied() -> None:
+    """Stubbed migrations."""
+    return None

--- a/tests/stubs/sitecustomize.py
+++ b/tests/stubs/sitecustomize.py
@@ -1,0 +1,16 @@
+import sys
+import types
+
+scripts_pkg = types.ModuleType("scripts")
+run_migrations = types.ModuleType("scripts.run_migrations")
+run_migrations.ensure_migrations_applied = lambda: None
+scripts_pkg.run_migrations = run_migrations
+sys.modules.setdefault("scripts", scripts_pkg)
+sys.modules.setdefault("scripts.run_migrations", run_migrations)
+
+utils_pkg = types.ModuleType("utils")
+validation_utils = types.ModuleType("utils.validation_utils")
+validation_utils.run_dual_copilot_validation = lambda *a, **k: None
+utils_pkg.validation_utils = validation_utils
+sys.modules.setdefault("utils", utils_pkg)
+sys.modules.setdefault("utils.validation_utils", validation_utils)

--- a/tests/test_codex_log_db.py
+++ b/tests/test_codex_log_db.py
@@ -1,0 +1,63 @@
+"""Tests for codex_log_db utilities."""
+
+import importlib.util
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    sys.modules[name] = module
+    return module
+
+
+BASE = Path(__file__).resolve().parent.parent / "utils"
+utils_pkg = types.ModuleType("utils")
+sys.modules["utils"] = utils_pkg
+_load("utils.cross_platform_paths", BASE / "cross_platform_paths.py")
+codex_log_db = _load("utils.codex_log_db", BASE / "codex_log_db.py")
+codex_log_cursor = codex_log_db.codex_log_cursor
+log_codex_start = codex_log_db.log_codex_start
+log_codex_end = codex_log_db.log_codex_end
+
+
+def test_log_codex_start_end(tmp_path, monkeypatch):
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+
+    log_codex_start("s1")
+    log_codex_end("s1", "done")
+
+    conn = sqlite3.connect(db_dir / "codex_log.db")
+    rows = conn.execute("SELECT session_id, event, summary FROM codex_log").fetchall()
+    conn.close()
+
+    assert rows == [("s1", "start", ""), ("s1", "end", "done")]
+
+
+def test_codex_log_cursor_batch(tmp_path, monkeypatch):
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+
+    with codex_log_cursor() as cursor:
+        cursor.executemany(
+            "INSERT INTO codex_log (session_id, event, summary, ts) VALUES (?, ?, ?, ?)",
+            [
+                ("a", "start", "", "t1"),
+                ("a", "log", "m1", "t2"),
+                ("b", "log", "m2", "t3"),
+            ],
+        )
+
+    conn = sqlite3.connect(db_dir / "codex_log.db")
+    count = conn.execute("SELECT COUNT(*) FROM codex_log").fetchone()[0]
+    conn.close()
+    assert count == 3
+

--- a/utils/codex_log_db.py
+++ b/utils/codex_log_db.py
@@ -1,0 +1,65 @@
+"""Codex session logging utilities."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Iterator
+
+from utils.cross_platform_paths import CrossPlatformPathManager
+
+
+DB_NAME = "codex_log.db"
+TABLE_NAME = "codex_log"
+
+
+@contextmanager
+def codex_log_cursor(db_name: str = DB_NAME) -> Iterator[sqlite3.Cursor]:
+    """Yield a database cursor for batch Codex log inserts.
+
+    Ensures the Codex log table exists and commits on success.
+    """
+    workspace: Path = CrossPlatformPathManager.get_workspace_path()
+    db_path = workspace / "databases" / db_name
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS codex_log (
+                session_id TEXT,
+                event TEXT,
+                summary TEXT,
+                ts TEXT
+            )
+            """
+        )
+        yield cursor
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def log_codex_start(session_id: str) -> None:
+    """Record the start of a Codex session."""
+    with codex_log_cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO codex_log (session_id, event, summary, ts) VALUES (?, ?, ?, ?)",
+            (session_id, "start", "", datetime.now(UTC).isoformat()),
+        )
+
+
+def log_codex_end(session_id: str, summary: str) -> None:
+    """Record the end of a Codex session."""
+    with codex_log_cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO codex_log (session_id, event, summary, ts) VALUES (?, ?, ?, ?)",
+            (session_id, "end", summary, datetime.now(UTC).isoformat()),
+        )
+
+
+__all__ = ["codex_log_cursor", "log_codex_start", "log_codex_end"]
+


### PR DESCRIPTION
## Summary
- add `codex_log_cursor` context manager for batch Codex log inserts
- export `log_codex_start` and `log_codex_end` helpers
- test codex logging utilities

## Testing
- `ruff check utils/codex_log_db.py tests/test_codex_log_db.py tests/stubs/sitecustomize.py tests/stubs/scripts/run_migrations.py tests/stubs/scripts/__init__.py`
- `cd tests && PYTHONPATH=stubs pytest test_codex_log_db.py -p no:cov -o addopts='' -c ../pytest.ini`


------
https://chatgpt.com/codex/tasks/task_e_689530c3a658833196ce43bdf9f664f1