### PR TITLE
feat: add timestamped codex session logging

### DIFF
--- a/tests/test_session_logging.py
+++ b/tests/test_session_logging.py
@@ -1,0 +1,28 @@
+"""Verify codex logging includes timestamps and session IDs."""
+
+from datetime import datetime
+
+import unified_session_management_system as usm
+
+
+def test_log_action_includes_timestamp(monkeypatch):
+    calls: dict[str, str] = {}
+
+    def fake_log(session_id, action, statement, metadata=""):
+        calls.update(
+            session_id=session_id,
+            action=action,
+            statement=statement,
+            metadata=metadata,
+        )
+
+    monkeypatch.setattr(usm, "log_codex_action", fake_log)
+
+    usm.log_action("sess-1", "start", "message")
+
+    assert calls["session_id"] == "sess-1"
+    assert calls["action"] == "start"
+    assert calls["statement"] == "message"
+    # Ensure metadata contains a parseable timestamp
+    assert calls["metadata"]
+    datetime.fromisoformat(calls["metadata"])


### PR DESCRIPTION
## Summary
- log Codex actions with UTC timestamps in session management and WLC session manager
- cover timestamped logging with unit test

## Testing
- `ruff check unified_session_management_system.py scripts/wlc_session_manager.py tests/test_session_logging.py`
- `pytest -c /dev/null tests/test_session_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68954f8433d48331ac19e63f30060035