### PR TITLE
feat: add failure recovery patterns and monitoring hooks

### DIFF
--- a/src/recovery/routines.py
+++ b/src/recovery/routines.py
@@ -12,8 +12,8 @@ from typing import Any, Callable, Dict, Iterable
 
 import sqlite3
 
-from monitoring import anomaly
-from session import validators
+from ..monitoring import anomaly
+from ..session import validators
 
 
 def reconnect_database(
@@ -64,6 +64,26 @@ def retry_sync(
     raise last_exc
 
 
+def restart_service(restart: Callable[[], Any]) -> bool:
+    """Attempt to restart a service using ``restart``."""
+
+    try:
+        restart()
+        return True
+    except Exception:
+        return False
+
+
+def revert_state(revert: Callable[[], Any]) -> bool:
+    """Attempt to revert application state using ``revert``."""
+
+    try:
+        revert()
+        return True
+    except Exception:
+        return False
+
+
 def handle_alerts(
     models: Dict[str, anomaly.Model],
     metrics: Dict[str, float],
@@ -95,4 +115,10 @@ def handle_alerts(
     return counts
 
 
-__all__ = ["reconnect_database", "retry_sync", "handle_alerts"]
+__all__ = [
+    "reconnect_database",
+    "retry_sync",
+    "restart_service",
+    "revert_state",
+    "handle_alerts",
+]

--- a/tests/monitoring/test_failure_monitoring.py
+++ b/tests/monitoring/test_failure_monitoring.py
@@ -1,0 +1,19 @@
+from src.monitoring import alerts
+
+
+def test_monitor_failures_triggers_routines():
+    messages = ["service alpha down", "state cache corrupt"]
+    calls = {"service_crash": 0, "state_corruption": 0}
+
+    def restart() -> None:
+        calls["service_crash"] += 1
+
+    def revert() -> None:
+        calls["state_corruption"] += 1
+
+    results = alerts.monitor_failures(
+        messages,
+        {"service_crash": restart, "state_corruption": revert},
+    )
+    assert results == {"service_crash": True, "state_corruption": True}
+    assert calls == {"service_crash": 1, "state_corruption": 1}

--- a/tests/recovery/test_routines.py
+++ b/tests/recovery/test_routines.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 
-from recovery import routines
+from src.recovery import routines
 
 
 def test_reconnect_database_retry():
@@ -53,3 +53,20 @@ def test_handle_alerts_triggers_recovery():
     assert result == {"reconnects": 1, "sync_retries": 1}
     assert len(factory_calls) == 1
     assert len(sync_calls) == 1
+
+
+def test_restart_service_executes_callback():
+    calls: list[int] = []
+
+    def restart() -> None:
+        calls.append(1)
+
+    assert routines.restart_service(restart)
+    assert calls == [1]
+
+
+def test_revert_state_handles_error():
+    def revert() -> None:
+        raise RuntimeError("boom")
+
+    assert routines.revert_state(revert) is False


### PR DESCRIPTION
## Summary
- define reusable failure patterns for service crashes and state corruption
- add restart and state-revert routines
- monitor logs to trigger recovery routines on matching patterns

## Testing
- `ruff check src/recovery src/monitoring tests/recovery tests/monitoring`
- `PYTHONPATH=. pytest tests/recovery/test_routines.py tests/monitoring/test_failure_monitoring.py`


------
https://chatgpt.com/codex/tasks/task_e_6895851087008331ae734b1e0137618e