### PR TITLE
feat: include codex log in session archives

### DIFF
--- a/artifact_manager.py
+++ b/artifact_manager.py
@@ -334,10 +334,14 @@ def package_session(
 
     codex_log = repo_root / "databases" / "codex_log.db"
     if codex_log.exists():
+        target_dir = tmp_dir / "databases"
         try:
-            shutil.copy2(codex_log, tmp_dir / "codex_log.db")
+            target_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(codex_log, target_dir / "codex_log.db")
         except OSError as exc:  # pragma: no cover - log only
-            logger.error("Failed to copy %s into %s: %s", codex_log, tmp_dir, exc)
+            logger.error(
+                "Failed to copy %s into %s: %s", codex_log, target_dir, exc
+            )
 
     changed_files = detect_tmp_changes(tmp_dir, repo_root)
     if not changed_files:

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import subprocess
 import sqlite3
 import sys
 import time
@@ -323,7 +322,6 @@ def main(argv: list[str] | None = None) -> None:
         repo_root = Path(__file__).resolve().parents[1]
         tmp_dir = repo_root / "tmp"
         tmp_dir.mkdir(exist_ok=True)
-        subprocess.run(["git", "add", "databases/codex_log.db"], cwd=repo_root, check=False)
         package_session(
             tmp_dir,
             repo_root,

--- a/tests/test_artifact_manager.py
+++ b/tests/test_artifact_manager.py
@@ -99,7 +99,7 @@ def test_package_session_includes_codex_log_db(repo: Path) -> None:
     archive = package_session(tmp_dir, repo, policy)
     assert archive and archive.exists(), "archive missing"
     with ZipFile(archive) as zf:
-        assert "codex_log.db" in zf.namelist()
+        assert "databases/codex_log.db" in zf.namelist()
 
 
 def test_package_session_no_changes_returns_none(repo: Path, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary
- package codex_log.db within session archives
- ensure wrap-up uses artifact_manager without manual git adds
- update tests for new archive structure

## Testing
- `ruff check artifact_manager.py scripts/wlc_session_manager.py tests/test_artifact_manager.py`
- `pytest tests/test_artifact_manager.py tests/test_wlc_session_manager.py tests/test_wlc_session_manager_cli.py tests/test_wlc_session_manager_importpath.py`
- `python scripts/wlc_session_manager.py --wrap-up`
- `unzip -l codex_sessions/codex-session_20250808_012457.zip`

------
https://chatgpt.com/codex/tasks/task_e_68954f8a4d048331b7b33c3b1391df80