### PR TITLE
feat: add public coverage check for safe test runner

### DIFF
--- a/final_compliance_validation.py
+++ b/final_compliance_validation.py
@@ -3,7 +3,6 @@
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 # Add scripts to path
 sys.path.insert(0, str(Path.cwd() / 'scripts'))

--- a/scripts/run_tests_safe.py
+++ b/scripts/run_tests_safe.py
@@ -19,6 +19,11 @@ def _has_pytest_cov() -> bool:
         return False
 
 
+def check_pytest_cov_available() -> bool:
+    """Return whether the pytest-cov plugin can be used."""
+    return _has_pytest_cov()
+
+
 def _has_json_report() -> bool:
     """Check if pytest-json-report plugin is available."""
     try:
@@ -151,6 +156,7 @@ if __name__ == "__main__":  # pragma: no cover
 __all__ = [
     "_has_pytest_cov",
     "_has_json_report",
+    "check_pytest_cov_available",
     "run_pytest_safe",
     "main",
 ]


### PR DESCRIPTION
## Summary
- add `check_pytest_cov_available` helper wrapping `_has_pytest_cov`
- export helper via `__all__` and clean up unused import in final validation script

## Testing
- `ruff check scripts/run_tests_safe.py final_compliance_validation.py`
- `pytest` *(fails: tests/monitoring/test_anomaly_pipeline.py)*

------
https://chatgpt.com/codex/tasks/task_e_6896e6d22e18833181ca20f4f6bab477