### PR TITLE
feat: add session wrapper and output chunking tools

### DIFF
--- a/.github/scripts/session_wrapper.sh
+++ b/.github/scripts/session_wrapper.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# session_wrapper.sh
+# Utilities for wrapping commands with buffering and recovering session metadata.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUFFER_MANAGER="$REPO_ROOT/tools/shell_buffer_manager.sh"
+META_DIR="$REPO_ROOT/.session_meta"
+
+wrap_command() {
+    local cmd="$*"
+    local session_id
+    if command -v uuidgen >/dev/null 2>&1; then
+        session_id=$(uuidgen)
+    else
+        session_id=$(date +%s)
+    fi
+    mkdir -p "$META_DIR"
+    bash "$BUFFER_MANAGER" "$cmd"
+    local status=$?
+    cat >"$META_DIR/${session_id}.json" <<METAEOF
+{"session_id":"$session_id","command":"$cmd","status":$status}
+METAEOF
+    echo "$session_id"
+    return $status
+}
+
+recover_session() {
+    local session_id="$1"
+    local file="$META_DIR/${session_id}.json"
+    if [ -f "$file" ]; then
+        cat "$file"
+    else
+        echo "Session $session_id not found" >&2
+        return 1
+    fi
+}
+
+if [ "$#" -gt 0 ]; then
+    cmd="$1"; shift
+    case "$cmd" in
+        wrap_command)
+            wrap_command "$@"
+            ;;
+        recover_session)
+            recover_session "$@"
+            ;;
+        *)
+            echo "Unknown command: $cmd" >&2
+            exit 1
+            ;;
+    esac
+fi

