### PR TITLE
docs: add task stubs for Codex log database

### DIFF
--- a/docs/dedicated_codex_log_database_tasks.md
+++ b/docs/dedicated_codex_log_database_tasks.md
@@ -1,0 +1,24 @@
+# Dedicated Codex Log Database – Task Stubs
+
+This document outlines task stubs for implementing a dedicated Codex log database that records all Codex actions and statements for each session and ensures the log database is included with every commit.
+
+## Task Stubs
+
+1. **Initialize Session Logging**
+   - [ ] Create or open the session's Codex log database.
+   - [ ] Record session start metadata (e.g., session ID, timestamp).
+
+2. **Record Codex Actions**
+   - [ ] Provide an interface to log each Codex action with its statement and optional metadata.
+   - [ ] Ensure entries are timestamped and associated with the active session ID.
+
+3. **Finalize Session Logging**
+   - [ ] Record session completion summary.
+   - [ ] Copy the log database to a commit-ready location.
+   - [ ] Stage the log database files for commit using `git add`.
+
+4. **Commit Workflow Integration**
+   - [ ] Verify that `.gitattributes` tracks database files with Git LFS.
+   - [ ] Include the finalized log database in commits for lessons-learned analysis.
+
+These stubs provide a framework for integrating comprehensive Codex session logging into the repository's commit process.

--- a/scripts/DEDICATED_CODEX_LOG_DATABASE_TASKS.py
+++ b/scripts/DEDICATED_CODEX_LOG_DATABASE_TASKS.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Task stubs for the dedicated Codex log database workflow."""
+from utils.codex_log_db import (  # noqa: F401
+    init_codex_log_db,
+    record_codex_action,
+    finalize_codex_log_db,
+    log_codex_start,
+    log_codex_end,
+)
+
+def initialize_session(session_id: str) -> None:
+    """Initialize logging for a Codex session.
+
+    Task stub: call ``init_codex_log_db`` and ``log_codex_start``.
+    """
+    raise NotImplementedError("Session initialization not implemented")
+
+def log_action(session_id: str, action: str, statement: str, metadata: str = "") -> None:
+    """Record a Codex action and its statement.
+
+    Task stub: use ``record_codex_action`` to persist the entry.
+    """
+    raise NotImplementedError("Action logging not implemented")
+
+def finalize_session(session_id: str, summary: str) -> None:
+    """Finalize the Codex session log and stage it for commit.
+
+    Task stub: call ``log_codex_end`` and ``finalize_codex_log_db``.
+    """
+    raise NotImplementedError("Session finalization not implemented")
+
+__all__ = [
+    "initialize_session",
+    "log_action",
+    "finalize_session",
+]


### PR DESCRIPTION
## Summary
- outline task stubs for a dedicated Codex log database workflow
- add placeholder functions to scaffold session logging actions

## Testing
- `ruff check scripts/DEDICATED_CODEX_LOG_DATABASE_TASKS.py`
- `pytest` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_6895680accdc83319c62e0e5b8f2ea60