### PR TITLE
feat: add corrections API and log component

### DIFF
--- a/src/dashboard/api/corrections.py
+++ b/src/dashboard/api/corrections.py
@@ -1,0 +1,41 @@
+"""API endpoint exposing recent corrections from synchronization events."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+from typing import Any, Dict, List
+
+from flask import Blueprint, jsonify
+
+
+ANALYTICS_DB = Path("databases/analytics.db")
+
+bp = Blueprint("corrections", __name__)
+
+
+def fetch_recent_corrections(limit: int = 10, db_path: Path = ANALYTICS_DB) -> List[Dict[str, Any]]:
+    """Return the most recent synchronization corrections."""
+
+    rows: List[Dict[str, Any]] = []
+    if db_path.exists():
+        with sqlite3.connect(db_path) as conn:
+            cur = conn.execute(
+                "SELECT ts, source, target FROM sync_events_log ORDER BY ts DESC LIMIT ?",
+                (limit,),
+            )
+            rows = [
+                {"timestamp": r[0], "entity": r[1], "resolution": r[2]}
+                for r in cur.fetchall()
+            ]
+    return rows
+
+
+@bp.route("/api/corrections")
+def corrections() -> Any:
+    """Flask route exposing recent synchronization corrections as JSON."""
+    return jsonify(fetch_recent_corrections(db_path=ANALYTICS_DB))
+
+
+__all__ = ["bp", "fetch_recent_corrections", "ANALYTICS_DB"]
+

--- a/tests/dashboard/test_correction_log_ui.py
+++ b/tests/dashboard/test_correction_log_ui.py
@@ -1,0 +1,41 @@
+"""Tests for corrections API and Vue component."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from flask import Flask
+
+from src.dashboard.api import corrections as corrections_api
+
+
+def _setup_db(tmp_path: Path) -> Path:
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE sync_events_log (source TEXT, target TEXT, ts TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO sync_events_log VALUES ('entity-a', 'resolved', '2024-01-01')"
+        )
+    return db
+
+
+def test_corrections_api(tmp_path, monkeypatch):
+    db = _setup_db(tmp_path)
+    monkeypatch.setattr(corrections_api, "ANALYTICS_DB", db)
+    app = Flask(__name__)
+    app.register_blueprint(corrections_api.bp)
+    client = app.test_client()
+    data = client.get("/api/corrections").get_json()
+    assert data[0]["entity"] == "entity-a"
+    assert data[0]["resolution"] == "resolved"
+
+
+def test_vue_component_includes_fields():
+    vue_path = Path("web/dashboard/components/CorrectionLog.vue")
+    content = vue_path.read_text()
+    assert "log.entity" in content
+    assert "log.resolution" in content
+

--- a/web/dashboard/components/CorrectionLog.vue
+++ b/web/dashboard/components/CorrectionLog.vue
@@ -2,8 +2,8 @@
   <ul class="correction-log">
     <li v-for="log in logs" :key="log.timestamp">
       <span class="timestamp">{{ log.timestamp }}</span>
-      <span class="path">{{ log.path }}</span>
-      <span class="status">{{ log.status }}</span>
+      <span class="entity">{{ log.entity }}</span>
+      <span class="resolution">{{ log.resolution }}</span>
     </li>
   </ul>
 </template>


### PR DESCRIPTION
## Summary
- expose `/api/corrections` endpoint backed by `sync_events_log`
- show correction entries with timestamp, entity, and resolution in `CorrectionLog` component
- cover corrections API and Vue component with tests

## Testing
- `ruff check src/dashboard/api/corrections.py tests/dashboard/test_correction_log_ui.py`
- `python -m pytest -c /dev/null tests/dashboard/test_correction_log_ui.py tests/dashboard/test_correction_logs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68955bbe967c83318451431dfb26f21b