### PR TITLE
feat: add schema mismatch detection with rollback support

### DIFF
--- a/src/schema/__init__.py
+++ b/src/schema/__init__.py
@@ -1,7 +1,22 @@
 import logging
+from copy import deepcopy
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-def rollback() -> None:
-    """Rollback schema changes in case of failure."""
+_snapshot: Optional[Dict[str, Any]] = None
+
+
+def store_state(state: Dict[str, Any]) -> None:
+    """Store a pre-conflict snapshot for potential rollback."""
+    global _snapshot
+    _snapshot = deepcopy(state)
+
+
+def rollback() -> Optional[Dict[str, Any]]:
+    """Rollback schema changes in case of failure.
+
+    Returns the stored snapshot so callers can restore state.
+    """
     logger.info("Schema rollback executed")
+    return deepcopy(_snapshot) if _snapshot is not None else None

--- a/src/schema/schema_mapper.py
+++ b/src/schema/schema_mapper.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any, Dict
 
-from . import logger
+from . import logger, store_state
 
 
 class SchemaMapper:
@@ -17,13 +17,19 @@ class SchemaMapper:
     def transaction(self):
         """Provide a transactional context with rollback support."""
         snapshot = deepcopy(self.schema)
+        store_state(snapshot)
         try:
             yield
         except Exception:
             from . import rollback
-            rollback()
-            self.schema = snapshot
+            restored = rollback()
+            self.schema = restored if restored is not None else snapshot
             raise
+
+    @staticmethod
+    def _schema_mismatch(current: Any, incoming: Any) -> bool:
+        """Return True if the types of the values do not match."""
+        return type(current) is not type(incoming)
 
     def apply(self, updates: Dict[str, Any], strategy: str = "merge") -> Dict[str, Any]:
         """Apply updates to the schema using the given conflict strategy."""
@@ -32,6 +38,19 @@ class SchemaMapper:
             for key, value in updates.items():
                 if key in self.schema and self.schema[key] != value:
                     logger.info("Conflict detected for '%s'", key)
+                    if self._schema_mismatch(self.schema[key], value):
+                        logger.info("Schema mismatch for '%s'", key)
+                        if strategy == "merge":
+                            logger.info("Merge skipped for '%s'; keeping original", key)
+                            continue
+                        if strategy == "overwrite":
+                            self.schema[key] = value
+                            logger.info("Overwrote '%s'", key)
+                            continue
+                        if strategy == "manual":
+                            logger.info("Manual resolution required for '%s'", key)
+                            raise ValueError(f"Manual resolution required for '{key}'")
+                        raise ValueError(f"Unknown strategy '{strategy}'")
                     if strategy == "merge":
                         if isinstance(self.schema[key], dict) and isinstance(value, dict):
                             self.schema[key] = {**self.schema[key], **value}

--- a/tests/schema/test_schema_mapper_conflicts.py
+++ b/tests/schema/test_schema_mapper_conflicts.py
@@ -41,3 +41,14 @@ def test_manual_resolution_triggers_rollback(monkeypatch, caplog):
     assert mapper.schema == {"a": 1}
     assert called.get("done")
     assert "Manual resolution required" in caplog.text
+
+
+def test_mismatch_detection(caplog):
+    base = {"a": 1}
+    mapper = SchemaMapper(base)
+    updates = {"a": {"x": 1}}
+    with caplog.at_level("INFO"):
+        result = mapper.apply(updates, strategy="merge")
+    assert result == {"a": 1}
+    assert "Schema mismatch for 'a'" in caplog.text
+    assert "Merge skipped for 'a'" in caplog.text


### PR DESCRIPTION
## Summary
- add module-level snapshot storage to enable rollbacks
- detect schema mismatches and handle merge, overwrite, or manual strategies with logging
- cover mismatch handling in schema mapper tests

## Testing
- `ruff check src/schema/__init__.py src/schema/schema_mapper.py tests/schema/test_schema_mapper_conflicts.py`
- `pytest tests/schema/test_schema_mapper_conflicts.py`


------
https://chatgpt.com/codex/tasks/task_e_68955114d5148331bdf1af9caa204882