### PR TITLE
fix: handle database logging failures gracefully

### DIFF
--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -202,12 +202,25 @@ def _log_violation(details: str) -> None:
     analytics_db = workspace / "databases" / "analytics.db"
     analytics_db.parent.mkdir(parents=True, exist_ok=True)
     ensure_violation_logs(analytics_db, validate=False)
-    with sqlite3.connect(analytics_db) as conn:
-        conn.execute(
-            "INSERT INTO violation_logs (timestamp, details) VALUES (?, ?)",
-            (datetime.now().isoformat(), details),
-        )
-        conn.commit()
+    try:
+        with sqlite3.connect(analytics_db) as conn:
+            conn.execute(
+                "INSERT INTO violation_logs (timestamp, details) VALUES (?, ?)",
+                (datetime.now().isoformat(), details),
+            )
+            conn.commit()
+    except sqlite3.Error as exc:
+        try:
+            logging.error("Failed to log violation: %s", exc)
+            send_dashboard_alert(
+                {
+                    "event": "violation_log_error",
+                    "details": details,
+                    "error": str(exc),
+                }
+            )
+        except Exception:
+            pass
 
 
 def _log_rollback(target: str, backup: str | None = None) -> None:
@@ -216,12 +229,26 @@ def _log_rollback(target: str, backup: str | None = None) -> None:
     analytics_db = workspace / "databases" / "analytics.db"
     analytics_db.parent.mkdir(parents=True, exist_ok=True)
     ensure_rollback_logs(analytics_db, validate=False)
-    with sqlite3.connect(analytics_db) as conn:
-        conn.execute(
-            "INSERT INTO rollback_logs (target, backup, timestamp) VALUES (?, ?, ?)",
-            (target, backup, datetime.now().isoformat()),
-        )
-        conn.commit()
+    try:
+        with sqlite3.connect(analytics_db) as conn:
+            conn.execute(
+                "INSERT INTO rollback_logs (target, backup, timestamp) VALUES (?, ?, ?)",
+                (target, backup, datetime.now().isoformat()),
+            )
+            conn.commit()
+    except sqlite3.Error as exc:
+        try:
+            logging.error("Failed to log rollback: %s", exc)
+            send_dashboard_alert(
+                {
+                    "event": "rollback_log_error",
+                    "target": target,
+                    "backup": backup,
+                    "error": str(exc),
+                }
+            )
+        except Exception:
+            pass
 
 
 def _ensure_recursion_pid_log(db_path: Path) -> None:

--- a/tests/compliance/test_logging_graceful_failures.py
+++ b/tests/compliance/test_logging_graceful_failures.py
@@ -1,0 +1,37 @@
+import sqlite3
+
+from enterprise_modules import compliance
+
+
+def test_log_violation_db_failure(monkeypatch):
+    def fail_connect(*args, **kwargs):
+        raise sqlite3.OperationalError("db down")
+
+    monkeypatch.setattr(compliance, "ensure_violation_logs", lambda *a, **k: None)
+    monkeypatch.setattr(compliance.sqlite3, "connect", fail_connect)
+    alerts = []
+    monkeypatch.setattr(compliance, "send_dashboard_alert", lambda data: alerts.append(data))
+    logs = []
+    monkeypatch.setattr(compliance.logging, "error", lambda *args, **kwargs: logs.append(args[0] if args else ""))
+
+    compliance._log_violation("test_violation")
+
+    assert alerts, "dashboard alert not sent on db failure"
+    assert logs, "error not logged on db failure"
+
+
+def test_log_rollback_db_failure(monkeypatch):
+    def fail_connect(*args, **kwargs):
+        raise sqlite3.OperationalError("db down")
+
+    monkeypatch.setattr(compliance, "ensure_rollback_logs", lambda *a, **k: None)
+    monkeypatch.setattr(compliance.sqlite3, "connect", fail_connect)
+    alerts = []
+    monkeypatch.setattr(compliance, "send_dashboard_alert", lambda data: alerts.append(data))
+    logs = []
+    monkeypatch.setattr(compliance.logging, "error", lambda *args, **kwargs: logs.append(args[0] if args else ""))
+
+    compliance._log_rollback("target", "backup")
+
+    assert alerts, "dashboard alert not sent on db failure"
+    assert logs, "error not logged on db failure"


### PR DESCRIPTION
## Summary
- guard compliance logging against sqlite errors and alert dashboard on failure
- add tests for graceful degradation when logging fails

## Testing
- `ruff check enterprise_modules/compliance.py tests/compliance/test_logging_graceful_failures.py`
- `pytest -o addopts="" tests/compliance`
- `bash .git/hooks/pre-commit-lfs`


------
https://chatgpt.com/codex/tasks/task_e_6895312bb3708331b1cf6ec9d0ab5c25