### PR TITLE
feat: add service health monitoring and alerting

### DIFF
--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,1 +1,5 @@
 """Monitoring package."""
+
+from .service_health import check_service, run_health_checks, SERVICES
+
+__all__ = ["check_service", "run_health_checks", "SERVICES"]

--- a/monitoring/service_health.py
+++ b/monitoring/service_health.py
@@ -1,0 +1,81 @@
+"""Service health and uptime monitoring utilities."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Dict, Optional
+
+import requests
+
+from web_gui.monitoring.alerting.alert_manager import trigger_alert
+
+WORKSPACE_ROOT = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+DB_PATH = WORKSPACE_ROOT / "analytics.db"
+
+# Default service endpoints used by :func:`run_health_checks`.
+SERVICES = {
+    "sync_engine": "http://localhost:8000/health",
+    "dashboard": "http://localhost:5000/api/health",
+    "anomaly": "http://localhost:5001/health",
+}
+
+
+def _ensure_table(conn: sqlite3.Connection) -> None:
+    """Ensure the ``service_uptime`` table exists."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS service_uptime (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            service TEXT NOT NULL,
+            status TEXT NOT NULL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+
+def check_service(
+    name: str,
+    url: str,
+    *,
+    db_path: Optional[Path] = None,
+) -> bool:
+    """Return ``True`` when ``url`` responds with HTTP 200.
+
+    Results are recorded in ``service_uptime`` and a critical alert is
+    triggered when the service is unreachable.
+    """
+
+    try:  # pragma: no cover - network errors handled uniformly
+        healthy = requests.get(url, timeout=5).status_code == 200
+    except Exception:
+        healthy = False
+
+    path = db_path or DB_PATH
+    with sqlite3.connect(path) as conn:
+        _ensure_table(conn)
+        conn.execute(
+            "INSERT INTO service_uptime(service, status) VALUES(?, ?)",
+            (name, "up" if healthy else "down"),
+        )
+        conn.commit()
+
+    if not healthy:
+        trigger_alert(f"{name} service unreachable", "critical")
+    return healthy
+
+
+def run_health_checks(*, db_path: Optional[Path] = None) -> Dict[str, bool]:
+    """Check default ``SERVICES`` and return their status map."""
+
+    return {
+        name: check_service(name, url, db_path=db_path)
+        for name, url in SERVICES.items()
+    }
+
+
+__all__ = ["check_service", "run_health_checks", "SERVICES"]
+

--- a/ops/monitoring_setup.md
+++ b/ops/monitoring_setup.md
@@ -1,0 +1,42 @@
+# Monitoring Setup
+
+The monitoring utilities check the uptime of critical services and emit
+alerts when failures occur.
+
+## Monitored Services
+
+| Service       | Health Endpoint                  |
+|---------------|----------------------------------|
+| Sync Engine   | `http://localhost:8000/health`   |
+| Dashboard     | `http://localhost:5000/api/health` |
+| Anomaly       | `http://localhost:5001/health`   |
+
+## Health Checks
+
+Run `monitoring.service_health.run_health_checks` to poll the endpoints. Each
+result is stored in the `service_uptime` table of `analytics.db` for uptime
+analysis.
+
+## Alerting
+
+Failures trigger `critical` alerts via `web_gui.monitoring.alerting.alert_manager`.
+The alert pipeline sends notifications to stdout, simulated email, SMS, and the
+dashboard.
+
+## Verification
+
+To verify alerts, simulate a failure:
+
+```bash
+python - <<'PY'
+from monitoring.service_health import check_service
+from web_gui.monitoring.alerting.notification_engine import NOTIFICATION_LOG, EMAIL_LOG, SMS_LOG
+check_service("sync_engine", "http://localhost:9/health")
+print(NOTIFICATION_LOG[-1])
+print(EMAIL_LOG[-1])
+print(SMS_LOG[-1])
+PY
+```
+
+The logs will show the alert dispatched for the unreachable service.
+

