### PR TITLE
chore: ensure codex log db tracked by LFS

### DIFF
--- a/codex_log.db
+++ b/codex_log.db
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cac6e2606fc373873276935c05cbd96ea9920353dec9d6b612ed41ffea00aced
+size 8192

--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -13,6 +13,19 @@ if str(ROOT) not in sys.path:
 from utils.validation_utils import anti_recursion_guard
 
 
+def ensure_codex_log_tracked() -> None:
+    """Ensure ``codex_log.db`` is tracked by Git LFS."""
+    result = subprocess.run(
+        ["git", "lfs", "ls-files"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if "codex_log.db" not in result.stdout:
+        msg = "codex_log.db must be managed by Git LFS"
+        raise RuntimeError(msg)
+
+
 @anti_recursion_guard
 def main() -> int:
     """Run ``ruff`` and ``pytest`` sequentially.
@@ -21,10 +34,9 @@ def main() -> int:
     commands succeed.
     """
 
-    commands = [
-        ["ruff", "check", "."],
-        ["pytest"],
-    ]
+    ensure_codex_log_tracked()
+
+    commands = [["ruff", "check", "."], ["pytest"]]
 
     for cmd in commands:
         result = subprocess.run(cmd)


### PR DESCRIPTION
## Summary
- add codex_log.db and confirm it's stored via Git LFS
- extend run_checks to verify codex_log.db is LFS-managed before running tooling

## Testing
- `python scripts/run_checks.py` *(fails: F401 unused import, F821 undefined name)*
- `pytest` *(fails: tests/quantum/test_interfaces.py)*

------
https://chatgpt.com/codex/tasks/task_e_68953603df4883319327bd10906d7a8e