### PR TITLE
feat: add anomaly detection loop and session lifecycle metrics

### DIFF
--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -45,15 +45,18 @@ def anomaly_metrics(monitoring_db: Path = MONITORING_DB) -> Dict[str, float]:
 def session_lifecycle_stats(db_path: Path = ANALYTICS_DB) -> Dict[str, float]:
     """Aggregate session lifecycle statistics for dashboard display."""
 
-    stats = {"count": 0, "avg_duration": 0.0}
+    stats = {"count": 0, "avg_duration": 0.0, "success_rate": 0.0}
     if db_path.exists():
         with sqlite3.connect(db_path) as conn:
             cur = conn.execute(
-                "SELECT COUNT(*), AVG(duration_seconds) FROM session_lifecycle"
+                "SELECT COUNT(*), AVG(duration_seconds), SUM(CASE WHEN status='success' THEN 1 ELSE 0 END) FROM session_lifecycle",
             )
-            count, avg = cur.fetchone()
+            count, avg, success = cur.fetchone()
             stats["count"] = int(count or 0)
             stats["avg_duration"] = float(avg or 0.0)
+            stats["success_rate"] = (
+                float(success or 0) / stats["count"] if stats["count"] else 0.0
+            )
     return stats
 
 
@@ -154,3 +157,4 @@ __all__ = [
     "session_lifecycle_stats",
     "_load_corrections",
 ]
+

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -291,6 +291,7 @@
 <h2>Session Lifecycle</h2>
 <div>Total Sessions: <span id="session_count">{{ lifecycle.count }}</span></div>
 <div>Average Duration: <span id="avg_duration">{{ lifecycle.avg_duration }}</span></div>
+<div>Success Rate: <span id="success_rate">{{ lifecycle.success_rate }}</span></div>
 
 <h2>Audit Results</h2>
 <ul id="audit_results">

--- a/tests/dashboard/test_session_lifecycle_stats.py
+++ b/tests/dashboard/test_session_lifecycle_stats.py
@@ -22,3 +22,4 @@ def test_session_lifecycle_stats(tmp_path: Path) -> None:
     stats = session_lifecycle_stats(db)
     assert stats["count"] == 2
     assert stats["avg_duration"] == 2.0
+    assert stats["success_rate"] == 1.0

--- a/tests/test_session_management_integrity.py
+++ b/tests/test_session_management_integrity.py
@@ -1,5 +1,5 @@
 import pytest
-
+import unified_session_management_system as usm
 from unified_session_management_system import prevent_recursion
 
 
@@ -11,10 +11,28 @@ def test_prevent_recursion_allows_single_call():
     assert add_one(1) == 2
 
 
-def test_prevent_recursion_blocks_recursive_call():
+def test_prevent_recursion_blocks_recursive_call(monkeypatch):
+    monkeypatch.setattr(usm, "record_codex_action", lambda *a, **k: None)
+
     @prevent_recursion
     def recurse(n: int) -> int:
         return 0 if n == 0 else recurse(n - 1)
 
     with pytest.raises(RuntimeError):
         recurse(1)
+
+
+def test_prevent_recursion_logs(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        usm, "record_codex_action", lambda *args: calls.append(args)
+    )
+
+    @usm.prevent_recursion
+    def recurse(n: int = 0) -> None:
+        if n == 0:
+            recurse(n + 1)
+
+    with pytest.raises(RuntimeError):
+        recurse()
+    assert any(a[1] == "anti_recursion_triggered" for a in calls)

--- a/unified_monitoring_optimization_system.py
+++ b/unified_monitoring_optimization_system.py
@@ -564,7 +564,6 @@ def auto_heal_session(
         )
     else:
         anomalies = list(anomalies)
-    anomalies = [a for a in anomalies if a.get("anomaly_score", 0) > 0.5]
     if not anomalies:
         return False
     if manager is None:
@@ -589,6 +588,7 @@ def anomaly_detection_loop(
     *,
     iterations: Optional[int] = None,
     contamination: float = 0.1,
+    threshold: float = 0.5,
     manager: Optional[UnifiedSessionManagementSystem] = None,
     db_path: Optional[Path] = None,
     model_path: Optional[Path] = None,
@@ -625,9 +625,12 @@ def anomaly_detection_loop(
             db_path=db_path,
             model_path=model_path,
         )
-        if anomalies:
+        filtered = [
+            a for a in anomalies if a.get("anomaly_score", 0) > threshold
+        ]
+        if filtered:
             auto_heal_session(
-                anomalies=anomalies, manager=manager, db_path=db_path
+                anomalies=filtered, manager=manager, db_path=db_path
             )
         count += 1
         if iterations is None or count < iterations:


### PR DESCRIPTION
## Summary
- train and evaluate isolation forest models for monitoring and trigger auto-heal when anomalies exceed threshold
- record session duration and outcome metrics during finalize_session and surface success rates on dashboard
- add tests for anomaly detection auto-heal and recursion logging

## Testing
- `ruff check unified_monitoring_optimization_system.py unified_session_management_system.py dashboard/enterprise_dashboard.py tests/monitoring/test_anomaly_detection.py tests/test_session_management.py tests/test_session_management_integrity.py tests/dashboard/test_session_lifecycle_stats.py`
- `pytest tests/monitoring/test_anomaly_detection.py tests/test_session_management.py tests/test_session_management_integrity.py tests/dashboard/test_session_lifecycle_stats.py`


------
https://chatgpt.com/codex/tasks/task_e_6896fecbc40883318ce523767eedb451