### PR TITLE
feat: add Codex action logger

### DIFF
--- a/databases/schemas/codex_logs.sql
+++ b/databases/schemas/codex_logs.sql
@@ -1,0 +1,10 @@
+-- Schema for Codex action logs
+CREATE TABLE IF NOT EXISTS codex_logs (
+    id INTEGER PRIMARY KEY,
+    session_id TEXT,
+    timestamp TEXT,
+    action TEXT,
+    statement TEXT,
+    metadata TEXT
+);
+

--- a/tests/test_codex_action_logger.py
+++ b/tests/test_codex_action_logger.py
@@ -1,0 +1,46 @@
+"""Tests for the ``codex_action_logger`` module."""
+
+import json
+import sqlite3
+
+from utils import codex_action_logger
+
+
+def test_init_creates_table(tmp_path, monkeypatch):
+    """``init_codex_log_db`` should create the ``codex_logs`` table."""
+
+    db_file = tmp_path / "codex_logs.db"
+    monkeypatch.setattr(codex_action_logger, "_CODEX_LOG_DB", db_file)
+    monkeypatch.setattr(codex_action_logger, "_SESSION_ID", None)
+
+    codex_action_logger.init_codex_log_db("session-1")
+
+    assert db_file.exists()
+    with sqlite3.connect(db_file) as conn:
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='codex_logs'"
+        )
+        assert cursor.fetchone() is not None
+
+
+def test_record_and_finalize(tmp_path, monkeypatch):
+    """Actions should be recorded and the DB path returned on finalize."""
+
+    db_file = tmp_path / "codex_logs.db"
+    monkeypatch.setattr(codex_action_logger, "_CODEX_LOG_DB", db_file)
+    monkeypatch.setattr(codex_action_logger, "_SESSION_ID", None)
+
+    codex_action_logger.init_codex_log_db("s1")
+    codex_action_logger.record_codex_action(
+        "action", "statement", metadata={"foo": "bar"}
+    )
+    path = codex_action_logger.finalize_codex_log_db()
+
+    assert path == db_file
+    with sqlite3.connect(db_file) as conn:
+        rows = conn.execute(
+            "SELECT session_id, action, statement, metadata FROM codex_logs"
+        ).fetchall()
+
+    assert rows == [("s1", "action", "statement", json.dumps({"foo": "bar"}))]
+

--- a/utils/codex_action_logger.py
+++ b/utils/codex_action_logger.py
@@ -1,0 +1,86 @@
+"""Session-aware Codex action logging utilities."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+_CODEX_LOG_DB: Optional[Path] = None
+_SESSION_ID: Optional[str] = None
+
+
+def init_codex_log_db(session_id: str) -> Path:
+    """Initialize the Codex log database for the given ``session_id``.
+
+    The database contains a ``codex_logs`` table used to record actions
+    taken by Codex during the session. The table is created if it does
+    not already exist.
+    """
+
+    global _CODEX_LOG_DB, _SESSION_ID
+
+    _SESSION_ID = session_id
+    if _CODEX_LOG_DB is None:
+        _CODEX_LOG_DB = Path("databases/codex_logs.db")
+
+    _CODEX_LOG_DB.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(_CODEX_LOG_DB) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS codex_logs(
+                id INTEGER PRIMARY KEY,
+                session_id TEXT,
+                timestamp TEXT,
+                action TEXT,
+                statement TEXT,
+                metadata TEXT
+            )
+            """
+        )
+        conn.commit()
+
+    return _CODEX_LOG_DB
+
+
+def record_codex_action(
+    action: str, statement: str, *, metadata: dict | None = None
+) -> None:
+    """Insert a Codex action entry into the log database."""
+
+    if _CODEX_LOG_DB is None or _SESSION_ID is None:
+        raise RuntimeError("Codex log database has not been initialized")
+
+    with sqlite3.connect(_CODEX_LOG_DB) as conn:
+        conn.execute(
+            """
+            INSERT INTO codex_logs (
+                session_id, timestamp, action, statement, metadata
+            ) VALUES (?, datetime('now'), ?, ?, ?)
+            """,
+            (
+                _SESSION_ID,
+                action,
+                statement,
+                json.dumps(metadata) if metadata is not None else "",
+            ),
+        )
+        conn.commit()
+
+
+def finalize_codex_log_db() -> Path:
+    """Finalize logging and return the database file path."""
+
+    if _CODEX_LOG_DB is None:
+        raise RuntimeError("Codex log database has not been initialized")
+
+    return _CODEX_LOG_DB
+
+
+__all__ = [
+    "init_codex_log_db",
+    "record_codex_action",
+    "finalize_codex_log_db",
+]
+


### PR DESCRIPTION
## Summary
- implement session-aware Codex action logger with init, record, and finalize helpers
- add codex_logs SQL schema
- add unit tests for action logging

## Testing
- `ruff check utils/codex_action_logger.py tests/test_codex_action_logger.py`
- `pytest tests/test_codex_action_logger.py tests/test_codex_log_db.py`


------
https://chatgpt.com/codex/tasks/task_e_6895542792888331b59ae15930f2649d