### PR TITLE
feat: add codex action logging to session management

### DIFF
--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -42,6 +42,7 @@ from utils.validation_utils import anti_recursion_guard, validate_enterprise_env
 from utils.lessons_learned_integrator import store_lesson
 from unified_session_management_system import ensure_no_zero_byte_files
 from utils.logging_utils import ANALYTICS_DB
+from utils.codex_log_db import log_codex_action
 
 try:
     from scripts.orchestrators.unified_wrapup_orchestrator import (
@@ -221,6 +222,7 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
         entry_id, session_id = start_session_entry(conn)
         if entry_id is None:
             raise RuntimeError("Failed to create session entry in the database.")
+        log_codex_action(session_id, "session_start", "WLC session starting")
         compliance_score = 1.0
         try:
             with ensure_no_zero_byte_files(
@@ -228,6 +230,11 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
             ):
                 for i in tqdm(range(steps), desc="WLC Session", unit="step"):
                     logging.info("Step %d/%d completed", i + 1, steps)
+                    log_codex_action(
+                        session_id,
+                        "step_complete",
+                        f"Step {i + 1}/{steps} completed",
+                    )
                     sleep_time = 0.1
                     if os.getenv("TEST"):
                         sleep_time = 0.01
@@ -236,10 +243,17 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
                 orchestrator = UnifiedWrapUpOrchestrator(
                     workspace_path=str(CrossPlatformPathManager.get_workspace_path())
                 )
+                log_codex_action(session_id, "orchestrator_start", "Executing orchestrator")
                 result = orchestrator.execute_unified_wrapup()
                 compliance_score = result.compliance_score / 100.0
+                log_codex_action(
+                    session_id,
+                    "orchestrator_complete",
+                    f"Orchestrator finished with score {compliance_score:.2f}",
+                )
         except Exception as exc:  # noqa: BLE001
             logging.exception("WLC session failed")
+            log_codex_action(session_id, "session_failure", str(exc))
             zero_count = _zero_byte_count(session_id)
             finalize_session_entry(
                 conn, entry_id, 0.0, zero_byte_files=zero_count, error=str(exc)
@@ -249,6 +263,11 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
         zero_count = _zero_byte_count(session_id)
         finalize_session_entry(
             conn, entry_id, compliance_score, zero_byte_files=zero_count
+        )
+        log_codex_action(
+            session_id,
+            "session_end",
+            f"Session completed with score {compliance_score:.2f}",
         )
         store_lesson(
             description=f"WLC session completed with score {compliance_score:.2f}",
@@ -268,7 +287,9 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
             orchestrator = orchestrator_cls(
                 workspace_path=str(CrossPlatformPathManager.get_workspace_path())
             )
+            log_codex_action(session_id, "post_session_orchestrator_start", "Running orchestrator post session")
             orchestrator.execute_unified_wrapup()
+            log_codex_action(session_id, "post_session_orchestrator_complete", "Post session orchestrator finished")
 
         validator = SecondaryCopilotValidator()
         validator.validate_corrections([__file__])
@@ -277,7 +298,9 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
         orchestrator = UnifiedWrapUpOrchestrator(
             workspace_path=str(CrossPlatformPathManager.get_workspace_path())
         )
+        log_codex_action(session_id, "env_orchestrator_start", "Running orchestrator via env flag")
         orchestrator.execute_unified_wrapup()
+        log_codex_action(session_id, "env_orchestrator_complete", "Env orchestrator finished")
 
     logging.info("WLC session completed")
 

--- a/unified_session_management_system.py
+++ b/unified_session_management_system.py
@@ -14,6 +14,7 @@ from utils.validation_utils import detect_zero_byte_files
 from scripts.session.anti_recursion_enforcer import anti_recursion_guard
 from enterprise_modules.compliance import validate_environment, ComplianceError
 from utils.logging_utils import ANALYTICS_DB
+from utils.codex_log_db import log_codex_action
 
 logger = logging.getLogger(__name__)
 
@@ -149,16 +150,28 @@ def main() -> int:
 
     system = UnifiedSessionManagementSystem()
     logger.info("Lifecycle start")
+    log_codex_action(system.session_id, "session_start", "Unified session lifecycle start")
     success = False
     with ensure_no_zero_byte_files(system.workspace_root, system.session_id):
+        log_codex_action(system.session_id, "start_session_begin", "Starting session")
         success = system.start_session()
+        log_codex_action(system.session_id, "start_session_complete", "Session started")
+        log_codex_action(system.session_id, "end_session_begin", "Ending session")
         system.end_session()
-        finalize_session(
+        log_codex_action(system.session_id, "end_session_complete", "Session ended")
+        log_codex_action(system.session_id, "finalize_session_begin", "Finalizing session logs")
+        hash_value = finalize_session(
             Path(system.workspace_root) / "logs",
             system.workspace_root,
             system.session_id,
         )
+        log_codex_action(
+            system.session_id,
+            "finalize_session_complete",
+            f"Session finalized with hash {hash_value}",
+        )
     logger.info("Lifecycle end")
+    log_codex_action(system.session_id, "session_end", "Unified session lifecycle end")
     print("Valid" if success else "Invalid")
     return 0 if success else 1
 


### PR DESCRIPTION
## Summary
- log codex actions for session lifecycle in unified session management
- track WLC session progress and orchestrator stages via codex log entries

## Testing
- `ruff check unified_session_management_system.py scripts/wlc_session_manager.py`
- `pytest tests/workflow/test_session_logging.py` *(fails: FileNotFoundError: No such file or directory: '/tmp/pytest-of-root/pytest-7/test_log_and_retrieve_session_0/analytics.db')*

------
https://chatgpt.com/codex/tasks/task_e_689536028f4c83318d0fb4f466131696