### PR TITLE
feat: add websocket sync listener

### DIFF
--- a/docs/realtime_sync.md
+++ b/docs/realtime_sync.md
@@ -10,6 +10,11 @@ channel. To enable WebSocket-based synchronization:
    `await engine.open_websocket(os.environ["SYNC_ENGINE_WS_URL"], apply)`
    where `apply` is a callback that applies received changes locally.
 
+   The engine registers a change listener internally and automatically
+   forwards all locally notified changes. Install the optional
+   [`websockets`](https://pypi.org/project/websockets/) dependency to enable
+   network communication.
+
 Queued local changes are sent automatically, and remote changes are applied
 in real time, enabling bi-directional updates across clients.
 

--- a/tests/sync/test_websocket_sync.py
+++ b/tests/sync/test_websocket_sync.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import List
 
 import websockets
 
@@ -53,4 +54,55 @@ async def _websocket_roundtrip() -> None:
 
 def test_websocket_bidirectional_sync() -> None:
     asyncio.run(_websocket_roundtrip())
+
+
+async def _websocket_multi_roundtrip() -> None:
+    peers = set()
+
+    async def handler(ws):
+        peers.add(ws)
+        try:
+            async for msg in ws:
+                for peer in peers:
+                    if peer is not ws:
+                        await peer.send(msg)
+        finally:
+            peers.remove(ws)
+
+    server = await websockets.serve(handler, "localhost", 8766)
+
+    engine_a = SyncEngine()
+    engine_b = SyncEngine()
+    applied_a: List[Change] = []
+    applied_b: List[Change] = []
+
+    task_a = asyncio.create_task(
+        engine_a.open_websocket("ws://localhost:8766", lambda c: applied_a.append(c))
+    )
+    task_b = asyncio.create_task(
+        engine_b.open_websocket("ws://localhost:8766", lambda c: applied_b.append(c))
+    )
+
+    await asyncio.sleep(0.1)
+
+    for i in range(2):
+        change = Change(id=f"a{i}", payload={"n": i}, timestamp=float(i))
+        engine_a.notify_change(change)
+    for i in range(2):
+        change = Change(id=f"b{i}", payload={"n": i}, timestamp=float(i))
+        engine_b.notify_change(change)
+
+    await asyncio.sleep(0.2)
+    assert applied_b == [Change(id="a0", payload={"n": 0}, timestamp=0.0), Change(id="a1", payload={"n": 1}, timestamp=1.0)]
+    assert applied_a == [Change(id="b0", payload={"n": 0}, timestamp=0.0), Change(id="b1", payload={"n": 1}, timestamp=1.0)]
+
+    task_a.cancel()
+    task_b.cancel()
+    await asyncio.gather(task_a, task_b, return_exceptions=True)
+    server.close()
+    await server.wait_closed()
+
+
+def test_websocket_multi_message_sync() -> None:
+    asyncio.run(_websocket_multi_roundtrip())
 


### PR DESCRIPTION
## Summary
- add WebSocket listener to SyncEngine for real-time change propagation
- test multi-message bidirectional synchronization
- document SYNC_ENGINE_WS_URL configuration

## Testing
- `ruff check src/sync/engine.py tests/sync/test_websocket_sync.py`
- `pytest tests/sync/test_realtime_sync.py tests/sync/test_websocket_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68956252ff4c8331a97d085513307844