### PR TITLE
feat: add realtime sync engine

### DIFF
--- a/src/sync/__init__.py
+++ b/src/sync/__init__.py
@@ -1,0 +1,5 @@
+"""Synchronization utilities."""
+
+from .engine import Change, SyncEngine
+
+__all__ = ["Change", "SyncEngine"]

--- a/src/sync/engine.py
+++ b/src/sync/engine.py
@@ -1,0 +1,75 @@
+"""Simple real-time synchronization engine.
+
+Provides a change listener, outgoing queue and safe application of
+remote updates with conflict detection and idempotency checks.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Callable, Deque, List, Optional, Set
+
+
+@dataclass(frozen=True)
+class Change:
+    """Representation of a single change event."""
+
+    id: str
+    payload: dict
+    timestamp: float
+
+
+class SyncEngine:
+    """Coordinate real-time synchronization with peers."""
+
+    def __init__(self) -> None:
+        self._listeners: List[Callable[[Change], None]] = []
+        self.outgoing: Deque[Change] = deque()
+        self._applied_ids: Set[str] = set()
+
+    # change-listener
+    def register_listener(self, callback: Callable[[Change], None]) -> None:
+        """Register a *callback* to be notified of local changes."""
+
+        self._listeners.append(callback)
+
+    def notify_change(self, change: Change) -> None:
+        """Record a local change and notify listeners."""
+
+        self.outgoing.append(change)
+        for cb in list(self._listeners):
+            cb(change)
+
+    # outgoing queue propagation
+    def propagate(self, send: Callable[[Change], None]) -> None:
+        """Send queued changes to peers using ``send`` and clear the queue."""
+
+        while self.outgoing:
+            change = self.outgoing.popleft()
+            send(change)
+
+    # idempotent remote apply with conflict detection
+    def apply_remote_change(
+        self,
+        change: Change,
+        apply: Callable[[Change], None],
+        conflict: Optional[Callable[[Change], bool]] = None,
+    ) -> bool:
+        """Apply a remote *change* if safe.
+
+        Returns ``True`` if the change was applied locally, ``False`` if the
+        change was ignored because it was already processed or a conflict was
+        detected.
+        """
+
+        if change.id in self._applied_ids:
+            return False
+
+        if conflict and conflict(change):
+            self._applied_ids.add(change.id)
+            return False
+
+        apply(change)
+        self._applied_ids.add(change.id)
+        return True

--- a/tests/sync/__init__.py
+++ b/tests/sync/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for real-time synchronization."""

--- a/tests/sync/test_realtime_sync.py
+++ b/tests/sync/test_realtime_sync.py
@@ -1,0 +1,44 @@
+from src.sync.engine import Change, SyncEngine
+
+
+def test_change_listener_and_queue():
+    engine = SyncEngine()
+    heard = []
+    engine.register_listener(lambda c: heard.append(c))
+    change = Change(id="1", payload={"x": 1}, timestamp=0.0)
+    engine.notify_change(change)
+    assert heard == [change]
+    assert list(engine.outgoing) == [change]
+
+
+def test_outgoing_queue_propagation():
+    engine = SyncEngine()
+    change = Change(id="2", payload={}, timestamp=0.0)
+    engine.notify_change(change)
+    sent = []
+    engine.propagate(lambda c: sent.append(c))
+    assert sent == [change]
+    assert not engine.outgoing
+
+
+def test_remote_change_idempotency_and_conflict():
+    engine = SyncEngine()
+    applied = []
+    change = Change(id="3", payload={}, timestamp=0.0)
+
+    def apply(c: Change) -> None:
+        applied.append(c)
+
+    assert engine.apply_remote_change(change, apply)
+    assert applied == [change]
+    assert not engine.apply_remote_change(change, apply)
+    assert applied == [change]
+
+    change2 = Change(id="4", payload={}, timestamp=0.0)
+
+    def conflict_detector(_: Change) -> bool:
+        return True
+
+    assert not engine.apply_remote_change(change2, apply, conflict_detector)
+    assert change2 not in applied
+    assert not engine.apply_remote_change(change2, apply, conflict_detector)


### PR DESCRIPTION
## Summary
- add simple real-time sync engine with change listeners and outgoing queue
- ensure idempotent conflict-aware handling of remote changes
- cover listener, propagation, and conflict scenarios in new tests

## Testing
- `ruff check src/sync/engine.py tests/sync/test_realtime_sync.py`
- `pytest tests/sync/test_realtime_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689553b8cb6c8331994f49122f599bc6