### PR TITLE
feat: validate session wrap-up and lifecycle metrics

### DIFF
--- a/session_protocol_validator.py
+++ b/session_protocol_validator.py
@@ -1,15 +1,46 @@
 """CLI wrapper for :mod:`validation.protocols.session`."""
 
+import sqlite3
+import sys
+import traceback
+from datetime import datetime
+
 from validation.protocols.session import SessionProtocolValidator
 from utils.cross_platform_paths import verify_environment_variables
 from utils.validation_utils import anti_recursion_guard
+from utils.logging_utils import ANALYTICS_DB
 
 __all__ = ["SessionProtocolValidator", "main"]
+
+
+def _log_session_event(message: str) -> None:
+    """Persist a session log entry to ``analytics.db``."""
+    ts = datetime.utcnow().isoformat()
+    with sqlite3.connect(ANALYTICS_DB) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS session_logs (
+                ts TEXT NOT NULL,
+                message TEXT NOT NULL
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO session_logs (ts, message) VALUES (?, ?)",
+            (ts, message),
+        )
+
+
+def _check_recursion_depth(limit: int | None = None) -> None:
+    """Log an anomaly if call stack depth exceeds ``limit``."""
+    depth = len(traceback.extract_stack())
+    max_depth = limit or sys.getrecursionlimit()
+    if depth > max_depth:
+        _log_session_event(f"recursion_depth_exceeded:{depth}/{max_depth}")
 
 
 @anti_recursion_guard
 def main() -> int:
     """Delegate to :class:`~validation.protocols.session.SessionProtocolValidator`."""
+    _check_recursion_depth()
     verify_environment_variables()
     return SessionProtocolValidator.main()
 

--- a/tests/session/test_wrap_up_validation.py
+++ b/tests/session/test_wrap_up_validation.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import unified_session_management_system as usms
+
+
+def _prepare_logs(tmp_path: Path) -> Path:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "app.log").write_text("ok")
+    return log_dir
+
+
+def test_finalize_session_detects_open_handles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_dir = _prepare_logs(tmp_path)
+    monkeypatch.setattr(usms, "ANALYTICS_DB", tmp_path / "analytics.db")
+    monkeypatch.setattr(usms, "record_codex_action", lambda *a, **k: None)
+    handle = (tmp_path / "leak.txt").open("w")
+    try:
+        with pytest.raises(RuntimeError):
+            usms.finalize_session(log_dir, tmp_path, session_id="s1")
+    finally:
+        handle.close()
+
+
+def test_finalize_session_detects_open_transactions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_dir = _prepare_logs(tmp_path)
+    monkeypatch.setattr(usms, "ANALYTICS_DB", tmp_path / "analytics.db")
+    monkeypatch.setattr(usms, "record_codex_action", lambda *a, **k: None)
+    conn = sqlite3.connect(":memory:")
+    conn.execute("BEGIN")
+    try:
+        with pytest.raises(RuntimeError):
+            usms.finalize_session(log_dir, tmp_path, session_id="s2")
+    finally:
+        conn.rollback()
+        conn.close()
+


### PR DESCRIPTION
## Summary
- ensure session finalization fails on lingering file handles or open transactions
- log recursion depth anomalies for session protocol validation
- incorporate session lifecycle metrics into compliance scoring

## Testing
- `ruff check unified_session_management_system.py session_protocol_validator.py enterprise_modules/compliance.py tests/session/test_wrap_up_validation.py`
- `pytest -o addopts="" tests/session/test_wrap_up_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68984d0d23c88331b0b28178c85f1d9f