--- a/README.md
+++ b/README.md
@@ -332,6 +332,14 @@ lines intelligently, preserving ANSI color codes and JSON boundaries.
 some_command | python tools/output_chunker.py
 ```
 
+For pattern-aware splitting, `tools/output_pattern_chunker.py` provides
+customizable boundary detection while maintaining ANSI sequences. To wrap
+commands and automatically record session metadata, use
+`.github/scripts/session_wrapper.sh`, which employs
+`tools/shell_buffer_manager.sh` to enforce hard cutoffs and redirect
+overflow to temporary logs. See `docs/SESSION_WRAPPER_USAGE.md` for
+examples.
+
 
 
 ### **Basic Usage**

--- a/docs/SESSION_WRAPPER_USAGE.md
+++ b/docs/SESSION_WRAPPER_USAGE.md
@@ -1,0 +1,25 @@
+# Session Wrapper and Buffer Utilities
+
+This guide explains how to use the `session_wrapper.sh` and
+`shell_buffer_manager.sh` scripts to safely execute commands while
+respecting Codex terminal limits.
+
+## Wrapping Commands
+
+```
+bash .github/scripts/session_wrapper.sh wrap_command "echo hello"
+```
+
+The wrapper executes the command through `shell_buffer_manager.sh`, writes
+session metadata to `.session_meta/<session_id>.json`, and prints the
+session identifier.
+
+## Recovering Sessions
+
+```
+bash .github/scripts/session_wrapper.sh recover_session <session_id>
+```
+
+This prints the stored metadata, enabling auditing or reruns. Overflow
+from long lines is stored under `/tmp/shell_buffer_overflow/`.
+

--- a/tests/test_intelligent_output_chunker.py
+++ b/tests/test_intelligent_output_chunker.py
@@ -1,0 +1,19 @@
+from tools.output_pattern_chunker import IntelligentOutputChunker
+
+
+def test_truncates_long_lines():
+    chunker = IntelligentOutputChunker(max_line_length=10)
+    line = "x" * 25
+    chunks = list(chunker.chunk_line(line))
+    assert len(chunks) == 3
+    assert all(len(c[0]) <= 10 for c in chunks)
+    assert all(c[1] for c in chunks)
+
+
+def test_preserves_ansi_sequences():
+    chunker = IntelligentOutputChunker(max_line_length=10)
+    red = "\x1b[31m" + ("x" * 20) + "\x1b[0m"
+    chunks = list(chunker.chunk_line(red))
+    assert all(c[0].startswith("\x1b[31m") for c in chunks)
+    assert all(c[0].endswith("\x1b[0m") for c in chunks)
+

--- a/tests/test_session_wrapper.py
+++ b/tests/test_session_wrapper.py
@@ -1,0 +1,26 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_wrap_and_recover(tmp_path):
+    script = Path('.github/scripts/session_wrapper.sh').resolve()
+    result = subprocess.run(
+        ['bash', str(script), 'wrap_command', 'echo', 'hi'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    session_id = result.stdout.strip().splitlines()[-1]
+    meta_file = Path('.session_meta') / f'{session_id}.json'
+    assert meta_file.exists()
+
+    recovered = subprocess.run(
+        ['bash', str(script), 'recover_session', session_id],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    meta = json.loads(recovered.stdout)
+    assert meta['command'] == 'echo hi'
+

--- a/tools/output_pattern_chunker.py
+++ b/tools/output_pattern_chunker.py
@@ -1,0 +1,77 @@
+"""Pattern aware output chunker.
+
+This module provides ``IntelligentOutputChunker`` which splits lines while
+respecting ANSI escape sequences and configurable boundary patterns.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, Iterator, List, Tuple
+
+
+class IntelligentOutputChunker:
+    """Chunk output lines using pattern hints."""
+
+    def __init__(self, max_line_length: int = 4000, patterns: Iterable[str] | None = None) -> None:
+        self.max_length = max_line_length
+        self.ansi_pattern = re.compile(r"\x1b\[[0-9;]*m")
+        self.patterns: List[str] = list(patterns or [",", " "])
+
+    def chunk_line(self, line: str) -> Iterator[Tuple[str, bool]]:
+        """Yield chunks of ``line`` no longer than ``max_line_length``.
+
+        If ANSI escape sequences are present, they are preserved across
+        chunks. When possible, chunks end at the provided ``patterns``.
+        Returns tuples of ``(chunk, is_overflow)``.
+        """
+        if len(line) <= self.max_length:
+            yield line, False
+            return
+
+        if self.ansi_pattern.search(line):
+            yield from self._chunk_ansi_line(line)
+        else:
+            yield from self._chunk_by_pattern(line)
+
+    def _chunk_ansi_line(self, line: str) -> Iterator[Tuple[str, bool]]:
+        chunks: list[str] = []
+        current = ""
+        ansi_stack: list[str] = []
+        i = 0
+        while i < len(line):
+            if line[i : i + 2] == "\x1b[":
+                end = line.find("m", i)
+                if end == -1:
+                    break
+                seq = line[i : end + 1]
+                if len(current) + len(seq) > self.max_length:
+                    yield current + "\x1b[0m", True
+                    current = "".join(ansi_stack)
+                current += seq
+                ansi_stack.append(seq)
+                i = end + 1
+            else:
+                if len(current) >= self.max_length:
+                    yield current + "\x1b[0m", True
+                    current = "".join(ansi_stack)
+                current += line[i]
+                i += 1
+        if current:
+            yield current + "\x1b[0m", True
+
+    def _chunk_by_pattern(self, line: str) -> Iterator[Tuple[str, bool]]:
+        start = 0
+        length = len(line)
+        while start < length:
+            end = min(start + self.max_length, length)
+            chunk = line[start:end]
+            for pat in self.patterns:
+                idx = chunk.rfind(pat)
+                if idx > 0 and idx + start != end and idx > self.max_length // 2:
+                    end = start + idx + 1
+                    chunk = line[start:end]
+                    break
+            yield chunk, length > self.max_length
+            start = end
+
+

--- a/tools/shell_buffer_manager.sh
+++ b/tools/shell_buffer_manager.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# shell_buffer_manager.sh
+# Hard cutoff and overflow redirection for shell command output.
+
+set -euo pipefail
+
+MAX_LINE_LENGTH=${MAX_LINE_LENGTH:-1550}
+TEMP_DIR=${TEMP_DIR:-/tmp/shell_buffer_overflow}
+SESSION_ID=${SESSION_ID:-$(date +%s)}
+mkdir -p "$TEMP_DIR"
+
+run_and_manage() {
+    local cmd="$1"
+    local overflow_file="$TEMP_DIR/overflow_${SESSION_ID}.log"
+    eval "$cmd" 2>&1 | while IFS= read -r line; do
+        local length=${#line}
+        if [ "$length" -gt "$MAX_LINE_LENGTH" ]; then
+            echo "${line:0:$MAX_LINE_LENGTH}"
+            echo "[OVERFLOW] Line truncated at $MAX_LINE_LENGTH chars. Full content: $overflow_file" >&2
+            echo "$line" >> "$overflow_file"
+        else
+            echo "$line"
+        fi
+    done
+}
+
+if [ "$#" -gt 0 ]; then
+    run_and_manage "$*"
+else
+    while IFS= read -r line; do
+        length=${#line}
+        if [ "$length" -gt "$MAX_LINE_LENGTH" ]; then
+            echo "${line:0:$MAX_LINE_LENGTH}"
+            echo "[OVERFLOW] Line truncated at $MAX_LINE_LENGTH chars." >&2
+        else
+            echo "$line"
+        fi
+    done
+fi
+


### PR DESCRIPTION
## Summary
- add shell_buffer_manager for hard line cutoffs and overflow logging
- introduce IntelligentOutputChunker with pattern-aware splitting
- provide session_wrapper to capture command metadata and recovery
- document session wrapper usage and expand README
- test line truncation, ANSI preservation, and session recovery

## Testing
- `ruff check tools/output_pattern_chunker.py tests/test_intelligent_output_chunker.py tests/test_session_wrapper.py`
- `pytest tests/test_intelligent_output_chunker.py tests/test_session_wrapper.py`
- `TEST_MODE=1 python scripts/wlc_session_manager.py --steps 1 --db-path databases/production.db --verbose` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_6895caf108788331af5c60fa1f3155af