### PR TITLE
feat: integrate weighted compliance metrics and placeholder trends

### DIFF
--- a/dashboard/templates/metrics.html
+++ b/dashboard/templates/metrics.html
@@ -17,6 +17,13 @@
 <p><strong>Resolved Placeholders:</strong> {{ metrics.resolved_placeholders | default(0) }}</p>
 <p><strong>Remediation Progress:</strong> {{ ((metrics.progress or 0) * 100) | round(1) }}%</p>
 
+<h2>Placeholder Trend</h2>
+<ul>
+{% for entry in metrics.placeholder_trend or [] %}
+    <li>{{ entry.timestamp }} - open: {{ entry.open }}, resolved: {{ entry.resolved }}</li>
+{% endfor %}
+</ul>
+
 <h2>Correction Logs</h2>
 <ul>
 {% for entry in metrics.correction_logs or [] %}

--- a/docs/COMPLIANCE_LOGGING_GUIDE.md
+++ b/docs/COMPLIANCE_LOGGING_GUIDE.md
@@ -21,6 +21,9 @@ dashboard.
   `databases/analytics.db` under the `compliance_scores` table.
 - The updater exposes a list of correction logs, the latest composite score and
   a trend of recent scores alongside placeholder and violation statistics.
+- `scripts/code_placeholder_audit.py` writes findings to
+  `analytics.db.todo_fixme_tracking` and triggers the metrics updater so that
+  placeholder counts immediately influence the composite score and trend data.
 
 ## Dashboard Display
 
@@ -28,7 +31,9 @@ dashboard.
   and renders each correction log with its individual score and rationale.
 - `dashboard/enterprise_dashboard.py` provides a `/compliance-metrics` route
   returning the most recent composite score, its component breakdown, and a
-  history of prior scores for trend visualizations.
+  history of prior scores for trend visualizations. Placeholder resolution
+  trends sourced from the audit snapshots are displayed alongside these
+  metrics to highlight ongoing remediation progress.
 
 Running `compliance_metrics_updater.py` after executing the correction logger
 keeps the dashboard synchronized with the latest corrections and compliance

--- a/scripts/compliance_aggregator.py
+++ b/scripts/compliance_aggregator.py
@@ -46,7 +46,6 @@ def aggregate_metrics(
         tests_failed,
         placeholders_open,
         placeholders_resolved,
-        composite,
         db_path,
         test_mode=test_mode,
     )

--- a/tests/dashboard/test_composite_score_persistence.py
+++ b/tests/dashboard/test_composite_score_persistence.py
@@ -28,7 +28,7 @@ def test_composite_score_persisted_and_served(tmp_path, monkeypatch):
         ).fetchone()
         assert row == (pytest.approx(breakdown["placeholder_score"], rel=1e-3), pytest.approx(score, rel=1e-3))
 
-    record_code_quality_metrics(5, 8, 2, 1, 4, score, db_path=db)
+    record_code_quality_metrics(5, 8, 2, 1, 4, db_path=db)
 
     client = ed.app.test_client()
     resp = client.get("/dashboard/compliance")

--- a/tests/test_compliance_metrics_updater.py
+++ b/tests/test_compliance_metrics_updater.py
@@ -60,6 +60,8 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch, simulate, test_mode):
     monkeypatch.setattr(module, "insert_event", _capture_event)
     monkeypatch.setattr(module, "validate_no_recursive_folders", lambda: None)
     monkeypatch.setattr(module, "validate_environment_root", lambda: None)
+    monkeypatch.setattr(module, "_run_ruff", lambda: 5)
+    monkeypatch.setattr(module, "_run_pytest", lambda: (8, 2))
 
     db_dir = tmp_path / "databases"
     db_dir.mkdir()
@@ -73,6 +75,15 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch, simulate, test_mode):
         )
         conn.execute(
             "INSERT INTO todo_fixme_tracking VALUES (0, 'open', 2, 'type1')"
+        )
+        conn.execute(
+            "CREATE TABLE placeholder_audit_snapshots (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER, open_count INTEGER, resolved_count INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO placeholder_audit_snapshots (timestamp, open_count, resolved_count) VALUES (1, 1, 0)"
+        )
+        conn.execute(
+            "INSERT INTO placeholder_audit_snapshots (timestamp, open_count, resolved_count) VALUES (2, 1, 1)"
         )
         conn.execute("CREATE TABLE correction_logs (compliance_score REAL)")
         conn.execute("INSERT INTO correction_logs VALUES (0.9)")
@@ -125,8 +136,11 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch, simulate, test_mode):
         return
     data = json.loads(metrics_file.read_text())
     assert data["metrics"]["placeholder_removal"] == 1
-    expected_score = max(0.0, min(1.0, (1 / (1 + 1)) - 0.15))
-    assert data["metrics"]["compliance_score"] == expected_score
+    assert data["metrics"]["placeholder_trend"]
+    lint_val = 100 if test_mode else 95
+    test_val = 100 if test_mode else 80
+    expected_score = 0.3 * lint_val + 0.5 * test_val + 0.2 * 50
+    assert data["metrics"]["composite_score"] == expected_score - 15
     assert data["metrics"]["violation_count"] == 1
     assert data["metrics"]["rollback_count"] == 1
     assert data["metrics"]["progress_status"] == "issues_pending"
@@ -139,6 +153,12 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch, simulate, test_mode):
     assert push_calls
     keys = {k for call in push_calls for k in call}
     assert {"lint_score", "test_score", "placeholder_score"}.issubset(keys)
+    if not test_mode:
+        with sqlite3.connect(analytics_db) as conn:
+            row = conn.execute(
+                "SELECT lint_score, test_score, placeholder_score, composite_score FROM code_quality_metrics ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+        assert row == pytest.approx((float(lint_val), float(test_val), 50.0, expected_score), rel=1e-3)
     assert executed
     logger_instance = DummyCorrectionLoggerRollback.instances[0]
     assert logger_instance.logged["violation"] == 1


### PR DESCRIPTION
## Summary
- persist weighted lint, test, and placeholder scores to analytics.db
- surface composite score and placeholder trends on the compliance dashboard
- document placeholder audit pipeline and expand tests for score calculations

## Testing
- `ruff check enterprise_modules/compliance.py dashboard/compliance_metrics_updater.py scripts/code_placeholder_audit.py scripts/compliance_aggregator.py tests/test_compliance_metrics_updater.py tests/dashboard/test_composite_score_persistence.py`
- `pytest tests/test_compliance_metrics_updater.py tests/dashboard/test_composite_score_persistence.py tests/placeholder_audit/test_placeholder_task_persistence.py`

------
https://chatgpt.com/codex/tasks/task_e_6896fe930d888331a7b1758d84d4d3eb