### PR TITLE
feat: add codex action logger database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ databases/analytics.db
 databases/*.db
 !databases/codex_log.db
 !databases/codex_session_logs.db
+!databases/codex_logs.db
 databases/*.zip
 analytics.db
 database_cleanup.log

--- a/README.md
+++ b/README.md
@@ -394,6 +394,11 @@ schema and commit workflow.
 Session tooling records actions in `databases/codex_log.db`. When
 `finalize_codex_log_db()` runs, the log is copied to
 `databases/codex_session_logs.db` and both files are staged for commit.
+For a simplified per-action audit trail, the `utils/codex_logger.py`
+helper stores timestamped `action` and `statement` entries in
+`databases/codex_logs.db`. Call `codex_logger.log_action()` during the
+session and `codex_logger.finalize_db()` to stage the database for
+commit.
 
 #### Environment variables
 

--- a/databases/codex_logs.db
+++ b/databases/codex_logs.db
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f558aa2763776a671415a5e139f6f3093f736841136702005750b5bab609e306
+size 8192

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -51,11 +51,15 @@ from utils.codex_log_db import (
     finalize_codex_log_db,
     log_codex_action,
 )
+from utils.codex_logger import init_db as init_codex_logs_db
+from utils.codex_logger import log_action as log_codex_logger_action
+from utils.codex_logger import finalize_db as finalize_codex_logs_db
 
 
 def log_action(session_id: str, action: str, statement: str) -> None:
     """Log a codex action with a UTC timestamp."""
     record_codex_action(session_id, action, statement, datetime.now(UTC).isoformat())
+    log_codex_logger_action(action, statement)
 
 try:
     from scripts.orchestrators.unified_wrapup_orchestrator import (
@@ -241,6 +245,7 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
         if entry_id is None:
             raise RuntimeError("Failed to create session entry in the database.")
         init_codex_log_db()
+        init_codex_logs_db()
         log_action(session_id, "session_start", "WLC session starting")
         log_codex_action(
             session_id,
@@ -341,6 +346,7 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
         log_action(session_id, "env_orchestrator_start", "Running orchestrator via env flag")
         orchestrator.execute_unified_wrapup()
         log_action(session_id, "env_orchestrator_complete", "Env orchestrator finished")
+    finalize_codex_logs_db()
     finalize_codex_log_db()
     log_codex_action(
         session_id,

--- a/tests/test_codex_logger.py
+++ b/tests/test_codex_logger.py
@@ -1,0 +1,33 @@
+import sqlite3
+import subprocess
+from pathlib import Path
+
+from utils import codex_logger
+
+
+def test_log_action_records_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    # Reload module to pick up workspace path
+    from importlib import reload
+    reload(codex_logger)
+
+    codex_logger.log_action("test", "hello world")
+    db_file = tmp_path / "databases" / "codex_logs.db"
+    assert db_file.exists()
+    with sqlite3.connect(db_file) as conn:
+        row = conn.execute("SELECT action, statement FROM codex_logs").fetchone()
+    assert row == ("test", "hello world")
+
+
+def test_codex_logs_tracked_by_lfs():
+    repo_root = Path(__file__).resolve().parents[1]
+    db_path = repo_root / "databases" / "codex_logs.db"
+    assert db_path.exists()
+    result = subprocess.run(
+        ["git", "lfs", "ls-files", str(db_path.relative_to(repo_root))],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=repo_root,
+    )
+    assert "codex_logs.db" in result.stdout

--- a/utils/codex_logger.py
+++ b/utils/codex_logger.py
@@ -1,0 +1,70 @@
+"""Utility for logging Codex actions and statements.
+
+This module provides a lightweight interface for recording Codex
+operations during a session.  Each entry is stored in a SQLite database
+(`databases/codex_logs.db`) with columns capturing the UTC timestamp,
+action name, and the associated statement.  The database is staged for
+commit (via Git LFS) when finalised.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from utils.cross_platform_paths import CrossPlatformPathManager
+
+DB_PATH = Path("databases/codex_logs.db")
+
+
+def _workspace_path() -> Path:
+    return CrossPlatformPathManager.get_workspace_path()
+
+
+def init_db() -> Path:
+    """Ensure the logging database and table exist."""
+    workspace = _workspace_path()
+    db_file = workspace / DB_PATH
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_file) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS codex_logs(
+                id INTEGER PRIMARY KEY,
+                ts TEXT NOT NULL,
+                action TEXT NOT NULL,
+                statement TEXT NOT NULL
+            )
+            """
+        )
+        conn.commit()
+    return db_file
+
+
+def log_action(action: str, statement: str, *, ts: Optional[str] = None) -> None:
+    """Insert a Codex log entry with a UTC timestamp."""
+    db_file = init_db()
+    ts_val = ts or datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_file) as conn:
+        conn.execute(
+            "INSERT INTO codex_logs (ts, action, statement) VALUES (?, ?, ?)",
+            (ts_val, action, statement),
+        )
+        conn.commit()
+
+
+def finalize_db() -> Path:
+    """Stage the database for commit and return its path."""
+    workspace = _workspace_path()
+    db_file = workspace / DB_PATH
+    if db_file.exists():
+        subprocess.run(
+            ["git", "add", str(DB_PATH)],
+            cwd=workspace,
+            check=True,
+        )
+    return db_file
+


### PR DESCRIPTION
## Summary
- add `codex_logs.db` SQLite database and utility for action/statement logging
- hook WLC session manager into new logger and stage DB on wrap-up
- document codex logger workflow and add regression tests

## Testing
- `ruff check utils/codex_logger.py scripts/wlc_session_manager.py tests/test_codex_logger.py`
- `pytest` *(fails: SyntaxError in `quantum/interfaces/quantum_templates.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68958d916b3c83318630149ae17afb98