### PR TITLE
fix: handle repeated start_session calls gracefully

### DIFF
--- a/session/session_lifecycle_metrics.py
+++ b/session/session_lifecycle_metrics.py
@@ -39,7 +39,15 @@ def start_session(session_id: str, *, workspace: Optional[str] = None) -> None:
     with sqlite3.connect(db_path) as conn:
         _ensure(conn)
         conn.execute(
-            "INSERT INTO session_lifecycle (session_id, start_ts, status) VALUES(?,?,'running')", 
+            """
+            INSERT INTO session_lifecycle (session_id, start_ts, status)
+            VALUES(?, ?, 'running')
+            ON CONFLICT(session_id) DO UPDATE SET
+                start_ts=excluded.start_ts,
+                status='running',
+                end_ts=NULL,
+                duration_seconds=NULL
+            """,
             (session_id, int(time.time()))
         )
         conn.commit()

--- a/tests/test_start_session_idempotent.py
+++ b/tests/test_start_session_idempotent.py
@@ -1,0 +1,29 @@
+"""Tests for repeated start_session calls.
+
+Ensures multiple invocations with the same session_id update
+the existing row rather than inserting duplicates.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from session.session_lifecycle_metrics import start_session
+
+
+def test_start_session_multiple_updates(tmp_path):
+    """Calling start_session twice should not create duplicate rows."""
+    session_id = "duplicate_session"
+    workspace = tmp_path
+
+    start_session(session_id, workspace=str(workspace))
+    start_session(session_id, workspace=str(workspace))
+
+    db_path = workspace / "databases" / "analytics.db"
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM session_lifecycle WHERE session_id=?",
+            (session_id,),
+        ).fetchone()[0]
+    assert count == 1
+


### PR DESCRIPTION
## Summary
- avoid duplicate primary key errors in `start_session` by using ON CONFLICT update
- add regression test to ensure multiple starts with same session id don't create extra rows

## Testing
- `ruff check session/session_lifecycle_metrics.py tests/test_start_session_idempotent.py`
- `pytest -c /dev/null tests/test_start_session_idempotent.py tests/compliance/test_session_lifecycle_metrics.py::TestStartSession::test_start_session_replace_existing -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e6c36f7483319669005c799a9833