### PR TITLE
fix: ensure accessible documentation formats

### DIFF
--- a/src/documentation_manager/__init__.py
+++ b/src/documentation_manager/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for managing documentation outputs."""
+
+from .utils import ensure_accessible_formats
+
+__all__ = ["ensure_accessible_formats"]

--- a/src/documentation_manager/utils.py
+++ b/src/documentation_manager/utils.py
@@ -1,0 +1,31 @@
+"""Helper utilities for documentation management."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+TEXT_FORMATS = {"md", "html"}
+
+
+def ensure_accessible_formats(formats: Iterable[str]) -> List[str]:
+    """Normalize and de-duplicate output formats.
+
+    Ensures that if a PDF output is requested, at least one accessible text
+    format (Markdown or HTML) is also present. Input format names are treated in
+    a case-insensitive manner and returned in lower-case order of first
+    appearance without duplicates.
+    """
+
+    seen: list[str] = []
+    result: list[str] = []
+    for fmt in formats:
+        lower = fmt.lower()
+        if lower not in seen:
+            seen.append(lower)
+            result.append(lower)
+    if "pdf" in seen and not (TEXT_FORMATS & set(seen)):
+        # Ensure markdown companion for PDF-only requests
+        if "md" not in seen:
+            result.append("md")
+    return result
+

--- a/tests/documentation_manager/test_utils.py
+++ b/tests/documentation_manager/test_utils.py
@@ -1,0 +1,16 @@
+
+
+from src.documentation_manager import ensure_accessible_formats
+
+def test_pdf_requires_text_companion():
+    assert ensure_accessible_formats(["PDF"]) == ["pdf", "md"]
+
+
+def test_deduplicates_and_normalizes_order():
+    formats = ["html", "pdf", "md", "PDF", "html"]
+    assert ensure_accessible_formats(formats) == ["html", "pdf", "md"]
+
+
+def test_no_extra_markdown_when_text_present():
+    assert ensure_accessible_formats(["pdf", "HTML"]) == ["pdf", "html"]
+


### PR DESCRIPTION
## Summary
- add utility to normalize documentation formats and ensure PDF outputs include a text-based companion
- add tests for format normalization and PDF accessibility requirements

## Testing
- `pytest tests/documentation_manager -q`


------
https://chatgpt.com/codex/tasks/task_e_68953b9bb1fc8331bfdd107080f6d5b8