### PR TITLE
feat: add codex session log database

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Placeholder Auditing:** detection script logs findings to `analytics.db:code_audit_log`
 - **Disaster Recovery Validation:** `UnifiedDisasterRecoverySystem` verifies external backup roots and restores files from `production_backup`
 - **Correction History:** cleanup and fix events recorded in `analytics.db:correction_history`
+- **Codex Session Logging:** `utils.codex_log_database` stores all Codex actions
+  and statements in `databases/codex_session_logs.db` for post-session review.
 - **Anti-Recursion Guards:** backup and session modules now enforce external backup roots.
 - **Analytics Migrations:** run `add_code_audit_log.sql`, `add_correction_history.sql`, `add_code_audit_history.sql`, `add_violation_logs.sql`, and `add_rollback_logs.sql` (use `sqlite3` manually if `analytics.db` shipped without the tables) or use the initializer. The `correction_history` table tracks file corrections with `user_id`, session ID, action, timestamp, and optional details. The new `code_audit_history` table records each audit entry along with the responsible user and timestamp.
 

--- a/databases/codex_session_logs.db
+++ b/databases/codex_session_logs.db
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d2bd96aedbe26fdaf56fc21d9036fb0f59f4c5bfca10dacbcb0ddf7cd4e761f
+size 12288

--- a/scripts/codex_logger.py
+++ b/scripts/codex_logger.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""CLI for logging Codex actions to the session log database."""
+
+from __future__ import annotations
+
+import argparse
+
+from utils.codex_log_database import log_codex_event
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Log a Codex action")
+    parser.add_argument("action", help="Action performed")
+    parser.add_argument("statement", help="Associated statement")
+    parser.add_argument(
+        "--session-id", default="default", help="Identifier for the session"
+    )
+    args = parser.parse_args()
+    log_codex_event(args.action, args.statement, session_id=args.session_id)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_codex_log_database.py
+++ b/tests/test_codex_log_database.py
@@ -1,0 +1,18 @@
+"""Tests for the Codex session log database."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+from utils.codex_log_database import fetch_codex_events, log_codex_event
+
+
+def test_log_and_fetch() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "codex_test.db"
+        log_codex_event("action", "statement", session_id="s1", db_path=db_path)
+        events = fetch_codex_events(session_id="s1", db_path=db_path)
+        assert events and events[0]["action"] == "action"
+        assert events[0]["statement"] == "statement"
+

--- a/utils/codex_log_database.py
+++ b/utils/codex_log_database.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Codex session log database utilities.
+
+Records Codex actions and statements into an SQLite database so each
+session's activity can be reviewed after commit.
+
+Features:
+* Database-first path: ``databases/codex_session_logs.db`` under
+  ``GH_COPILOT_WORKSPACE``.
+* Anti-recursion guard to prevent recursive invocation.
+* Dual-copilot validation by confirming record counts post-insert.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from utils.validation_utils import anti_recursion_guard
+from utils.log_utils import log_message
+
+
+DEFAULT_DB = (
+    Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    / "databases"
+    / "codex_session_logs.db"
+)
+
+TABLE = "codex_session_log"
+
+
+def _ensure_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {TABLE} (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT,
+                timestamp TEXT NOT NULL,
+                action TEXT NOT NULL,
+                statement TEXT
+            );
+            """
+        )
+
+
+@anti_recursion_guard
+def log_codex_event(
+    action: str,
+    statement: str,
+    *,
+    session_id: str = "default",
+    db_path: Path = DEFAULT_DB,
+) -> None:
+    """Log a Codex action and associated statement."""
+
+    _ensure_db(db_path)
+    ts = datetime.utcnow().isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            f"INSERT INTO {TABLE} (session_id, timestamp, action, statement) VALUES (?, ?, ?, ?)",
+            (session_id, ts, action, statement),
+        )
+        count = conn.execute(f"SELECT COUNT(*) FROM {TABLE}").fetchone()[0]
+    log_message("codex_log_db", f"Logged action '{action}' (total records: {count})")
+
+
+def fetch_codex_events(
+    *, session_id: Optional[str] = None, db_path: Path = DEFAULT_DB
+) -> List[Dict[str, str]]:
+    """Return codex log entries optionally filtered by session."""
+
+    _ensure_db(db_path)
+    query = f"SELECT session_id, timestamp, action, statement FROM {TABLE}"
+    params: List[str] = []
+    if session_id is not None:
+        query += " WHERE session_id = ?"
+        params.append(session_id)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(query, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+__all__ = ["log_codex_event", "fetch_codex_events", "DEFAULT_DB", "TABLE"]
+


### PR DESCRIPTION
## Summary
- add utilities to record Codex actions into a dedicated SQLite log database
- provide CLI helper for logging Codex actions
- document Codex session logging workflow and add tests

## Testing
- `ruff check utils/codex_log_database.py scripts/codex_logger.py tests/test_codex_log_database.py`
- `pytest tests/test_codex_log_database.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68958a9ffe7c833181f52c6f533cac8f