### PR TITLE
fix: use composite score API in compliance aggregator

### DIFF
--- a/scripts/compliance_aggregator.py
+++ b/scripts/compliance_aggregator.py
@@ -11,7 +11,7 @@ import argparse
 from typing import Any, Dict
 
 from enterprise_modules.compliance import (
-    calculate_compliance_score,
+    calculate_composite_score,
     record_code_quality_metrics,
 )
 
@@ -27,27 +27,17 @@ def aggregate_metrics(
     test_mode: bool = False,
 ) -> Dict[str, Any]:
     """Return composite compliance metrics and optionally persist them."""
-    composite = calculate_compliance_score(
+    composite, breakdown = calculate_composite_score(
         ruff_issues,
         tests_passed,
         tests_failed,
         placeholders_open,
         placeholders_resolved,
     )
-
-    total_tests = tests_passed + tests_failed
-    test_score = (tests_passed / total_tests * 100) if total_tests else 0.0
-    lint_score = max(0.0, 100 - ruff_issues)
-    total_placeholders = placeholders_open + placeholders_resolved
-    placeholder_score = (
-        placeholders_resolved / total_placeholders * 100
-        if total_placeholders
-        else 100.0
-    )
     breakdown = {
-        "lint_score": round(lint_score, 2),
-        "test_score": round(test_score, 2),
-        "placeholder_score": round(placeholder_score, 2),
+        "lint_score": breakdown["lint_score"],
+        "test_score": breakdown["test_score"],
+        "placeholder_score": breakdown["placeholder_score"],
     }
 
     record_code_quality_metrics(

--- a/tests/compliance/test_compliance_aggregator.py
+++ b/tests/compliance/test_compliance_aggregator.py
@@ -4,7 +4,7 @@ import sqlite3
 import pytest
 
 from scripts.compliance_aggregator import aggregate_metrics
-from enterprise_modules.compliance import calculate_compliance_score
+from enterprise_modules.compliance import calculate_composite_score
 
 
 def test_aggregate_metrics_persist(tmp_path: Path) -> None:
@@ -14,21 +14,23 @@ def test_aggregate_metrics_persist(tmp_path: Path) -> None:
         tests_passed=8,
         tests_failed=2,
         placeholders_open=1,
+        placeholders_resolved=4,
         db_path=db,
     )
-    expected = calculate_compliance_score(5, 8, 2, 1, 0)
+    expected, breakdown = calculate_composite_score(5, 8, 2, 1, 4)
     assert result["composite_score"] == expected
+    assert result["breakdown"]["placeholder_score"] == breakdown["placeholder_score"]
     with sqlite3.connect(db) as conn:
         row = conn.execute(
-            "SELECT ruff_issues, tests_passed, tests_failed, placeholders_open, composite_score FROM code_quality_metrics"
+            "SELECT ruff_issues, tests_passed, tests_failed, placeholders_open, placeholders_resolved, composite_score FROM code_quality_metrics"
         ).fetchone()
-        assert row == (5, 8, 2, 1, expected)
+        assert row == (5, 8, 2, 1, 4, expected)
 
 
 def test_composite_score_in_dashboard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db = tmp_path / "databases" / "analytics.db"
     db.parent.mkdir(parents=True)
-    aggregate_metrics(1, 3, 1, 2, db_path=db)
+    aggregate_metrics(1, 3, 1, 2, placeholders_resolved=1, db_path=db)
     with sqlite3.connect(db) as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS todo_fixme_tracking (placeholder_type TEXT, status TEXT)"
@@ -45,5 +47,5 @@ def test_composite_score_in_dashboard(tmp_path: Path, monkeypatch: pytest.Monkey
     ed.metrics_updater._fetch_compliance_metrics = lambda **_: {}
     client = ed.app.test_client()
     data = client.get("/metrics").get_json()
-    expected = calculate_compliance_score(1, 3, 1, 2, 0)
+    expected, _ = calculate_composite_score(1, 3, 1, 2, 1)
     assert data["composite_score"] == expected


### PR DESCRIPTION
## Summary
- use `enterprise_modules.compliance.calculate_composite_score` in compliance aggregator
- forward open and resolved placeholder counts to scoring
- extend tests for updated API and placeholder ratios

## Testing
- `ruff check scripts/compliance_aggregator.py tests/compliance/test_compliance_aggregator.py`
- `pytest tests/compliance/test_compliance_aggregator.py`


------
https://chatgpt.com/codex/tasks/task_e_6896e25186e48331919b657c70cb69ca