### PR TITLE
feat: log script metrics with indexed timestamps

### DIFF
--- a/tests/test_quick_database_query.py
+++ b/tests/test_quick_database_query.py
@@ -1,0 +1,23 @@
+import sqlite3
+
+from scripts.quick_database_query import log_metrics
+
+
+def test_log_metrics_creates_table_and_index(tmp_path):
+    db = tmp_path / "analytics.db"
+    log_metrics("success", db)
+
+    with sqlite3.connect(db) as conn:
+        cols = {row[1]: row for row in conn.execute("PRAGMA table_info(script_metrics)")}
+        assert "id" in cols and cols["id"][5] == 1  # primary key
+        assert "ts" in cols
+
+        indexes = [row[1] for row in conn.execute("PRAGMA index_list(script_metrics)")]
+        assert "idx_script_metrics_ts" in indexes
+
+        cur = conn.execute("SELECT script, status, ts FROM script_metrics")
+        row = cur.fetchone()
+        assert row[0] == "quick_database_query"
+        assert row[1] == "success"
+        assert isinstance(row[2], int)
+


### PR DESCRIPTION
## Summary
- add autoincrement id and indexed timestamp to `script_metrics`
- allow overriding analytics path for logging and store ts as integer
- test script metrics schema and timestamp index

## Testing
- `ruff check scripts/quick_database_query.py tests/test_quick_database_query.py`
- `pytest tests/test_quick_database_query.py`

------
https://chatgpt.com/codex/tasks/task_e_6896eb5089a48331bbf3bab879eb3b11