### PR TITLE
feat: add anomaly detector for sync metrics

### DIFF
--- a/src/monitoring/anomaly_detector.py
+++ b/src/monitoring/anomaly_detector.py
@@ -1,0 +1,87 @@
+"""Anomaly detection utilities using statistical and machine learning models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+import sqlite3
+from sklearn.ensemble import IsolationForest
+
+
+@dataclass
+class MetricModel:
+    """Container for per-metric anomaly detection models."""
+
+    mean: float
+    std: float
+    isolation_forest: IsolationForest
+
+
+def _load_metrics(db_path: Path) -> Dict[str, List[float]]:
+    """Load historical metric values from ``analytics.db``.
+
+    The database is expected to contain a table named ``sync_metrics`` with
+    columns ``metric`` (text) and ``value`` (numeric).
+    """
+
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute("SELECT metric, value FROM sync_metrics")
+        metrics: Dict[str, List[float]] = {}
+        for metric, value in cur:
+            try:
+                v = float(value)
+            except (TypeError, ValueError):
+                continue
+            metrics.setdefault(metric, []).append(v)
+    finally:
+        conn.close()
+    return metrics
+
+
+def train_models(db_path: Path) -> Dict[str, MetricModel]:
+    """Train baseline models using historical metrics from ``db_path``."""
+
+    metrics = _load_metrics(db_path)
+    models: Dict[str, MetricModel] = {}
+    for metric, values in metrics.items():
+        if not values:
+            continue
+        mean = sum(values) / len(values)
+        variance = sum((v - mean) ** 2 for v in values) / len(values)
+        std = variance ** 0.5
+        forest = IsolationForest(random_state=0).fit([[v] for v in values])
+        models[metric] = MetricModel(mean, std, forest)
+    return models
+
+
+def detect_anomalies(
+    data: Dict[str, float],
+    models: Dict[str, MetricModel],
+    *,
+    z_threshold: float = 3.0,
+) -> Dict[str, bool]:
+    """Return flags for metrics that appear anomalous.
+
+    A metric is flagged if either the z-score exceeds ``z_threshold`` or the
+    Isolation Forest model predicts it as an outlier.
+    """
+
+    anomalies: Dict[str, bool] = {}
+    for metric, value in data.items():
+        model = models.get(metric)
+        if model is None:
+            continue
+        if model.std == 0:
+            z_flag = value != model.mean
+        else:
+            z_flag = abs(value - model.mean) / model.std > z_threshold
+        iso_flag = model.isolation_forest.predict([[value]])[0] == -1
+        anomalies[metric] = z_flag or iso_flag
+    return anomalies
+
+
+__all__ = ["MetricModel", "train_models", "detect_anomalies"]
+

--- a/tests/monitoring/test_anomaly_detection.py
+++ b/tests/monitoring/test_anomaly_detection.py
@@ -1,6 +1,9 @@
 from pathlib import Path
+import sqlite3
 
 from src.monitoring.anomaly import detect_anomalies, train_baseline_models
+from src.monitoring.anomaly_detector import detect_anomalies as db_detect_anomalies
+from src.monitoring.anomaly_detector import train_models as db_train_models
 
 
 def _data_dir() -> Path:
@@ -17,4 +20,38 @@ def test_detects_known_anomaly() -> None:
 def test_detects_memory_spike() -> None:
     models = train_baseline_models(_data_dir())
     anomalies = detect_anomalies(models, {"memory_usage": 160})
+    assert anomalies["memory_usage"]
+
+
+def _create_db(db_path: Path) -> Path:
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE sync_metrics(metric TEXT, value REAL)")
+    conn.executemany(
+        "INSERT INTO sync_metrics(metric, value) VALUES (?, ?)",
+        [
+            ("cpu_usage", 10.0),
+            ("cpu_usage", 12.0),
+            ("cpu_usage", 11.0),
+            ("memory_usage", 100.0),
+            ("memory_usage", 98.0),
+            ("memory_usage", 102.0),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_db_detects_known_anomaly(tmp_path: Path) -> None:
+    db_file = _create_db(tmp_path / "analytics.db")
+    models = db_train_models(db_file)
+    anomalies = db_detect_anomalies({"cpu_usage": 25, "memory_usage": 103}, models)
+    assert anomalies["cpu_usage"]
+    assert not anomalies["memory_usage"]
+
+
+def test_db_detects_memory_spike(tmp_path: Path) -> None:
+    db_file = _create_db(tmp_path / "analytics.db")
+    models = db_train_models(db_file)
+    anomalies = db_detect_anomalies({"memory_usage": 160}, models)
     assert anomalies["memory_usage"]


### PR DESCRIPTION
## Summary
- implement `anomaly_detector` module using z-score and Isolation Forest models trained from `analytics.db`
- expose `detect_anomalies` API and tests for database-backed detection

## Testing
- `ruff check src/monitoring/anomaly_detector.py tests/monitoring/test_anomaly_detection.py`
- `pytest tests/monitoring/test_anomaly_detection.py::test_db_detects_known_anomaly tests/monitoring/test_anomaly_detection.py::test_db_detects_memory_spike tests/monitoring/test_anomaly_detection.py::test_detects_known_anomaly tests/monitoring/test_anomaly_detection.py::test_detects_memory_spike -q`
- `python secondary_copilot_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_68956d62b9a48331b7b296e609671dc0