### PR TITLE
feat: add output management utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,26 @@ Set `CLW_MAX_LINE_LENGTH=1550` in your environment (e.g. in `.env`) before invok
 `clw` prevents session resets by ensuring no line exceeds this limit. When in doubt, redirect long
 output to a file and view it with `clw` in small chunks.
 
+### Additional Output Management Tools
+
+For cases where you need to execute a command and automatically truncate overly
+long lines, use `tools/shell_output_manager.sh`. Wrap any command with
+`safe_execute` to ensure lines longer than 4000 characters are redirected to a
+temporary log while a truncated preview is printed.
+
+```bash
+source tools/shell_output_manager.sh
+safe_execute "some_command producing huge output"
+```
+
+When streaming data from other processes or needing structured chunking, the
+Python utility `tools/output_chunker.py` can be used as a filter to split long
+lines intelligently, preserving ANSI color codes and JSON boundaries.
+
+```bash
+some_command | python tools/output_chunker.py
+```
+
 
 
 ### **Basic Usage**

--- a/tests/test_output_chunker.py
+++ b/tests/test_output_chunker.py
@@ -1,0 +1,16 @@
+from tools.output_chunker import OutputChunker
+
+
+def test_chunker_handles_short_line():
+    chunker = OutputChunker(max_line_length=10)
+    chunks = list(chunker.chunk_line("short"))
+    assert chunks == [("short", False)]
+
+
+def test_chunker_splits_long_line():
+    chunker = OutputChunker(max_line_length=10)
+    long_line = "x" * 25
+    chunks = list(chunker.chunk_line(long_line))
+    assert len(chunks) == 3
+    assert all(len(c[0]) <= 10 for c in chunks)
+    assert all(c[1] for c in chunks)

