### PR TITLE
feat: derive lessons from codex logs

### DIFF
--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -40,7 +40,10 @@ from tqdm import tqdm
 from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.validation_utils import anti_recursion_guard, validate_enterprise_environment
-from utils.lessons_learned_integrator import store_lesson
+from utils.lessons_learned_integrator import (
+    extract_lessons_from_codex_logs,
+    store_lesson,
+)
 from unified_session_management_system import ensure_no_zero_byte_files
 from utils.logging_utils import ANALYTICS_DB
 from utils.codex_log_db import log_codex_action
@@ -282,6 +285,9 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
             validation_status="validated",
             tags="wlc",
         )
+        codex_db = CrossPlatformPathManager.get_workspace_path() / "databases" / "codex_log.db"
+        for lesson in extract_lessons_from_codex_logs(codex_db):
+            store_lesson(**lesson)
 
         if run_orchestrator:
             orchestrator_cls = UnifiedWrapUpOrchestrator

--- a/tests/test_lessons_learned.py
+++ b/tests/test_lessons_learned.py
@@ -1,0 +1,92 @@
+import sqlite3
+from contextlib import contextmanager
+
+import scripts.wlc_session_manager as wsm
+import utils.codex_log_db as codex_db_mod
+from utils.lessons_learned_integrator import extract_lessons_from_codex_logs
+
+
+def test_extract_lessons_from_codex_logs(tmp_path):
+    db = tmp_path / "codex_log.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE codex_log (session_id TEXT, event TEXT, summary TEXT, ts TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO codex_log VALUES (?,?,?,?)",
+            ("s1", "end", "Be concise", "2024-01-01T00:00:00Z"),
+        )
+    lessons = extract_lessons_from_codex_logs(db)
+    assert lessons == [
+        {
+            "description": "Be concise",
+            "source": "codex_log",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "validation_status": "pending",
+            "tags": "codex",
+        }
+    ]
+
+
+def test_run_session_stores_codex_lessons(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    backup_root = tmp_path / "backup"
+    backup_root.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+    monkeypatch.delenv("TEST_MODE", raising=False)
+
+    codex_db = workspace / "databases" / "codex_log.db"
+    codex_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(codex_db) as conn:
+        conn.execute(
+            "CREATE TABLE codex_log (session_id TEXT, event TEXT, summary TEXT, ts TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO codex_log VALUES (?,?,?,?)",
+            ("s1", "end", "Review results", "2024-01-02T00:00:00Z"),
+        )
+    monkeypatch.setattr(codex_db_mod, "CODEX_LOG_DB", codex_db)
+
+    @contextmanager
+    def dummy_no_zero(path, session_id):
+        yield
+
+    monkeypatch.setattr(wsm, "ensure_no_zero_byte_files", dummy_no_zero)
+
+    class DummyOrchestrator:
+        def __init__(self, workspace_path=None):
+            pass
+
+        def execute_unified_wrapup(self):
+            return type("R", (), {"compliance_score": 100.0})()
+
+    monkeypatch.setattr(wsm, "UnifiedWrapUpOrchestrator", DummyOrchestrator)
+
+    class DummyValidator:
+        def validate_corrections(self, files):
+            return True
+
+    monkeypatch.setattr(wsm, "SecondaryCopilotValidator", lambda: DummyValidator())
+    monkeypatch.setattr(wsm, "validate_environment", lambda: True)
+
+    stored = []
+
+    def fake_store_lesson(description, source, timestamp, validation_status, *, tags=None, db_path=None):
+        stored.append(
+            {
+                "description": description,
+                "source": source,
+                "timestamp": timestamp,
+                "validation_status": validation_status,
+                "tags": tags,
+            }
+        )
+
+    monkeypatch.setattr(wsm, "store_lesson", fake_store_lesson)
+
+    session_db = workspace / "databases" / "session.db"
+    wsm.run_session(0, session_db, False, run_orchestrator=False)
+
+    assert any(lesson["description"] == "Review results" for lesson in stored)


### PR DESCRIPTION
## Summary
- add `extract_lessons_from_codex_logs` to pull lessons from Codex log summaries
- store Codex-derived lessons during WLC session wrap-up
- test lesson extraction and WLC integration with Codex logs

## Testing
- `ruff check utils/lessons_learned_integrator.py scripts/wlc_session_manager.py tests/test_lessons_learned.py`
- `pytest tests/test_lessons_learned.py`


------
https://chatgpt.com/codex/tasks/task_e_68954f1f3e308331bbeb9dfaa1e69175