### PR TITLE
feat: harmonize simulator stubs with API

### DIFF
--- a/src/quantum/simulators/__init__.py
+++ b/src/quantum/simulators/__init__.py
@@ -5,6 +5,8 @@ future quantum backends. For setup and usage instructions see
 ``docs/quantum_integration.md``.
 """
 
+from .base import QuantumSimulator
 from .basic import BasicSimulator
+from .simple import SimpleSimulator
 
-__all__ = ["BasicSimulator"]
+__all__ = ["QuantumSimulator", "BasicSimulator", "SimpleSimulator"]

--- a/src/quantum/simulators/basic.py
+++ b/src/quantum/simulators/basic.py
@@ -6,10 +6,12 @@ Refer to ``docs/quantum_integration.md`` for full setup and integration details.
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any, Sequence, Dict
+
+from .base import QuantumSimulator
 
 
-class BasicSimulator:
+class BasicSimulator(QuantumSimulator):
     """Simple simulator returning all-zero bitstring counts.
 
     Parameters
@@ -21,14 +23,16 @@ class BasicSimulator:
     def __init__(self, shots: int = 1024) -> None:
         self.shots = shots
 
-    def run(self, circuit: Sequence[Any]) -> dict[str, int]:
-        """Simulate a circuit using a deterministic model.
+    def run(self, circuit: Any, **_: Any) -> Dict[str, Any]:
+        """Simulate ``circuit`` using a deterministic model.
 
         Each element in ``circuit`` is treated as a qubit initialized to ``|0>``.
         The simulator returns a single measurement outcome consisting entirely of
-        zeros with ``shots`` counts.
+        zeros with ``shots`` counts. Extra keyword arguments are ignored to
+        maintain compatibility with hardware backends.
 
         See ``docs/quantum_integration.md`` for integration guidance.
         """
-        zeros = "0" * len(list(circuit))
+        qubits = list(circuit) if isinstance(circuit, Sequence) else [circuit]
+        zeros = "0" * len(qubits)
         return {zeros: self.shots}

--- a/tests/quantum/simulators/__init__.py
+++ b/tests/quantum/simulators/__init__.py
@@ -1,0 +1,1 @@
+# Integration tests package for quantum simulator stubs.

--- a/tests/quantum/simulators/test_stub_interactions.py
+++ b/tests/quantum/simulators/test_stub_interactions.py
@@ -1,0 +1,12 @@
+from src.quantum.simulators import BasicSimulator, SimpleSimulator, QuantumSimulator
+
+
+def test_basic_simulator_all_zero_output():
+    sim = BasicSimulator(shots=10)
+    result = sim.run(["q0", "q1"], extra="ignore")
+    assert result == {"00": 10}
+
+
+def test_simulators_share_interface():
+    for cls in (BasicSimulator, SimpleSimulator):
+        assert issubclass(cls, QuantumSimulator)


### PR DESCRIPTION
## Summary
- expose QuantumSimulator and SimpleSimulator from simulator package
- align BasicSimulator with QuantumSimulator interface
- add integration tests for simulator stubs

## Testing
- `ruff check src/quantum/simulators tests/quantum/simulators`
- `pytest tests/quantum/simulators/`


------
https://chatgpt.com/codex/tasks/task_e_689584f4a5b0833183c8f4ec5bda3436