--- a/tests/monitoring/test_service_health.py
+++ b/tests/monitoring/test_service_health.py
@@ -1,0 +1,33 @@
+"""Tests for service health monitoring."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from monitoring.service_health import check_service
+from web_gui.monitoring.alerting import notification_engine
+
+
+def test_check_service_alerts(monkeypatch, tmp_path: Path) -> None:
+    """Ensure a down service records uptime and triggers alerts."""
+
+    notification_engine.NOTIFICATION_LOG.clear()
+    notification_engine.EMAIL_LOG.clear()
+    notification_engine.SMS_LOG.clear()
+
+    def fake_get(url: str, timeout: int = 5):  # pragma: no cover - simple stub
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("monitoring.service_health.requests.get", fake_get)
+    db = tmp_path / "health.db"
+    result = check_service("sync", "http://localhost:1/health", db_path=db)
+    assert result is False
+    with sqlite3.connect(db) as conn:
+        row = conn.execute(
+            "SELECT service, status FROM service_uptime"
+        ).fetchone()
+    assert row == ("sync", "down")
+    assert any("sync service unreachable" in msg for msg in notification_engine.NOTIFICATION_LOG)
+    assert notification_engine.EMAIL_LOG
+    assert notification_engine.SMS_LOG

--- a/web_gui/monitoring/alerting/escalation_rules.py
+++ b/web_gui/monitoring/alerting/escalation_rules.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import Callable, Dict, List
 
-from .notification_engine import route_to_dashboard, send_notification
+from .notification_engine import (
+    route_to_dashboard,
+    send_email,
+    send_notification,
+    send_sms,
+)
 
 __all__ = ["get_escalation_level", "get_pipeline"]
 
@@ -16,8 +21,8 @@ ESCALATION_MAP: Dict[str, str] = {
 }
 
 PIPELINES: Dict[str, List[Callable[[str, str], None]]] = {
-    "critical": [send_notification, route_to_dashboard],
-    "warning": [send_notification],
+    "critical": [send_notification, send_email, send_sms, route_to_dashboard],
+    "warning": [send_notification, send_email],
     "info": [send_notification],
 }
 

--- a/web_gui/monitoring/alerting/notification_engine.py
+++ b/web_gui/monitoring/alerting/notification_engine.py
@@ -3,6 +3,9 @@
 This module provides simple notification handlers used by the alerting
 pipeline. Handlers share a common signature of ``(level, message)`` and
 append information to in-memory logs so tests can assert on side effects.
+
+Additional handlers ``send_email`` and ``send_sms`` emulate email/SMS
+notifications by recording messages to dedicated logs.
 """
 
 from __future__ import annotations
@@ -12,8 +15,19 @@ from typing import List, Tuple
 # In-memory logs used for test assertions
 NOTIFICATION_LOG: List[str] = []
 ROUTE_LOG: List[Tuple[str, str]] = []
+EMAIL_LOG: List[str] = []
+SMS_LOG: List[str] = []
 
-__all__ = ["send_notification", "route_to_dashboard", "NOTIFICATION_LOG"]
+__all__ = [
+    "send_notification",
+    "route_to_dashboard",
+    "send_email",
+    "send_sms",
+    "NOTIFICATION_LOG",
+    "ROUTE_LOG",
+    "EMAIL_LOG",
+    "SMS_LOG",
+]
 
 
 def send_notification(level: str, message: str) -> None:
@@ -27,4 +41,18 @@ def route_to_dashboard(level: str, message: str) -> None:
     """Placeholder router forwarding alerts to dashboards."""
     ROUTE_LOG.append((level, message))
     print(f"ROUTE[{level.upper()}] {message}")
+
+
+def send_email(level: str, message: str) -> None:
+    """Record an email alert."""
+    formatted = f"EMAIL[{level.upper()}] {message}"
+    EMAIL_LOG.append(formatted)
+    print(formatted)
+
+
+def send_sms(level: str, message: str) -> None:
+    """Record an SMS alert."""
+    formatted = f"SMS[{level.upper()}] {message}"
+    SMS_LOG.append(formatted)
+    print(formatted)
 

--- a/web_gui/monitoring/health_checks.py
+++ b/web_gui/monitoring/health_checks.py
@@ -205,7 +205,9 @@ def run_all_checks(
     if notifier or dashboard_router:
         pipeline_handlers = []
         if notifier is not None:
-            pipeline_handlers.append(lambda _level, msg: notifier(msg))
+            pipeline_handlers.append(
+                lambda lvl, msg: notifier(f"[{lvl.upper()}] {msg}")
+            )
         if dashboard_router is not None:
             pipeline_handlers.append(dashboard_router)
 


### PR DESCRIPTION
## Summary
- add service health checks for sync engine, dashboard, anomaly services with alerting and uptime logging
- extend alerting with email and SMS handlers and include severity in notifier output
- document monitoring setup and tests

## Testing
- `ruff check monitoring/__init__.py monitoring/service_health.py web_gui/monitoring/alerting/escalation_rules.py web_gui/monitoring/alerting/notification_engine.py tests/monitoring/test_service_health.py web_gui/monitoring/health_checks.py`
- `pytest tests/monitoring/test_service_health.py tests/web_gui/test_web_gui_monitoring_health_checks.py`
- `python - <<'PY'\nfrom monitoring.service_health import check_service\nfrom web_gui.monitoring.alerting.notification_engine import NOTIFICATION_LOG, EMAIL_LOG, SMS_LOG\ncheck_service("sync_engine", "http://localhost:9/health")\nprint(NOTIFICATION_LOG[-1])\nprint(EMAIL_LOG[-1])\nprint(SMS_LOG[-1])\nPY`


------
https://chatgpt.com/codex/tasks/task_e_6895c3750ea883318c18731e4dd2e306