### PR TITLE
feat: document Codex log DB and add session tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,24 @@ is Git LFS-tracked; ensure `ALLOW_AUTOLFS=1` and verify with `git lfs status`
 before committing. See [docs/codex_logging.md](docs/codex_logging.md) for the
 schema and commit workflow.
 
+### Codex Log Database
+
+`utils/codex_log_db.py` writes session actions to `databases/codex_log.db` and
+copies a finalized snapshot to `databases/codex_session_logs.db`. Configure the
+environment with `GH_COPILOT_WORKSPACE` and an external `GH_COPILOT_BACKUP_ROOT`
+before running tools. Optional variables such as `SESSION_ID_SOURCE` supply a
+custom session identifier and `TEST_MODE=1` disables writes during tests. Set
+`ALLOW_AUTOLFS=1` so the `.db` files are Git LFS‑tracked. After finalizing a
+session, include the databases in commits:
+
+```bash
+git add databases/codex_log.db databases/codex_session_logs.db
+git lfs status databases/codex_log.db
+```
+
+See [docs/codex_logging.md](docs/codex_logging.md) for full API usage and
+workflow details.
+
 ### Unified Deployment Orchestrator CLI
 Manage orchestration tasks with start/stop controls:
 

--- a/docs/codex_logging.md
+++ b/docs/codex_logging.md
@@ -20,13 +20,20 @@ single table:
 Utilities in `utils/codex_log_db.py` manage the database:
 
 ```python
-from utils.codex_log_db import init_codex_log_db, record_codex_action
+from utils.codex_log_db import (
+    init_codex_log_db,
+    record_codex_action,
+    finalize_codex_log_db,
+)
 
 init_codex_log_db()
 record_codex_action(session_id, "generate", "created script", metadata="...")
+finalize_codex_log_db()
 ```
 
-The module automatically creates `codex_log.db` if it does not exist.
+The module automatically creates `codex_log.db` if it does not exist and
+`finalize_codex_log_db()` copies it to `codex_session_logs.db` while staging both
+files with `git add`.
 
 ### Environment variables
 

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -45,7 +45,12 @@ from utils.lessons_learned_integrator import (
 )
 from unified_session_management_system import ensure_no_zero_byte_files
 from utils.logging_utils import ANALYTICS_DB
-from utils.codex_log_db import init_codex_log_db, record_codex_action
+from utils.codex_log_db import (
+    init_codex_log_db,
+    record_codex_action,
+    finalize_codex_log_db,
+    log_codex_action,
+)
 
 
 def log_action(session_id: str, action: str, statement: str) -> None:

--- a/tests/test_codex_action_logger.py
+++ b/tests/test_codex_action_logger.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+import pytest
 
 from utils import codex_action_logger
 
@@ -43,4 +44,17 @@ def test_record_and_finalize(tmp_path, monkeypatch):
         ).fetchall()
 
     assert rows == [("s1", "action", "statement", json.dumps({"foo": "bar"}))]
+
+
+def test_calls_without_init_raise(monkeypatch):
+    """Calling logging helpers before init should raise ``RuntimeError``."""
+
+    monkeypatch.setattr(codex_action_logger, "_CODEX_LOG_DB", None)
+    monkeypatch.setattr(codex_action_logger, "_SESSION_ID", None)
+
+    with pytest.raises(RuntimeError):
+        codex_action_logger.record_codex_action("a", "b")
+
+    with pytest.raises(RuntimeError):
+        codex_action_logger.finalize_codex_log_db()
 


### PR DESCRIPTION
## Summary
- document Codex log database usage and commit workflow
- stage Codex log files after session finalization
- test Codex action logger and WLC session manager database staging

## Testing
- `ruff check utils/codex_log_db.py scripts/wlc_session_manager.py tests/test_codex_action_logger.py tests/test_wlc_session_manager.py`
- `pytest --no-cov tests/test_codex_action_logger.py tests/test_wlc_session_manager.py::test_run_session_creates_and_stages_codex_db`

------
https://chatgpt.com/codex/tasks/task_e_6895580061ac8331834f5b8fd38c6df3