### PR TITLE
feat: add Codex logging utilities

### DIFF
--- a/tests/test_compliance_decorators.py
+++ b/tests/test_compliance_decorators.py
@@ -5,6 +5,7 @@ import pytest
 from enterprise_modules.compliance import ComplianceError
 from enterprise_modules.file_utils import write_file_safely
 from utils.logging_utils import log_session_event
+from utils.codex_logging import log_codex_action
 
 
 def test_write_file_safely_forbidden(monkeypatch, tmp_path):
@@ -35,6 +36,21 @@ def test_log_session_event_forbidden(monkeypatch, tmp_path):
 
     with pytest.raises(ComplianceError):
         log_session_event("s", "e", db_path=db_file)
+
+
+def test_log_codex_action_forbidden(monkeypatch, tmp_path):
+    """log_codex_action raises when validation fails."""
+
+    monkeypatch.setattr(
+        "utils.codex_logging.validate_enterprise_operation",
+        lambda *a, **k: False,
+    )
+
+    db_file = tmp_path / "db.sqlite"
+    db_file.touch()
+
+    with pytest.raises(ComplianceError):
+        log_codex_action("s", "a", "stmt", db_path=db_file)
 
 
 

--- a/tests/workflow/test_codex_logging.py
+++ b/tests/workflow/test_codex_logging.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from utils.codex_logging import log_codex_action, get_codex_history
+
+
+def test_log_and_retrieve_codex_action(tmp_path: Path) -> None:
+    db = tmp_path / "codex.db"
+    session_id = "session-1"
+    assert log_codex_action(session_id, "run", "stmt1", db_path=db)
+    assert log_codex_action(session_id, "finish", "stmt2", db_path=db)
+
+    history = get_codex_history(session_id, db_path=db)
+    assert [h["action"] for h in history] == ["run", "finish"]
+    assert all("timestamp" in h and "statement" in h for h in history)

--- a/utils/codex_logging.py
+++ b/utils/codex_logging.py
@@ -1,0 +1,73 @@
+"""Codex logging utilities for gh_COPILOT Enterprise Toolkit"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from enterprise_modules.database_utils import (
+    enterprise_database_context,
+    execute_safe_insert,
+    execute_safe_query,
+)
+from enterprise_modules.compliance import (
+    ComplianceError,
+    validate_enterprise_operation,
+)
+
+CODEX_LOG_DB = Path("databases") / "codex_session_logs.db"
+
+
+def log_codex_action(
+    session_id: str,
+    action: str,
+    statement: str,
+    *,
+    db_path: Path = CODEX_LOG_DB,
+) -> bool:
+    """Record a Codex action in the codex log database with compliance checks."""
+    if not validate_enterprise_operation(str(db_path)):
+        raise ComplianceError(f"Forbidden database write: {db_path}")
+
+    timestamp = datetime.now(UTC).isoformat()
+    with enterprise_database_context(str(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS codex_log (
+                session_id TEXT,
+                action TEXT,
+                statement TEXT,
+                timestamp TEXT
+            )
+            """
+        )
+        data = {
+            "session_id": session_id,
+            "action": action,
+            "statement": statement,
+            "timestamp": timestamp,
+        }
+        return execute_safe_insert(conn, "codex_log", data)
+
+
+def get_codex_history(
+    session_id: str,
+    *,
+    db_path: Path = CODEX_LOG_DB,
+) -> list:
+    """Retrieve Codex actions for ``session_id`` ordered by timestamp."""
+    with enterprise_database_context(str(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS codex_log (
+                session_id TEXT,
+                action TEXT,
+                statement TEXT,
+                timestamp TEXT
+            )
+            """
+        )
+        rows = execute_safe_query(
+            conn,
+            "SELECT action, statement, timestamp FROM codex_log WHERE session_id=? ORDER BY timestamp",
+            (session_id,),
+        )
+        return [dict(r) for r in rows] if rows else []


### PR DESCRIPTION
## Summary
- add codex logging helpers using enterprise database utils
- test codex logging workflow and compliance handling

## Testing
- `ruff check utils/codex_logging.py tests/test_compliance_decorators.py tests/workflow/test_codex_logging.py`
- `pytest` *(fails: NameError: name 'contextmanager' is not defined in utils/codex_log_db.py)*

------
https://chatgpt.com/codex/tasks/task_e_689557e69f1083318494b2026c07b274