### PR TITLE
feat(database): add sync runner logging

### DIFF
--- a/src/database/sync_runner.py
+++ b/src/database/sync_runner.py
@@ -1,0 +1,52 @@
+"""Run database synchronization with logging.
+
+This module provides a convenience wrapper around :class:`Engine` that logs
+the lifecycle of a synchronization run. Logs are written to ``logs/sync`` with
+rotation and retention.
+"""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from .engine import Engine
+
+
+LOG_DIR = Path("logs/sync")
+LOG_FILE = LOG_DIR / "sync.log"
+
+logger = logging.getLogger(__name__)
+
+
+def _configure_logger() -> None:
+    """Configure the rotating file logger if not already configured."""
+
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    if logger.handlers:
+        return
+
+    handler = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=5)
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+    handler.setFormatter(formatter)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+
+
+_configure_logger()
+
+
+def run_sync(a_path: str | Path, b_path: str | Path) -> None:
+    """Synchronize two SQLite databases and log start, success, and errors."""
+
+    logger.info("Sync started")
+    try:
+        engine_a = Engine(a_path)
+        engine_b = Engine(b_path)
+        engine_a.sync_with(engine_b)
+        logger.info("Sync completed successfully")
+    except Exception:  # pragma: no cover - ensures logging of unexpected errors
+        logger.exception("Sync failed")
+        raise
+

--- a/tests/database/test_sync_logging.py
+++ b/tests/database/test_sync_logging.py
@@ -1,0 +1,57 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.database import sync_runner
+
+
+def _setup_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT, updated_at REAL)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _read_log() -> str:
+    with sync_runner.LOG_FILE.open() as f:
+        return f.read()
+
+
+def test_run_sync_logs_success(tmp_path):
+    if sync_runner.LOG_FILE.exists():
+        sync_runner.LOG_FILE.write_text("")
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+    _setup_db(db_a)
+    _setup_db(db_b)
+
+    sync_runner.run_sync(db_a, db_b)
+
+    log_content = _read_log()
+    assert "Sync started" in log_content
+    assert "Sync completed successfully" in log_content
+
+
+def test_run_sync_logs_error(tmp_path, monkeypatch):
+    if sync_runner.LOG_FILE.exists():
+        sync_runner.LOG_FILE.write_text("")
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+    _setup_db(db_a)
+    _setup_db(db_b)
+
+    def boom(self, other):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(sync_runner.Engine, "sync_with", boom)
+
+    with pytest.raises(RuntimeError):
+        sync_runner.run_sync(db_a, db_b)
+
+    log_content = _read_log()
+    assert "Sync started" in log_content
+    assert "Sync failed" in log_content
+


### PR DESCRIPTION
## Summary
- log start, success, and failures for database sync operations
- store rotating sync logs under `logs/sync/`
- test sync runner log output for success and error cases

## Testing
- `ruff check src/database/sync_runner.py tests/database/test_sync_logging.py`
- `pytest tests/database/test_sync_logging.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68954798f4ec8331917f97d5458d064e