### PR TITLE
chore: run ruff auto-fix and resolve lint warnings

### DIFF
--- a/docs/testing/linting.md
+++ b/docs/testing/linting.md
@@ -1,0 +1,6 @@
+# Linting
+
+- Ran `ruff check --fix .` to auto-correct style issues.
+- Verified with `ruff check .` that no violations remain.
+
+Generated on 2025-08-07 23:33 UTC.

--- a/tests/web_gui/test_config_security.py
+++ b/tests/web_gui/test_config_security.py
@@ -4,7 +4,6 @@ from typing import Generator
 import pytest
 
 from web_gui.scripts.config.production_config import ProductionConfig
-from web_gui.scripts.config.staging_config import StagingConfig
 
 
 @pytest.fixture(autouse=True)

--- a/web_gui/monitoring/alerting/notification_engine.py
+++ b/web_gui/monitoring/alerting/notification_engine.py
@@ -7,17 +7,13 @@ append information to in-memory logs so tests can assert on side effects.
 
 from __future__ import annotations
 
-from typing import List
-
-NOTIFICATION_LOG: List[str] = []
-
-__all__ = ["send_notification", "route_to_dashboard", "NOTIFICATION_LOG"]
-
-NOTIFICATION_LOG: List[str] = []
+from typing import List, Tuple
 
 # In-memory logs used for test assertions
 NOTIFICATION_LOG: List[str] = []
 ROUTE_LOG: List[Tuple[str, str]] = []
+
+__all__ = ["send_notification", "route_to_dashboard", "NOTIFICATION_LOG"]
 
 
 def send_notification(level: str, message: str) -> None:

--- a/web_gui/security/authentication.py
+++ b/web_gui/security/authentication.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Mapping, MutableMapping
+from typing import Mapping
 
 from flask import Flask
 


### PR DESCRIPTION
## Summary
- run `ruff check --fix` across the repo
- fix remaining F821 errors in monitoring modules
- document linting run

## Testing
- `ruff check .`
- `pytest` *(fails: tests/test_analytics_modules.py)*
- `pytest tests/web_gui/test_config_security.py`


------
https://chatgpt.com/codex/tasks/task_e_689535c2b7c08331ac24b3c3774d3d06