### PR TITLE
feat: surface real-time placeholder metrics in dashboard

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -599,8 +599,13 @@ class ComplianceMetricsUpdater:
             json.dumps(metrics.get("recent_rollbacks", []), indent=2),
             encoding="utf-8",
         )
+        placeholder_payload = {
+            "open": metrics.get("open_placeholders", 0),
+            "resolved": metrics.get("resolved_placeholders", 0),
+            "breakdown": metrics.get("placeholder_breakdown", {}),
+        }
         placeholder_file.write_text(
-            json.dumps(metrics.get("placeholder_breakdown", {}), indent=2),
+            json.dumps(placeholder_payload, indent=2),
             encoding="utf-8",
         )
         logging.info(f"Dashboard metrics updated: {dashboard_file}")
@@ -651,6 +656,8 @@ class ComplianceMetricsUpdater:
             "compliance_score": float(metrics.get("compliance_score", 0.0)),
             "violation_count": float(metrics.get("violation_count", 0.0)),
             "rollback_count": float(metrics.get("rollback_count", 0.0)),
+            "open_placeholders": float(metrics.get("open_placeholders", 0.0)),
+            "resolved_placeholders": float(metrics.get("resolved_placeholders", 0.0)),
         }
         push_metrics(monitoring_metrics, table="enterprise_metrics", db_path=ANALYTICS_DB)
         score_breakdown = metrics.get("score_breakdown", {})

--- a/scripts/ingest_test_and_lint_results.py
+++ b/scripts/ingest_test_and_lint_results.py
@@ -12,6 +12,7 @@ from scripts.compliance.update_compliance_metrics import (
     _ensure_metrics_table,
     _ensure_table,
 )
+from scripts.code_placeholder_audit import get_latest_placeholder_snapshot
 
 RUFF_JSON = Path("ruff_report.json")
 PYTEST_JSON = Path(".report.json")  # default name from pytest --json-report
@@ -50,6 +51,8 @@ def ingest(
         _ensure_table(conn)
         _ensure_metrics_table(conn)
 
+        run_ts = int(time.time() * 1000)
+
         # --- Ruff issues log ---
         conn.execute(
             """
@@ -66,7 +69,10 @@ def ingest(
                 issues = len(data) if isinstance(data, list) else int(data.get("issue_count", 0))
             except Exception:
                 issues = 0
-        conn.execute("INSERT INTO ruff_issue_log(issues) VALUES(?)", (issues,))
+        conn.execute(
+            "INSERT INTO ruff_issue_log(run_timestamp, issues) VALUES(?,?)",
+            (run_ts, issues),
+        )
 
         # --- Pytest stats ---
         conn.execute(
@@ -87,13 +93,18 @@ def ingest(
                 passed = int(summary.get("passed", 0))
             except Exception:
                 total = passed = 0
-        conn.execute("INSERT INTO test_run_stats(passed,total) VALUES(?,?)", (passed, total))
+        conn.execute(
+            "INSERT INTO test_run_stats(run_timestamp, passed,total) VALUES(?,?,?)",
+            (run_ts, passed, total),
+        )
 
         # --- Compliance metrics ---
-        # L: Lint (ruff) score, T: Test score, P: Placeholder score (set to 0 here)
+        # Retrieve latest placeholder snapshot for placeholder score
+        open_ph, resolved_ph = get_latest_placeholder_snapshot(conn)
         L = max(0.0, 100.0 - float(issues))
         T = (float(passed) / total * 100.0) if total else 0.0
-        P = 0.0  # Placeholder score not available at ingest
+        denom = open_ph + resolved_ph
+        P = (float(resolved_ph) / denom * 100.0) if denom else 100.0
         composite = 0.3 * L + 0.5 * T + 0.2 * P
         ts = int(time.time())
         # Insert into metrics history (newer normalized table)
@@ -106,9 +117,7 @@ def ingest(
                 composite_score, source, meta_json
             ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
             """,
-            # Placeholder snapshot data is not yet available at ingest time, so
-            # store zeros rather than NULL to keep the schema consistent.
-            (ts, issues, passed, total, 0, 0, L, T, P, composite, "ingest_pipeline", None),
+            (ts, issues, passed, total, open_ph, resolved_ph, L, T, P, composite, "ingest_pipeline", None),
         )
         row_id = cur.lastrowid
         # Insert into legacy compliance_scores table
@@ -120,7 +129,7 @@ def ingest(
                 placeholders_open, placeholders_resolved
             ) VALUES (?,?,?,?,?,?,?,?,?,?)
             """,
-            (ts, L, T, P, composite, issues, passed, total, 0, 0),
+            (ts, L, T, P, composite, issues, passed, total, open_ph, resolved_ph),
         )
         conn.commit()
 


### PR DESCRIPTION
## Summary
- log placeholder audit counts and snapshots to analytics.db for dashboard use
- merge placeholder metrics into lint/test ingestion pipeline
- expose real-time placeholder counts through compliance dashboard hooks

## Testing
- `ruff check scripts/ingest_test_and_lint_results.py scripts/code_placeholder_audit.py dashboard/compliance_metrics_updater.py`
- `pytest tests/placeholder_audit/test_metrics_logging.py tests/compliance/test_ingest_test_and_lint_results.py tests/compliance/test_compliance_pipeline_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6896fa170b5c8331b46cb7618277a5e3