### PR TITLE
feat: enhance dashboard auth security

### DIFF
--- a/tests/dashboard/auth/test_security.py
+++ b/tests/dashboard/auth/test_security.py
@@ -23,3 +23,9 @@ def test_rate_limit(monkeypatch, manager):
         manager.start_session("secret")
     with pytest.raises(ValueError):
         manager.start_session("secret")
+
+
+def test_refresh_invalid_session(monkeypatch, manager):
+    monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    with pytest.raises(ValueError):
+        manager.refresh_session("secret", "does-not-exist")

--- a/tests/dashboard/test_auth.py
+++ b/tests/dashboard/test_auth.py
@@ -23,3 +23,15 @@ def test_failed_auth_flow(monkeypatch, manager):
     assert not manager.validate("bad", "none")
     session = manager.start_session("secret")
     assert not manager.validate("secret", "wrong")
+
+
+def test_session_refresh_and_expiry(monkeypatch, manager):
+    monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    session = manager.start_session("secret")
+    new_session = manager.refresh_session("secret", session)
+    assert new_session != session
+    assert not manager.validate("secret", session)
+    assert manager.validate("secret", new_session)
+    now = auth.time.time()
+    monkeypatch.setattr(auth.time, "time", lambda: now + manager.session_timeout + 1)
+    assert not manager.validate("secret", new_session)

--- a/tests/dashboard/test_auth_security.py
+++ b/tests/dashboard/test_auth_security.py
@@ -14,11 +14,15 @@ def manager() -> auth.SessionManager:
 
 def test_bruteforce_protection(monkeypatch, manager) -> None:
     monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
-    for _ in range(2):
+    for _ in range(manager.max_attempts):
         with pytest.raises(ValueError):
             manager.start_session("bad")
     with pytest.raises(ValueError):
-        manager.start_session("bad")
+        manager.start_session("secret")
+    now = auth.time.time()
+    monkeypatch.setattr(auth.time, "time", lambda: now + 61)
+    session = manager.start_session("secret")
+    assert manager.validate("secret", session)
 
 
 def test_csrf_and_auth(monkeypatch, manager, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add session expiry, refresh support, and lockout protection to dashboard auth
- enforce CSRF checks and brute-force lockout in auth tests
- cover session refresh/expiry and invalid refresh scenarios

## Testing
- `ruff check src/dashboard/auth.py tests/dashboard/test_auth.py tests/dashboard/test_auth_security.py tests/dashboard/auth/test_security.py`
- `pytest tests/dashboard/test_auth.py tests/dashboard/test_auth_security.py tests/dashboard/auth/test_security.py`


------
https://chatgpt.com/codex/tasks/task_e_689578a2a4c083318466a2b58bc25235