### PR TITLE
feat: track placeholder audit metrics

### DIFF
--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -1342,6 +1342,16 @@ def main(
             __name__,
             f"{TEXT['info']} logged {inserted} findings to {analytics}",
         )
+        try:
+            metrics = collect_metrics(db_path=Path(":memory:"))
+            metrics["placeholder_findings"] = float(inserted)
+            push_metrics(metrics, db_path=analytics)
+        except Exception as exc:
+            log_message(
+                __name__,
+                f"{TEXT['error']} metrics collection failed: {exc}",
+                level=logging.ERROR,
+            )
     if export:
         export.write_text(json.dumps(results, indent=2), encoding="utf-8")
     tasks = generate_removal_tasks(results, production, analytics)

--- a/tests/placeholder_audit/test_metrics_logging.py
+++ b/tests/placeholder_audit/test_metrics_logging.py
@@ -94,3 +94,43 @@ def test_metrics_logged_and_dashboard_updated(tmp_path, monkeypatch):
         data = json.loads(metrics_row[0])
         assert data["placeholder_open"] >= 1
         assert data["placeholder_resolved"] == 0
+
+
+def test_collect_metrics_called_for_findings(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "b.py").write_text("# TODO\n")
+
+    analytics = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dashboard"
+
+    calls: list[dict] = []
+
+    def _tracking_collect_metrics(**kwargs):
+        calls.append(kwargs)
+        return {"cpu_percent": 0.0}
+
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setattr(secondary_copilot_validator, "run_flake8", lambda *a, **k: True)
+    monkeypatch.setattr(
+        secondary_copilot_validator,
+        "SecondaryCopilotValidator",
+        lambda: SimpleNamespace(validate_corrections=lambda *a, **k: True),
+    )
+    monkeypatch.setattr(
+        "scripts.code_placeholder_audit.ComplianceMetricsUpdater",
+        lambda *a, **k: SimpleNamespace(
+            update=lambda *a, **k: None, validate_update=lambda *a, **k: True
+        ),
+    )
+    monkeypatch.setattr("scripts.code_placeholder_audit.collect_metrics", _tracking_collect_metrics)
+    monkeypatch.setattr("scripts.code_placeholder_audit.push_metrics", _fake_push_metrics)
+
+    assert main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(dash_dir / "compliance"),
+    )
+
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- add monitoring hooks to log placeholder audit findings via collect_metrics
- verify metrics collection with new tests

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder_audit/test_metrics_logging.py`
- `pytest tests/placeholder_audit/test_metrics_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68985d540ba88331bc9fa403dc64c394