### PR TITLE
fix: default placeholder counts to zero

### DIFF
--- a/scripts/ingest_test_and_lint_results.py
+++ b/scripts/ingest_test_and_lint_results.py
@@ -106,7 +106,9 @@ def ingest(
                 composite_score, source, meta_json
             ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
             """,
-            (ts, issues, passed, total, None, None, L, T, P, composite, "ingest_pipeline", None),
+            # Placeholder snapshot data is not yet available at ingest time, so
+            # store zeros rather than NULL to keep the schema consistent.
+            (ts, issues, passed, total, 0, 0, L, T, P, composite, "ingest_pipeline", None),
         )
         row_id = cur.lastrowid
         # Insert into legacy compliance_scores table

--- a/tests/compliance/test_ingest_test_and_lint_results.py
+++ b/tests/compliance/test_ingest_test_and_lint_results.py
@@ -99,7 +99,7 @@ class TestIngest:
                 "FROM compliance_metrics_history WHERE id=?",
                 (row_id,),
             ).fetchone()
-        assert row == (2, 20, 25, None, None)
+        assert row == (2, 20, 25, 0, 0)
 
     def test_ingest_handles_missing_files(self, temp_workspace):
         row_id = ingest(str(temp_workspace))


### PR DESCRIPTION
## Summary
- default placeholder metrics to zero during ingestion when snapshot data is missing
- update ingestion test to validate zero placeholder counts

## Testing
- `ruff check scripts/ingest_test_and_lint_results.py tests/compliance/test_ingest_test_and_lint_results.py`
- `pytest tests/compliance/test_ingest_test_and_lint_results.py tests/compliance/test_compliance_pipeline_integration.py`
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_6896eb73cd508331a693f72e0e095706