### PR TITLE
feat: sanitize table names and handle tables without id

### DIFF
--- a/database_first_synchronization_engine.py
+++ b/database_first_synchronization_engine.py
@@ -17,11 +17,28 @@ This module provides three main classes:
 
 from __future__ import annotations
 
+import re
 import sqlite3
 import threading
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List
+
+
+_TABLE_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def sanitize_table_name(name: str) -> str:
+    """Return *name* if it is a valid table identifier.
+
+    Only alphanumeric characters and underscores are allowed.  Any other
+    character raises :class:`ValueError` to prevent SQL injection via table
+    names.
+    """
+
+    if not _TABLE_RE.fullmatch(name):
+        raise ValueError(f"Invalid table name: {name!r}")
+    return name
 
 
 class SchemaMapper:
@@ -121,13 +138,29 @@ class SyncManager:
                 self.mapper.map(conn_a, conn_b)
                 self.mapper.map(conn_b, conn_a)
 
-                tables_a = {r[0] for r in conn_a.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-                tables_b = {r[0] for r in conn_b.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+                tables_a = {
+                    sanitize_table_name(r[0])
+                    for r in conn_a.execute("SELECT name FROM sqlite_master WHERE type='table'")
+                }
+                tables_b = {
+                    sanitize_table_name(r[0])
+                    for r in conn_b.execute("SELECT name FROM sqlite_master WHERE type='table'")
+                }
                 tables = tables_a | tables_b
 
                 for table in tables:
-                    rows_a = {row["id"]: dict(row) for row in conn_a.execute(f"SELECT * FROM {table}")}
-                    rows_b = {row["id"]: dict(row) for row in conn_b.execute(f"SELECT * FROM {table}")}
+                    conn_ref = conn_a if table in tables_a else conn_b
+                    pk = self._get_primary_key(conn_ref, table)
+                    if pk != "id":
+                        continue
+                    rows_a = {
+                        row[pk]: dict(row)
+                        for row in conn_a.execute(f'SELECT * FROM "{table}"')
+                    }
+                    rows_b = {
+                        row[pk]: dict(row)
+                        for row in conn_b.execute(f'SELECT * FROM "{table}"')
+                    }
                     table_policy: ConflictPolicy = policy
                     if resolver_registry and table in resolver_registry:
                         custom = resolver_registry[table]
@@ -137,22 +170,22 @@ class SyncManager:
                             else ResolverPolicy(custom)
                         )
 
-                    for pk in rows_a.keys() | rows_b.keys():
-                        in_a = pk in rows_a
-                        in_b = pk in rows_b
+                    for pk_val in rows_a.keys() | rows_b.keys():
+                        in_a = pk_val in rows_a
+                        in_b = pk_val in rows_b
                         if in_a and in_b:
-                            row = rows_a[pk]
-                            other = rows_b[pk]
+                            row = rows_a[pk_val]
+                            other = rows_b[pk_val]
                             if row != other:
                                 merged = table_policy.resolve(table, row, other)
                                 decision = "a" if merged == row else "b"
-                                self._log_conflict(db_a, db_b, table, pk, decision)
+                                self._log_conflict(db_a, db_b, table, pk_val, decision)
                                 self._upsert(conn_a, table, merged)
                                 self._upsert(conn_b, table, merged)
                         elif in_a:
-                            self._upsert(conn_b, table, rows_a[pk])
+                            self._upsert(conn_b, table, rows_a[pk_val])
                         else:
-                            self._upsert(conn_a, table, rows_b[pk])
+                            self._upsert(conn_a, table, rows_b[pk_val])
 
                 conn_a.commit()
                 conn_b.commit()
@@ -204,11 +237,23 @@ class SyncManager:
             time.sleep(interval)
 
     @staticmethod
+    def _get_primary_key(conn: sqlite3.Connection, table: str) -> str | None:
+        """Return the name of the primary key column for ``table``."""
+
+        safe_table = sanitize_table_name(table)
+        info = conn.execute(f'PRAGMA table_info("{safe_table}")').fetchall()
+        for column in info:
+            if column[5]:
+                return column[1]
+        return None
+
+    @staticmethod
     def _upsert(conn: sqlite3.Connection, table: str, row: Dict[str, Any]) -> None:
-        cols = ", ".join(row.keys())
+        safe_table = sanitize_table_name(table)
+        cols = ", ".join(f'"{c}"' for c in row.keys())
         marks = ", ".join("?" for _ in row)
         conn.execute(
-            f"REPLACE INTO {table} ({cols}) VALUES ({marks})",
+            f'REPLACE INTO "{safe_table}" ({cols}) VALUES ({marks})',
             tuple(row.values()),
         )
 


### PR DESCRIPTION
## Summary
- add sanitize_table_name helper and primary-key detection
- guard SQL queries against invalid table names
- test skipping tables lacking id and rejecting malicious names

## Testing
- `ruff check database_first_synchronization_engine.py tests/test_database_first_synchronization_engine.py`
- `pytest tests/test_database_first_synchronization_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68953cdae8b4833197e3131f3041775d