### PR TITLE
feat: add shell buffer manager and safe executor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,11 @@ The console cannot reliably display lines longer than **4096 bytes**. Use standa
 
 If output might exceed the limit, redirect it to a log file and review it in chunks with these commands to prevent line overflows.
 
+The repository also provides `tools/shell_buffer_manager.sh`, which trims each
+line to 4 KB and stores any overflow in `/tmp/gh_copilot_sessions`. Use the
+`safe_shell_execute` helper from `utils.general_utils` to run commands through
+this buffer manager and receive a summary of overflow locations.
+
 ## Allowed Tools and Commands (Agent Behavior)
 
 When using the terminal or editing files, the agent must adhere to the following rules:

--- a/tests/test_shell_buffer_manager.py
+++ b/tests/test_shell_buffer_manager.py
@@ -1,0 +1,18 @@
+import shutil
+from pathlib import Path
+
+from utils.general_utils import safe_shell_execute
+
+
+def test_safe_shell_execute_overflow(capsys):
+    target = Path("/tmp/gh_copilot_sessions")
+    if target.exists():
+        shutil.rmtree(target)
+    cmd = "python - <<'PY'\nprint('A' * 5000)\nPY"
+    out = safe_shell_execute(cmd)
+    assert len(out.strip()) == 4096
+    summary = capsys.readouterr().out
+    assert "overflow logged to:" in summary
+    files = list(target.glob("overflow_*"))
+    assert len(files) == 1
+    assert files[0].read_text() == "A" * (5000 - 4096)

--- a/utils/general_utils.py
+++ b/utils/general_utils.py
@@ -1,6 +1,12 @@
 """General utility functions for script entrypoints."""
 
+from pathlib import Path
+import shlex
+import subprocess
 from typing import Any, Callable
+
+
+BUFFER_SCRIPT = Path(__file__).resolve().parent.parent / "tools" / "shell_buffer_manager.sh"
 
 
 def operations_main(main_func: Callable[..., Any]) -> None:
@@ -8,3 +14,21 @@ def operations_main(main_func: Callable[..., Any]) -> None:
     result = main_func()
     if result is not None:
         print(result)
+
+
+def safe_shell_execute(command: str) -> str:
+    """Run ``command`` with 4 KB line cutoff and overflow logging.
+
+    Output beyond 4 KB per line is redirected to files under
+    ``/tmp/gh_copilot_sessions``. A summary of overflow locations is printed
+    after execution. The truncated standard output is returned.
+    """
+
+    cmd = f"bash -c {shlex.quote(command)} | {BUFFER_SCRIPT}"
+    proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    overflow_files = [line.split(":", 1)[1] for line in proc.stderr.splitlines() if line.startswith("OVERFLOW:")]
+    if overflow_files:
+        print("overflow logged to:")
+        for path in overflow_files:
+            print(f"  - {path}")
+    return proc.stdout


### PR DESCRIPTION
## Summary
- implement 4KB line cutoff script with overflow logging to /tmp/gh_copilot_sessions
- add safe_shell_execute helper to run commands through the buffer manager and report overflows
- document new tooling in AGENTS guidelines and test overflow handling

## Testing
- `ruff format utils/general_utils.py tests/test_shell_buffer_manager.py`
- `ruff check utils/general_utils.py tests/test_shell_buffer_manager.py`
- `pyright utils/general_utils.py tests/test_shell_buffer_manager.py`
- `pytest tests/test_shell_buffer_manager.py tests/test_new_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68961b993ea483319f0bc86b6a09dc26