### PR TITLE
test: add codex log DB tests and session DB validation

### DIFF
--- a/tests/test_codex_log_db.py
+++ b/tests/test_codex_log_db.py
@@ -26,6 +26,29 @@ log_codex_start = codex_log_db.log_codex_start
 log_codex_end = codex_log_db.log_codex_end
 
 
+def test_init_db_creates_codex_actions(tmp_path, monkeypatch):
+    db_file = tmp_path / "codex_log.db"
+    monkeypatch.setattr(codex_log_db, "CODEX_LOG_DB", db_file)
+    codex_log_db.init_db()
+    assert db_file.exists()
+    with sqlite3.connect(db_file) as conn:
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='codex_actions'"
+        )
+        assert cursor.fetchone() is not None
+
+
+def test_log_codex_action_inserts_row(tmp_path, monkeypatch):
+    db_file = tmp_path / "codex_log.db"
+    monkeypatch.setattr(codex_log_db, "CODEX_LOG_DB", db_file)
+    codex_log_db.log_codex_action("s1", "act", "stmt", "meta")
+    with sqlite3.connect(db_file) as conn:
+        rows = conn.execute(
+            "SELECT session_id, action, statement, metadata FROM codex_actions"
+        ).fetchall()
+    assert rows == [("s1", "act", "stmt", "meta")]
+
+
 def test_log_codex_start_end(tmp_path, monkeypatch):
     db_dir = tmp_path / "databases"
     db_dir.mkdir()

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -5,15 +5,25 @@ import pytest
 
 import unified_session_management_system as usm
 from unified_session_management_system import ensure_no_zero_byte_files, finalize_session
+import utils.validation_utils as validation_utils
 from utils.validation_utils import _LOCK_DIR
 import sys
 import types
+from utils import codex_log_db
 
 _stub = types.ModuleType("correction_logger_and_rollback")
 _stub.CorrectionLoggerRollback = object
 sys.modules.setdefault("scripts.correction_logger_and_rollback", _stub)
 import scripts
 scripts.correction_logger_and_rollback = _stub
+sys.modules["utils"].validation_utils = validation_utils
+
+sk_stub = types.ModuleType("sklearn")
+ensemble_stub = types.ModuleType("sklearn.ensemble")
+ensemble_stub.IsolationForest = object
+sk_stub.ensemble = ensemble_stub
+sys.modules.setdefault("sklearn", sk_stub)
+sys.modules.setdefault("sklearn.ensemble", ensemble_stub)
 
 
 class DummyValidator:
@@ -49,7 +59,7 @@ def test_ensure_no_zero_byte_files_detects(tmp_path):
     empty_file = tmp_path / "empty.txt"
     empty_file.touch()
     with pytest.raises(RuntimeError):
-        with ensure_no_zero_byte_files(tmp_path):
+        with ensure_no_zero_byte_files(tmp_path, "s1"):
             pass
 
 
@@ -77,12 +87,16 @@ def test_lifecycle_logging(monkeypatch, tmp_path, caplog):
         raising=False,
     )
     monkeypatch.setattr(usms.UnifiedSessionManagementSystem, "_cleanup_zero_byte_files", lambda self: [])
+    codex_db = tmp_path / "codex_log.db"
+    monkeypatch.setattr(codex_log_db, "CODEX_LOG_DB", codex_db)
     system = usms.UnifiedSessionManagementSystem(workspace_root=str(tmp_path))
     with caplog.at_level(logging.INFO):
         system.start_session()
         system.end_session()
     assert any("Lifecycle start" in r.getMessage() for r in caplog.records)
     assert any("Lifecycle end" in r.getMessage() for r in caplog.records)
+    codex_log_db.log_codex_action(system.session_id, "session_complete", "ok")
+    assert codex_db.exists()
 
 
 def test_metrics_and_recovery(monkeypatch, tmp_path):
@@ -151,7 +165,7 @@ def test_zero_byte_logging(tmp_path, monkeypatch):
     empty = tmp_path / "empty.txt"
     empty.touch()
     with pytest.raises(RuntimeError):
-        with ensure_no_zero_byte_files(tmp_path):
+        with ensure_no_zero_byte_files(tmp_path, "s1"):
             pass
     import sqlite3
     with sqlite3.connect(db_file) as conn:


### PR DESCRIPTION
## Summary
- verify `init_db` creates codex_actions table and `log_codex_action` writes entries
- ensure session management simulates codex log DB creation

## Testing
- `ruff check tests/test_codex_log_db.py tests/test_session_management.py`
- `pytest tests/test_codex_log_db.py tests/test_session_management.py`

------
https://chatgpt.com/codex/tasks/task_e_689539e57a548331aaef92012ecd0ba2