### PR TITLE
feat: track placeholder metric in compliance scores

### DIFF
--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -421,10 +421,12 @@ class ComplianceMetricsUpdater:
             if total_placeholders
             else 100.0
         )
+        weighted_score = 0.3 * lint_score + 0.5 * test_score + 0.2 * placeholder_score
         scores = {
             "lint_score": round(lint_score, 2),
             "test_score": round(test_score, 2),
             "placeholder_score": round(placeholder_score, 2),
+            "weighted_score": round(weighted_score, 2),
             "composite": round(composite, 2),
         }
         violation_penalty = metrics["violation_count"] * 10
@@ -434,6 +436,7 @@ class ComplianceMetricsUpdater:
         scores["rollback_penalty"] = rollback_penalty
         metrics["composite_score"] = composite_adj
         metrics["composite_compliance_score"] = composite_adj
+        metrics["weighted_score"] = scores["weighted_score"]
         metrics["score_breakdown"] = scores
         metrics["lint_score"] = scores["lint_score"]
         metrics["test_score"] = scores["test_score"]

--- a/enterprise_modules/compliance.py
+++ b/enterprise_modules/compliance.py
@@ -585,6 +585,7 @@ def persist_compliance_score(
     db.parent.mkdir(parents=True, exist_ok=True)
     breakdown = breakdown or {}
     with sqlite3.connect(db) as conn:
+        _ensure_metrics_table(conn)
         conn.execute(
             """CREATE TABLE IF NOT EXISTS compliance_scores (
                 timestamp TEXT,
@@ -609,6 +610,24 @@ def persist_compliance_score(
                 float(breakdown.get("lint_score", 0.0)),
                 float(breakdown.get("test_score", 0.0)),
                 float(breakdown.get("placeholder_score", 0.0)),
+            ),
+        )
+        ts = int(datetime.now().timestamp())
+        conn.execute(
+            """INSERT INTO compliance_metrics_history (
+                timestamp, ruff_issues, tests_passed, tests_failed,
+                placeholders_open, placeholders_resolved,
+                placeholder_score, composite_score
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                ts,
+                int(breakdown.get("ruff_issues", 0)),
+                int(breakdown.get("tests_passed", 0)),
+                int(breakdown.get("tests_failed", 0)),
+                int(breakdown.get("placeholders_open", 0)),
+                int(breakdown.get("placeholders_resolved", 0)),
+                float(breakdown.get("placeholder_score", 0.0)),
+                float(score),
             ),
         )
         conn.commit()

--- a/scripts/compliance/update_compliance_metrics.py
+++ b/scripts/compliance/update_compliance_metrics.py
@@ -142,9 +142,13 @@ def _compute(c: ComplianceComponents) -> Tuple[float, float, float, float]:
     L = min(100.0, max(0.0, 100.0 - float(c.ruff_issues)))
     T = (float(c.tests_passed) / c.tests_total * 100.0) if c.tests_total else 0.0
     denom = c.placeholders_open + c.placeholders_resolved
-    P = (float(c.placeholders_resolved) / denom * 100.0) if denom else 0.0
-    composite = 0.3 * L + 0.5 * T + 0.2 * P
-    return L, T, P, composite
+    placeholder_score = (
+        float(c.placeholders_resolved) / denom * 100.0
+        if denom
+        else 0.0
+    )
+    composite = 0.3 * L + 0.5 * T + 0.2 * placeholder_score
+    return L, T, placeholder_score, composite
 
 
 def update_compliance_metrics(workspace: Optional[str] = None, db_path: Optional[Path] = None) -> float:
@@ -158,7 +162,7 @@ def update_compliance_metrics(workspace: Optional[str] = None, db_path: Optional
         _ensure_table(conn)
         _ensure_metrics_table(conn)
         comp = _fetch_components(conn)
-        L, T, P, composite = _compute(comp)
+        L, T, placeholder_score, composite = _compute(comp)
         ts = int(time.time())
         # Write to unified history table
         conn.execute(
@@ -179,7 +183,7 @@ def update_compliance_metrics(workspace: Optional[str] = None, db_path: Optional
                 comp.placeholders_resolved,
                 L,
                 T,
-                P,
+                placeholder_score,
                 composite,
                 "update_compliance",
                 None,
@@ -198,7 +202,7 @@ def update_compliance_metrics(workspace: Optional[str] = None, db_path: Optional
                 ts,
                 L,
                 T,
-                P,
+                placeholder_score,
                 composite,
                 comp.ruff_issues,
                 comp.tests_passed,

--- a/tests/test_code_quality_score.py
+++ b/tests/test_code_quality_score.py
@@ -7,6 +7,7 @@ def test_score_returns_ratios_and_score():
     assert breakdown["lint_score"] == 100.0
     assert breakdown["test_pass_ratio"] == 1.0
     assert breakdown["placeholder_resolution_ratio"] == 1.0
+    assert breakdown["placeholder_score"] == 100.0
 
 
 def test_score_handles_mixed_inputs():
@@ -14,6 +15,7 @@ def test_score_handles_mixed_inputs():
     assert score == 81.0
     assert breakdown["test_pass_ratio"] == 0.8
     assert breakdown["placeholder_resolution_ratio"] == 0.7
+    assert breakdown["placeholder_score"] == 70.0
 
 
 def test_score_handles_zero_tests():


### PR DESCRIPTION
## Summary
- compute placeholder score when updating compliance metrics and persist in analytics.db
- expose weighted compliance score (0.3*lint + 0.5*test + 0.2*placeholder) on dashboard
- serialize placeholder metric in compliance helpers and tests

## Testing
- `ruff check scripts/compliance/update_compliance_metrics.py dashboard/compliance_metrics_updater.py enterprise_modules/compliance.py tests/test_code_quality_score.py tests/dashboard/test_composite_score_persistence.py`
- `pytest tests/test_code_quality_score.py tests/dashboard/test_composite_score_persistence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896fa1616548331916b772c404ac910