### PR TITLE
feat: track placeholder tasks for compliance

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -268,8 +268,9 @@ class ComplianceMetricsUpdater:
                 open_ph = metrics["open_placeholders"]
                 resolved_ph = metrics["resolved_placeholders"]
                 denominator = resolved_ph + open_ph
-                base_score = resolved_ph / denominator if denominator else 1.0
-                metrics["compliance_score"] = base_score
+                resolution_ratio = resolved_ph / denominator if denominator else 1.0
+                metrics["placeholder_resolution_ratio"] = resolution_ratio
+                metrics["compliance_score"] = resolution_ratio
 
                 try:
                     cur.execute(
@@ -324,7 +325,9 @@ class ComplianceMetricsUpdater:
                     metrics["rollback_count"] = 0
                     logging.warning("rollback_logs table missing")
                 penalty = 0.1 * metrics["violation_count"] + 0.05 * metrics["rollback_count"]
-                metrics["compliance_score"] = max(0.0, min(1.0, base_score - penalty))
+                metrics["compliance_score"] = max(
+                    0.0, min(1.0, resolution_ratio - penalty)
+                )
 
                 # Pattern mining quality metrics
                 try:

--- a/tests/placeholder_audit/test_placeholder_task_persistence.py
+++ b/tests/placeholder_audit/test_placeholder_task_persistence.py
@@ -1,10 +1,34 @@
 from pathlib import Path
 import sqlite3
 
-from scripts.code_placeholder_audit import log_placeholder_tasks
-
 
 def test_placeholder_task_persistence(tmp_path: Path) -> None:
+    import sys
+    import types
+
+    sys.modules["dashboard.compliance_metrics_updater"] = types.SimpleNamespace(
+        ComplianceMetricsUpdater=None
+    )
+    sys.modules["unified_script_generation_system"] = types.SimpleNamespace(
+        EnterpriseUtility=None
+    )
+    sys.modules["quantum"] = types.ModuleType("quantum")
+    sys.modules[
+        "scripts.monitoring.unified_monitoring_optimization_system"
+    ] = types.SimpleNamespace(
+        EnterpriseUtility=object,
+        push_metrics=lambda *a, **k: None,
+        collect_metrics=lambda: {},
+    )
+    sys.modules["monitoring"] = types.ModuleType("monitoring")
+    sys.modules["monitoring.health_monitor"] = types.ModuleType(
+        "monitoring.health_monitor"
+    )
+    sys.modules["quantum_algorithm_library_expansion"] = types.ModuleType(
+        "quantum_algorithm_library_expansion"
+    )
+    from scripts.code_placeholder_audit import log_placeholder_tasks
+
     db = tmp_path / "analytics.db"
     tasks = [
         {
@@ -20,7 +44,6 @@ def test_placeholder_task_persistence(tmp_path: Path) -> None:
     assert inserted == 1
     with sqlite3.connect(db) as conn:
         row = conn.execute(
-            "SELECT file_path, line_number, placeholder_type, context, suggestion, status FROM todo_fixme_tracking"
+            "SELECT file_path, line_number, pattern, context, suggestion, status FROM placeholder_tasks"
         ).fetchone()
     assert row == ("foo.py", 10, "TODO", "TODO", "fix", "open")
-


### PR DESCRIPTION
## Summary
- persist placeholder audit results in a dedicated `placeholder_tasks` table and track open vs resolved status
- compute placeholder resolution ratios in compliance metrics and feed open/resolved counts into scoring
- verify placeholder resolution improves composite compliance scores

## Testing
- `ruff check scripts/code_placeholder_audit.py dashboard/compliance_metrics_updater.py tests/placeholder_audit/test_placeholder_task_persistence.py tests/dashboard/test_compliance_metrics_updater.py`
- `PYTEST_ADDOPTS="" pytest tests/placeholder_audit/test_placeholder_task_persistence.py tests/dashboard/test_compliance_metrics_updater.py`


------
https://chatgpt.com/codex/tasks/task_e_6896eb3402088331b2fe659b04782699