### PR TITLE
feat: add recovery routines for monitoring alerts

### DIFF
--- a/src/recovery/__init__.py
+++ b/src/recovery/__init__.py
@@ -1,0 +1,5 @@
+"""Recovery utilities and routines."""
+
+from .routines import reconnect_database, retry_sync, handle_alerts
+
+__all__ = ["reconnect_database", "retry_sync", "handle_alerts"]

--- a/src/recovery/routines.py
+++ b/src/recovery/routines.py
@@ -1,0 +1,98 @@
+"""Failure recovery routines.
+
+This module provides simple handlers that attempt to recover from
+transient issues.  It includes database reconnection logic, sync retry
+helpers and integration hooks for monitoring alerts.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, Iterable
+
+import sqlite3
+
+from monitoring import anomaly
+from session import validators
+
+
+def reconnect_database(
+    factory: Callable[[], sqlite3.Connection],
+    *,
+    attempts: int = 3,
+    delay: float = 0.1,
+) -> sqlite3.Connection:
+    """Return a database connection using ``factory`` with retries.
+
+    The ``factory`` callable is invoked until it succeeds or ``attempts``
+    are exhausted.  ``delay`` specifies the pause between attempts in
+    seconds.
+    """
+
+    last_exc: Exception | None = None
+    for _ in range(attempts):
+        try:
+            return factory()
+        except Exception as exc:  # pragma: no cover - defensive
+            last_exc = exc
+            time.sleep(delay)
+    assert last_exc is not None  # for mypy
+    raise last_exc
+
+
+def retry_sync(
+    action: Callable[[], Any],
+    *,
+    attempts: int = 3,
+    delay: float = 0.1,
+) -> Any:
+    """Execute ``action`` with retry semantics.
+
+    The ``action`` callable is invoked until it completes without
+    raising an exception or ``attempts`` are exhausted.  The result of
+    the successful invocation is returned.
+    """
+
+    last_exc: Exception | None = None
+    for _ in range(attempts):
+        try:
+            return action()
+        except Exception as exc:
+            last_exc = exc
+            time.sleep(delay)
+    assert last_exc is not None  # for mypy
+    raise last_exc
+
+
+def handle_alerts(
+    models: Dict[str, anomaly.Model],
+    metrics: Dict[str, float],
+    connections: Iterable[sqlite3.Connection],
+    conn_factory: Callable[[], sqlite3.Connection],
+    sync_action: Callable[[], Any],
+) -> Dict[str, int]:
+    """Trigger recovery routines based on monitoring alerts.
+
+    Returns a mapping with counts of performed actions.  A sync retry is
+    attempted when anomalies are detected by
+    :func:`monitoring.anomaly.detect_anomalies`.  Open connections
+    reported by :func:`session.validators.check_open_connections`
+    trigger database reconnection attempts using ``conn_factory``.
+    """
+
+    counts = {"reconnects": 0, "sync_retries": 0}
+
+    anomalies = anomaly.detect_anomalies(models, metrics)
+    if any(anomalies.values()):
+        retry_sync(sync_action)
+        counts["sync_retries"] += 1
+
+    open_conns = validators.check_open_connections(list(connections))
+    for _ in open_conns:
+        reconnect_database(conn_factory)
+        counts["reconnects"] += 1
+
+    return counts
+
+
+__all__ = ["reconnect_database", "retry_sync", "handle_alerts"]

--- a/tests/recovery/test_routines.py
+++ b/tests/recovery/test_routines.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sqlite3
+
+from recovery import routines
+
+
+def test_reconnect_database_retry():
+    attempts: list[int] = []
+
+    def factory() -> sqlite3.Connection:
+        if len(attempts) < 2:
+            attempts.append(1)
+            raise RuntimeError("fail")
+        return sqlite3.connect(":memory:")
+
+    conn = routines.reconnect_database(factory, attempts=3, delay=0)
+    assert isinstance(conn, sqlite3.Connection)
+    assert len(attempts) == 2
+
+
+def test_retry_sync_success_after_failures():
+    calls: list[int] = []
+
+    def action() -> str:
+        if len(calls) < 1:
+            calls.append(1)
+            raise ValueError("boom")
+        return "ok"
+
+    assert routines.retry_sync(action, attempts=2, delay=0) == "ok"
+    assert len(calls) == 1
+
+
+def test_handle_alerts_triggers_recovery():
+    models = {"m": (0.0, 1.0)}
+    metrics = {"m": 5.0}  # z-score 5 -> anomaly
+
+    conn = sqlite3.connect(":memory:")
+
+    factory_calls: list[int] = []
+
+    def factory() -> sqlite3.Connection:
+        factory_calls.append(1)
+        return sqlite3.connect(":memory:")
+
+    sync_calls: list[int] = []
+
+    def sync_action() -> None:
+        sync_calls.append(1)
+
+    result = routines.handle_alerts(models, metrics, [conn], factory, sync_action)
+    assert result == {"reconnects": 1, "sync_retries": 1}
+    assert len(factory_calls) == 1
+    assert len(sync_calls) == 1


### PR DESCRIPTION
## Summary
- add recovery module with database reconnection and sync retry helpers
- integrate recovery handlers with anomaly detection and session validators
- test recovery routines against simulated failures

## Testing
- `ruff check src/recovery/routines.py tests/recovery/test_routines.py`
- `pytest tests/recovery/test_routines.py`


------
https://chatgpt.com/codex/tasks/task_e_68956d6453c883319938a96f98b0e485