### PR TITLE
chore: ensure codex log db tracked by LFS

### DIFF
--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -21,7 +21,8 @@ def ensure_codex_log_tracked() -> None:
         text=True,
         check=False,
     )
-    if "codex_log.db" not in result.stdout:
+    tracked = any(line.rstrip().endswith(" codex_log.db") for line in result.stdout.splitlines())
+    if result.returncode != 0 or not tracked:
         msg = "codex_log.db must be managed by Git LFS"
         raise RuntimeError(msg)
 


### PR DESCRIPTION
## Summary
- validate codex_log.db is managed by Git LFS before running checks

## Testing
- `ruff check scripts/run_checks.py`
- `ruff check .` *(fails: F401 `web_gui.scripts.config.staging_config.StagingConfig` imported but unused, F821 `Tuple` undefined, F821 `pipeline` undefined, F401 `typing.MutableMapping` imported but unused)*
- `pytest` *(fails: tests/quantum/test_interfaces.py)*

------
https://chatgpt.com/codex/tasks/task_e_68954f8c13748331aeb6d137cdd3bb5a