### PR TITLE
feat: add dashboard session auth validation

### DIFF
--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""Dashboard package exposing authentication utilities."""
+
+from . import auth
+
+__all__ = ["auth"]

--- a/src/dashboard/auth.py
+++ b/src/dashboard/auth.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Simple token and session validation utilities for the dashboard."""
+
+from dataclasses import dataclass
+import os
+import uuid
+from typing import Set
+
+# Placeholder functions for security enhancements.
+# TODO: integrate proper rate limiting (e.g., Redis or similar)
+def _check_rate_limit() -> None:
+    """Placeholder for future rate limiting logic."""
+    pass
+
+# TODO: integrate multi-factor authentication mechanisms
+
+def _check_mfa() -> None:
+    """Placeholder for future multi-factor authentication logic."""
+    pass
+
+
+@dataclass
+class SessionManager:
+    """Manage in-memory sessions for the dashboard."""
+
+    active_sessions: Set[str]
+
+    @classmethod
+    def create(cls) -> "SessionManager":
+        return cls(active_sessions=set())
+
+    def start_session(self, token: str) -> str:
+        """Start a session if the token matches the expected value.
+
+        Parameters
+        ----------
+        token:
+            Token provided by the client.
+        """
+        _check_rate_limit()
+        expected = os.environ.get("DASHBOARD_AUTH_TOKEN", "")
+        if token != expected:
+            raise ValueError("Invalid token")
+        _check_mfa()
+        session_id = str(uuid.uuid4())
+        self.active_sessions.add(session_id)
+        return session_id
+
+    def validate(self, token: str, session_id: str) -> bool:
+        """Return True if token and session identifier are valid."""
+        expected = os.environ.get("DASHBOARD_AUTH_TOKEN", "")
+        if token != expected:
+            return False
+        return session_id in self.active_sessions
+
+    def end_session(self, session_id: str) -> None:
+        """Remove a session identifier from the active set."""
+        self.active_sessions.discard(session_id)

--- a/tests/dashboard/test_auth.py
+++ b/tests/dashboard/test_auth.py
@@ -1,0 +1,25 @@
+import pytest
+
+from src.dashboard import auth
+
+
+@pytest.fixture()
+def manager():
+    return auth.SessionManager.create()
+
+
+def test_successful_auth_flow(monkeypatch, manager):
+    monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    session = manager.start_session("secret")
+    assert manager.validate("secret", session)
+    manager.end_session(session)
+    assert not manager.validate("secret", session)
+
+
+def test_failed_auth_flow(monkeypatch, manager):
+    monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    with pytest.raises(ValueError):
+        manager.start_session("bad")
+    assert not manager.validate("bad", "none")
+    session = manager.start_session("secret")
+    assert not manager.validate("secret", "wrong")


### PR DESCRIPTION
## Summary
- add SessionManager for token and session validation
- stub rate limiting and MFA hooks
- test successful and failed auth flows

## Testing
- `ruff check src/dashboard/__init__.py src/dashboard/auth.py tests/dashboard/test_auth.py`
- `pytest tests/dashboard/test_auth.py -vv --no-cov`
- `python scripts/wlc_session_manager.py` *(fails: RuntimeError: Zero-byte files detected)*

------
https://chatgpt.com/codex/tasks/task_e_689553acd6388331b40ece35c8b66c50