### PR TITLE
fix: clamp compliance metric scores

### DIFF
--- a/tests/compliance/metrics_updater/test_updater.py
+++ b/tests/compliance/metrics_updater/test_updater.py
@@ -18,3 +18,12 @@ def test_custom_weights_and_precision():
 def test_zero_total_weight():
     updater = MetricsUpdater(weights={"x": 0, "y": 0})
     assert updater.composite({"x": 1, "y": 1}) == 0.0
+
+
+def test_scores_clamped_and_negative_weights_ignored():
+    """Scores are constrained to ``[0, 1]`` and negative weights skipped."""
+    updater = MetricsUpdater(weights={"a": 1, "b": -1, "c": 1})
+    scores = {"a": 1.5, "b": 1.0, "c": -0.5}
+    # Weight 'b' is negative and ignored.  Scores for 'a' and 'c' are clamped
+    # to 1.0 and 0.0 respectively resulting in an average of 0.5.
+    assert updater.composite(scores) == 0.5


### PR DESCRIPTION
## Summary
- clamp compliance scores to [0,1] and skip negative weights
- add regression tests for clamped scores and negative weights

## Testing
- `ruff check src/compliance/metrics/updater.py tests/compliance/metrics_updater/test_updater.py`
- `pytest tests/compliance/metrics_updater/test_updater.py -q`
- `pytest tests/test_compliance_metrics_scheduler.py tests/test_compliance_metrics_updater.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68954852e3d08331a8242049f748f7d0