### PR TITLE
feat: add conflict resolution to schema mapper

### DIFF
--- a/src/schema/__init__.py
+++ b/src/schema/__init__.py
@@ -1,0 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+def rollback() -> None:
+    """Rollback schema changes in case of failure."""
+    logger.info("Schema rollback executed")

--- a/src/schema/schema_mapper.py
+++ b/src/schema/schema_mapper.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from copy import deepcopy
+from typing import Any, Dict
+
+from . import logger
+
+
+class SchemaMapper:
+    """Apply updates to a schema with conflict resolution strategies."""
+
+    def __init__(self, base_schema: Dict[str, Any]):
+        self.schema = base_schema
+
+    @contextmanager
+    def transaction(self):
+        """Provide a transactional context with rollback support."""
+        snapshot = deepcopy(self.schema)
+        try:
+            yield
+        except Exception:
+            from . import rollback
+            rollback()
+            self.schema = snapshot
+            raise
+
+    def apply(self, updates: Dict[str, Any], strategy: str = "merge") -> Dict[str, Any]:
+        """Apply updates to the schema using the given conflict strategy."""
+        strategy = strategy.lower()
+        with self.transaction():
+            for key, value in updates.items():
+                if key in self.schema and self.schema[key] != value:
+                    logger.info("Conflict detected for '%s'", key)
+                    if strategy == "merge":
+                        if isinstance(self.schema[key], dict) and isinstance(value, dict):
+                            self.schema[key] = {**self.schema[key], **value}
+                            logger.info("Merged '%s'", key)
+                        else:
+                            logger.info("Merge skipped for '%s'; keeping original", key)
+                    elif strategy == "overwrite":
+                        self.schema[key] = value
+                        logger.info("Overwrote '%s'", key)
+                    elif strategy == "manual":
+                        logger.info("Manual resolution required for '%s'", key)
+                        raise ValueError(f"Manual resolution required for '{key}'")
+                    else:
+                        raise ValueError(f"Unknown strategy '{strategy}'")
+                else:
+                    self.schema[key] = value
+        return self.schema

--- a/tests/schema/test_schema_mapper_conflicts.py
+++ b/tests/schema/test_schema_mapper_conflicts.py
@@ -1,0 +1,43 @@
+import pytest
+
+import src.schema as schema
+from src.schema.schema_mapper import SchemaMapper
+
+
+def test_merge_resolution(caplog):
+    base = {"a": {"x": 1}, "b": 2}
+    mapper = SchemaMapper(base)
+    updates = {"a": {"y": 2}, "b": 3}
+    with caplog.at_level("INFO"):
+        result = mapper.apply(updates, strategy="merge")
+    assert result == {"a": {"x": 1, "y": 2}, "b": 2}
+    assert "Merged 'a'" in caplog.text
+    assert "Merge skipped for 'b'" in caplog.text
+
+
+def test_overwrite_resolution(caplog):
+    base = {"a": {"x": 1}, "b": 2}
+    mapper = SchemaMapper(base)
+    updates = {"a": {"y": 2}, "b": 3}
+    with caplog.at_level("INFO"):
+        result = mapper.apply(updates, strategy="overwrite")
+    assert result == {"a": {"y": 2}, "b": 3}
+    assert "Overwrote 'a'" in caplog.text
+    assert "Overwrote 'b'" in caplog.text
+
+
+def test_manual_resolution_triggers_rollback(monkeypatch, caplog):
+    base = {"a": 1}
+    mapper = SchemaMapper(base)
+    updates = {"a": 2}
+    called = {}
+
+    def fake_rollback():
+        called["done"] = True
+
+    monkeypatch.setattr(schema, "rollback", fake_rollback)
+    with caplog.at_level("INFO"), pytest.raises(ValueError):
+        mapper.apply(updates, strategy="manual")
+    assert mapper.schema == {"a": 1}
+    assert called.get("done")
+    assert "Manual resolution required" in caplog.text


### PR DESCRIPTION
## Summary
- add SchemaMapper with merge, overwrite, and manual conflict strategies
- log conflict resolutions and support transactional rollback
- cover all resolution modes with dedicated tests

## Testing
- `ruff check src/schema/schema_mapper.py tests/schema/test_schema_mapper_conflicts.py`
- `pytest tests/schema/test_schema_mapper_conflicts.py -vv`
- `python scripts/wlc_session_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68953d1134b48331ad83fccc9b8c827f