### PR TITLE
feat: add correction log UI with filtering

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -40,6 +40,8 @@ This module is designed to meet enterprise auditability and compliance standards
   `web_gui.scripts.flask_apps.enterprise_dashboard`)
 - **Templates:** Jinja2 HTML (`dashboard/templates/`)
 - **Static Content:** CSS, JS, images (`dashboard/static/`)
+- **Correction Log UI:** Vue component (`web/dashboard/components/CorrectionLog.vue`) fetches
+  `/corrections/logs` and supports client-side filtering and pagination.
 - **Data Sources:** `production.db`, `analytics.db`, `monitoring.db`
 - **Primary Endpoints:** `/`, `/database`, `/backup`, `/migration`, `/deployment`, `/api/scripts`, `/api/health`, `/metrics_stream`, `/dashboard/compliance`
 - **Session Logging:** All actions are recorded in `production.db` and mirrored in `analytics.db`

--- a/dashboard/routes/corrections.py
+++ b/dashboard/routes/corrections.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 from src.dashboard.api.logs import (
     ANALYTICS_DB,
@@ -16,7 +16,15 @@ bp = Blueprint("dashboard_corrections", __name__)
 @bp.route("/corrections/logs")
 @require_session()
 def correction_logs() -> Any:
-    """Return recent correction log entries as JSON."""
-    return jsonify(fetch_recent_correction_logs(db_path=ANALYTICS_DB))
+    """Return recent correction log entries as JSON.
+
+    Supports an optional ``limit`` query parameter to control the number of
+    rows returned, enabling simple pagination on the client side.
+    """
+    limit = request.args.get("limit", type=int)
+    kwargs = {"db_path": ANALYTICS_DB}
+    if limit:
+        kwargs["limit"] = limit
+    return jsonify(fetch_recent_correction_logs(**kwargs))
 
 __all__ = ["bp", "ANALYTICS_DB"]

--- a/tests/dashboard/corrections/test_correction_logs_route.py
+++ b/tests/dashboard/corrections/test_correction_logs_route.py
@@ -14,8 +14,12 @@ def _create_db(tmp_path: Path) -> Path:
         conn.execute(
             "CREATE TABLE correction_logs(timestamp TEXT, path TEXT, status TEXT)"
         )
-        conn.execute(
-            "INSERT INTO correction_logs VALUES ('2024-01-01', 'file.py', 'fixed')"
+        conn.executemany(
+            "INSERT INTO correction_logs VALUES (?,?,?)",
+            [
+                ("2024-01-01", "file.py", "fixed"),
+                ("2024-01-02", "other.py", "pending"),
+            ],
         )
     return db
 
@@ -27,10 +31,23 @@ def test_correction_logs_endpoint(tmp_path, monkeypatch):
     app.register_blueprint(corrections_route.bp)
     client = app.test_client()
     data = client.get("/corrections/logs").get_json()
-    assert data[0]["path"] == "file.py"
+    assert len(data) == 2
+    assert data[0]["path"] == "other.py"
+
+
+def test_correction_logs_limit_query(tmp_path, monkeypatch):
+    db = _create_db(tmp_path)
+    monkeypatch.setattr(corrections_route, "ANALYTICS_DB", db)
+    app = Flask(__name__)
+    app.register_blueprint(corrections_route.bp)
+    client = app.test_client()
+    data = client.get("/corrections/logs?limit=1").get_json()
+    assert len(data) == 1
 
 
 def test_vue_component_has_pagination():
     content = Path("web/dashboard/components/CorrectionLog.vue").read_text()
     assert "nextPage" in content
     assert "pagedLogs" in content
+    assert "filteredLogs" in content
+    assert "/corrections/logs" in content

--- a/tests/dashboard/test_correction_log_ui.py
+++ b/tests/dashboard/test_correction_log_ui.py
@@ -38,4 +38,6 @@ def test_vue_component_includes_fields():
     content = vue_path.read_text()
     assert "log.entity" in content
     assert "log.resolution" in content
+    assert 'class="timestamp"' in content
+    assert 'v-model="filter"' in content
 

--- a/web/dashboard/components/CorrectionLog.vue
+++ b/web/dashboard/components/CorrectionLog.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <input v-model="filter" placeholder="Filter logs" />
     <ul class="correction-log">
       <li v-for="log in pagedLogs" :key="log.timestamp">
         <span class="timestamp">{{ log.timestamp }}</span>
@@ -17,26 +18,30 @@
 <script>
 export default {
   name: 'CorrectionLog',
-  props: {
-    logs: {
-      type: Array,
-      default: () => [],
-    },
-    pageSize: {
-      type: Number,
-      default: 5,
-    },
-  },
   data() {
-    return { page: 1 };
+    return {
+      logs: [],
+      page: 1,
+      pageSize: 5,
+      filter: '',
+    };
   },
   computed: {
+    filteredLogs() {
+      if (!this.filter) return this.logs;
+      const term = this.filter.toLowerCase();
+      return this.logs.filter(
+        (l) =>
+          l.entity.toLowerCase().includes(term) ||
+          l.resolution.toLowerCase().includes(term)
+      );
+    },
     totalPages() {
-      return Math.ceil(this.logs.length / this.pageSize) || 1;
+      return Math.ceil(this.filteredLogs.length / this.pageSize) || 1;
     },
     pagedLogs() {
       const start = (this.page - 1) * this.pageSize;
-      return this.logs.slice(start, start + this.pageSize);
+      return this.filteredLogs.slice(start, start + this.pageSize);
     },
   },
   methods: {
@@ -46,6 +51,16 @@ export default {
     prevPage() {
       if (this.page > 1) this.page -= 1;
     },
+    fetchLogs() {
+      fetch('/corrections/logs?limit=50')
+        .then((r) => r.json())
+        .then((d) => {
+          this.logs = d;
+        });
+    },
+  },
+  created() {
+    this.fetchLogs();
   },
 };
 </script>


### PR DESCRIPTION
## Summary
- add CorrectionLog Vue component that fetches `/corrections/logs` and supports client-side filtering and pagination
- allow `/corrections/logs` API to accept `limit` query parameter
- document and test correction log functionality

## Testing
- `ruff check dashboard/routes/corrections.py tests/dashboard/corrections/test_correction_logs_route.py tests/dashboard/test_correction_log_ui.py`
- `pytest tests/dashboard/corrections/test_correction_logs_route.py tests/dashboard/test_correction_log_ui.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68956d7e498c833184ec1b00e5a58627