### PR TITLE
chore: add type hints to schema mapper transaction

### DIFF
--- a/src/schema/schema_mapper.py
+++ b/src/schema/schema_mapper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Any, Dict, Iterator
 
 from . import logger
 
@@ -10,11 +10,11 @@ from . import logger
 class SchemaMapper:
     """Apply updates to a schema with conflict resolution strategies."""
 
-    def __init__(self, base_schema: Dict[str, Any]):
+    def __init__(self, base_schema: Dict[str, Any]) -> None:
         self.schema = base_schema
 
     @contextmanager
-    def transaction(self):
+    def transaction(self) -> Iterator[None]:
         """Provide a transactional context with rollback support."""
         snapshot = deepcopy(self.schema)
         try:


### PR DESCRIPTION
## Summary
- add explicit return types to `SchemaMapper` initialization and transaction context manager

## Testing
- `ruff check src/schema/schema_mapper.py`
- `pyright src --stats`
- `pytest tests/schema/test_schema_mapper_conflicts.py tests/documentation/test_link_and_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68954e3cc7148331841ede28b1eec2ba