### PR TITLE
test: add codex logging and session log staging tests

### DIFF
--- a/tests/workflow/test_codex_logging.py
+++ b/tests/workflow/test_codex_logging.py
@@ -1,9 +1,19 @@
+import sqlite3
 from pathlib import Path
 
-from utils.codex_logging import log_codex_action, get_codex_history
+import pytest
+
+from utils.codex_logging import get_codex_history, log_codex_action
 
 
-def test_log_and_retrieve_codex_action(tmp_path: Path) -> None:
+def test_log_and_retrieve_codex_action(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "utils.codex_logging.validate_enterprise_operation", lambda *_a, **_k: True
+    )
+    monkeypatch.setattr(
+        "enterprise_modules.database_utils.validate_enterprise_operation",
+        lambda *_a, **_k: True,
+    )
     db = tmp_path / "codex.db"
     session_id = "session-1"
     assert log_codex_action(session_id, "run", "stmt1", db_path=db)
@@ -11,4 +21,12 @@ def test_log_and_retrieve_codex_action(tmp_path: Path) -> None:
 
     history = get_codex_history(session_id, db_path=db)
     assert [h["action"] for h in history] == ["run", "finish"]
-    assert all("timestamp" in h and "statement" in h for h in history)
+    assert [h["statement"] for h in history] == ["stmt1", "stmt2"]
+    assert all("timestamp" in h for h in history)
+
+    with sqlite3.connect(db) as conn:
+        rows = conn.execute(
+            "SELECT action, statement FROM codex_log WHERE session_id=? ORDER BY timestamp",
+            (session_id,),
+        ).fetchall()
+    assert rows == [("run", "stmt1"), ("finish", "stmt2")]


### PR DESCRIPTION
## Summary
- add regression test for codex logging insertion and retrieval order
- ensure git_safe_add_commit stages codex session logs

## Testing
- `ruff check tests/workflow/test_codex_logging.py tests/test_git_safe_add_commit.py`
- `pytest tests/workflow/test_codex_logging.py tests/test_git_safe_add_commit.py`
- `pytest` *(fails: tests/quantum/test_interfaces.py)*

------
https://chatgpt.com/codex/tasks/task_e_68956123f7ec8331a3c2aa439f75538b