### PR TITLE
feat: enhance codex logging with structured metadata

### DIFF
--- a/docs/codex_logging.md
+++ b/docs/codex_logging.md
@@ -4,16 +4,21 @@ This document describes how Codex sessions record activity in the repository.
 
 ## Database schema
 
-Codex events are stored in `databases/codex_log.db`, an SQLite database with a
-single table:
+Codex events are stored in `databases/codex_log.db`, an SQLite database with two
+tables:
 
 - `codex_actions`
   - `id` – integer primary key
   - `session_id` – identifier for the Codex session
-  - `ts` – timestamp when the action was recorded
+  - `ts` – ISO 8601 UTC timestamp when the action was recorded
   - `action` – name of the action
   - `statement` – free‑form details about the action
-  - `metadata` – optional JSON or text metadata
+  - `metadata` – optional metadata stored as JSON text
+- `codex_log`
+  - `session_id` – identifier for the Codex session
+  - `event` – `start` or `end`
+  - `summary` – optional session summary text
+  - `ts` – ISO 8601 UTC timestamp when the event was recorded
 
 ## Usage
 
@@ -27,7 +32,7 @@ from utils.codex_log_db import (
 )
 
 init_codex_log_db()
-record_codex_action(session_id, "generate", "created script", metadata="...")
+record_codex_action(session_id, "generate", "created script", metadata={"foo": 1})
 finalize_codex_log_db()
 ```
 

--- a/session_management_consolidation_executor.py
+++ b/session_management_consolidation_executor.py
@@ -74,7 +74,7 @@ class EnterpriseUtility:
     def perform_utility_function(self) -> bool:
         """Check workspace for zero-byte files and log any findings."""
         try:
-            with ensure_no_zero_byte_files(self.workspace_path):
+            with ensure_no_zero_byte_files(self.workspace_path, "consolidation"):
                 return True
         except RuntimeError as exc:
             self.logger.error("[ERROR] %s", exc)

--- a/tests/test_codex_action_logger.py
+++ b/tests/test_codex_action_logger.py
@@ -57,7 +57,7 @@ def test_record_and_finalize(tmp_path, monkeypatch):
 
     calls: list[list[str]] = []
 
-    def fake_run(cmd, cwd=None, check=False):
+    def fake_run(cmd, cwd=None, check=True):
         calls.append(cmd)
         class Result:
             returncode = 0
@@ -67,9 +67,9 @@ def test_record_and_finalize(tmp_path, monkeypatch):
 
     codex_log_db.init_codex_log_db()
     codex_log_db.record_codex_action("s1", "action", "statement", "meta")
-    src = codex_log_db.finalize_codex_log_db()
+    copied = codex_log_db.finalize_codex_log_db()
 
-    assert src == db_file
+    assert copied == session_file
     assert session_file.exists()
 
     with sqlite3.connect(db_file) as conn:

--- a/tests/test_codex_log_db.py
+++ b/tests/test_codex_log_db.py
@@ -1,12 +1,13 @@
 """Tests for codex_log_db helper functions."""
 
+import json
 import sqlite3
 
 from utils import codex_log_db
 
 
-def test_init_db_creates_codex_actions(tmp_path, monkeypatch):
-    """init_codex_log_db should create the codex_actions table."""
+def test_init_db_creates_tables(tmp_path, monkeypatch):
+    """init_codex_log_db should create required tables."""
     db_file = tmp_path / "codex_log.db"
     monkeypatch.setattr(codex_log_db, "CODEX_LOG_DB", db_file)
 
@@ -14,10 +15,13 @@ def test_init_db_creates_codex_actions(tmp_path, monkeypatch):
 
     assert db_file.exists()
     with sqlite3.connect(db_file) as conn:
-        cursor = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='codex_actions'"
-        )
-        assert cursor.fetchone() is not None
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'",
+            )
+        }
+    assert {"codex_actions", "codex_log"} <= tables
 
 
 def test_record_codex_action_inserts_row(tmp_path, monkeypatch):
@@ -29,10 +33,26 @@ def test_record_codex_action_inserts_row(tmp_path, monkeypatch):
 
     with sqlite3.connect(db_file) as conn:
         rows = conn.execute(
-            "SELECT session_id, action, statement, metadata FROM codex_actions"
+            "SELECT session_id, action, statement, metadata FROM codex_actions",
         ).fetchall()
 
     assert rows == [("s1", "act", "stmt", "meta")]
+
+
+def test_record_codex_action_serializes_metadata(tmp_path, monkeypatch):
+    """Dictionary metadata should be stored as JSON and timestamp in UTC."""
+    db_file = tmp_path / "codex_log.db"
+    monkeypatch.setattr(codex_log_db, "CODEX_LOG_DB", db_file)
+
+    codex_log_db.record_codex_action("s1", "act", "stmt", {"a": 1})
+
+    with sqlite3.connect(db_file) as conn:
+        ts, metadata = conn.execute(
+            "SELECT ts, metadata FROM codex_actions",
+        ).fetchone()
+
+    assert ts.endswith("+00:00")
+    assert json.loads(metadata) == {"a": 1}
 
 
 def test_finalize_codex_log_db_copies_db(tmp_path, monkeypatch):
@@ -47,6 +67,16 @@ def test_finalize_codex_log_db_copies_db(tmp_path, monkeypatch):
         lambda: tmp_path,
     )
 
+    calls = []
+
+    def fake_run(cmd, cwd=None, check=True):
+        calls.append(cmd)
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(codex_log_db.subprocess, "run", fake_run)
+
     codex_log_db.log_codex_action("s1", "act", "stmt")
     copied = codex_log_db.finalize_codex_log_db()
 
@@ -54,8 +84,9 @@ def test_finalize_codex_log_db_copies_db(tmp_path, monkeypatch):
     assert dest.exists()
     with sqlite3.connect(dest) as conn:
         rows = conn.execute(
-            "SELECT session_id, action, statement FROM codex_actions"
+            "SELECT session_id, action, statement FROM codex_actions",
         ).fetchall()
 
     assert rows == [("s1", "act", "stmt")]
+    assert any(cmd[:2] == ["git", "add"] for cmd in calls)
 


### PR DESCRIPTION
## Summary
- add UTC timestamps and JSON metadata support to Codex action log
- document Codex log tables and metadata usage
- fix zero-byte check utility to pass session id

## Testing
- `ruff check utils/codex_log_db.py tests/test_codex_log_db.py`
- `pytest -c /dev/null tests/test_codex_log_db.py tests/test_codex_action_logger.py tests/test_wlc_session_manager_integration.py tests/test_wlc_session_manager.py tests/test_session_management.py tests/test_lessons_learned.py tests/database/test_codex_log_db.py` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_6895830e7b208331ab5b786ae2a9a0de