### PR TITLE
feat: revise composite compliance scoring

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -369,6 +369,7 @@ class ComplianceMetricsUpdater:
             tests_passed,
             tests_failed,
             metrics.get("open_placeholders", 0),
+            metrics.get("resolved_placeholders", 0),
         )
         # ``calculate_composite_compliance_score`` returns individual scores
         # along with a combined ``composite`` value. Apply additional penalties

--- a/dashboard/integrated_dashboard.py
+++ b/dashboard/integrated_dashboard.py
@@ -111,6 +111,7 @@ def _load_metrics() -> dict[str, Any]:
                                 row["tests_passed"],
                                 row["tests_failed"],
                                 row["placeholders"],
+                                0,
                             )
                             metrics["compliance_score"] = scores["composite"]
                             metrics["composite_score"] = row["composite_score"]

--- a/scripts/compliance_aggregator.py
+++ b/scripts/compliance_aggregator.py
@@ -26,7 +26,11 @@ def aggregate_metrics(
 ) -> Dict[str, Any]:
     """Return composite compliance metrics and optionally persist them."""
     scores = calculate_composite_compliance_score(
-        ruff_issues, tests_passed, tests_failed, placeholders_open
+        ruff_issues,
+        tests_passed,
+        tests_failed,
+        placeholders_open,
+        placeholders_resolved,
     )
     record_code_quality_metrics(
         ruff_issues,

--- a/tests/compliance/test_compliance_aggregator.py
+++ b/tests/compliance/test_compliance_aggregator.py
@@ -16,7 +16,7 @@ def test_aggregate_metrics_persist(tmp_path: Path) -> None:
         placeholders_open=1,
         db_path=db,
     )
-    expected = calculate_composite_compliance_score(5, 8, 2, 1)["composite"]
+    expected = calculate_composite_compliance_score(5, 8, 2, 1, 0)["composite"]
     assert result["composite_score"] == expected
     with sqlite3.connect(db) as conn:
         row = conn.execute(
@@ -45,5 +45,5 @@ def test_composite_score_in_dashboard(tmp_path: Path, monkeypatch: pytest.Monkey
     ed.metrics_updater._fetch_compliance_metrics = lambda **_: {}
     client = ed.app.test_client()
     data = client.get("/metrics").get_json()
-    expected = calculate_composite_compliance_score(1, 3, 1, 2)["composite"]
+    expected = calculate_composite_compliance_score(1, 3, 1, 2, 0)["composite"]
     assert data["composite_score"] == expected

--- a/utils/validation_utils.py
+++ b/utils/validation_utils.py
@@ -20,7 +20,8 @@ def calculate_composite_compliance_score(
     ruff_issues: int,
     tests_passed: int,
     tests_failed: int,
-    placeholders: int,
+    placeholders_open: int,
+    placeholders_resolved: int,
 ) -> Dict[str, float]:
     """Return detailed compliance scores for dashboard display.
 
@@ -32,23 +33,31 @@ def calculate_composite_compliance_score(
         Number of tests that passed.
     tests_failed: int
         Number of tests that failed.
-    placeholders: int
-        Remaining placeholder markers in the repository.
+    placeholders_open: int
+        Count of unresolved placeholder markers in the repository.
+    placeholders_resolved: int
+        Count of resolved placeholders.
 
     Returns
     -------
     Dict[str, float]
         Dictionary containing ``lint_score``, ``test_score``,
-        ``placeholder_score`` and ``composite``. The composite score is
-        weighted at 40% lint, 40% tests, and 20% placeholders.
+        ``placeholder_score`` and ``composite``. The composite score
+        weighs lint, tests, and placeholder progress at 30%, 50%, and
+        20% respectively. Placeholder progress ``P`` is computed as
+        ``resolved / (open + resolved) * 100``.
     """
 
     total_tests = tests_passed + tests_failed
     test_score = (tests_passed / total_tests * 100) if total_tests else 0.0
     lint_score = max(0.0, 100 - ruff_issues)
-    placeholder_score = max(0.0, 100 - (10 * placeholders))
+    placeholder_total = placeholders_open + placeholders_resolved
+    if placeholder_total:
+        placeholder_score = placeholders_resolved / placeholder_total * 100
+    else:
+        placeholder_score = 100.0
     composite = round(
-        0.4 * lint_score + 0.4 * test_score + 0.2 * placeholder_score,
+        0.3 * lint_score + 0.5 * test_score + 0.2 * placeholder_score,
         2,
     )
     return {

--- a/validation/compliance_report_generator.py
+++ b/validation/compliance_report_generator.py
@@ -151,6 +151,7 @@ def generate_compliance_report(
             pytest_metrics["passed"],
             pytest_metrics["failed"],
             placeholder_count,
+            0,
         )
         summary = {
             "timestamp": timestamp,


### PR DESCRIPTION
## Summary
- account for placeholder resolution in compliance scores
- update composite score weights to 30/50/20 for lint/tests/placeholders
- adjust dashboard, validation, and tests for new scoring signature

## Testing
- `ruff check utils/validation_utils.py scripts/compliance_aggregator.py validation/compliance_report_generator.py dashboard/integrated_dashboard.py dashboard/compliance_metrics_updater.py tests/compliance/test_compliance_aggregator.py`
- `pytest tests/compliance/test_compliance_aggregator.py`
- `pytest` *(fails: tests/monitoring/test_anomaly_pipeline.py)*

------
https://chatgpt.com/codex/tasks/task_e_6896cc1100bc83319478e8c57ac408ef