### PR TITLE
docs: add codex logging guide and README link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Ensure the development environment is correctly configured **before** making any
   * *Optional variables:* **WORKSPACE\_ROOT** (alias for `GH_COPILOT_WORKSPACE`), **FLASK\_SECRET\_KEY** (for the optional Flask web UI, default `'your_secret_key'` – replace in production), **FLASK\_RUN\_PORT** (Flask dev server port, default 5000), **CONFIG\_PATH** (path to a custom config file if not using the default `config/enterprise.json`), **WEB\_DASHBOARD\_ENABLED** (`"1"` or `"0"` to toggle logging of performance metrics with `[DASHBOARD]` tags). Configure these as needed if using those features.
 * After installing dependencies and setting variables, **run the test suite** (see [Testing and Validation](#testing-and-validation)) to verify the environment is correctly set up.
 * For procedures on restoring Git LFS-managed files, consult [docs/git_lfs_recovery.md](docs/git_lfs_recovery.md).
+* For details on the Codex logging database schema and commit workflow, see [docs/codex_logging.md](docs/codex_logging.md).
 
 ## Output Safety and `clw`
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,13 @@ python scripts/session/COMPREHENSIVE_WORKSPACE_MANAGER.py --SessionStart -AutoFi
 python scripts/session/COMPREHENSIVE_WORKSPACE_MANAGER.py --SessionEnd
 ```
 
+Codex session activity is recorded in the `databases/codex_log.db` SQLite
+database. Set `GH_COPILOT_WORKSPACE` to the repository root and
+`GH_COPILOT_BACKUP_ROOT` to an external path before running the CLI. Because
+`codex_log.db` is a binary artifact, ensure Git LFS is installed and tracking
+the file. See [docs/codex_logging.md](docs/codex_logging.md) for the database
+schema and commit workflow.
+
 ### Unified Deployment Orchestrator CLI
 Manage orchestration tasks with start/stop controls:
 

--- a/docs/codex_logging.md
+++ b/docs/codex_logging.md
@@ -1,0 +1,52 @@
+# Codex Logging
+
+This document describes how Codex sessions are recorded in the
+`databases/codex_log.db` SQLite database and how to commit updates
+responsibly.
+
+## Database Schema
+
+The database contains two tables:
+
+| Table | Purpose | Columns |
+|-------|---------|---------|
+| `codex_actions` | Records individual actions taken during a session. | `id INTEGER PRIMARY KEY`, `session_id TEXT`, `ts TEXT`, `action TEXT`, `statement TEXT`, `metadata TEXT` |
+| `codex_log` | Tracks session start and end events. | `session_id TEXT`, `event TEXT`, `summary TEXT`, `ts TEXT` |
+
+## Usage
+
+Utilities in `utils/codex_log_db.py` manage the database:
+
+```python
+from utils import codex_log_db
+
+codex_log_db.log_codex_start(session_id)
+codex_log_db.log_codex_action(session_id, "action", "statement", "meta")
+codex_log_db.log_codex_end(session_id, "summary")
+```
+
+Use `codex_log_cursor()` for batch inserts and `init_db()` to create the
+tables if they do not exist.
+
+## Required Environment Variables
+
+Before logging, set:
+
+- `GH_COPILOT_WORKSPACE` – absolute path to the repository root.
+- `GH_COPILOT_BACKUP_ROOT` – external directory for backups.
+- `ALLOW_AUTOLFS` – set to `1` to allow automatic Git LFS tracking.
+
+## Commit Process and Git LFS
+
+`codex_log.db` is a binary artifact stored under `databases/` and managed with
+Git LFS. When committing session data:
+
+1. Run `git lfs install` if not already configured.
+2. Verify tracking with `git lfs ls-files | grep codex_log.db`.
+3. Stage the database with `git add databases/codex_log.db`.
+4. Commit alongside related code or documentation changes.
+
+Git LFS ensures the repository remains lightweight and avoids corruption of
+the database file. Refer to `docs/git_lfs_recovery.md` for recovery procedures
+if LFS data becomes inconsistent.
+


### PR DESCRIPTION
## Summary
- document codex logging database schema, usage, env vars, and Git LFS workflow
- reference codex logging in README session management section
- note new codex logging guide in AGENTS instructions

## Testing
- `ruff format docs/codex_logging.md README.md` *(fails: Failed to parse README.md:4:1: Expected a statement)*
- `pytest` *(fails: tests/quantum/test_interfaces.py)*

------
https://chatgpt.com/codex/tasks/task_e_68954419080083319df8a19ca5fe3183