### PR TITLE
feat(ssot): add status reconciler and tests

### DIFF
--- a/scripts/docs_status_reconciler.py
+++ b/scripts/docs_status_reconciler.py
@@ -1,0 +1,99 @@
+"""Reconcile Phase 5 task progress with task stubs.
+
+This script parses ``docs/PHASE5_TASKS_STARTED.md`` and
+``docs/task_stubs.md`` to ensure their progress values match.
+It writes a JSON index of task progress and can be run in
+``--check`` mode to fail when drift is detected.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+from jsonschema import validate
+
+PHASE5_PATH = Path("docs/PHASE5_TASKS_STARTED.md")
+TASK_STUBS_PATH = Path("docs/task_stubs.md")
+SCHEMA_PATH = Path("scripts/schemas/status_index.schema.json")
+STATUS_INDEX_PATH = Path("status_index.json")
+
+
+def _parse_phase5(path: Path) -> dict[str, int]:
+    """Return mapping of task name to progress percentage."""
+    tasks: dict[str, int] = {}
+    current: str | None = None
+    for line in path.read_text().splitlines():
+        heading = re.match(r"^##\s+\d+\.\s+(.*)", line)
+        if heading:
+            current = heading.group(1).strip()
+            continue
+        if current:
+            progress = re.search(r"Progress:\**\s*(\d+)%", line)
+            if progress:
+                tasks[current] = int(progress.group(1))
+                current = None
+    return tasks
+
+
+def _parse_task_stubs(path: Path) -> dict[str, int]:
+    """Return mapping from task stubs table."""
+    tasks: dict[str, int] = {}
+    lines = path.read_text().splitlines()
+    for line in lines:
+        if not line.startswith("|") or line.startswith("| Task "):
+            continue
+        parts = [p.strip() for p in line.strip().strip("|").split("|")]
+        if len(parts) < 7:
+            continue
+        name = parts[0]
+        match = re.match(r"(\d+)%", parts[-1])
+        if match:
+            tasks[name] = int(match.group(1))
+    return tasks
+
+
+def reconcile(
+    phase5_path: Path = PHASE5_PATH,
+    stubs_path: Path = TASK_STUBS_PATH,
+    *,
+    schema_path: Path = SCHEMA_PATH,
+    index_path: Path = STATUS_INDEX_PATH,
+    check: bool = False,
+) -> dict[str, dict[str, int]]:
+    """Generate status index and optionally fail on drift.
+
+    Returns a mapping of tasks with differing progress values.
+    """
+    phase5 = _parse_phase5(phase5_path)
+    stubs = _parse_task_stubs(stubs_path)
+    status_index = phase5
+
+    schema = json.loads(schema_path.read_text())
+    validate(status_index, schema)
+    index_path.write_text(json.dumps(status_index, indent=2, sort_keys=True))
+
+    drift: dict[str, dict[str, int]] = {}
+    for task, pct in phase5.items():
+        stub_pct = stubs.get(task)
+        if stub_pct != pct:
+            drift[task] = {"phase5": pct, "stubs": stub_pct or 0}
+    if check and drift:
+        raise SystemExit(1)
+    return drift
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Fail on drift")
+    args = parser.parse_args(argv)
+    try:
+        reconcile(check=args.check)
+    except SystemExit as exc:
+        return exc.code
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/schemas/status_index.schema.json
+++ b/scripts/schemas/status_index.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Status Index",
+  "type": "object",
+  "additionalProperties": {
+    "type": "integer",
+    "minimum": 0,
+    "maximum": 100
+  }
+}

--- a/tests/docs_status_reconciler_test.py
+++ b/tests/docs_status_reconciler_test.py
@@ -1,0 +1,79 @@
+"""Tests for docs_status_reconciler."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import docs_status_reconciler as reconciler
+
+
+def _write(path: Path, content: str) -> Path:
+    path.write_text(content)
+    return path
+
+
+def test_reconcile_success(tmp_path: Path) -> None:
+    phase5 = _write(
+        tmp_path / "PHASE5_TASKS_STARTED.md",
+        """
+## 1. TaskA
+- [x] **Progress:** 100%
+""".strip(),
+    )
+    stubs = _write(
+        tmp_path / "task_stubs.md",
+        """
+| Task | Design | Development | Testing | Documentation | Planning | Progress |
+| --- | --- | --- | --- | --- | --- | --- |
+| TaskA | d | d | t | doc | plan | 100% |
+""".strip(),
+    )
+    schema = _write(
+        tmp_path / "schema.json",
+        json.dumps({"type": "object", "additionalProperties": {"type": "integer"}}),
+    )
+    index = tmp_path / "status_index.json"
+
+    drift = reconciler.reconcile(
+        phase5_path=phase5,
+        stubs_path=stubs,
+        schema_path=schema,
+        index_path=index,
+        check=False,
+    )
+    assert drift == {}
+    assert json.loads(index.read_text()) == {"TaskA": 100}
+
+
+def test_reconcile_drift(tmp_path: Path) -> None:
+    phase5 = _write(
+        tmp_path / "PHASE5_TASKS_STARTED.md",
+        """
+## 1. TaskA
+- [ ] **Progress:** 50%
+""".strip(),
+    )
+    stubs = _write(
+        tmp_path / "task_stubs.md",
+        """
+| Task | Design | Development | Testing | Documentation | Planning | Progress |
+| --- | --- | --- | --- | --- | --- | --- |
+| TaskA | d | d | t | doc | plan | 40% |
+""".strip(),
+    )
+    schema = _write(
+        tmp_path / "schema.json",
+        json.dumps({"type": "object", "additionalProperties": {"type": "integer"}}),
+    )
+    index = tmp_path / "status_index.json"
+
+    with pytest.raises(SystemExit):
+        reconciler.reconcile(
+            phase5_path=phase5,
+            stubs_path=stubs,
+            schema_path=schema,
+            index_path=index,
+            check=True,
+        )


### PR DESCRIPTION
## Summary
- add script to validate doc progress and produce status index
- define JSON schema for status index
- cover reconciler behavior with tests

## Testing
- `ruff check scripts/docs_status_reconciler.py tests/docs_status_reconciler_test.py`
- `pytest tests/docs_status_reconciler_test.py -q`
- `bash tools/pre-commit-lfs.sh`

------
https://chatgpt.com/codex/tasks/task_e_68984730c33883318c17c9d04cbf32a1