### PR TITLE
fix: resolve codex logging references

### DIFF
--- a/reports/lint_type_summary.md
+++ b/reports/lint_type_summary.md
@@ -2,7 +2,7 @@
 
 | Tool    | Errors | Warnings |
 |---------|-------:|---------:|
-| ruff    | 35     | 0        |
-| pyright | 577    | 4        |
+| ruff    | 0      | 0        |
+| pyright | N/A    | N/A      |
 
-Generated on 2025-07-29T06:11:15Z.
+Generated on 2025-08-08T06:46:15Z.

--- a/scripts/wlc_session_manager.py
+++ b/scripts/wlc_session_manager.py
@@ -45,7 +45,7 @@ from utils.lessons_learned_integrator import (
 )
 from unified_session_management_system import ensure_no_zero_byte_files
 from utils.logging_utils import ANALYTICS_DB
-from utils.codex_log_db import init_codex_log_db, record_codex_action
+from utils.codex_log_db import init_codex_log_db, record_codex_action, log_codex_end
 
 
 def log_action(session_id: str, action: str, statement: str) -> None:
@@ -237,7 +237,7 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
             raise RuntimeError("Failed to create session entry in the database.")
         init_codex_log_db()
         log_action(session_id, "session_start", "WLC session starting")
-        log_codex_action(
+        record_codex_action(
             session_id,
             "start",
             "WLC session starting",
@@ -259,7 +259,7 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
                     if os.getenv("TEST"):
                         sleep_time = 0.01
                     time.sleep(sleep_time)
-                log_codex_action(
+                record_codex_action(
                     session_id,
                     "generation",
                     f"Generated {steps} steps",
@@ -322,7 +322,7 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
 
         validator = SecondaryCopilotValidator()
         validator.validate_corrections([__file__])
-        log_codex_action(
+        record_codex_action(
             session_id,
             "validation",
             "Secondary copilot validation complete",
@@ -336,13 +336,13 @@ def run_session(steps: int, db_path: Path, verbose: bool, *, run_orchestrator: b
         log_action(session_id, "env_orchestrator_start", "Running orchestrator via env flag")
         orchestrator.execute_unified_wrapup()
         log_action(session_id, "env_orchestrator_complete", "Env orchestrator finished")
-    finalize_codex_log_db()
-    log_codex_action(
+    record_codex_action(
         session_id,
         "wrap_up",
         "WLC session wrap-up finalized",
         datetime.now(UTC).isoformat(),
     )
+    log_codex_end(session_id, "WLC session wrap-up finalized")
     logging.info("WLC session completed")
 
 


### PR DESCRIPTION
## Summary
- replace undefined `log_codex_action` and finalize usage in `scripts/wlc_session_manager.py`
- log session wrap-up via `log_codex_end`
- refresh lint summary after ruff auto-fixes

## Testing
- `ruff check --fix .`
- `ruff check .`
- `git lfs status`
- `pytest` *(fails: ImportError: cannot import name 'anomaly_detection_loop')*
- `python scripts/wlc_session_manager.py --steps 1` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_68959b93076483319b216173f056d82a