### PR TITLE
fix: handle missing quantum text score import

### DIFF
--- a/template_engine/objective_similarity_scorer.py
+++ b/template_engine/objective_similarity_scorer.py
@@ -24,7 +24,18 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.feature_extraction.text import CountVectorizer
 from tqdm import tqdm
-from quantum_algorithm_library_expansion import quantum_text_score
+
+# ``quantum_text_score`` is optional. If the quantum library is missing or
+# shadowed by a stub module, fall back to a no-op implementation so imports do
+# not fail during testing.
+try:  # pragma: no cover - exercised in regression tests
+    from quantum_algorithm_library_expansion import quantum_text_score
+except Exception:  # pragma: no cover - executed when import fails
+    def quantum_text_score(_text: str) -> float:
+        """Return a neutral score when quantum support is unavailable."""
+
+        return 0.0
+
 from utils.lessons_learned_integrator import load_lessons, apply_lessons
 
 DEFAULT_PRODUCTION_DB = Path("databases/production.db")

--- a/tests/test_objective_similarity_scorer_fallback.py
+++ b/tests/test_objective_similarity_scorer_fallback.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+import types
+
+
+def test_quantum_text_score_fallback(monkeypatch):
+    """Ensure scorer provides a fallback when quantum library is unavailable."""
+    monkeypatch.delitem(sys.modules, "template_engine.objective_similarity_scorer", raising=False)
+    dummy = types.ModuleType("quantum_algorithm_library_expansion")
+    monkeypatch.setitem(sys.modules, "quantum_algorithm_library_expansion", dummy)
+
+    scorer = importlib.import_module("template_engine.objective_similarity_scorer")
+    assert scorer.quantum_text_score("demo") == 0.0
+
+    # Remove patched module so subsequent tests import the real implementation.
+    monkeypatch.delitem(sys.modules, "template_engine.objective_similarity_scorer", raising=False)


### PR DESCRIPTION
## Summary
- handle missing `quantum_text_score` gracefully in `objective_similarity_scorer`
- add regression test for quantum text score fallback

## Testing
- `ruff check template_engine/objective_similarity_scorer.py tests/test_objective_similarity_scorer_fallback.py tests/documentation/test_documentation_manager_templates.py tests/test_compliance_metrics_updater.py tests/test_archive_scripts.py`
- `pytest tests/documentation/test_documentation_manager_templates.py tests/test_compliance_metrics_updater.py tests/test_archive_scripts.py tests/test_objective_similarity_scorer_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_6896fa1b3c148331aea5642426e8ebce