### PR TITLE
feat: enhance dashboard auth security

### DIFF
--- a/src/dashboard/api/corrections.py
+++ b/src/dashboard/api/corrections.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List
 
 from flask import Blueprint, jsonify
 
+from src.dashboard.auth import require_session
+
 
 ANALYTICS_DB = Path("databases/analytics.db")
 
@@ -32,6 +34,7 @@ def fetch_recent_corrections(limit: int = 10, db_path: Path = ANALYTICS_DB) -> L
 
 
 @bp.route("/api/corrections")
+@require_session()
 def corrections() -> Any:
     """Flask route exposing recent synchronization corrections as JSON."""
     return jsonify(fetch_recent_corrections(db_path=ANALYTICS_DB))

--- a/src/dashboard/api/logs.py
+++ b/src/dashboard/api/logs.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List
 
 from flask import Blueprint, jsonify
 
+from src.dashboard.auth import require_session
+
 # Default path to analytics database storing correction logs
 ANALYTICS_DB = Path("databases/analytics.db")
 
@@ -40,6 +42,7 @@ def fetch_recent_correction_logs(limit: int = 10, db_path: Path = ANALYTICS_DB) 
 
 
 @bp.route("/correction-logs")
+@require_session()
 def correction_logs() -> Any:
     """Flask route exposing recent correction logs as JSON."""
     return jsonify(fetch_recent_correction_logs(db_path=ANALYTICS_DB))

--- a/src/dashboard/auth.py
+++ b/src/dashboard/auth.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 """Simple token and session validation utilities for the dashboard."""
 
 from dataclasses import dataclass
+import base64
+import hashlib
+import hmac
+import json
 import os
+import secrets
+import time
 import uuid
-from typing import Set
+from functools import wraps
+from typing import Any, Callable, Dict, Optional
 
 # Placeholder functions for security enhancements.
 # TODO: integrate proper rate limiting (e.g., Redis or similar)
@@ -24,11 +31,13 @@ def _check_mfa() -> None:
 class SessionManager:
     """Manage in-memory sessions for the dashboard."""
 
-    active_sessions: Set[str]
+    active_sessions: Dict[str, str]
+    failed_attempts: int = 0
+    max_attempts: int = 5
 
     @classmethod
