### PR TITLE
feat: enable websocket change propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,14 @@ uses Server-Sent Events by default and works with Flask's ``Response`` when
 
 Compliance metrics are generated with `dashboard/compliance_metrics_updater.py`.
 This script reads from `analytics.db` and writes `dashboard/compliance/metrics.json`.
+### SyncEngine WebSocket Configuration
+
+Real-time data synchronization is provided by `src.sync.engine.SyncEngine`.
+To enable WebSocket-based propagation, start a broadcast WebSocket server and
+set `SYNC_ENGINE_WS_URL` to its endpoint (for example, `ws://localhost:8765`).
+Instantiate `SyncEngine` and call `await engine.open_websocket(os.environ["SYNC_ENGINE_WS_URL"], apply_callback)`
+where `apply_callback` applies incoming changes locally. See `docs/realtime_sync.md` for details.
+
 The compliance score is averaged from records in the `correction_logs` table.
 Correction history is summarized via `scripts/correction_logger_and_rollback.py`.
 The `summarize_corrections()` routine now keeps only the most recent entries

--- a/docs/realtime_sync.md
+++ b/docs/realtime_sync.md
@@ -1,0 +1,15 @@
+# Real-time Synchronization
+
+The `SyncEngine` can propagate changes to connected peers over a WebSocket
+channel. To enable WebSocket-based synchronization:
+
+1. Start a WebSocket server that broadcasts messages to all participants.
+2. Set the environment variable `SYNC_ENGINE_WS_URL` to the server's URL
+   (for example `ws://localhost:8765`).
+3. Create a `SyncEngine` instance and call
+   `await engine.open_websocket(os.environ["SYNC_ENGINE_WS_URL"], apply)`
+   where `apply` is a callback that applies received changes locally.
+
+Queued local changes are sent automatically, and remote changes are applied
+in real time, enabling bi-directional updates across clients.
+

--- a/src/sync/engine.py
+++ b/src/sync/engine.py
@@ -6,9 +6,14 @@ remote updates with conflict detection and idempotency checks.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Callable, Deque, List, Optional, Set
+
+import websockets
+from websockets.exceptions import ConnectionClosed
 
 
 @dataclass(frozen=True)
@@ -73,3 +78,39 @@ class SyncEngine:
         apply(change)
         self._applied_ids.add(change.id)
         return True
+
+    # websocket propagation
+    async def _next_outgoing(self) -> Change:
+        """Wait for and return the next outgoing change."""
+
+        while not self.outgoing:
+            await asyncio.sleep(0.01)
+        return self.outgoing.popleft()
+
+    async def open_websocket(self, uri: str, apply: Callable[[Change], None]) -> None:
+        """Connect to a websocket ``uri`` and handle bi-directional sync.
+
+        Changes queued via :meth:`notify_change` are sent to the websocket.
+        Remote changes received from peers are applied using ``apply``.
+        The coroutine runs until cancelled.
+        """
+
+        async with websockets.connect(uri) as ws:
+            async def sender() -> None:
+                try:
+                    while True:
+                        change = await self._next_outgoing()
+                        await ws.send(json.dumps(asdict(change)))
+                except (asyncio.CancelledError, ConnectionClosed):
+                    pass
+
+            async def receiver() -> None:
+                try:
+                    async for message in ws:
+                        data = json.loads(message)
+                        change = Change(**data)
+                        self.apply_remote_change(change, apply)
+                except (asyncio.CancelledError, ConnectionClosed):
+                    pass
+
+            await asyncio.gather(sender(), receiver())

--- a/tests/sync/test_websocket_sync.py
+++ b/tests/sync/test_websocket_sync.py
@@ -1,0 +1,56 @@
+import asyncio
+
+import websockets
+
+from src.sync.engine import Change, SyncEngine
+
+
+async def _websocket_roundtrip() -> None:
+    peers = set()
+
+    async def handler(ws):
+        peers.add(ws)
+        try:
+            async for msg in ws:
+                for peer in peers:
+                    if peer is not ws:
+                        await peer.send(msg)
+        finally:
+            peers.remove(ws)
+
+    server = await websockets.serve(handler, "localhost", 8765)
+
+    engine_a = SyncEngine()
+    engine_b = SyncEngine()
+    applied_a = []
+    applied_b = []
+
+    task_a = asyncio.create_task(
+        engine_a.open_websocket("ws://localhost:8765", lambda c: applied_a.append(c))
+    )
+    task_b = asyncio.create_task(
+        engine_b.open_websocket("ws://localhost:8765", lambda c: applied_b.append(c))
+    )
+
+    await asyncio.sleep(0.1)
+
+    change_a = Change(id="a", payload={"n": 1}, timestamp=0.0)
+    engine_a.notify_change(change_a)
+    await asyncio.sleep(0.1)
+    assert applied_b == [change_a]
+
+    change_b = Change(id="b", payload={"n": 2}, timestamp=0.0)
+    engine_b.notify_change(change_b)
+    await asyncio.sleep(0.1)
+    assert applied_a == [change_b]
+
+    task_a.cancel()
+    task_b.cancel()
+    await asyncio.gather(task_a, task_b, return_exceptions=True)
+    server.close()
+    await server.wait_closed()
+
+
+def test_websocket_bidirectional_sync() -> None:
+    asyncio.run(_websocket_roundtrip())
+


### PR DESCRIPTION
## Summary
- add websocket helper to SyncEngine for bi-directional real-time updates
- test websocket round-trip propagation between engines
- document configuration for WebSocket-based SyncEngine

## Testing
- `ruff check src/sync/engine.py tests/sync/test_realtime_sync.py tests/sync/test_websocket_sync.py`
- `pytest tests/sync/test_realtime_sync.py tests/sync/test_websocket_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68955d2bb9288331b2e6bde9b39d4082