### PR TITLE
feat: add correction log endpoint and paginated UI component

### DIFF
--- a/dashboard/routes/__init__.py
+++ b/dashboard/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Flask route blueprints for dashboard."""

--- a/dashboard/routes/corrections.py
+++ b/dashboard/routes/corrections.py
@@ -1,0 +1,22 @@
+"""Expose correction log entries for the dashboard."""
+
+from __future__ import annotations
+
+from typing import Any
+from flask import Blueprint, jsonify
+
+from src.dashboard.api.logs import (
+    ANALYTICS_DB,
+    fetch_recent_correction_logs,
+)
+from src.dashboard.auth import require_session
+
+bp = Blueprint("dashboard_corrections", __name__)
+
+@bp.route("/corrections/logs")
+@require_session()
+def correction_logs() -> Any:
+    """Return recent correction log entries as JSON."""
+    return jsonify(fetch_recent_correction_logs(db_path=ANALYTICS_DB))
+
+__all__ = ["bp", "ANALYTICS_DB"]

--- a/tests/dashboard/corrections/test_correction_logs_route.py
+++ b/tests/dashboard/corrections/test_correction_logs_route.py
@@ -1,0 +1,36 @@
+"""Tests for correction log endpoint and Vue component pagination."""
+
+import sqlite3
+from pathlib import Path
+
+from flask import Flask
+
+from dashboard.routes import corrections as corrections_route
+
+
+def _create_db(tmp_path: Path) -> Path:
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE correction_logs(timestamp TEXT, path TEXT, status TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO correction_logs VALUES ('2024-01-01', 'file.py', 'fixed')"
+        )
+    return db
+
+
+def test_correction_logs_endpoint(tmp_path, monkeypatch):
+    db = _create_db(tmp_path)
+    monkeypatch.setattr(corrections_route, "ANALYTICS_DB", db)
+    app = Flask(__name__)
+    app.register_blueprint(corrections_route.bp)
+    client = app.test_client()
+    data = client.get("/corrections/logs").get_json()
+    assert data[0]["path"] == "file.py"
+
+
+def test_vue_component_has_pagination():
+    content = Path("web/dashboard/components/CorrectionLog.vue").read_text()
+    assert "nextPage" in content
+    assert "pagedLogs" in content

--- a/web/dashboard/components/CorrectionLog.vue
+++ b/web/dashboard/components/CorrectionLog.vue
@@ -1,12 +1,18 @@
 <template>
-  <ul class="correction-log">
-    <li v-for="log in logs" :key="log.timestamp">
-      <span class="timestamp">{{ log.timestamp }}</span>
-      <span class="entity">{{ log.entity }}</span>
-      <span class="resolution">{{ log.resolution }}</span>
-    </li>
-  </ul>
-</template>
+  <div>
+    <ul class="correction-log">
+      <li v-for="log in pagedLogs" :key="log.timestamp">
+        <span class="timestamp">{{ log.timestamp }}</span>
+        <span class="entity">{{ log.entity }}</span>
+        <span class="resolution">{{ log.resolution }}</span>
+      </li>
+    </ul>
+    <div class="pagination">
+      <button @click="prevPage" :disabled="page === 1">Prev</button>
+      <button @click="nextPage" :disabled="page === totalPages">Next</button>
+    </div>
+  </div>
+ </template>
 
 <script>
 export default {
@@ -15,6 +21,30 @@ export default {
     logs: {
       type: Array,
       default: () => [],
+    },
+    pageSize: {
+      type: Number,
+      default: 5,
+    },
+  },
+  data() {
+    return { page: 1 };
+  },
+  computed: {
+    totalPages() {
+      return Math.ceil(this.logs.length / this.pageSize) || 1;
+    },
+    pagedLogs() {
+      const start = (this.page - 1) * this.pageSize;
+      return this.logs.slice(start, start + this.pageSize);
+    },
+  },
+  methods: {
+    nextPage() {
+      if (this.page < this.totalPages) this.page += 1;
+    },
+    prevPage() {
+      if (this.page > 1) this.page -= 1;
     },
   },
 };
@@ -31,5 +61,10 @@ export default {
 }
 .timestamp {
   font-weight: bold;
+}
+.pagination {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- expose correction log entries via new Flask route
- add paginated CorrectionLog Vue component
- test correction route and component with mocked data

## Testing
- `pytest tests/dashboard/corrections/`
- `ruff check dashboard/routes/corrections.py tests/dashboard/corrections/test_correction_logs_route.py`
- `npx --yes eslint web/dashboard/components/CorrectionLog.vue` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_689567ad1f8883319a5a242b20abfd62