### PR TITLE
fix: cap documentation compliance score

### DIFF
--- a/documentation/enterprise_documentation_manager.py
+++ b/documentation/enterprise_documentation_manager.py
@@ -112,6 +112,8 @@ class EnterpriseDocumentationManager:
     def calculate_compliance(self, content: str) -> float:
         """Compute a simple compliance score."""
         score = len(content.strip()) / 100.0
+        if score > 1.0:
+            score = 1.0
         self.logger.info(f"{TEXT_INDICATORS['info']} Compliance score {score:.2f}")
         return score
 

--- a/tests/documentation_manager/test_compliance.py
+++ b/tests/documentation_manager/test_compliance.py
@@ -1,0 +1,15 @@
+from documentation.enterprise_documentation_manager import EnterpriseDocumentationManager
+
+
+def test_calculate_compliance_capped(tmp_path, monkeypatch):
+    monkeypatch.setenv('GH_COPILOT_WORKSPACE', str(tmp_path))
+    manager = EnterpriseDocumentationManager(db_path=':memory:')
+    score = manager.calculate_compliance('x' * 250)
+    assert score == 1.0
+
+
+def test_calculate_compliance_basic(tmp_path, monkeypatch):
+    monkeypatch.setenv('GH_COPILOT_WORKSPACE', str(tmp_path))
+    manager = EnterpriseDocumentationManager(db_path=':memory:')
+    score = manager.calculate_compliance('x' * 50)
+    assert 0 < score < 1.0


### PR DESCRIPTION
## Summary
- clamp documentation compliance scores to a maximum of 1
- add regression tests for compliance scoring edge cases

## Testing
- `ruff check documentation/enterprise_documentation_manager.py tests/documentation_manager/test_compliance.py`
- `pytest tests/documentation_manager -q`


------
https://chatgpt.com/codex/tasks/task_e_68953b9330008331ad3e33a7c8a7c465