### PR TITLE
feat: implement codex log session helpers

### DIFF
--- a/databases/codex_log.db
+++ b/databases/codex_log.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9375d5402e9ff122e73c6a26b25dd675c5ecb68dd1cf65fd35f129f669b0573e
+oid sha256:57e3068b044e82e16bf43b062fb82815503c5ff09da3d29c20aa039a178f48f0
 size 8192

--- a/databases/codex_session_logs.db
+++ b/databases/codex_session_logs.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9375d5402e9ff122e73c6a26b25dd675c5ecb68dd1cf65fd35f129f669b0573e
+oid sha256:57e3068b044e82e16bf43b062fb82815503c5ff09da3d29c20aa039a178f48f0
 size 8192

--- a/docs/codex_logging.md
+++ b/docs/codex_logging.md
@@ -35,6 +35,23 @@ The module automatically creates `codex_log.db` if it does not exist and
 `finalize_codex_log_db()` copies it to `codex_session_logs.db` while staging both
 files with `git add`.
 
+### Helper script
+
+For a simplified workflow, `scripts/DEDICATED_CODEX_LOG_DATABASE_TASKS.py` wraps
+these utilities:
+
+```python
+from scripts.DEDICATED_CODEX_LOG_DATABASE_TASKS import (
+    finalize_session,
+    initialize_session,
+    log_action,
+)
+
+initialize_session(session_id)
+log_action(session_id, "generate", "created script")
+finalize_session(session_id, "session complete")
+```
+
 ### Environment variables
 
 `GH_COPILOT_WORKSPACE` must point to the repository root so the utility can

--- a/scripts/DEDICATED_CODEX_LOG_DATABASE_TASKS.py
+++ b/scripts/DEDICATED_CODEX_LOG_DATABASE_TASKS.py
@@ -1,33 +1,57 @@
 #!/usr/bin/env python3
 """Task stubs for the dedicated Codex log database workflow."""
-from utils.codex_log_db import (  # noqa: F401
-    init_codex_log_db,
-    record_codex_action,
+"""Convenience wrappers for Codex action logging."""
+
+from utils.codex_log_db import (
     finalize_codex_log_db,
-    log_codex_start,
+    init_codex_log_db,
     log_codex_end,
+    log_codex_start,
+    record_codex_action,
 )
 
 def initialize_session(session_id: str) -> None:
     """Initialize logging for a Codex session.
 
-    Task stub: call ``init_codex_log_db`` and ``log_codex_start``.
+    Parameters
+    ----------
+    session_id:
+        Identifier for the active Codex session.
     """
-    raise NotImplementedError("Session initialization not implemented")
+
+    init_codex_log_db()
+    log_codex_start(session_id)
 
 def log_action(session_id: str, action: str, statement: str, metadata: str = "") -> None:
     """Record a Codex action and its statement.
 
-    Task stub: use ``record_codex_action`` to persist the entry.
+    Parameters
+    ----------
+    session_id:
+        Identifier for the current session.
+    action:
+        Short name describing the action.
+    statement:
+        Free-form text describing the action in detail.
+    metadata:
+        Optional JSON or text metadata to persist alongside the action.
     """
-    raise NotImplementedError("Action logging not implemented")
+
+    record_codex_action(session_id, action, statement, metadata)
 
 def finalize_session(session_id: str, summary: str) -> None:
     """Finalize the Codex session log and stage it for commit.
 
-    Task stub: call ``log_codex_end`` and ``finalize_codex_log_db``.
+    Parameters
+    ----------
+    session_id:
+        Identifier for the active session.
+    summary:
+        Human-readable summary of the session outcome.
     """
-    raise NotImplementedError("Session finalization not implemented")
+
+    log_codex_end(session_id, summary)
+    finalize_codex_log_db()
 
 __all__ = [
     "initialize_session",

--- a/tests/test_dedicated_codex_log_database_tasks.py
+++ b/tests/test_dedicated_codex_log_database_tasks.py
@@ -1,0 +1,27 @@
+import scripts.DEDICATED_CODEX_LOG_DATABASE_TASKS as tasks
+
+def test_initialize_session(monkeypatch):
+    calls = []
+    monkeypatch.setattr(tasks, "init_codex_log_db", lambda: calls.append("init"))
+    monkeypatch.setattr(tasks, "log_codex_start", lambda s: calls.append(("start", s)))
+    tasks.initialize_session("s1")
+    assert calls == ["init", ("start", "s1")]
+
+def test_log_action(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(
+        tasks,
+        "record_codex_action",
+        lambda session_id, action, statement, metadata: recorded.append(
+            (session_id, action, statement, metadata)
+        ),
+    )
+    tasks.log_action("s1", "act", "stmt", "meta")
+    assert recorded == [("s1", "act", "stmt", "meta")]
+
+def test_finalize_session(monkeypatch):
+    calls = []
+    monkeypatch.setattr(tasks, "log_codex_end", lambda s, summary: calls.append(("end", s, summary)))
+    monkeypatch.setattr(tasks, "finalize_codex_log_db", lambda: calls.append("final"))
+    tasks.finalize_session("s1", "ok")
+    assert calls == [("end", "s1", "ok"), "final"]


### PR DESCRIPTION
## Summary
- add helper functions to manage Codex session logging
- document dedicated Codex log database helper script
- test Codex log session helpers

## Testing
- `ruff check scripts/DEDICATED_CODEX_LOG_DATABASE_TASKS.py tests/test_dedicated_codex_log_database_tasks.py`
- `pytest tests/test_dedicated_codex_log_database_tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68956dd55a9c833194f3d61bf199984f