### PR TITLE
feat: package codex log DB in session wrap-up

### DIFF
--- a/artifact_manager.py
+++ b/artifact_manager.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -330,6 +331,13 @@ def package_session(
 
     sessions_dir = repo_root / lfs_policy.session_artifact_dir
     logger.info("Session artifacts directory resolved to %s", sessions_dir)
+
+    codex_log = repo_root / "databases" / "codex_log.db"
+    if codex_log.exists():
+        try:
+            shutil.copy2(codex_log, tmp_dir / "codex_log.db")
+        except OSError as exc:  # pragma: no cover - log only
+            logger.error("Failed to copy %s into %s: %s", codex_log, tmp_dir, exc)
 
     changed_files = detect_tmp_changes(tmp_dir, repo_root)
     if not changed_files:

--- a/tests/test_artifact_manager.py
+++ b/tests/test_artifact_manager.py
@@ -86,6 +86,22 @@ def test_package_and_recover(repo: Path) -> None:
     assert (tmp_dir / "a.txt").exists()
 
 
+def test_package_session_includes_codex_log_db(repo: Path) -> None:
+    """codex_log.db is bundled into the session archive."""
+
+    db_dir = repo / "databases"
+    db_dir.mkdir()
+    (db_dir / "codex_log.db").write_text("log", encoding="utf-8")
+    tmp_dir = repo / "tmp"
+    tmp_dir.mkdir()
+
+    policy = LfsPolicy(repo)
+    archive = package_session(tmp_dir, repo, policy)
+    assert archive and archive.exists(), "archive missing"
+    with ZipFile(archive) as zf:
+        assert "codex_log.db" in zf.namelist()
+
+
 def test_package_session_no_changes_returns_none(repo: Path, caplog: pytest.LogCaptureFixture) -> None:
     """Packaging with no file changes should return ``None`` and log nothing."""
 

--- a/tools/git_safe_add_commit.py
+++ b/tools/git_safe_add_commit.py
@@ -104,6 +104,8 @@ def main(argv: List[str] | None = None) -> int:
     if not GOVERNANCE_DOC.exists():
         print("Missing governance standards document: docs/GOVERNANCE_STANDARDS.md")
         return 1
+    if Path("databases/codex_log.db").exists():
+        _run(["git", "add", "databases/codex_log.db"])
     files = _staged_files()
     allow = os.getenv("ALLOW_AUTOLFS") == "1"
     for f in files:


### PR DESCRIPTION
## Summary
- include `databases/codex_log.db` in temporary artifacts before zipping so session archives retain the log database
- add `--wrap-up` workflow to `wlc_session_manager` that stages the log DB and packages artifacts
- automatically stage `codex_log.db` during safe commits and test for its presence in archives

## Testing
- `TEST_MODE=1 python scripts/wlc_session_manager.py --wrap-up`
- `unzip -l codex_sessions/codex-session_20250807_233724.zip`
- `ruff check artifact_manager.py scripts/wlc_session_manager.py tests/test_artifact_manager.py tools/git_safe_add_commit.py`
- `pytest tests/test_artifact_manager.py tests/test_git_safe_add_commit.py tests/git_lfs/test_git_safe_add_commit_autolfs.py`


------
https://chatgpt.com/codex/tasks/task_e_689536032f0c8331aaba20a2b132f4ee