### PR TITLE
feat: add session wrapper for command preservation

### DIFF
--- a/.github/docs/session_wrapper.md
+++ b/.github/docs/session_wrapper.md
@@ -1,0 +1,18 @@
+# Session Wrapper
+
+The repository provides a helper script at `.github/scripts/session_wrapper.sh` for preserving command sessions.
+
+## Usage
+
+```bash
+# Initialize the session metadata directory
+.github/scripts/session_wrapper.sh setup_session_preservation
+
+# Run a command and capture its session id
+session_id=$(.github/scripts/session_wrapper.sh wrap_command "ls -al")
+
+# Recover metadata for a previous session
+.github/scripts/session_wrapper.sh recover_session "$session_id"
+```
+
+Session metadata and command logs are stored under `~/.gh_copilot_sessions`.


### PR DESCRIPTION
## Summary
- add `.github/scripts/session_wrapper.sh` to wrap commands and record session metadata under `~/.gh_copilot_sessions`
- document session wrapper usage in `.github/docs/session_wrapper.md`

## Testing
- `ruff check .`
- `pytest` *(fails: tests/monitoring/test_anomaly_pipeline.py)*

------
https://chatgpt.com/codex/tasks/task_e_6896158738648331b2e24cd7f22b5c48