### PR TITLE
docs: document sync engine and dashboard monitoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Ensure the development environment is correctly configured **before** making any
   * **SESSION_ID_SOURCE** – Optional override for the session identifier used by Codex logging. When unset, a UUID is generated.
   * **TEST_MODE** – Set to "1" in test environments to disable side effects (e.g., database writes) in scripts like `scripts/wlc_session_manager.py`.
   * **ALLOW_AUTOLFS** – Set to "1" to enable automatic Git LFS tracking for binary or large files.
+  * **SYNC_ENGINE_WS_URL** – Optional WebSocket endpoint for real-time database synchronization. `SyncEngine` broadcasts changes through this URL, logs events to `analytics.db`, and surfaces metrics on the dashboard.
   * *Optional variables:* **WORKSPACE\_ROOT** (alias for `GH_COPILOT_WORKSPACE`), **FLASK\_SECRET\_KEY** (for the optional Flask web UI, default `'your_secret_key'` – replace in production), **FLASK\_RUN\_PORT** (Flask dev server port, default 5000), **CONFIG\_PATH** (path to a custom config file if not using the default `config/enterprise.json`), **WEB\_DASHBOARD\_ENABLED** (`"1"` or `"0"` to toggle logging of performance metrics with `[DASHBOARD]` tags). Configure these as needed if using those features.
 * After installing dependencies and setting variables, **run the test suite** (see [Testing and Validation](#testing-and-validation)) to verify the environment is correctly set up.
 * For procedures on restoring Git LFS-managed files, consult [docs/git_lfs_recovery.md](docs/git_lfs_recovery.md).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Correction History:** cleanup and fix events recorded in `analytics.db:correction_history`
 - **Anti-Recursion Guards:** backup and session modules now enforce external backup roots.
 - **Analytics Migrations:** run `add_code_audit_log.sql`, `add_correction_history.sql`, `add_code_audit_history.sql`, `add_violation_logs.sql`, and `add_rollback_logs.sql` (use `sqlite3` manually if `analytics.db` shipped without the tables) or use the initializer. The `correction_history` table tracks file corrections with `user_id`, session ID, action, timestamp, and optional details. The new `code_audit_history` table records each audit entry along with the responsible user and timestamp.
+- **Real-Time Sync Engine:** `SyncManager` and `SyncWatcher` log synchronization outcomes to `analytics.db` and feed live statistics to the dashboard.
+- **Dashboard Metrics View:** compliance, synchronization, and monitoring metrics refresh live when `LOG_WEBSOCKET_ENABLED=1`.
+- **Monitoring Pipeline:** anomaly detection results stored in `analytics.db` appear on the dashboard's monitoring panels.
 
 - **Quantum Placeholder Utilities:** see [quantum/README.md](quantum/README.md) for simulated optimizer and search helpers. `quantum_optimizer.run_quantum_routine` includes placeholder hooks for annealing and search routines; entanglement correction is not implemented. These stubs run on Qiskit simulators and ignore `use_hardware=True` until real hardware integration lands. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) for current status.
 - **Phase 6 Quantum Demo:** `quantum_integration_orchestrator.py` demonstrates a simulated quantum
@@ -873,6 +876,8 @@ To enable WebSocket-based propagation, start a broadcast WebSocket server and
 set `SYNC_ENGINE_WS_URL` to its endpoint (for example, `ws://localhost:8765`).
 Instantiate `SyncEngine` and call `await engine.open_websocket(os.environ["SYNC_ENGINE_WS_URL"], apply_callback)`
 where `apply_callback` applies incoming changes locally. See `docs/realtime_sync.md` for details.
+
+Synchronization outcomes are logged to `databases/analytics.db`, allowing the dashboard to surface live sync statistics.
 
 The compliance score is averaged from records in the `correction_logs` table.
 Correction history is summarized via `scripts/correction_logger_and_rollback.py`.

--- a/docs/DATABASE_SYNC_GUIDE.md
+++ b/docs/DATABASE_SYNC_GUIDE.md
@@ -28,6 +28,8 @@ watcher = SyncWatcher(manager)
 watcher.watch_pairs([(db_a, db_b), (db_c, db_d)], policy="last-write-wins")
 ```
 
+Synchronization events and conflict statistics are stored in `databases/analytics.db`. The dashboard reads these records to display live synchronization metrics alongside other system health data.
+
 ## Conflict Policies
 The synchronization engine supports pluggable conflict resolution. Use the
 `"last-write-wins"` policy for timestamp-based merges or supply a custom merge

--- a/docs/MONITORING_GUIDE.md
+++ b/docs/MONITORING_GUIDE.md
@@ -22,4 +22,4 @@ This guide describes the anomaly detection pipeline provided by
   (`artifacts/anomaly_iforest.pkl`).
 
 Aggregated anomaly counts and average scores are available through
-`dashboard.enterprise_dashboard.anomaly_metrics`.
+`dashboard.enterprise_dashboard.anomaly_metrics` and appear on the dashboard's monitoring panels for real-time visibility.

--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -5,14 +5,14 @@ This dashboard provides visibility into compliance metrics and rollback history.
 ## Setup
 
 1. Ensure the virtual environment is activated.
-2. Run the Flask app:
+2. Export `LOG_WEBSOCKET_ENABLED=1` to stream live metrics, and set `SYNC_ENGINE_WS_URL` if the sync engine broadcasts over WebSockets.
+3. Run the Flask app:
 
 ```bash
 python dashboard/integrated_dashboard.py
 ```
 
-The application will attempt to read `metrics.json` and `databases/analytics.db`. If the
-analytics database is missing, the dashboard will still load with empty metrics and logs.
+The application reads compliance, synchronization, and monitoring data from `databases/analytics.db`. If the analytics database is missing, the dashboard still loads but metrics panels will be empty.
 
 ## Screenshots
 Screenshots are stored as base64 text to avoid committing binary files. Recreate them

--- a/docs/realtime_sync.md
+++ b/docs/realtime_sync.md
@@ -18,3 +18,5 @@ channel. To enable WebSocket-based synchronization:
 Queued local changes are sent automatically, and remote changes are applied
 in real time, enabling bi-directional updates across clients.
 
+All applied changes are recorded in `databases/analytics.db`, which feeds the dashboard's synchronization metrics.
+


### PR DESCRIPTION
## Summary
- document SYNC_ENGINE_WS_URL usage and dashboard metrics streaming
- expand sync engine and monitoring docs with analytics.db dashboard integration
- clarify dashboard setup for live synchronization and anomaly metrics

## Testing
- `ruff check .` *(fails: F821 Undefined name `log_codex_action` in scripts/wlc_session_manager.py)*
- `pytest` *(fails: tests/quantum/test_simulators.py)*

------
https://chatgpt.com/codex/tasks/task_e_689584fd2274833199e6260721471d4c