### PR TITLE
feat: add real-time SQLite sync engine

### DIFF
--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -1,0 +1,6 @@
+"""Database utilities including a lightweight sync engine."""
+
+from .engine import Engine
+
+__all__ = ["Engine"]
+

--- a/src/database/engine.py
+++ b/src/database/engine.py
@@ -1,0 +1,138 @@
+"""Realtime SQLite change listeners with bidirectional sync."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from threading import Lock
+from typing import Any, Callable, Dict, List
+
+from src.schema.schema_mapper import SchemaMapper
+
+
+class ChangeStream:
+    """Manage change listeners for database triggers."""
+
+    def __init__(self) -> None:
+        self._listeners: List[Callable[[str, str, Dict[str, Any]], None]] = []
+        self._lock = Lock()
+
+    def register(self, callback: Callable[[str, str, Dict[str, Any]], None]) -> None:
+        """Register a callback receiving (operation, table, row)."""
+
+        with self._lock:
+            self._listeners.append(callback)
+
+    def notify(self, operation: str, table: str, row: Dict[str, Any]) -> None:
+        with self._lock:
+            listeners = list(self._listeners)
+        for callback in listeners:
+            callback(operation, table, row)
+
+
+class Engine:
+    """SQLite engine with change-stream triggers and bidirectional sync."""
+
+    def __init__(self, path: Path | str, mapper: SchemaMapper | None = None) -> None:
+        self.path = Path(path)
+        self.conn = sqlite3.connect(self.path, check_same_thread=False)
+        self.conn.row_factory = sqlite3.Row
+        self.stream = ChangeStream()
+        self.mapper = mapper or SchemaMapper({})
+        self.conn.create_function("notify_change", 3, self._notify_change)
+
+    # ------------------------------------------------------------------
+    # change stream handling
+    def _notify_change(self, operation: str, table: str, rowid: int) -> None:
+        row = self.conn.execute(f"SELECT * FROM {table} WHERE id=?", (rowid,)).fetchone()
+        payload = dict(row) if row else {"id": rowid}
+        self.stream.notify(operation, table, payload)
+
+    def install_triggers(self, table: str) -> None:
+        """Install change-stream triggers for ``table``."""
+
+        self.conn.execute(
+            f"""
+            CREATE TRIGGER IF NOT EXISTS {table}_notify_insert
+            AFTER INSERT ON {table}
+            BEGIN
+                SELECT notify_change('insert', '{table}', NEW.id);
+            END;
+            """
+        )
+        self.conn.execute(
+            f"""
+            CREATE TRIGGER IF NOT EXISTS {table}_notify_update
+            AFTER UPDATE ON {table}
+            BEGIN
+                SELECT notify_change('update', '{table}', NEW.id);
+            END;
+            """
+        )
+        self.conn.execute(
+            f"""
+            CREATE TRIGGER IF NOT EXISTS {table}_notify_delete
+            AFTER DELETE ON {table}
+            BEGIN
+                SELECT notify_change('delete', '{table}', OLD.id);
+            END;
+            """
+        )
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    # synchronization
+    def _resolve_conflict(self, a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
+        """Use ``SchemaMapper`` to resolve conflicting rows."""
+
+        mapper = SchemaMapper(dict(a))
+        if b.get("updated_at", 0) > a.get("updated_at", 0):
+            return mapper.apply(b, strategy="overwrite")
+        return a
+
+    @staticmethod
+    def _upsert(conn: sqlite3.Connection, table: str, row: Dict[str, Any]) -> None:
+        columns = ", ".join(row.keys())
+        placeholders = ", ".join(["?"] * len(row))
+        updates = ", ".join([f"{c}=excluded.{c}" for c in row.keys()])
+        conn.execute(
+            f"INSERT INTO {table} ({columns}) VALUES ({placeholders}) "
+            f"ON CONFLICT(id) DO UPDATE SET {updates}",
+            tuple(row.values()),
+        )
+
+    def sync_with(self, other: "Engine") -> None:
+        """Bidirectionally synchronize this engine with ``other``."""
+
+        tables_self = {
+            r[0] for r in self.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        tables_other = {
+            r[0] for r in other.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        for table in tables_self | tables_other:
+            rows_self = (
+                {row["id"]: dict(row) for row in self.conn.execute(f"SELECT * FROM {table}")}
+                if table in tables_self
+                else {}
+            )
+            rows_other = (
+                {row["id"]: dict(row) for row in other.conn.execute(f"SELECT * FROM {table}")}
+                if table in tables_other
+                else {}
+            )
+            for pk in rows_self.keys() | rows_other.keys():
+                in_self = pk in rows_self
+                in_other = pk in rows_other
+                if in_self and in_other:
+                    if rows_self[pk] != rows_other[pk]:
+                        merged = self._resolve_conflict(rows_self[pk], rows_other[pk])
+                        self._upsert(self.conn, table, merged)
+                        self._upsert(other.conn, table, merged)
+                elif in_self:
+                    self._upsert(other.conn, table, rows_self[pk])
+                else:
+                    self._upsert(self.conn, table, rows_other[pk])
+        self.conn.commit()
+        other.conn.commit()
+

--- a/tests/database/test_real_time_sync.py
+++ b/tests/database/test_real_time_sync.py
@@ -1,0 +1,68 @@
+import sqlite3
+import threading
+import time
+
+from src.database.engine import Engine
+
+
+def _setup_db(path):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT, updated_at REAL)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_real_time_sync_concurrent_updates(tmp_path):
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+    _setup_db(db_a)
+    _setup_db(db_b)
+
+    engine_a = Engine(db_a)
+    engine_b = Engine(db_b)
+    engine_a.install_triggers("items")
+    engine_b.install_triggers("items")
+
+    events_a = []
+    events_b = []
+    engine_a.stream.register(lambda op, tbl, row: events_a.append((op, row["value"])))
+    engine_b.stream.register(lambda op, tbl, row: events_b.append((op, row["value"])))
+
+    def update_a():
+        with engine_a.conn:
+            engine_a.conn.execute(
+                "INSERT INTO items(id, value, updated_at) VALUES (1, 'A1', 1)"
+            )
+
+    def update_b():
+        time.sleep(0.1)
+        with engine_b.conn:
+            engine_b.conn.execute(
+                "INSERT INTO items(id, value, updated_at) VALUES (1, 'B1', 2)"
+            )
+
+    t1 = threading.Thread(target=update_a)
+    t2 = threading.Thread(target=update_b)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    engine_a.sync_with(engine_b)
+
+    with engine_a.conn:
+        value_a = engine_a.conn.execute(
+            "SELECT value FROM items WHERE id=1"
+        ).fetchone()[0]
+    with engine_b.conn:
+        value_b = engine_b.conn.execute(
+            "SELECT value FROM items WHERE id=1"
+        ).fetchone()[0]
+
+    assert value_a == "B1"
+    assert value_b == "B1"
+    assert any(op == "insert" for op, _ in events_a)
+    assert any(op == "insert" for op, _ in events_b)
+


### PR DESCRIPTION
## Summary
- add lightweight database engine with SQLite change-stream triggers
- implement bidirectional sync using SchemaMapper for conflict resolution
- test real-time synchronization under concurrent writes

## Testing
- `ruff check src/database/engine.py tests/database/test_real_time_sync.py`
- `pytest tests/database/test_real_time_sync.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_6895448a93ac833193da4207c9200462