### PR TITLE
chore(ci): run lint and tests on all pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,9 @@
 name: CI
 on:
   push:
-    tags:
-      - 'v*'
-    paths:
-      - '**.py'
-      - '**.md'
-      - '.github/**'
-      - 'docs/**'
-      - 'documentation/**'
+    branches: ["**"]
   pull_request:
     branches: [main]
-    paths:
-      - '**.py'
-      - '**.md'
-      - '.github/**'
-      - 'docs/**'
-      - 'documentation/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- trigger CI on every branch push to ensure linters and tests run for all commits

## Testing
- `ruff check . --select E722`
- `pyright scripts/analysis`
- `pytest tests/test_archive_scripts.py`

------
https://chatgpt.com/codex/tasks/task_e_6896ff067bec8331907f949135b8459b