### PR TITLE
test: add codex logging tests and integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,13 +391,21 @@ schema and commit workflow.
 
 ### Codex Log Database
 
-`utils/codex_log_db.py` writes session actions to `databases/codex_log.db` and
-copies a finalized snapshot to `databases/codex_session_logs.db`. Configure the
-environment with `GH_COPILOT_WORKSPACE` and an external `GH_COPILOT_BACKUP_ROOT`
-before running tools. Optional variables such as `SESSION_ID_SOURCE` supply a
-custom session identifier and `TEST_MODE=1` disables writes during tests. Set
-`ALLOW_AUTOLFS=1` so the `.db` files are Git LFS‑tracked. After finalizing a
-session, include the databases in commits:
+Session tooling records actions in `databases/codex_log.db`. When
+`finalize_codex_log_db()` runs, the log is copied to
+`databases/codex_session_logs.db` and both files are staged for commit.
+
+#### Environment variables
+
+- `GH_COPILOT_WORKSPACE` – path to the repository root.
+- `GH_COPILOT_BACKUP_ROOT` – external backup directory.
+- `ALLOW_AUTOLFS` – set to `1` so the `.db` files are Git LFS‑tracked.
+- `SESSION_ID_SOURCE` – optional custom session identifier.
+- `TEST_MODE` – set to `1` to disable writes during tests.
+
+#### Commit workflow
+
+After calling `finalize_codex_log_db()` include the databases in your commit:
 
 ```bash
 git add databases/codex_log.db databases/codex_session_logs.db

--- a/tests/test_codex_action_logger.py
+++ b/tests/test_codex_action_logger.py
@@ -1,60 +1,87 @@
-"""Tests for the ``codex_action_logger`` module."""
+"""Tests for Codex logging utilities."""
 
-import json
 import sqlite3
-import pytest
+from pathlib import Path
+import sys
+import types
 
-from utils import codex_action_logger
+
+class DummyTqdm(list):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def update(self, *args, **kwargs):
+        return None
+
+
+def _tqdm(iterable=None, *args, **kwargs):
+    return DummyTqdm(iterable or [])
+
+
+sys.modules.setdefault("tqdm", types.SimpleNamespace(tqdm=_tqdm))
+from utils import codex_log_db
 
 
 def test_init_creates_table(tmp_path, monkeypatch):
-    """``init_codex_log_db`` should create the ``codex_logs`` table."""
+    """``init_codex_log_db`` should create the ``codex_actions`` table."""
 
-    db_file = tmp_path / "codex_logs.db"
-    monkeypatch.setattr(codex_action_logger, "_CODEX_LOG_DB", db_file)
-    monkeypatch.setattr(codex_action_logger, "_SESSION_ID", None)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    db_file = tmp_path / "codex_log.db"
+    session_file = tmp_path / "codex_session_logs.db"
+    monkeypatch.setattr(codex_log_db, "CODEX_LOG_DB", db_file)
+    monkeypatch.setattr(codex_log_db, "CODEX_SESSION_LOG_DB", session_file)
 
-    codex_action_logger.init_codex_log_db("session-1")
+    codex_log_db.init_codex_log_db()
 
     assert db_file.exists()
     with sqlite3.connect(db_file) as conn:
         cursor = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='codex_logs'"
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='codex_actions'"
         )
         assert cursor.fetchone() is not None
 
 
 def test_record_and_finalize(tmp_path, monkeypatch):
-    """Actions should be recorded and the DB path returned on finalize."""
+    """Actions should be recorded and the DB staged on finalize."""
 
-    db_file = tmp_path / "codex_logs.db"
-    monkeypatch.setattr(codex_action_logger, "_CODEX_LOG_DB", db_file)
-    monkeypatch.setattr(codex_action_logger, "_SESSION_ID", None)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backup"))
 
-    codex_action_logger.init_codex_log_db("s1")
-    codex_action_logger.record_codex_action(
-        "action", "statement", metadata={"foo": "bar"}
-    )
-    path = codex_action_logger.finalize_codex_log_db()
+    db_file = tmp_path / "codex_log.db"
+    session_file = tmp_path / "codex_session_logs.db"
+    monkeypatch.setattr(codex_log_db, "CODEX_LOG_DB", db_file)
+    monkeypatch.setattr(codex_log_db, "CODEX_SESSION_LOG_DB", session_file)
 
-    assert path == db_file
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, cwd=None, check=False):
+        calls.append(cmd)
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(codex_log_db.subprocess, "run", fake_run)
+
+    codex_log_db.init_codex_log_db()
+    codex_log_db.record_codex_action("s1", "action", "statement", "meta")
+    src = codex_log_db.finalize_codex_log_db()
+
+    assert src == db_file
+    assert session_file.exists()
+
     with sqlite3.connect(db_file) as conn:
         rows = conn.execute(
-            "SELECT session_id, action, statement, metadata FROM codex_logs"
+            "SELECT session_id, action, statement, metadata FROM codex_actions"
         ).fetchall()
 
-    assert rows == [("s1", "action", "statement", json.dumps({"foo": "bar"}))]
-
-
-def test_calls_without_init_raise(monkeypatch):
-    """Calling logging helpers before init should raise ``RuntimeError``."""
-
-    monkeypatch.setattr(codex_action_logger, "_CODEX_LOG_DB", None)
-    monkeypatch.setattr(codex_action_logger, "_SESSION_ID", None)
-
-    with pytest.raises(RuntimeError):
-        codex_action_logger.record_codex_action("a", "b")
-
-    with pytest.raises(RuntimeError):
-        codex_action_logger.finalize_codex_log_db()
+    assert rows == [("s1", "action", "statement", "meta")]
+    assert any(
+        cmd[:2] == ["git", "add"]
+        and str(Path(cmd[-2])) == str(db_file.relative_to(tmp_path))
+        and str(Path(cmd[-1])) == str(session_file.relative_to(tmp_path))
+        for cmd in calls
+    )
 

--- a/tests/test_wlc_session_manager_integration.py
+++ b/tests/test_wlc_session_manager_integration.py
@@ -1,0 +1,98 @@
+"""Integration tests for ``wlc_session_manager``."""
+
+from contextlib import contextmanager
+from pathlib import Path
+import sys
+import types
+
+
+class DummyTqdm(list):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def update(self, *args, **kwargs):
+        return None
+
+
+def _tqdm(iterable=None, *args, **kwargs):
+    return DummyTqdm(iterable or [])
+
+
+sys.modules.setdefault("tqdm", types.SimpleNamespace(tqdm=_tqdm))
+sys.modules.setdefault("psutil", types.SimpleNamespace())
+
+from scripts import wlc_session_manager
+from utils import codex_log_db
+
+
+def _dummy_result():
+    class Result:
+        compliance_score = 100.0
+
+    return Result()
+
+
+def test_run_session_creates_and_stages_db(tmp_path, monkeypatch):
+    """Running a session should create and stage the Codex log DB."""
+
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backup"))
+    monkeypatch.setenv("TEST", "1")
+    monkeypatch.setenv("TEST_MODE", "0")
+
+    db_file = tmp_path / "codex_log.db"
+    session_file = tmp_path / "codex_session_logs.db"
+    monkeypatch.setattr(codex_log_db, "CODEX_LOG_DB", db_file)
+    monkeypatch.setattr(codex_log_db, "CODEX_SESSION_LOG_DB", session_file)
+
+    # Stub out heavy dependencies
+    monkeypatch.setattr(wlc_session_manager, "validate_environment", lambda: True)
+    monkeypatch.setattr(wlc_session_manager, "setup_logging", lambda verbose: tmp_path / "log.txt")
+
+    class DummyValidator:
+        def validate_corrections(self, files):
+            return None
+
+    monkeypatch.setattr(wlc_session_manager, "SecondaryCopilotValidator", DummyValidator)
+
+    class DummyOrchestrator:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def execute_unified_wrapup(self):
+            return _dummy_result()
+
+    monkeypatch.setattr(wlc_session_manager, "UnifiedWrapUpOrchestrator", DummyOrchestrator)
+    monkeypatch.setattr(wlc_session_manager, "extract_lessons_from_codex_logs", lambda db: [])
+    monkeypatch.setattr(wlc_session_manager, "store_lesson", lambda **kw: None)
+
+    @contextmanager
+    def dummy_zero_byte(_path, _session_id):
+        yield
+
+    monkeypatch.setattr(wlc_session_manager, "ensure_no_zero_byte_files", dummy_zero_byte)
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, cwd=None, check=False):
+        calls.append(cmd)
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(codex_log_db.subprocess, "run", fake_run)
+
+    wlc_session_manager.run_session(1, tmp_path / "prod.db", verbose=False)
+
+    assert db_file.exists()
+    assert session_file.exists()
+    assert any(
+        cmd[:2] == ["git", "add"]
+        and str(Path(cmd[-2])) == str(db_file.relative_to(tmp_path))
+        and str(Path(cmd[-1])) == str(session_file.relative_to(tmp_path))
+        for cmd in calls
+    )
+


### PR DESCRIPTION
## Summary
- document codex log database environment and commit workflow
- test codex logging API and wlc session integration

## Testing
- `ruff check tests/test_codex_action_logger.py tests/test_wlc_session_manager_integration.py`
- `pytest --override-ini="addopts=" tests/test_codex_action_logger.py tests/test_wlc_session_manager_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_689557b06f108331853c560c3630c3d9