### PR TITLE
fix: correct metrics weighting and rounding

### DIFF
--- a/src/compliance/metrics/updater.py
+++ b/src/compliance/metrics/updater.py
@@ -1,0 +1,42 @@
+"""Utilities for computing compliance metric aggregates."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Mapping
+
+
+@dataclass
+class MetricsUpdater:
+    """Combine raw metric scores into a single composite value.
+
+    The updater applies a weighted average to individual metric scores and
+    rounds the result to the desired precision.  Weights are normalised so that
+    the final score is always in the range ``[0.0, 1.0]`` regardless of the
+    provided weight magnitudes.
+    """
+
+    weights: Mapping[str, float] = field(
+        default_factory=lambda: {"lint": 0.4, "tests": 0.4, "placeholders": 0.2}
+    )
+    precision: int = 2
+
+    def composite(self, scores: Mapping[str, float]) -> float:
+        """Return the normalised weighted score for ``scores``.
+
+        Missing metrics simply contribute ``0``.  The result is rounded to the
+        number of decimal places specified by ``precision``.  A ``0`` score is
+        returned when the total weight is ``0`` to avoid division errors.
+        """
+
+        total_weight = sum(self.weights.values())
+        if total_weight <= 0:
+            return 0.0
+
+        total = Decimal("0")
+        for key, weight in self.weights.items():
+            total += Decimal(str(scores.get(key, 0.0))) * Decimal(str(weight))
+
+        result = total / Decimal(str(total_weight))
+        quant = Decimal("1").scaleb(-self.precision)
+        return float(result.quantize(quant, rounding=ROUND_HALF_UP))

--- a/tests/compliance/metrics_updater/test_updater.py
+++ b/tests/compliance/metrics_updater/test_updater.py
@@ -1,0 +1,20 @@
+from src.compliance.metrics.updater import MetricsUpdater
+
+
+def test_default_weighting_and_rounding():
+    updater = MetricsUpdater()
+    scores = {"lint": 0.75, "tests": 0.5, "placeholders": 1.0}
+    # 0.4*0.75 + 0.4*0.5 + 0.2*1.0 = 0.7 -> rounded to 0.7
+    assert updater.composite(scores) == 0.7
+
+
+def test_custom_weights_and_precision():
+    updater = MetricsUpdater(weights={"a": 1, "b": 2}, precision=3)
+    scores = {"a": 0.3333, "b": 0.6666}
+    # Weighted average: (0.3333*1 + 0.6666*2) / 3 = 0.5555 -> rounded to 0.556
+    assert updater.composite(scores) == 0.556
+
+
+def test_zero_total_weight():
+    updater = MetricsUpdater(weights={"x": 0, "y": 0})
+    assert updater.composite({"x": 1, "y": 1}) == 0.0


### PR DESCRIPTION
## Summary
- add metrics updater utility with normalized weighting and half-up rounding
- cover weighting precision in new tests

## Testing
- `ruff check src/compliance/metrics/updater.py tests/compliance/metrics_updater/test_updater.py`
- `pytest tests/compliance/metrics_updater -v`


------
https://chatgpt.com/codex/tasks/task_e_6895366116548331a37064bcd2390955