--- a/tools/output_chunker.py
+++ b/tools/output_chunker.py
@@ -1,0 +1,137 @@
+"""Utility for chunking overly long output lines.
+
+This module provides the OutputChunker class which reads lines and yields
+chunks that do not exceed a configurable length. It preserves ANSI escape
+sequences and attempts to break JSON and other structured data at
+natural boundaries.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+from typing import Iterator, Tuple
+
+
+class OutputChunker:
+    """Chunk lines while preserving common structure."""
+
+    def __init__(self, max_line_length: int = 4000) -> None:
+        self.max_length = max_line_length
+        self.ansi_pattern = re.compile(r"\x1b\[[0-9;]*m")
+        self.chunk_counter = 0
+
+    def detect_patterns(self, line: str) -> dict:
+        """Identify line structure for intelligent chunking."""
+        return {
+            "ansi_colored": bool(self.ansi_pattern.search(line)),
+            "json_like": line.strip().startswith("{")
+            or line.strip().startswith("["),
+            "log_entry": re.match(r"^\d{4}-\d{2}-\d{2}", line.strip()),
+            "csv_like": "," in line and line.count(",") > 3,
+            "whitespace_heavy": len(line.strip()) < len(line) * 0.3,
+        }
+
+    def chunk_line(self, line: str) -> Iterator[Tuple[str, bool]]:
+        """Chunk line intelligently based on patterns."""
+        if len(line) <= self.max_length:
+            yield line, False
+            return
+
+        patterns = self.detect_patterns(line)
+
+        if patterns["ansi_colored"]:
+            yield from self._chunk_ansi_line(line)
+        elif patterns["json_like"]:
+            yield from self._chunk_json_line(line)
+        else:
+            yield from self._chunk_simple(line)
+
+    def _chunk_ansi_line(self, line: str) -> Iterator[Tuple[str, bool]]:
+        """Chunk while preserving ANSI escape sequences."""
+        chunks: list[str] = []
+        current_chunk = ""
+        ansi_stack: list[str] = []
+        i = 0
+        while i < len(line):
+            if line[i : i + 2] == "\x1b[":
+                ansi_end = line.find("m", i)
+                if ansi_end != -1:
+                    ansi_seq = line[i : ansi_end + 1]
+                    if len(current_chunk + ansi_seq) < self.max_length:
+                        current_chunk += ansi_seq
+                        ansi_stack.append(ansi_seq)
+                        i = ansi_end + 1
+                    else:
+                        yield self._close_ansi_chunk(
+                            current_chunk, ansi_stack
+                        ), True
+                        current_chunk = self._open_ansi_chunk(ansi_stack) + ansi_seq
+                        i = ansi_end + 1
+                else:
+                    i += 1
+            else:
+                if len(current_chunk) < self.max_length:
+                    current_chunk += line[i]
+                    i += 1
+                else:
+                    yield self._close_ansi_chunk(current_chunk, ansi_stack), True
+                    current_chunk = self._open_ansi_chunk(ansi_stack)
+        if current_chunk:
+            yield self._close_ansi_chunk(current_chunk, ansi_stack), len(line) > self.max_length
+
+    def _close_ansi_chunk(self, chunk: str, ansi_stack: list[str]) -> str:
+        """Close ANSI sequences for clean chunk ending."""
+        return chunk + "\x1b[0m"
+
+    def _open_ansi_chunk(self, ansi_stack: list[str]) -> str:
+        """Reopen ANSI sequences for chunk continuation."""
+        return "".join(ansi_stack)
+
+    def _chunk_json_line(self, line: str) -> Iterator[Tuple[str, bool]]:
+        """Chunk JSON at logical boundaries."""
+        brace_level = 0
+        current_chunk = ""
+        for char in line:
+            current_chunk += char
+            if char in "[{":
+                brace_level += 1
+            elif char in "}]":
+                brace_level -= 1
+            if len(current_chunk) >= self.max_length and brace_level == 0:
+                yield current_chunk, True
+                current_chunk = ""
+        if current_chunk:
+            yield current_chunk, len(line) > self.max_length
+
+    def _chunk_simple(self, line: str) -> Iterator[Tuple[str, bool]]:
+        """Simple character-based chunking."""
+        for i in range(0, len(line), self.max_length):
+            chunk = line[i : i + self.max_length]
+            is_overflow = len(line) > self.max_length
+            yield chunk, is_overflow
+
+
+def process_output() -> None:
+    """Process STDIN and chunk any long lines."""
+    chunker = OutputChunker()
+    temp_file = None
+    for line in sys.stdin:
+        for chunk, is_overflow in chunker.chunk_line(line.rstrip("\n")):
+            if is_overflow and temp_file is None:
+                temp_file = tempfile.NamedTemporaryFile(
+                    mode="w", delete=False, prefix="shell_overflow_", suffix=".log"
+                )
+                print(
+                    f"[CHUNKED] Output overflow detected. Full content: {temp_file.name}",
+                    file=sys.stderr,
+                )
+            print(chunk)
+            if temp_file:
+                temp_file.write(chunk + "\n")
+    if temp_file:
+        temp_file.close()
+
+
+if __name__ == "__main__":
+    process_output()

--- a/tools/shell_output_manager.sh
+++ b/tools/shell_output_manager.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# shell_output_manager.sh
+# Truncate lines exceeding a safe length to avoid terminal overflows.
+
+MAX_LINE_LENGTH=4000
+TEMP_DIR="/tmp/shell_session_overflow"
+SESSION_ID=$(date +%s)
+
+safe_execute() {
+    local command="$1"
+    local temp_file="${TEMP_DIR}/overflow_${SESSION_ID}.log"
+
+    mkdir -p "$TEMP_DIR"
+
+    # Execute with line length monitoring
+    $command 2>&1 | while IFS= read -r line; do
+        line_length=${#line}
+        if [ "$line_length" -gt "$MAX_LINE_LENGTH" ]; then
+            # Truncate and redirect overflow
+            echo "${line:0:$MAX_LINE_LENGTH}" >&1
+            echo "[OVERFLOW] Line truncated at $MAX_LINE_LENGTH chars. Full content: $temp_file" >&1
+            echo "$line" >> "$temp_file"
+        else
+            echo "$line" >&1
+        fi
+    done
+}
+


### PR DESCRIPTION
## Summary
- add shell_output_manager.sh for truncating overly long command lines
- add output_chunker.py utility with pattern-aware line chunking
- document and test new output management tools

## Testing
- `ruff check tools/output_chunker.py tests/test_output_chunker.py`
- `pytest tests/test_output_chunker.py`

------
https://chatgpt.com/codex/tasks/task_e_6895b6b639608331b33faf04a6caf32a