### PR TITLE
feat: add logging hooks for sync workflows

### DIFF
--- a/tests/database/test_sync_runner_logging.py
+++ b/tests/database/test_sync_runner_logging.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.database.sync_runner import run_sync
+
+
+def _empty_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE t (id INTEGER)")
+
+
+def test_run_sync_logging(tmp_path: Path) -> None:
+    a = tmp_path / "a.db"
+    b = tmp_path / "b.db"
+    _empty_db(a)
+    _empty_db(b)
+    events: list[tuple[str, dict]] = []
+    run_sync(a, b, log_hook=lambda e, ctx: events.append((e, ctx)))
+    assert events[0][0] == "sync.start"
+    assert events[-1][0] == "sync.end"
+
+
+def test_run_sync_logging_error(tmp_path: Path, monkeypatch) -> None:
+    a = tmp_path / "a.db"
+    b = tmp_path / "b.db"
+    _empty_db(a)
+    _empty_db(b)
+
+    def boom(*_args, **_kwargs):  # pragma: no cover - raised for logging
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr("src.database.sync_runner.Engine.sync_with", boom)
+    events: list[tuple[str, dict]] = []
+    with pytest.raises(RuntimeError):
+        run_sync(a, b, log_hook=lambda e, ctx: events.append((e, ctx)))
+    assert any(e == "sync.error" for e, _ in events)
+

--- a/tests/sync/test_logging_hooks.py
+++ b/tests/sync/test_logging_hooks.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from src.sync.engine import Change, SyncEngine
+
+
+def test_propagate_logging(tmp_path) -> None:
+    events: list[tuple[str, dict]] = []
+    engine = SyncEngine(log_hook=lambda e, ctx: events.append((e, ctx)))
+    change = Change(id="1", payload={}, timestamp=0.0)
+    engine.notify_change(change)
+    engine.propagate(lambda c: None)
+    assert events[0][0] == "propagate.start"
+    assert events[-1][0] == "propagate.end"
+    assert events[-1][1].get("sent") == 1
+
+
+def test_propagate_logging_error() -> None:
+    events: list[tuple[str, dict]] = []
+    engine = SyncEngine(log_hook=lambda e, ctx: events.append((e, ctx)))
+    change = Change(id="1", payload={}, timestamp=0.0)
+    engine.notify_change(change)
+
+    def send(_: Change) -> None:  # pragma: no cover - raised for logging
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        engine.propagate(send)
+    assert any(e == "propagate.error" for e, _ in events)
+
+
+def test_apply_logging() -> None:
+    events: list[tuple[str, dict]] = []
+    engine = SyncEngine(log_hook=lambda e, ctx: events.append((e, ctx)))
+    change = Change(id="1", payload={}, timestamp=0.0)
+
+    def apply(_: Change) -> None:
+        pass
+
+    assert engine.apply_remote_change(change, apply)
+    assert events[0][0] == "apply.start"
+    assert events[-1][0] == "apply.end"
+    assert events[-1][1].get("status") == "applied"
+
+
+def test_apply_logging_error() -> None:
+    events: list[tuple[str, dict]] = []
+    engine = SyncEngine(log_hook=lambda e, ctx: events.append((e, ctx)))
+    change = Change(id="1", payload={}, timestamp=0.0)
+
+    def apply(_: Change) -> None:  # pragma: no cover - raised for logging
+        raise ValueError("bad")
+
+    with pytest.raises(ValueError):
+        engine.apply_remote_change(change, apply)
+    assert any(e == "apply.error" for e, _ in events)
+


### PR DESCRIPTION
## Summary
- add optional log hooks to sync engine propagate and apply methods
- extend database sync runner to emit structured log events
- test logging for propagate/apply operations and sync runner

## Testing
- `ruff check src/sync/engine.py src/database/sync_runner.py tests/sync/test_logging_hooks.py tests/database/test_sync_runner_logging.py`
- `pytest tests/sync/test_logging_hooks.py tests/database/test_sync_runner_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_689567bd97788331aa4f4ff2fcd217ad