### PR TITLE
feat: ensure analytics db initialization

### DIFF
--- a/final_compliance_validation.py
+++ b/final_compliance_validation.py
@@ -40,7 +40,7 @@ def main():
     # Test 2: Ingestion module exists and imports
     print("2️⃣ Testing ingestion modules...")
     try:
-        from scripts.ingest_test_and_lint_results import ingest, _db
+        from scripts.ingest_test_and_lint_results import ingest, _db, _ensure_db_path
         print("   ✅ ingest_test_and_lint_results: Import successful")
         
         from session.session_lifecycle_metrics import start_session, end_session
@@ -109,11 +109,10 @@ def main():
     try:
         import tempfile
         import sqlite3
-        
+
         # Test ingestion database auto-creation
         temp_dir = tempfile.mkdtemp()
-        from scripts.ingest_test_and_lint_results import _ensure_db_path, _db
-        
+
         test_db_path = _db(temp_dir)
         _ensure_db_path(test_db_path)
         

--- a/scripts/ingest_test_and_lint_results.py
+++ b/scripts/ingest_test_and_lint_results.py
@@ -22,6 +22,14 @@ def _db(workspace: Optional[str] = None) -> Path:
     return ws / "databases" / "analytics.db"
 
 
+def _ensure_db_path(db_path: Path) -> None:
+    """Ensure the database file and its parent directories exist."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if not db_path.exists():
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("SELECT 1")
+
+
 def ingest(
     workspace: Optional[str] = None,
     ruff_json: Optional[Path] = None,
@@ -33,7 +41,7 @@ def ingest(
     """
     ws = Path(workspace or os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
     db_path = _db(workspace)
-    db_path.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_db_path(db_path)
     ruff_path = ruff_json or ws / RUFF_JSON
     pytest_path = pytest_json or ws / PYTEST_JSON
 
@@ -120,5 +128,6 @@ if __name__ == "__main__":  # pragma: no cover
 
 __all__ = [
     "_db",
+    "_ensure_db_path",
     "ingest",
 ]


### PR DESCRIPTION
## Summary
- add `_ensure_db_path` helper to create analytics database directories and files
- export helper and use it in `ingest_test_and_lint_results`
- adjust final compliance validation to import the new helper

## Testing
- `ruff check scripts/ingest_test_and_lint_results.py final_compliance_validation.py tests/compliance/test_ingest_test_and_lint_results.py`
- `pytest` *(fails: tests/monitoring/test_anomaly_pipeline.py: error)*

------
https://chatgpt.com/codex/tasks/task_e_6896cc359eac83319dc26c4077ffe2f6