### PR TITLE
feat: add codex action log database

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Phase 5 scoring guidelines.
 ## 🏗️ CORE ARCHITECTURE
 
 ### **Enterprise Systems**
-- **Multiple SQLite Databases:** `databases/production.db`, `databases/analytics.db`, `databases/monitoring.db`
-- [ER Diagrams](docs/ER_DIAGRAMS.md) for key databases
+- **Multiple SQLite Databases:** `databases/production.db`, `databases/analytics.db`, `databases/monitoring.db`, `databases/codex_logs.db`
+  - [ER Diagrams](docs/ER_DIAGRAMS.md) for key databases
 - **Flask Enterprise Dashboard:** run `python web_gui_integration_system.py` to launch the metrics and compliance dashboard
 - **Template Intelligence Platform:** tracks generated scripts
 - **Enterprise HTML Templates:** reusable base layouts, components, mobile views, and email templates under `templates/`
@@ -208,6 +208,8 @@ python scripts/database/add_code_audit_log.py
 sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
 sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
 sqlite3 databases/analytics.db < databases/migrations/add_code_audit_history.sql
+# Initialize codex log database
+python scripts/codex_log_db.py --init
 sqlite3 databases/analytics.db < databases/migrations/add_violation_logs.sql
 sqlite3 databases/analytics.db < databases/migrations/add_rollback_logs.sql
 sqlite3 databases/analytics.db < databases/migrations/create_todo_fixme_tracking.sql

--- a/databases/codex_logs.db
+++ b/databases/codex_logs.db
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5f64d63844aa92dabc37957cec4ba5554c6823bbda870eba047c42d7ddb6ada
+size 12288

--- a/scripts/codex_log_db.py
+++ b/scripts/codex_log_db.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Codex log database utilities.
+
+This module provides helpers to initialize and append to a dedicated
+``codex_logs.db`` SQLite database. Each log entry captures the action and
+statement issued by Codex during a session. The resulting database can be
+committed for post-session analysis and lessons learned processing.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from datetime import datetime
+
+DEFAULT_DB_PATH = Path("databases/codex_logs.db")
+
+
+def init_db(db_path: Path = DEFAULT_DB_PATH) -> None:
+    """Ensure the codex log database exists with the proper schema."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS codex_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                action TEXT NOT NULL,
+                statement TEXT NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+
+def log_action(action: str, statement: str, *, db_path: Path = DEFAULT_DB_PATH) -> None:
+    """Record a codex action and statement into the database."""
+    init_db(db_path)
+    timestamp = datetime.utcnow().isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO codex_logs (timestamp, action, statement) VALUES (?, ?, ?)",
+            (timestamp, action, statement),
+        )
+        conn.commit()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Codex log database helper")
+    parser.add_argument("--action", help="Action performed by Codex")
+    parser.add_argument("--statement", help="Associated statement")
+    parser.add_argument(
+        "--init",
+        action="store_true",
+        help="Initialize the database and exit",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=DEFAULT_DB_PATH,
+        help="Path to codex log database",
+    )
+    args = parser.parse_args()
+    if args.init:
+        init_db(args.db_path)
+    elif args.action and args.statement:
+        log_action(args.action, args.statement, db_path=args.db_path)
+    else:
+        parser.error("Provide --init or both --action and --statement")

--- a/tests/test_codex_log_db.py
+++ b/tests/test_codex_log_db.py
@@ -1,0 +1,14 @@
+import sqlite3
+from pathlib import Path
+
+from scripts.codex_log_db import init_db, log_action
+
+
+def test_log_action_creates_entry(tmp_path: Path) -> None:
+    db_path = tmp_path / "codex_logs.db"
+    init_db(db_path)
+    log_action("test", "example", db_path=db_path)
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute("SELECT action, statement FROM codex_logs")
+        rows = cur.fetchall()
+    assert rows == [("test", "example")]


### PR DESCRIPTION
## Summary
- add codex log database utilities to record actions and statements
- document codex log database usage and initialization
- cover codex log database with unit test

## Testing
- `ruff check scripts/codex_log_db.py tests/test_codex_log_db.py`
- `pytest tests/test_codex_log_db.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68958a9ffe7c833181f52c6f533cac8f