### PR TITLE
style: remove unused pytest import

### DIFF
--- a/tests/test_rename_files_with_spaces.py
+++ b/tests/test_rename_files_with_spaces.py
@@ -2,7 +2,6 @@ from pathlib import Path, PureWindowsPath
 import types
 import sys
 
-import pytest
 import rename_files_with_spaces as rfs
 
 def test_relative_path_unix():


### PR DESCRIPTION
## Summary
- run ruff autofix
- remove unused pytest import in test_rename_files_with_spaces

## Testing
- `ruff check .`
- `pytest` *(fails: tests/test_analytics_modules.py)*

------
https://chatgpt.com/codex/tasks/task_e_68954e6cf6c08331802128b694d5f757