### PR TITLE
fix: store placeholder compliance as percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1271,7 +1271,7 @@ The audit results are used by the `/dashboard/compliance` endpoint to
 report ongoing placeholder removal progress and overall compliance
 metrics. A machine-readable summary is also written to
 `dashboard/compliance/placeholder_summary.json`. This file tracks total
-findings, resolved counts, and the current compliance score. Refer to
+findings, resolved counts, and the current compliance score (0–100%). Refer to
 the JSON schema in [dashboard/README.md](dashboard/README.md#placeholder_summaryjson-schema).
 ```
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -134,7 +134,7 @@ compliance issues immediately.
 
 The `/dashboard/compliance` endpoint returns compliance information as JSON, combining live metrics from `analytics.db` and correction/rollback summaries from `dashboard/compliance/correction_summary.json`.
 
-`metrics.json` uses the following schema (applies to both `dashboard/metrics.json` and `dashboard/compliance/metrics.json`):
+`metrics.json` uses the following schema (applies to both `dashboard/metrics.json` and `dashboard/compliance/metrics.json`). `compliance_score` values are percentages from 0 to 100:
 
 ```json
 {
@@ -178,7 +178,7 @@ The endpoint is used by the dashboard UI and can be queried by external tools fo
 
 ### `placeholder_summary.json` Schema
 
-`dashboard/compliance/placeholder_summary.json` contains the latest placeholder audit status:
+`dashboard/compliance/placeholder_summary.json` contains the latest placeholder audit status. The `compliance_score` is expressed as a percentage from 0 to 100:
 
 ```json
 {

--- a/docs/AUDITING_WORKFLOW.md
+++ b/docs/AUDITING_WORKFLOW.md
@@ -15,8 +15,8 @@ This project includes an automated placeholder audit to keep the codebase compli
 4. Pass `--apply-fixes` to remove placeholder comments directly from source files. The
    audit also cleans up any placeholder metadata that is no longer needed.
 5. `dashboard/compliance_metrics_updater.py` reads `analytics.db` and recomputes the
-   `compliance_score` based on remaining open or ticketed placeholders. Run it to
-   refresh the dashboard after each audit/enforcement.
+   `compliance_score` (0–100%) based on remaining open or ticketed placeholders. Run it
+   to refresh the dashboard after each audit/enforcement.
 
 The `DatabaseComplianceChecker` now corrects common issues automatically. Its
 `correct_file` routine removes placeholder markers (such as `TODO` or

--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -675,13 +675,14 @@ def update_dashboard(
 
     denominator = open_count + resolved
     compliance = resolved / denominator if denominator else 1.0
+    compliance_pct = compliance * 100
     status = "complete" if open_count == 0 else "issues_pending"
     compliance_status = "compliant" if open_count == 0 else "non_compliant"
     data = {
         "timestamp": datetime.now().isoformat(),
         "findings": open_count,
         "resolved_count": resolved,
-        "compliance_score": compliance,
+        "compliance_score": compliance_pct,
         "progress": resolved / denominator if denominator else 1.0,
         "progress_status": status,
         "compliance_status": compliance_status,
@@ -695,7 +696,7 @@ def update_dashboard(
     dashboard_metrics = {
         "open_placeholders": open_count,
         "resolved_placeholders": resolved,
-        "compliance_score": compliance,
+        "compliance_score": compliance_pct,
         "progress": data["progress"],
         "auto_removal_count": auto_removal_count,
     }
@@ -720,7 +721,7 @@ def update_dashboard(
                     data["timestamp"],
                     open_count,
                     resolved,
-                    compliance,
+                    compliance_pct,
                     data["progress"],
                     auto_removal_count,
                 ),

--- a/tests/placeholder_audit/test_summary_creation.py
+++ b/tests/placeholder_audit/test_summary_creation.py
@@ -31,7 +31,7 @@ def test_summary_file_created_after_runs(tmp_path):
     expected1 = (
         data1["resolved_count"] / denominator1 if denominator1 else 1.0
     )
-    assert data1["compliance_score"] == expected1
+    assert data1["compliance_score"] == expected1 * 100
     assert "progress_status" in data1
     assert "compliance_status" in data1
     assert isinstance(data1.get("placeholder_counts"), dict)
@@ -53,7 +53,7 @@ def test_summary_file_created_after_runs(tmp_path):
     expected2 = (
         data2["resolved_count"] / denominator2 if denominator2 else 1.0
     )
-    assert data2["compliance_score"] == expected2
+    assert data2["compliance_score"] == expected2 * 100
     assert "placeholder_counts" in data2
 
 
@@ -77,4 +77,4 @@ def test_compliance_score_zero_denominator(tmp_path):
     data = json.loads(summary.read_text())
     assert data["findings"] == 0
     assert data["resolved_count"] == 0
-    assert data["compliance_score"] == 1.0
+    assert data["compliance_score"] == 100.0


### PR DESCRIPTION
## Summary
- adjust code placeholder audit dashboard updates to store compliance scores as percentages
- document placeholder compliance as a 0–100% value
- align tests with percentage-based compliance scores

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder_audit/test_summary_creation.py`
- `pytest tests/placeholder_audit/test_summary_creation.py tests/placeholder_audit/test_metrics_logging.py tests/test_code_placeholder_audit_utils.py tests/test_code_placeholder_audit_logger.py tests/dashboard/test_placeholder_summary.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e60fe16c83318125842d3a8e5d68