### PR TITLE
feat: add compliance charts and export options

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -27,6 +27,7 @@ This module is designed to meet enterprise auditability and compliance standards
 | Session Management           | Track, control, and validate current and historical sessions                                |
 | Database Operations          | Manage, browse, and synchronize all enterprise databases (production, analytics, monitoring) |
 | Compliance Reporting         | Visualizes DUAL COPILOT validation, compliance status, audit/rollback history               |
+| Compliance Score Visualization | Real-time Chart.js graphs with L/T/P gauges and CSV/JSON export options |
 | Backup and Recovery          | Initiate enterprise backup jobs, view logs, run restores, manage backup retention           |
 | Visual Processing Indicators | Progress bars, phase indicators, detailed execution status                                   |
 | Quantum Monitoring           | Extensible hooks for quantum and advanced analytics                                         |

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,33 @@
+"""Flask dashboard application with compliance export routes."""
+
+from __future__ import annotations
+
+import csv
+import io
+from flask import Response
+
+from .enterprise_dashboard import app
+from scripts.compliance.update_compliance_metrics import fetch_recent_compliance
+
+
+@app.route("/api/compliance_scores.csv")
+def compliance_scores_csv() -> Response:
+    """Return recent compliance metrics as CSV for download."""
+    rows = fetch_recent_compliance(limit=20)
+    output = io.StringIO()
+    writer = csv.DictWriter(
+        output,
+        fieldnames=[
+            "timestamp",
+            "composite",
+            "lint_score",
+            "test_score",
+            "placeholder_score",
+        ],
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+    return Response(output.getvalue(), mimetype="text/csv")
+
+
+__all__ = ["app"]

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -7,3 +7,17 @@ h1 {
     color: #333;
 }
 
+.gauge {
+    width: 120px;
+    height: 60px;
+}
+
+.status-indicator {
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: #fff;
+}
+.status-green { background: #2ecc71; }
+.status-yellow { background: #f1c40f; color: #000; }
+.status-red { background: #e74c3c; }
+

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -7,19 +7,55 @@
     <script src="{{ url_for('static', filename='chart.min.js') }}"></script>
     <script src="{{ url_for('static', filename='placeholder_chart.js') }}"></script>
     <script>
+        let lintGauge, testGauge, placeholderGauge;
+        function initGauges(){
+            const base = {
+                type: 'doughnut',
+                data: {
+                    labels: ['score', 'rest'],
+                    datasets: [{
+                        data: [0, 100],
+                        backgroundColor: ['#2e86de', '#eee'],
+                        borderWidth: 0,
+                    }],
+                },
+                options: {
+                    rotation: -Math.PI,
+                    circumference: Math.PI,
+                    cutout: '70%',
+                    plugins: { legend: { display: false } },
+                },
+            };
+            lintGauge = new Chart(document.getElementById('lintGauge'), JSON.parse(JSON.stringify(base)));
+            testGauge = new Chart(document.getElementById('testGauge'), JSON.parse(JSON.stringify(base)));
+            placeholderGauge = new Chart(document.getElementById('placeholderGauge'), JSON.parse(JSON.stringify(base)));
+        }
+        function updateGauge(chart, value){
+            if(!chart) return;
+            chart.data.datasets[0].data = [value, 100 - value];
+            chart.update();
+        }
         function updateMetrics(data){
-            document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
-            document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
-            if(data.composite_score !== undefined){
-                document.getElementById('composite_score').textContent = data.composite_score.toFixed(2);
-            }
+        document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
+        document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
+        if(data.composite_score !== undefined){
+            document.getElementById('composite_score').textContent = data.composite_score.toFixed(2);
+        }
             document.getElementById('ruff_issues').textContent = data.ruff_issues || 0;
             document.getElementById('tests_passed').textContent = data.tests_passed || 0;
             document.getElementById('tests_failed').textContent = data.tests_failed || 0;
-            document.getElementById('lint_score').textContent = (data.lint_score ?? 0).toFixed(2);
-            document.getElementById('test_score').textContent = (data.test_score ?? 0).toFixed(2);
-            document.getElementById('placeholder_score').textContent = (data.placeholder_score ?? 0).toFixed(2);
-            document.getElementById('open_placeholders').textContent = data.open_placeholders || 0;
+        document.getElementById('lint_score').textContent = (data.lint_score ?? 0).toFixed(2);
+        document.getElementById('test_score').textContent = (data.test_score ?? 0).toFixed(2);
+        document.getElementById('placeholder_score').textContent = (data.placeholder_score ?? 0).toFixed(2);
+        updateGauge(lintGauge, data.lint_score ?? 0);
+        updateGauge(testGauge, data.test_score ?? 0);
+        updateGauge(placeholderGauge, data.placeholder_score ?? 0);
+        const comp = data.composite_score ?? data.compliance_score;
+        const alert = document.getElementById('compliance_alert');
+        alert.textContent = comp.toFixed(2);
+        alert.className = 'status-indicator ' +
+            (comp >= 90 ? 'status-green' : comp >= 75 ? 'status-yellow' : 'status-red');
+        document.getElementById('open_placeholders').textContent = data.open_placeholders || 0;
             document.getElementById('resolved_placeholders').textContent = data.resolved_placeholders || 0;
             const prog = data.progress !== undefined ? (data.progress * 100).toFixed(1) + '%' : '0%';
             document.getElementById('remediation_progress').textContent = prog;
@@ -154,6 +190,7 @@
             fetch('/corrections').then(r=>r.json()).then(updateCorrections);
         }
         window.onload = function(){
+            initGauges();
             if(!!window.EventSource){
                 const es = new EventSource('/metrics_stream');
                 es.onmessage = function(evt){
@@ -197,6 +234,16 @@
     <strong>Lint Score:</strong> <span id="lint_score">{{ metrics.lint_score | default(0) }}</span><br>
     <strong>Test Score:</strong> <span id="test_score">{{ metrics.test_score | default(0) }}</span><br>
     <strong>Placeholder Score:</strong> <span id="placeholder_score">{{ metrics.placeholder_score | default(0) }}</span><br>
+    <div id="score_gauges">
+        <canvas id="lintGauge" class="gauge"></canvas>
+        <canvas id="testGauge" class="gauge"></canvas>
+        <canvas id="placeholderGauge" class="gauge"></canvas>
+    </div>
+    <div class="exports">
+        <a href="/api/compliance_scores" id="export-json">Download JSON</a> |
+        <a href="/api/compliance_scores.csv" id="export-csv">Download CSV</a>
+    </div>
+    <div>Composite Alert: <span id="compliance_alert" class="status-indicator">--</span></div>
     <strong>Open Placeholders:</strong> <span id="open_placeholders">{{ metrics.open_placeholders | default(0) }}</span><br>
     <strong>Resolved Placeholders:</strong> <span id="resolved_placeholders">{{ metrics.resolved_placeholders | default(0) }}</span><br>
     <strong>Remediation Progress:</strong> <span id="remediation_progress">{{ ((metrics.progress or 0) * 100) | round(1) }}%</span><br>


### PR DESCRIPTION
## Summary
- add CSV export route for compliance scores
- show real-time compliance gauges and alerts in dashboard
- document new Chart.js widgets and exports

## Testing
- `ruff check dashboard/app.py tests/dashboard/test_score_serialization.py`
- `pytest tests/dashboard/test_score_serialization.py`

------
https://chatgpt.com/codex/tasks/task_e_6896e16658308331a2133b691736f2cc