-    def create(cls) -> "SessionManager":
-        return cls(active_sessions=set())
+    def create(cls, max_attempts: int = 5) -> "SessionManager":
+        return cls(active_sessions={}, failed_attempts=0, max_attempts=max_attempts)
 
     def start_session(self, token: str) -> str:
         """Start a session if the token matches the expected value.
@@ -41,11 +50,20 @@ class SessionManager:
         _check_rate_limit()
         expected = os.environ.get("DASHBOARD_AUTH_TOKEN", "")
         if token != expected:
+            self.failed_attempts += 1
+            if self.failed_attempts >= self.max_attempts:
+                raise ValueError("Too many failed attempts")
             raise ValueError("Invalid token")
+        self.failed_attempts = 0
         _check_mfa()
         session_id = str(uuid.uuid4())
-        self.active_sessions.add(session_id)
+        csrf_token = secrets.token_hex(16)
+        self.active_sessions[session_id] = csrf_token
         return session_id
+
+    def get_csrf_token(self, session_id: str) -> Optional[str]:
+        """Return the CSRF token for a given session."""
+        return self.active_sessions.get(session_id)
 
     def validate(self, token: str, session_id: str) -> bool:
         """Return True if token and session identifier are valid."""
@@ -56,4 +74,70 @@ class SessionManager:
 
     def end_session(self, session_id: str) -> None:
         """Remove a session identifier from the active set."""
-        self.active_sessions.discard(session_id)
+        self.active_sessions.pop(session_id, None)
+
+
+SESSION_MANAGER = SessionManager.create()
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _b64decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def generate_jwt(payload: Dict[str, Any], secret: str, expires_in: int = 3600) -> str:
+    """Return a signed JWT for the given payload."""
+    header = {"alg": "HS256", "typ": "JWT"}
+    payload = payload.copy()
+    payload["exp"] = int(time.time()) + expires_in
+    header_b64 = _b64encode(json.dumps(header).encode())
+    payload_b64 = _b64encode(json.dumps(payload).encode())
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    signature = hmac.new(secret.encode(), signing_input, hashlib.sha256).hexdigest()
+    return f"{header_b64}.{payload_b64}.{signature}"
+
+
+def decode_jwt(token: str, secret: str) -> Dict[str, Any]:
+    """Decode and validate a signed JWT."""
+    try:
+        header_b64, payload_b64, signature = token.split(".")
+        signing_input = f"{header_b64}.{payload_b64}".encode()
+        expected_sig = hmac.new(secret.encode(), signing_input, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(expected_sig, signature):
+            raise ValueError("Invalid signature")
+        payload = json.loads(_b64decode(payload_b64))
+        if payload.get("exp", 0) < time.time():
+            raise ValueError("Token expired")
+        return payload
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError("Invalid token") from exc
+
+
+def require_session(manager: SessionManager | None = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator enforcing session and CSRF checks on Flask routes."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            from flask import abort, request
+
+            mgr = manager or SESSION_MANAGER
+            expected = os.environ.get("DASHBOARD_AUTH_TOKEN")
+            if expected:
+                token = request.headers.get("X-Auth-Token", "")
+                session_id = request.headers.get("X-Session-Id", "")
+                if not mgr.validate(token, session_id):
+                    abort(401)
+                if request.method not in {"GET", "HEAD", "OPTIONS"}:
+                    csrf = request.headers.get("X-CSRF-Token", "")
+                    if mgr.get_csrf_token(session_id) != csrf:
+                        abort(403)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/dashboard/test_auth_security.py
+++ b/tests/dashboard/test_auth_security.py
@@ -1,0 +1,54 @@
+import pytest
+import sqlite3
+
+from flask import Flask
+
+from src.dashboard import auth
+from src.dashboard.api import logs as logs_api
+
+
+@pytest.fixture()
+def manager() -> auth.SessionManager:
+    return auth.SessionManager.create(max_attempts=3)
+
+
+def test_bruteforce_protection(monkeypatch, manager) -> None:
+    monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    for _ in range(2):
+        with pytest.raises(ValueError):
+            manager.start_session("bad")
+    with pytest.raises(ValueError):
+        manager.start_session("bad")
+
+
+def test_csrf_and_auth(monkeypatch, manager, tmp_path) -> None:
+    monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    monkeypatch.setattr(auth, "SESSION_MANAGER", manager)
+
+    db_path = tmp_path / "analytics.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE correction_logs(timestamp TEXT, path TEXT, status TEXT)"
+        )
+
+    app = Flask(__name__)
+    monkeypatch.setattr(logs_api, "ANALYTICS_DB", db_path)
+    app.register_blueprint(logs_api.bp)
+
+    @app.route("/needs-csrf", methods=["POST"])
+    @auth.require_session(manager)
+    def needs_csrf() -> str:
+        return "ok"
+
+    client = app.test_client()
+    session_id = manager.start_session("secret")
+    csrf = manager.get_csrf_token(session_id)
+
+    assert client.get("/correction-logs").status_code == 401
+    headers = {"X-Auth-Token": "secret", "X-Session-Id": session_id}
+    assert client.get("/correction-logs", headers=headers).status_code == 200
+
+    assert client.post("/needs-csrf", headers=headers).status_code == 403
+    headers["X-CSRF-Token"] = csrf
+    assert client.post("/needs-csrf", headers=headers).status_code == 200
+


### PR DESCRIPTION
## Summary
- add session and JWT utilities with brute-force and CSRF protections
- guard dashboard API endpoints with authentication decorator
- test session auth, brute-force lockout, and CSRF requirements

## Testing
- `ruff check src/dashboard/auth.py src/dashboard/api/logs.py src/dashboard/api/corrections.py tests/dashboard/test_auth_security.py`
- `python -m pytest tests/dashboard/test_auth_security.py -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_689561b2c1808331a0ade96b8cca6f3c