### PR TITLE
feat: expose dashboard websocket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN cp .env.example .env
 ENV GH_COPILOT_WORKSPACE=/app
 ENV GH_COPILOT_BACKUP_ROOT=/backup
 ENV FLASK_SECRET_KEY=changeme
+ENV LOG_WEBSOCKET_ENABLED=1
 
 # Switch to the non-root user
 USER appuser
@@ -34,7 +35,8 @@ USER appuser
 # Port 5005: Authentication service
 # Port 5006: Reserved for future use
 # Port 8080: Web interface
-EXPOSE 5000 5001 5002 5003 5004 5005 5006 8080
+# Port 8765: WebSocket metrics stream
+EXPOSE 5000 5001 5002 5003 5004 5005 5006 8080 8765
 
 HEALTHCHECK --interval=30s --timeout=5s CMD ["python", "scripts/docker_healthcheck.py"]
 

--- a/deploy/dashboard.yaml
+++ b/deploy/dashboard.yaml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  dashboard:
+    build: ..
+    command: python dashboard/enterprise_dashboard.py
+    environment:
+      - GH_COPILOT_WORKSPACE=/app
+      - GH_COPILOT_BACKUP_ROOT=/backup
+      - FLASK_SECRET_KEY=${FLASK_SECRET_KEY:-your_secret_key}
+      - LOG_WEBSOCKET_ENABLED=1
+    ports:
+      - "8080:8080"
+      - "8765:8765"


### PR DESCRIPTION
## Summary
- expose WebSocket metrics stream on port 8765 in Docker image
- add deployment compose file enabling live updates with LOG_WEBSOCKET_ENABLED

## Testing
- `bash deploy/dashboard/deploy.sh staging`
- `ruff check .`
- `pytest` *(fails: ImportError while importing tests/test_quantum_package.py: No module named 'quantum.algorithms.base')*


------
https://chatgpt.com/codex/tasks/task_e_68956763837c8331b3578a63934c062c