### PR TITLE
fix: harden session lifecycle database interactions

### DIFF
--- a/session/session_lifecycle_metrics.py
+++ b/session/session_lifecycle_metrics.py
@@ -1,11 +1,12 @@
 """Session lifecycle metric helpers."""
+
 from __future__ import annotations
 
 from pathlib import Path
 import os
 import sqlite3
 import time
-from typing import Optional
+from typing import Callable, Optional
 
 __all__ = ["start_session", "end_session"]
 
@@ -16,14 +17,16 @@ def _db(workspace: Optional[str] = None) -> Path:
 
 
 def _ensure(conn: sqlite3.Connection) -> None:
-        conn.execute(
-            """CREATE TABLE IF NOT EXISTS session_lifecycle 
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS session_lifecycle 
             (session_id TEXT PRIMARY KEY, start_ts INTEGER NOT NULL, 
              end_ts INTEGER, duration_seconds REAL, 
              zero_byte_violations INTEGER DEFAULT 0, 
              recursion_flags INTEGER DEFAULT 0, 
              status TEXT DEFAULT 'running')"""
-        )
+    )
+
+
 def _ensure_db_path(db_path: Path) -> None:
     """Ensure the database path and parent directories exist."""
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -33,46 +36,75 @@ def _ensure_db_path(db_path: Path) -> None:
             conn.execute("SELECT 1")  # Just create the file
 
 
+def _retry(operation: Callable[[], None], retries: int = 3, delay: float = 0.1) -> None:
+    """Run *operation* with simple retries on OperationalError."""
+    for attempt in range(retries):
+        try:
+            operation()
+            return
+        except sqlite3.OperationalError:
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay)
+
+
 def start_session(session_id: str, *, workspace: Optional[str] = None) -> None:
     db_path = _db(workspace)
     _ensure_db_path(db_path)  # Ensure DB exists before operations
-    with sqlite3.connect(db_path) as conn:
-        _ensure(conn)
-        conn.execute(
-            """
-            INSERT INTO session_lifecycle (session_id, start_ts, status)
-            VALUES(?, ?, 'running')
-            ON CONFLICT(session_id) DO UPDATE SET
-                start_ts=excluded.start_ts,
-                status='running',
-                end_ts=NULL,
-                duration_seconds=NULL
-            """,
-            (session_id, int(time.time()))
-        )
-        conn.commit()
+
+    def operation() -> None:
+        with sqlite3.connect(db_path) as conn:
+            _ensure(conn)
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO session_lifecycle (session_id, start_ts, status)
+                VALUES(?, ?, 'running')
+                """,
+                (session_id, int(time.time())),
+            )
+            conn.commit()
+
+    _retry(operation)
 
 
 def end_session(
-    session_id: str, *, 
-    zero_byte_violations: int = 0, 
-    recursion_flags: int = 0, 
-    status: str = "success", 
-    workspace: Optional[str] = None
+    session_id: str,
+    *,
+    zero_byte_violations: int = 0,
+    recursion_flags: int = 0,
+    status: str = "success",
+    workspace: Optional[str] = None,
 ) -> None:
     db_path = _db(workspace)
     _ensure_db_path(db_path)  # Ensure DB exists before operations
-    with sqlite3.connect(db_path) as conn:
-        _ensure(conn)
-        cur = conn.execute("SELECT start_ts FROM session_lifecycle WHERE session_id=?", (session_id,))
-        row = cur.fetchone()
-        start_ts = row[0] if row else int(time.time())
-        end_ts = int(time.time())
-        duration = end_ts - start_ts
-        conn.execute(
-            """UPDATE session_lifecycle SET end_ts=?, duration_seconds=?, 
-            zero_byte_violations=?, recursion_flags=?, status=? WHERE session_id=?""", 
-            (end_ts, float(duration), int(zero_byte_violations), 
-             int(recursion_flags), status, session_id)
-        )
-        conn.commit()
+
+    def operation() -> None:
+        with sqlite3.connect(db_path) as conn:
+            _ensure(conn)
+            cur = conn.execute("SELECT start_ts FROM session_lifecycle WHERE session_id=?", (session_id,))
+            row = cur.fetchone()
+            if row:
+                start_ts = row[0]
+            else:
+                start_ts = int(time.time())
+                conn.execute(
+                    "INSERT OR IGNORE INTO session_lifecycle (session_id, start_ts, status) VALUES (?, ?, 'running')",
+                    (session_id, start_ts),
+                )
+            end_ts = int(time.time())
+            duration = time.time() - start_ts
+            conn.execute(
+                """UPDATE session_lifecycle SET end_ts=?, duration_seconds=?,
+                zero_byte_violations=?, recursion_flags=?, status=? WHERE session_id=?""",
+                (
+                    end_ts,
+                    float(duration),
+                    int(zero_byte_violations),
+                    int(recursion_flags),
+                    status,
+                    session_id,
+                ),
+            )
+            conn.commit()
+
+    _retry(operation)

--- a/tests/test_session_lifecycle_retries.py
+++ b/tests/test_session_lifecycle_retries.py
@@ -1,0 +1,67 @@
+"""Tests for retry logic handling sqlite OperationalError."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from session.session_lifecycle_metrics import end_session, start_session
+
+
+def test_start_session_retries_on_operational_error(monkeypatch, tmp_path):
+    """start_session should retry if the database is temporarily locked."""
+    session_id = "retry_start"
+    workspace = tmp_path
+
+    real_connect = sqlite3.connect
+    calls = {"count": 0}
+
+    def flaky_connect(*args, **kwargs):
+        if calls["count"] == 1:
+            calls["count"] += 1
+            raise sqlite3.OperationalError("database is locked")
+        calls["count"] += 1
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", flaky_connect)
+
+    start_session(session_id, workspace=str(workspace))
+
+    db_path = workspace / "databases" / "analytics.db"
+    with real_connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM session_lifecycle WHERE session_id=?",
+            (session_id,),
+        ).fetchone()[0]
+
+    assert count == 1
+
+
+def test_end_session_retries_on_operational_error(monkeypatch, tmp_path):
+    """end_session should retry if the database is temporarily locked."""
+    session_id = "retry_end"
+    workspace = tmp_path
+
+    start_session(session_id, workspace=str(workspace))
+
+    real_connect = sqlite3.connect
+    calls = {"count": 0}
+
+    def flaky_connect(*args, **kwargs):
+        if calls["count"] == 1:
+            calls["count"] += 1
+            raise sqlite3.OperationalError("database is locked")
+        calls["count"] += 1
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", flaky_connect)
+
+    end_session(session_id, workspace=str(workspace))
+
+    db_path = workspace / "databases" / "analytics.db"
+    with real_connect(db_path) as conn:
+        end_ts = conn.execute(
+            "SELECT end_ts FROM session_lifecycle WHERE session_id=?",
+            (session_id,),
+        ).fetchone()[0]
+
+    assert end_ts is not None

