### PR TITLE
feat: record placeholder metrics in monitoring

### DIFF
--- a/tests/placeholder_audit/test_metrics_logging.py
+++ b/tests/placeholder_audit/test_metrics_logging.py
@@ -1,8 +1,46 @@
 import json
 import sqlite3
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import secondary_copilot_validator
+
+stub_module = SimpleNamespace(
+    DualCopilotOrchestrator=lambda: SimpleNamespace(
+        validator=SimpleNamespace(validate_corrections=lambda *a, **k: True)
+    )
+)
+sys.modules.setdefault(
+    "scripts.validation.dual_copilot_orchestrator", stub_module
+)
+
+
+def _fake_collect_metrics(**_kwargs):
+    return {"cpu_percent": 0.0}
+
+
+def _fake_push_metrics(metrics, *, db_path=None, **_kwargs):
+    path = Path(db_path)
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS monitoring_metrics (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp DATETIME DEFAULT CURRENT_TIMESTAMP, metrics_json TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO monitoring_metrics (metrics_json) VALUES (?)",
+            (json.dumps(metrics),),
+        )
+        conn.commit()
+
+
+sys.modules.setdefault(
+    "unified_monitoring_optimization_system",
+    SimpleNamespace(
+        collect_metrics=_fake_collect_metrics,
+        push_metrics=_fake_push_metrics,
+        EnterpriseUtility=SimpleNamespace,
+    ),
+)
 
 from scripts.code_placeholder_audit import main
 
@@ -24,7 +62,9 @@ def test_metrics_logged_and_dashboard_updated(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         "scripts.code_placeholder_audit.ComplianceMetricsUpdater",
-        lambda *a, **k: SimpleNamespace(update=lambda *a, **k: None, validate_update=lambda *a, **k: True),
+        lambda *a, **k: SimpleNamespace(
+            update=lambda *a, **k: None, validate_update=lambda *a, **k: True
+        ),
     )
 
     assert main(
@@ -41,7 +81,16 @@ def test_metrics_logged_and_dashboard_updated(tmp_path, monkeypatch):
     assert "progress" in metrics["metrics"]
 
     with sqlite3.connect(analytics) as conn:
-        cur = conn.execute("SELECT open_placeholders, resolved_placeholders FROM placeholder_metrics")
+        cur = conn.execute(
+            "SELECT open_placeholders, resolved_placeholders FROM placeholder_metrics"
+        )
         row = cur.fetchone()
         assert row[0] >= 1
         assert row[1] == 0
+        cur = conn.execute(
+            "SELECT metrics_json FROM monitoring_metrics ORDER BY id DESC LIMIT 1"
+        )
+        metrics_row = cur.fetchone()
+        data = json.loads(metrics_row[0])
+        assert data["placeholder_open"] >= 1
+        assert data["placeholder_resolved"] == 0


### PR DESCRIPTION
## Summary
- capture placeholder open/resolved counts and system stats in `code_placeholder_audit`
- persist combined metrics for anomaly detection
- extend metrics logging test to assert monitoring payload

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder_audit/test_metrics_logging.py`
- `pytest -p no:cov --override-ini="addopts=" tests/placeholder_audit/test_metrics_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_689838ffde98833185794bb26a6d5102