### PR TITLE
feat: add pattern-aware shell output chunker

### DIFF
--- a/tests/tools/test_output_pattern_chunker.py
+++ b/tests/tools/test_output_pattern_chunker.py
@@ -1,0 +1,53 @@
+import io
+import os
+import sys
+
+import pytest
+
+from tools.output_pattern_chunker import OutputPatternChunker, process_shell_output
+
+
+@pytest.mark.parametrize(
+    "line,pattern",
+    [
+        ("\x1b[31m" + "a" * 40 + "\x1b[0m", "ansi"),
+        ('{"k": "' + "a" * 40 + '"}', "json"),
+        (",".join(str(i) for i in range(30)), "csv"),
+        ("def f():" + " pass" * 20, "code"),
+        ("diff --git a/b b/b" + " a" * 20, "git"),
+    ],
+)
+def test_pattern_detection(line, pattern):
+    chunker = OutputPatternChunker(max_line_length=20)
+    assert chunker.detect_pattern(line) == pattern
+
+
+def test_csv_chunking_preserves_fields():
+    line = ",".join(str(i) for i in range(30))
+    chunker = OutputPatternChunker(max_line_length=20)
+    chunks = [c for c, _ in chunker.chunk_line(line)]
+    assert all(len(c) <= 20 for c in chunks)
+    assert ",".join(chunks) == line
+
+
+def test_process_shell_output_creates_temp_file(monkeypatch):
+    long_line = "a" * 100
+    stdin = io.StringIO(long_line + "\n")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    monkeypatch.setattr(sys, "stdin", stdin)
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    monkeypatch.setattr("tools.output_pattern_chunker.OutputPatternChunker", lambda: OutputPatternChunker(max_line_length=20))
+    process_shell_output()
+
+    output_lines = stdout.getvalue().strip().splitlines()
+    assert len(output_lines) > 1
+    err = stderr.getvalue().strip()
+    assert "[CHUNKED]" in err
+    temp_path = err.split("Full content:")[-1].strip()
+    with open(temp_path, "r") as fh:
+        assert fh.read().strip() == long_line
+    os.remove(temp_path)

--- a/tools/output_pattern_chunker.py
+++ b/tools/output_pattern_chunker.py
@@ -1,40 +1,92 @@
-"""Pattern aware output chunker.
+"""Enhanced output chunker with pattern awareness.
 
-This module provides ``IntelligentOutputChunker`` which splits lines while
-respecting ANSI escape sequences and configurable boundary patterns.
+This module exposes :class:`OutputPatternChunker` which detects common
+output patterns such as ANSI coloured text, JSON blobs, log lines, CSV
+rows, source code and git output. Long lines are split into manageable
+chunks while preserving structural boundaries where possible. When a
+line exceeds the configured ``max_line_length`` the full, unmodified
+line is written to a temporary file so callers may inspect the original
+content.
+
+It also provides a small CLI utility :func:`process_shell_output` which
+reads from ``stdin`` and writes the chunked lines to ``stdout``.
 """
+
 from __future__ import annotations
 
+from dataclasses import dataclass
 import re
-from typing import Iterable, Iterator, List, Tuple
+import sys
+import tempfile
+from typing import Iterator, Tuple
+
+ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+LOG_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}")
+GIT_PATTERN = re.compile(r"^(diff --git|@@|index [0-9a-f]{7,}|commit [0-9a-f]{7,})")
 
 
-class IntelligentOutputChunker:
-    """Chunk output lines using pattern hints."""
+@dataclass
+class OutputPatternChunker:
+    """Chunk lines while preserving common structures."""
 
-    def __init__(self, max_line_length: int = 4000, patterns: Iterable[str] | None = None) -> None:
-        self.max_length = max_line_length
-        self.ansi_pattern = re.compile(r"\x1b\[[0-9;]*m")
-        self.patterns: List[str] = list(patterns or [",", " "])
+    max_line_length: int = 4000
 
+    def detect_pattern(self, line: str) -> str:
+        """Return a simple label describing the line pattern."""
+
+        stripped = line.strip()
+        if ANSI_PATTERN.search(line):
+            return "ansi"
+        if stripped.startswith("{") or stripped.startswith("["):
+            return "json"
+        if LOG_PATTERN.match(stripped):
+            return "log"
+        if "," in line and line.count(",") >= 3:
+            return "csv"
+        if GIT_PATTERN.match(stripped):
+            return "git"
+        if any(keyword in line for keyword in [
+            "def ",
+            "class ",
+            "import ",
+            "return",
+            "if ",
+            "for ",
+            "while ",
+            ";",
+        ]):
+            return "code"
+        return "plain"
+
+    # ------------------------------------------------------------------
+    # chunking helpers
+    # ------------------------------------------------------------------
     def chunk_line(self, line: str) -> Iterator[Tuple[str, bool]]:
         """Yield chunks of ``line`` no longer than ``max_line_length``.
 
