### PR TITLE
feat: add anomaly detection and session lifecycle metrics

### DIFF
--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -237,6 +237,14 @@
 {% endfor %}
 </ul>
 
+<h2>Anomaly Metrics</h2>
+<div>Threshold: <span id="anomaly_threshold">{{ anomaly.threshold }}</span></div>
+<div>Detected: <span id="anomaly_count">{{ anomaly.count }}</span></div>
+
+<h2>Session Lifecycle</h2>
+<div>Total Sessions: <span id="session_count">{{ lifecycle.count }}</span></div>
+<div>Average Duration: <span id="avg_duration">{{ lifecycle.avg_duration }}</span></div>
+
 <h2>Audit Results</h2>
 <ul id="audit_results">
 {% for row in audit_results %}

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,5 +1,6 @@
 """Monitoring package."""
 
 from .service_health import check_service, run_health_checks, SERVICES
+from .baseline_anomaly_detector import BaselineAnomalyDetector
 
-__all__ = ["check_service", "run_health_checks", "SERVICES"]
+__all__ = ["check_service", "run_health_checks", "SERVICES", "BaselineAnomalyDetector"]

--- a/monitoring/baseline_anomaly_detector.py
+++ b/monitoring/baseline_anomaly_detector.py
@@ -1,0 +1,35 @@
+"""Baseline anomaly detector using z-score from monitoring.db."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+import sqlite3
+
+
+@dataclass
+class BaselineAnomalyDetector:
+    """Detect anomalies via a simple z-score threshold."""
+
+    threshold: float = 3.0
+    db_path: Path = Path("databases/monitoring.db")
+    metric: str = "system_health_score"
+
+    def _fetch_values(self) -> List[float]:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute(f"SELECT {self.metric} FROM performance_metrics")
+            return [row[0] for row in cur.fetchall() if row[0] is not None]
+
+    def zscores(self) -> List[float]:
+        values = self._fetch_values()
+        if not values:
+            return []
+        mean = sum(values) / len(values)
+        variance = sum((v - mean) ** 2 for v in values) / len(values)
+        std = variance ** 0.5
+        if std == 0:
+            return [0.0 for _ in values]
+        return [(v - mean) / std for v in values]
+
+    def detect(self) -> List[bool]:
+        return [abs(z) > self.threshold for z in self.zscores()]

--- a/tests/dashboard/test_session_lifecycle_stats.py
+++ b/tests/dashboard/test_session_lifecycle_stats.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sqlite3
+
+from dashboard.enterprise_dashboard import session_lifecycle_stats
+
+
+def _create_db(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE session_lifecycle(session_id TEXT, duration_seconds REAL, status TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO session_lifecycle(session_id, duration_seconds, status) VALUES (?,?,?)",
+            [("a", 1.0, "success"), ("b", 3.0, "success")],
+        )
+        conn.commit()
+
+
+def test_session_lifecycle_stats(tmp_path: Path) -> None:
+    db = tmp_path / "analytics.db"
+    _create_db(db)
+    stats = session_lifecycle_stats(db)
+    assert stats["count"] == 2
+    assert stats["avg_duration"] == 2.0

--- a/tests/monitoring/test_baseline_anomaly_detector.py
+++ b/tests/monitoring/test_baseline_anomaly_detector.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sqlite3
+
+from monitoring.baseline_anomaly_detector import BaselineAnomalyDetector
+
+
+def _create_db(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE performance_metrics(system_health_score REAL)"
+        )
+        data = [(1.0,), (1.1,), (0.9,), (1.2,), (0.95,), (1.05,), (1.0,), (1.1,), (0.98,), (1.02,), (100.0,)]
+        conn.executemany(
+            "INSERT INTO performance_metrics(system_health_score) VALUES (?)",
+            data,
+        )
+        conn.commit()
+
+
+def test_detects_outlier(tmp_path: Path) -> None:
+    db = tmp_path / "monitoring.db"
+    _create_db(db)
+    detector = BaselineAnomalyDetector(db_path=db, threshold=2.0)
+    assert detector.detect()[-1]


### PR DESCRIPTION
## Summary
- add baseline z-score anomaly detector reading monitoring.db
- surface anomaly thresholds and session lifecycle stats on enterprise dashboard
- log session lifecycle metrics and finalization in consolidation executor

## Testing
- `ruff check monitoring/baseline_anomaly_detector.py monitoring/__init__.py dashboard/enterprise_dashboard.py session_management_consolidation_executor.py tests/monitoring/test_baseline_anomaly_detector.py tests/dashboard/test_session_lifecycle_stats.py`
- `pytest tests/monitoring/test_baseline_anomaly_detector.py tests/dashboard/test_session_lifecycle_stats.py tests/test_session_management.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e14b27c08331ad4fc93cf6c19aba