### PR TITLE
test: clarify negative ruff issue clamp

### DIFF
--- a/tests/compliance/test_update_compliance_metrics.py
+++ b/tests/compliance/test_update_compliance_metrics.py
@@ -394,4 +394,5 @@ class TestEdgeCases:
         )
         L, T, P, composite = _compute(comp)
         
-        assert L == 100.0  # Negative issues capped at 100
+        # Negative ruff issue counts are clamped to 100%
+        assert L == 100.0


### PR DESCRIPTION
## Summary
- clarify negative ruff issue test to assert L == 100 and document clamping behavior

## Testing
- `ruff check tests/compliance/test_update_compliance_metrics.py`
- `pytest tests/compliance/test_update_compliance_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e23592c883319080e7a7b47e38cd