### PR TITLE
fix: archive directories recursively in create_zip

### DIFF
--- a/src/scripts/archive/zip_utils.py
+++ b/src/scripts/archive/zip_utils.py
@@ -94,8 +94,9 @@ def extract_zip(zip_path: Path | str, dest_dir: Path | str, *, overwrite: bool =
 def create_zip(zip_path: Path | str, sources: Iterable[Path | str]) -> Path:
     """Create a zip archive at ``zip_path`` from ``sources``.
 
-    Non-existent source paths are ignored. The function returns the path
-    to the created archive.
+    Non-existent source paths are ignored. Directories are added
+    recursively so their entire contents are included. The function
+    returns the path to the created archive.
     """
 
     archive = Path(zip_path)
@@ -105,6 +106,11 @@ def create_zip(zip_path: Path | str, sources: Iterable[Path | str]) -> Path:
         for src in sources:
             path = Path(src)
             if not path.exists():
+                continue
+            if path.is_dir():
+                for item in path.rglob("*"):
+                    if item.is_file():
+                        zf.write(item, arcname=item.relative_to(path))
                 continue
             zf.write(path, arcname=path.name)
 

--- a/tests/archive_scripts/test_zip_utils.py
+++ b/tests/archive_scripts/test_zip_utils.py
@@ -38,3 +38,13 @@ def test_create_zip_ignores_missing(tmp_path):
     archive = create_zip(tmp_path / "out.zip", [existing, missing])
     with zipfile.ZipFile(archive) as zf:
         assert zf.namelist() == ["a.txt"]
+
+
+def test_create_zip_includes_directories(tmp_path):
+    folder = tmp_path / "src"
+    (folder / "sub").mkdir(parents=True)
+    (folder / "file1.txt").write_text("1")
+    (folder / "sub" / "file2.txt").write_text("2")
+    archive = create_zip(tmp_path / "out_dir.zip", [folder])
+    with zipfile.ZipFile(archive) as zf:
+        assert sorted(zf.namelist()) == ["file1.txt", "sub/file2.txt"]


### PR DESCRIPTION
## Summary
- support recursive directory inputs in `create_zip`
- test archiving folders and nested files

## Testing
- `ruff check src/scripts/archive/zip_utils.py tests/archive_scripts/test_zip_utils.py`
- `pytest tests/archive_scripts/`
- `python scripts/wlc_session_manager.py --steps 1` *(fails: NotADirectoryError: '/workspace/gh_COPILOT/databases/production.db')*

------
https://chatgpt.com/codex/tasks/task_e_68953b941d148331b4455442595d9d56