### PR TITLE
feat: add session wrap-up validators

### DIFF
--- a/src/session/__init__.py
+++ b/src/session/__init__.py
@@ -1,0 +1,11 @@
+"""Lightweight session utilities.
+
+This package provides minimal validation helpers used during test
+sessions.  Only the pieces required by the tests are implemented; the
+implementations favour simplicity over completeness.
+"""
+
+from .manager import SessionManager
+
+__all__ = ["SessionManager"]
+

--- a/src/session/manager.py
+++ b/src/session/manager.py
@@ -1,0 +1,52 @@
+"""Minimal session manager used by tests.
+
+The manager tracks resources that need validation when a session ends.
+It is intentionally small and is **not** a drop-in replacement for the
+production session manager.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+
+from .validators import check_logs, check_open_connections, check_temp_files
+
+
+class SessionManager:
+    """Coordinate shutdown validation for test sessions."""
+
+    def __init__(self, log_dir: Path, temp_dir: Path | None = None) -> None:
+        self.log_dir = Path(log_dir)
+        self.temp_dir = Path(temp_dir) if temp_dir else self.log_dir.parent
+        self._connections: list[sqlite3.Connection] = []
+
+    def register_connection(self, conn: sqlite3.Connection) -> None:
+        """Record a connection that should be closed on shutdown."""
+
+        self._connections.append(conn)
+
+    # --- shutdown -----------------------------------------------------
+    def shutdown(self) -> None:
+        """Run wrap-up validators.
+
+        Each validator returns a list of offending items.  If any are
+        present, a ``RuntimeError`` is raised to signal session wrap-up
+        failure.
+        """
+
+        open_conns = check_open_connections(self._connections)
+        if open_conns:
+            raise RuntimeError("open connections detected")
+
+        temp_files = check_temp_files(self.temp_dir)
+        if temp_files:
+            raise RuntimeError(f"temporary files remaining: {temp_files}")
+
+        empty_logs = check_logs(self.log_dir)
+        if empty_logs:
+            raise RuntimeError(f"empty log files detected: {empty_logs}")
+
+
+__all__ = ["SessionManager"]
+

--- a/src/session/validators.py
+++ b/src/session/validators.py
@@ -1,0 +1,54 @@
+"""Simple validators used during session shutdown.
+
+The functions in this module intentionally avoid external dependencies
+and keep the checks very small.  They return the list of offending items
+so callers can decide how to handle validation failures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+
+
+def check_open_connections(connections: list[sqlite3.Connection]) -> list[sqlite3.Connection]:
+    """Return connections that are still usable.
+
+    ``sqlite3`` connections expose ``execute`` even when a transaction is
+    active; attempting to issue a trivial query is a straightforward way
+    to determine whether the connection has already been closed.  Any
+    connection that executes the probe successfully is considered open
+    and returned in the result list.
+    """
+
+    open_conns: list[sqlite3.Connection] = []
+    for conn in connections:
+        try:
+            conn.execute("SELECT 1")
+        except Exception:
+            continue
+        else:
+            open_conns.append(conn)
+    return open_conns
+
+
+def check_temp_files(temp_dir: Path) -> list[Path]:
+    """Return ``*.tmp`` files located in ``temp_dir``."""
+
+    directory = Path(temp_dir)
+    return [p for p in directory.glob("*.tmp") if p.is_file()]
+
+
+def check_logs(log_dir: Path) -> list[Path]:
+    """Return empty ``*.log`` files present in ``log_dir``."""
+
+    directory = Path(log_dir)
+    offending: list[Path] = []
+    for log in directory.glob("*.log"):
+        if log.is_file() and log.stat().st_size == 0:
+            offending.append(log)
+    return offending
+
+
+__all__ = ["check_open_connections", "check_temp_files", "check_logs"]
+

--- a/tests/session/test_wrap_up_validators.py
+++ b/tests/session/test_wrap_up_validators.py
@@ -1,0 +1,51 @@
+"""Tests for session wrap-up validators."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.session import SessionManager
+
+
+def _make_manager(tmp_path: Path) -> SessionManager:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "app.log").write_text("ok")
+    temp_dir = tmp_path / "tmp"
+    temp_dir.mkdir()
+    return SessionManager(log_dir, temp_dir)
+
+
+def test_shutdown_fails_with_open_connections(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    conn = sqlite3.connect(":memory:")
+    mgr.register_connection(conn)
+    with pytest.raises(RuntimeError):
+        mgr.shutdown()
+    conn.close()
+
+
+def test_shutdown_fails_with_temp_files(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    temp_file = mgr.temp_dir / "left.tmp"
+    temp_file.write_text("bad")
+    with pytest.raises(RuntimeError):
+        mgr.shutdown()
+
+
+def test_shutdown_fails_with_empty_logs(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    empty = mgr.log_dir / "empty.log"
+    empty.touch()
+    with pytest.raises(RuntimeError):
+        mgr.shutdown()
+
+
+def test_shutdown_passes_when_clean(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    # No exception means success
+    mgr.shutdown()
+


### PR DESCRIPTION
## Summary
- add lightweight session validators for open connections, temp files and log completeness
- wire validators into a minimal session manager
- test session shutdown failure scenarios

## Testing
- `ruff check src/session tests/session/test_wrap_up_validators.py`
- `pytest tests/session/test_wrap_up_validators.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689566f60ab48331b01707b9804df48a