-        If ANSI escape sequences are present, they are preserved across
-        chunks. When possible, chunks end at the provided ``patterns``.
-        Returns tuples of ``(chunk, is_overflow)``.
+        Each yielded tuple is ``(chunk, overflow)`` where ``overflow`` is
+        ``True`` when the original line exceeded ``max_line_length``.
         """
-        if len(line) <= self.max_length:
+
+        if len(line) <= self.max_line_length:
             yield line, False
             return
 
-        if self.ansi_pattern.search(line):
-            yield from self._chunk_ansi_line(line)
+        pattern = self.detect_pattern(line)
+        if pattern == "ansi":
+            yield from self._chunk_ansi(line)
+        elif pattern == "json":
+            yield from self._chunk_json(line)
+        elif pattern == "csv":
+            yield from self._chunk_by_delimiter(line, ",")
+        elif pattern in {"log", "code", "git"}:
+            yield from self._chunk_by_delimiter(line, " ")
         else:
-            yield from self._chunk_by_pattern(line)
+            yield from self._chunk_simple(line)
 
-    def _chunk_ansi_line(self, line: str) -> Iterator[Tuple[str, bool]]:
-        chunks: list[str] = []
+    def _chunk_ansi(self, line: str) -> Iterator[Tuple[str, bool]]:
+        """Chunk while keeping ANSI sequences intact."""
+
         current = ""
         ansi_stack: list[str] = []
         i = 0
@@ -42,36 +94,94 @@ class IntelligentOutputChunker:
             if line[i : i + 2] == "\x1b[":
                 end = line.find("m", i)
                 if end == -1:
-                    break
+                    i += 1
+                    continue
                 seq = line[i : end + 1]
-                if len(current) + len(seq) > self.max_length:
-                    yield current + "\x1b[0m", True
-                    current = "".join(ansi_stack)
-                current += seq
-                ansi_stack.append(seq)
+                if len(current + seq) > self.max_line_length:
+                    yield self._close_ansi(current, ansi_stack), True
+                    current = self._open_ansi(ansi_stack) + seq
+                else:
+                    current += seq
+                    ansi_stack.append(seq)
                 i = end + 1
             else:
-                if len(current) >= self.max_length:
-                    yield current + "\x1b[0m", True
-                    current = "".join(ansi_stack)
+                if len(current) >= self.max_line_length:
+                    yield self._close_ansi(current, ansi_stack), True
+                    current = self._open_ansi(ansi_stack)
                 current += line[i]
                 i += 1
         if current:
-            yield current + "\x1b[0m", True
+            yield self._close_ansi(current, ansi_stack), True
 
-    def _chunk_by_pattern(self, line: str) -> Iterator[Tuple[str, bool]]:
-        start = 0
-        length = len(line)
-        while start < length:
-            end = min(start + self.max_length, length)
-            chunk = line[start:end]
-            for pat in self.patterns:
-                idx = chunk.rfind(pat)
-                if idx > 0 and idx + start != end and idx > self.max_length // 2:
-                    end = start + idx + 1
-                    chunk = line[start:end]
-                    break
-            yield chunk, length > self.max_length
-            start = end
+    def _open_ansi(self, stack: list[str]) -> str:
+        return "".join(stack)
+
+    def _close_ansi(self, chunk: str, stack: list[str]) -> str:
+        return chunk + "\x1b[0m"
+
+    def _chunk_json(self, line: str) -> Iterator[Tuple[str, bool]]:
+        level = 0
+        current = ""
+        for ch in line:
+            current += ch
+            if ch in "[{":
+                level += 1
+            elif ch in "}]":
+                level -= 1
+            if len(current) >= self.max_line_length and level == 0:
+                yield current, True
+                current = ""
+        if current:
+            yield current, True
+
+    def _chunk_by_delimiter(self, line: str, delim: str) -> Iterator[Tuple[str, bool]]:
+        tokens = line.split(delim)
+        current = ""
+        for token in tokens:
+            candidate = f"{current}{delim}{token}" if current else token
+            if len(candidate) > self.max_line_length:
+                if current:
+                    yield current, True
+                if len(token) > self.max_line_length:
+                    for i in range(0, len(token), self.max_line_length):
+                        yield token[i : i + self.max_line_length], True
+                    current = ""
+                else:
+                    current = token
+            else:
+                current = candidate
+        if current:
+            yield current, True
+
+    def _chunk_simple(self, line: str) -> Iterator[Tuple[str, bool]]:
+        for i in range(0, len(line), self.max_line_length):
+            yield line[i : i + self.max_line_length], True
 
 
+def process_shell_output() -> None:
+    """CLI helper reading from stdin and writing chunked lines to stdout."""
+
+    chunker = OutputPatternChunker()
+    temp_file = None
+    for raw_line in sys.stdin:
+        line = raw_line.rstrip("\n")
+        overflow = False
+        for chunk, is_overflow in chunker.chunk_line(line):
+            overflow = overflow or is_overflow
+            print(chunk)
+        if overflow:
+            if temp_file is None:
+                temp_file = tempfile.NamedTemporaryFile(
+                    mode="w", delete=False, prefix="shell_output_", suffix=".log"
+                )
+                print(
+                    f"[CHUNKED] Output overflow detected. Full content: {temp_file.name}",
+                    file=sys.stderr,
+                )
+            temp_file.write(raw_line)
+    if temp_file is not None:
+        temp_file.close()
+
+
+if __name__ == "__main__":
+    process_shell_output()


### PR DESCRIPTION
## Summary
- enhance output chunking with pattern detection for ANSI, JSON, logs, CSV, code, and git
- add `process_shell_output` CLI for chunking and archiving overflow
- cover pattern detection and CLI behavior with unit tests

## Testing
- `ruff check tools/output_pattern_chunker.py tests/tools/test_output_pattern_chunker.py`
- `pytest -q --no-cov tests/tools/test_output_pattern_chunker.py`


------
https://chatgpt.com/codex/tasks/task_e_68961b994f8083319132fcb84672cbde