--- a/tests/test_start_session_idempotent.py
+++ b/tests/test_start_session_idempotent.py
@@ -1,7 +1,7 @@
 """Tests for repeated start_session calls.
 
-Ensures multiple invocations with the same session_id update
-the existing row rather than inserting duplicates.
+Ensures multiple invocations with the same session_id do not
+insert duplicates or modify the original start timestamp.
 """
 
 from __future__ import annotations
@@ -12,18 +12,25 @@ from session.session_lifecycle_metrics import start_session
 
 
 def test_start_session_multiple_updates(tmp_path):
-    """Calling start_session twice should not create duplicate rows."""
+    """Calling start_session twice should keep one row and preserve start time."""
     session_id = "duplicate_session"
     workspace = tmp_path
 
     start_session(session_id, workspace=str(workspace))
-    start_session(session_id, workspace=str(workspace))
-
     db_path = workspace / "databases" / "analytics.db"
     with sqlite3.connect(db_path) as conn:
-        count = conn.execute(
-            "SELECT COUNT(*) FROM session_lifecycle WHERE session_id=?",
+        first_ts = conn.execute(
+            "SELECT start_ts FROM session_lifecycle WHERE session_id=?",
             (session_id,),
         ).fetchone()[0]
-    assert count == 1
 
+    start_session(session_id, workspace=str(workspace))
+
+    with sqlite3.connect(db_path) as conn:
+        count, min_ts, max_ts = conn.execute(
+            "SELECT COUNT(*), MIN(start_ts), MAX(start_ts) FROM session_lifecycle WHERE session_id=?",
+            (session_id,),
+        ).fetchone()
+
+    assert count == 1
+    assert min_ts == max_ts == first_ts


### PR DESCRIPTION
## Summary
- add retry helper for sqlite3 and ignore duplicate start inserts
- ensure end_session creates missing records and computes float durations
- test duplicate session starts and retry behavior on locked databases

## Testing
- `ruff check .` *(fails: scripts/wlc_session_manager.py:54:5 F821, scripts/wlc_session_manager.py:240:9 F821, tests/compliance/test_composite_bounds.py:9:8 F401, tests/compliance/test_ingestion_edge_cases.py:7:8 F401, tests/compliance/test_ingestion_edge_cases.py:9:27 F401, tests/dashboard/test_score_serialization.py:7:8 F401)*
- `ruff check session/session_lifecycle_metrics.py tests/test_start_session_idempotent.py tests/test_session_lifecycle_retries.py`
- `pytest tests/test_start_session_idempotent.py tests/test_session_lifecycle_retries.py`

------
https://chatgpt.com/codex/tasks/task_e_6896eb6be1a88331a89cc062928ea625