### PR TITLE
fix: auto-stage codex session logs

### DIFF
--- a/tests/test_git_safe_add_commit.py
+++ b/tests/test_git_safe_add_commit.py
@@ -93,3 +93,23 @@ def test_shell_help(tmp_path: Path) -> None:
     proc = subprocess.run(["bash", str(SH_SCRIPT), "-h"], cwd=tmp_path, capture_output=True, text=True)
     assert proc.returncode == 0
     assert "ALLOW_AUTOLFS" in proc.stdout
+
+
+def test_session_logs_auto_added(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    init_repo(tmp_path)
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    session_db = db_dir / "codex_session_logs.db"
+    session_db.write_bytes(b"0")
+
+    env = os.environ.copy()
+    env["ALLOW_AUTOLFS"] = "1"
+    env["PYTHONPATH"] = str(Path.cwd())
+    subprocess.run(["python", str(SCRIPT), "msg"], cwd=tmp_path, env=env, check=True)
+
+    tracked = subprocess.run(
+        ["git", "ls-files"], cwd=tmp_path, text=True, capture_output=True, check=True
+    ).stdout.splitlines()
+    assert "databases/codex_session_logs.db" in tracked
+    gitattributes = (tmp_path / ".gitattributes").read_text(encoding="utf-8")
+    assert "*.db" in gitattributes

--- a/tools/git_safe_add_commit.py
+++ b/tools/git_safe_add_commit.py
@@ -106,9 +106,11 @@ def main(argv: List[str] | None = None) -> int:
         return 1
     if Path("databases/codex_log.db").exists():
         _run(["git", "add", "databases/codex_log.db"])
-    if Path("databases/codex_session_logs.db").exists():
-        _run(["git", "add", "databases/codex_session_logs.db"])
     files = _staged_files()
+    session_db = "databases/codex_session_logs.db"
+    if session_db not in files and Path(session_db).exists():
+        _run(["git", "add", session_db])
+        files = _staged_files()
     allow = os.getenv("ALLOW_AUTOLFS") == "1"
     for f in files:
         path = Path(f)


### PR DESCRIPTION
## Summary
- ensure `codex_session_logs.db` is staged after collecting staged files so LFS checks can run
- add regression test for automatic session log staging and LFS tracking

## Testing
- `ruff check tools/git_safe_add_commit.py tests/test_git_safe_add_commit.py`
- `PYTHONPATH=$(pwd) pytest tests/test_git_safe_add_commit.py tests/git_lfs/test_git_safe_add_commit_autolfs.py`


------
https://chatgpt.com/codex/tasks/task_e_68955c90d2a88331adeeca93d3fa9556