### PR TITLE
feat: include resolved placeholders in compliance metrics scoring

### DIFF
--- a/tests/validation/test_compliance_scoring.py
+++ b/tests/validation/test_compliance_scoring.py
@@ -60,3 +60,11 @@ def test_calculate_composite_score_perfect_results() -> None:
     assert breakdown["test_weighted"] == 50.0
     assert breakdown["placeholder_weighted"] == 20.0
 
+
+def test_resolved_placeholders_affect_composite_score() -> None:
+    """Resolved placeholders should improve the overall composite score."""
+
+    score_unresolved, _ = calculate_composite_score(0, 10, 0, 5, 0)
+    score_resolved, _ = calculate_composite_score(0, 10, 0, 5, 5)
+    assert score_resolved > score_unresolved
+


### PR DESCRIPTION
## Summary
- ensure `_fetch_compliance_metrics` returns both open and resolved placeholder counts and forwards them to composite scoring and metric recording
- allow composite compliance scoring to accept resolved placeholder counts
- add unit test proving resolved placeholders improve composite score

## Testing
- `ruff check dashboard/compliance_metrics_updater.py tests/validation/test_compliance_scoring.py`
- `pytest tests/validation/test_compliance_scoring.py tests/test_compliance_metrics_updater.py::test_compliance_metrics_updater tests/dashboard/test_composite_score_persistence.py -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6896d08cb29883319cc48c61a206b71c