### PR TITLE
docs: document session lifecycle and disaster recovery usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Coverage](https://img.shields.io/badge/coverage-automated-blue)
 ![Ruff](https://img.shields.io/badge/ruff-linted-blue)
 
-**Status:** Active development with incremental improvements. Disaster recovery now enforces external backup roots and has verified restore tests, while session-management enhancements remain under construction.
+**Status:** Active development with incremental improvements. Disaster recovery now enforces external backup roots with verified restore tests, and session-management lifecycle APIs (`start_session` / `end_session`) are now available.
 
 > Combined checks: run `python scripts/run_checks.py` to execute `ruff` and `pytest` sequentially.
 > Tests: run `pytest` before committing. Current repository tests report multiple failures.

--- a/docs/BACKUP_COMPLIANCE_GUIDE.md
+++ b/docs/BACKUP_COMPLIANCE_GUIDE.md
@@ -26,3 +26,17 @@ following events:
 These logs help maintain compliance records for all backup and restore
 operations.
 
+## Usage Example
+
+```python
+from unified_disaster_recovery_system import UnifiedDisasterRecoverySystem
+
+system = UnifiedDisasterRecoverySystem()
+backup_file = system.schedule_backups()
+system.restore_backup(backup_file)
+```
+
+The `UnifiedDisasterRecoverySystem` enforces external backup roots and records
+each operation through the compliance logger, ensuring recoveries are both
+auditable and repeatable.
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.1.22] - 2025-08-12
+- Documented session lifecycle APIs (`start_session`/`end_session`) and refreshed hybrid integration example.
+- Added disaster recovery usage snippet in backup guide.
+- Verified documentation spelling with `codespell`.
+
 ## [4.1.21] - 2025-08-11
 - Resolved hard-coded workspace path in `EnterpriseUtility` to honor
   `GH_COPILOT_WORKSPACE`, restoring cross-platform compatibility.

--- a/docs/hybrid_copilot_codex_integration.md
+++ b/docs/hybrid_copilot_codex_integration.md
@@ -17,8 +17,8 @@ class EnhancedHybridCopilotCodexOrchestrator(HybridCopilotCodexOrchestrator):
         self.database_ecosystem = self.initialize_27_database_ecosystem()
 
     def execute_with_enterprise_hybrid_validation(self, task_name: str, phases: List[ProcessPhase]):
-        session_validation = self.session_manager.validate_session_startup()
-        if not session_validation.passed:
+        session_active = self.session_manager.start_session()
+        if not session_active:
             raise SessionIntegrityError("Enterprise session validation failed")
 
         primary_executor = RepositoryAwareCopilotExecutor(
@@ -44,6 +44,7 @@ class EnhancedHybridCopilotCodexOrchestrator(HybridCopilotCodexOrchestrator):
             enterprise_standards=self.load_enterprise_compliance_rules()
         )
 
+        self.session_manager.end_session()
         security_validation = self.session_manager.validate_no_recursive_folders()
         zero_byte_validation = self.session_manager.zero_byte_protector.scan_and_protect()
 


### PR DESCRIPTION
## Summary
- document `start_session`/`end_session` lifecycle in README and integration guide
- add `UnifiedDisasterRecoverySystem` usage example and update backup guide
- record documentation updates in changelog

## Testing
- `codespell -L Aer README.md docs/`
- `ruff check`
- `pytest` *(fails: tests/recovery/test_routines.py)*


------
https://chatgpt.com/codex/tasks/task_e_68957be97aa08331bb28ff46ea511bfd