### PR TITLE
fix: refine error handling in analysis and template engine

### DIFF
--- a/scripts/analysis/quick_database_analysis.py
+++ b/scripts/analysis/quick_database_analysis.py
@@ -56,9 +56,10 @@ def main():
                             if count > 0:
                                 scripts_in_databases += count
                                 sample_db_scripts[f"{db_file.name}.{table}"] = count
-                    except Exception:
+                    except (sqlite3.Error, OSError) as exc:
+                        print(f"{TEXT['error']} Query failed for {table}: {exc}")
                         continue
-        except Exception as e:
+        except (sqlite3.Error, OSError) as e:
             print(f"{TEXT['error']} Failed to analyze {db_file.name}: {e}")
 
     print(f"{TEXT['info']} Found approximately {scripts_in_databases} script entries in sampled databases")
@@ -81,7 +82,7 @@ def main():
             syntax_valid += 1
         except SyntaxError as e:
             syntax_errors.append(f"{script.name}: {e}")
-        except Exception as e:
+        except OSError as e:
             syntax_errors.append(f"{script.name}: {e}")
 
     print(f"{TEXT['info']} Sample syntax validation: {syntax_valid}/{len(sample_scripts)} scripts valid")

--- a/template_engine/auto_generator.py
+++ b/template_engine/auto_generator.py
@@ -47,7 +47,10 @@ except ImportError:  # pragma: no cover - optional dependency
 
     try:
         _qal = import_module("quantum_algorithm_library_expansion")
-    except Exception:
+    except ImportError as exc:
+        logging.getLogger(__name__).debug(
+            "Quantum library import failed: %s", exc
+        )
         _qal = None
 
     if _qal is not None:

--- a/template_engine/template_synchronizer.py
+++ b/template_engine/template_synchronizer.py
@@ -162,9 +162,9 @@ def _cluster_templates(templates: dict[str, str], n_clusters: int = 2) -> dict[s
                 f"sync_clusters={n_clusters},inertia={inertia:.2f},silhouette={silhouette:.4f}",
             )
         return reps
-    except Exception:
+    except Exception as exc:
         # If clustering fails, fallback to original templates
-        logger.exception("Clustering failed; using all templates")
+        logger.exception("Clustering failed; using all templates: %s", exc)
         return templates
 
 


### PR DESCRIPTION
## Summary
- log optional quantum library import failures during auto generation
- add explicit clustering failure context in template synchronizer
- harden quick database analysis by narrowing sqlite and OS error handling

## Testing
- `ruff check scripts/analysis/quick_database_analysis.py template_engine/auto_generator.py template_engine/template_synchronizer.py`
- `pyright scripts/analysis/quick_database_analysis.py template_engine/auto_generator.py template_engine/template_synchronizer.py`
- `pytest --override-ini addopts=""` *(fails: 266 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6896fa1a6944833199cc2dcd8a73b324