### PR TITLE
fix: tighten file renamer error handling

### DIFF
--- a/rename_files_with_spaces.py
+++ b/rename_files_with_spaces.py
@@ -6,8 +6,9 @@ Systematically rename all files in a directory to replace spaces with underscore
 
 from pathlib import Path
 from datetime import datetime
-from typing import Union
+from typing import List, Union
 import logging
+import re
 
 # Configure logging
 logging.basicConfig(
@@ -39,36 +40,31 @@ class FileRenamer:
         logger.info(f"✅ Directory validated: {self.target_directory}")
         return True
     
-    def get_files_with_spaces(self) -> list:
+    def get_files_with_spaces(self) -> List[Path]:
         """🔍 Identify all files that contain spaces in their names"""
-        files_with_spaces = []
-        
+        files_with_spaces: List[Path] = []
+
         try:
             for file_path in self.target_directory.iterdir():
-                if file_path.is_file() and ' ' in file_path.name:
+                if file_path.is_file() and " " in file_path.name:
                     files_with_spaces.append(file_path)
-                    
+
             logger.info(f"🔍 Found {len(files_with_spaces)} files with spaces")
-            
+
             # Log each file for transparency
             for file_path in files_with_spaces:
                 logger.info(f"   📄 {file_path.name}")
-                
-        except Exception as e:
+
+        except OSError as e:
             logger.error(f"❌ Error scanning directory: {e}")
             self.errors.append(f"Directory scan error: {e}")
-            
+
         return files_with_spaces
     
     def generate_new_filename(self, original_name: str) -> str:
         """🔄 Generate new filename by replacing spaces with underscores"""
-        # Replace spaces with underscores
-        new_name = original_name.replace(' ', '_')
-        
-        # Clean up any multiple underscores (just in case)
-        while '__' in new_name:
-            new_name = new_name.replace('__', '_')
-            
+        new_name = re.sub(r"\s+", "_", original_name)
+        new_name = re.sub(r"_+", "_", new_name)
         return new_name
     
     def rename_file_safely(self, file_path: Path) -> bool:
@@ -76,35 +72,35 @@ class FileRenamer:
         try:
             original_name = file_path.name
             new_name = self.generate_new_filename(original_name)
-            
+
             # Skip if no change needed
             if original_name == new_name:
                 logger.info(f"⏭️  Skipped (no spaces): {original_name}")
                 self.skipped_files.append(original_name)
                 return True
-            
+
             # Generate new path
             new_path = file_path.parent / new_name
-            
+
             # Check if target already exists
             if new_path.exists():
                 logger.warning(f"⚠️  Target exists, skipping: {new_name}")
                 self.skipped_files.append(f"{original_name} (target exists)")
                 return False
-            
+
             # Perform the rename
             file_path.rename(new_path)
-            
+
             logger.info(f"✅ Renamed: '{original_name}' → '{new_name}'")
             self.renamed_files.append({
-                'original': original_name,
-                'new': new_name,
-                'timestamp': datetime.now().isoformat()
+                "original": original_name,
+                "new": new_name,
+                "timestamp": datetime.now().isoformat(),
             })
-            
+
             return True
-            
-        except Exception as e:
+
+        except OSError as e:
             logger.error(f"❌ Error renaming {file_path.name}: {e}")
             self.errors.append(f"Rename error for {file_path.name}: {e}")
             return False
@@ -170,7 +166,7 @@ class FileRenamer:
             'operation_status': 'SUCCESS' if not self.errors else 'PARTIAL_SUCCESS' if self.renamed_files else 'FAILED'
         }
     
-    def log_summary(self, summary: dict):
+    def log_summary(self, summary: dict) -> None:
         """📋 Log comprehensive summary of the operation"""
         logger.info("="*60)
         logger.info("📊 FILE RENAMING OPERATION SUMMARY")


### PR DESCRIPTION
## Summary
- replace filename cleanup loop with regex-based normalization
- narrow file renamer exception handling to `OSError`
- add tests for existing targets and unreadable directories

## Testing
- `ruff check rename_files_with_spaces.py tests/test_rename_files_with_spaces.py`
- `pytest -o addopts= tests/test_rename_files_with_spaces.py`

------
https://chatgpt.com/codex/tasks/task_e_68953ce3d36883318fee25bb5461f544