### PR TITLE
feat: add quantum simulator stubs with tests

### DIFF
--- a/docs/quantum_integration.md
+++ b/docs/quantum_integration.md
@@ -1,0 +1,11 @@
+# Quantum Integration Tests
+
+## Simulator Stubs
+
+The simulator interfaces run entirely in software. Tests executed with:
+
+```
+pytest tests/quantum/test_simulators.py -vv
+```
+
+Result: **2 passed** confirming that the stubs operate without requiring external quantum hardware.

--- a/src/quantum/__init__.py
+++ b/src/quantum/__init__.py
@@ -1,0 +1,1 @@
+"""Quantum utility package for simulator stubs."""

--- a/src/quantum/simulators/__init__.py
+++ b/src/quantum/simulators/__init__.py
@@ -1,0 +1,6 @@
+"""Lightweight quantum simulator stubs."""
+
+from .base import QuantumSimulator
+from .simple import SimpleSimulator
+
+__all__ = ["QuantumSimulator", "SimpleSimulator"]

--- a/src/quantum/simulators/base.py
+++ b/src/quantum/simulators/base.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class QuantumSimulator(ABC):
+    """Abstract interface for local quantum circuit simulators."""
+
+    @abstractmethod
+    def run(self, circuit: Any, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - interface
+        """Simulate ``circuit`` and return a provider-agnostic result."""

--- a/src/quantum/simulators/simple.py
+++ b/src/quantum/simulators/simple.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .base import QuantumSimulator
+
+
+class SimpleSimulator(QuantumSimulator):
+    """Trivial simulator that echoes the circuit and marks result as simulated."""
+
+    def run(self, circuit: Any, **kwargs: Any) -> Dict[str, Any]:
+        return {"simulated": True, "circuit": str(circuit)}

--- a/tests/quantum/test_simulators.py
+++ b/tests/quantum/test_simulators.py
@@ -1,0 +1,11 @@
+from src.quantum.simulators import QuantumSimulator, SimpleSimulator
+
+
+def test_simple_simulator_runs_without_hardware():
+    sim = SimpleSimulator()
+    circuit = "dummy-circuit"
+    assert sim.run(circuit) == {"simulated": True, "circuit": "dummy-circuit"}
+
+
+def test_simple_simulator_is_interface():
+    assert issubclass(SimpleSimulator, QuantumSimulator)


### PR DESCRIPTION
## Summary
- add lightweight `QuantumSimulator` interface and `SimpleSimulator` stub
- cover simulator behavior with tests
- document simulator test results

## Testing
- `ruff check src/quantum/simulators tests/quantum/test_simulators.py`
- `pytest tests/quantum/test_simulators.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689577ce5dd88331b5f1155142c75163