### PR TITLE
refactor: consolidate placeholder tracking

### DIFF
--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -226,7 +226,7 @@ def _load_placeholder_details(limit: int = 50) -> Dict[str, List[Dict[str, Any]]
                 for r in cur.fetchall()
             ]
             cur = conn.execute(
-                "SELECT file, line FROM unresolved_placeholders ORDER BY file LIMIT ?",
+                "SELECT file_path, line_number FROM placeholder_tasks WHERE status='open' ORDER BY file_path LIMIT ?",
                 (limit,),
             )
             unresolved = [

--- a/docs/placeholder_audit_guide.md
+++ b/docs/placeholder_audit_guide.md
@@ -35,7 +35,7 @@ python scripts/code_placeholder_audit.py --apply-suggestions \
 ```
 
 Unresolved placeholders are recorded in `analytics.db` under the
-`unresolved_placeholders` table with their file paths and line numbers.
+`placeholder_tasks` table (entries with `status='open'`) with their file paths and line numbers.
 
 ## Viewing Results
 

--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -710,34 +710,6 @@ def log_findings(
     return inserted
 
 
-def record_unresolved_placeholders(
-    tasks: List[Dict[str, str]], analytics_db: Path, simulate: bool = False
-) -> int:
-    """Store unresolved placeholder locations in analytics.db."""
-
-    if simulate:
-        return 0
-    analytics_db.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(analytics_db) as conn:
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS unresolved_placeholders (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                file TEXT NOT NULL,
-                line INTEGER NOT NULL,
-                suggestion TEXT,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )
-            """
-        )
-        cur = conn.cursor()
-        for task in tasks:
-            cur.execute(
-                "INSERT INTO unresolved_placeholders (file, line, suggestion) VALUES (?, ?, ?)",
-                (task["file"], int(task["line"]), task["suggestion"]),
-            )
-        conn.commit()
-        return len(tasks)
 
 
 def apply_suggestions_to_files(
@@ -1349,7 +1321,6 @@ def main(
         tasks = apply_suggestions_to_files(tasks, analytics)
     if not simulate:
         inserted = log_placeholder_tasks(tasks, analytics)
-        record_unresolved_placeholders(tasks, analytics)
     for task in tasks:
         log_message(__name__, f"[TASK] {task['task']}")
     if task_report:

--- a/tests/placeholder/test_code_placeholder_audit.py
+++ b/tests/placeholder/test_code_placeholder_audit.py
@@ -167,12 +167,12 @@ def test_apply_suggestions_updates_file_and_db(tmp_path, monkeypatch):
     assert "FIXME" not in src.read_text()
     with sqlite3.connect(analytics_db) as conn:
         unresolved = conn.execute(
-            "SELECT COUNT(*) FROM unresolved_placeholders"
+            "SELECT COUNT(*) FROM placeholder_tasks"
         ).fetchone()[0]
     assert unresolved == 0
 
 
-def test_unresolved_placeholders_logged(tmp_path, monkeypatch):
+def test_placeholder_tasks_logged(tmp_path, monkeypatch):
     workspace = tmp_path / "ws"
     workspace.mkdir()
     src = workspace / "sample.py"
@@ -200,6 +200,6 @@ def test_unresolved_placeholders_logged(tmp_path, monkeypatch):
     )
     with sqlite3.connect(analytics_db) as conn:
         row = conn.execute(
-            "SELECT file, line FROM unresolved_placeholders"
+            "SELECT file_path, line_number FROM placeholder_tasks"
         ).fetchone()
     assert row == (str(src), 1)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -119,13 +119,13 @@ def test_placeholder_details_endpoint(tmp_path, monkeypatch):
             "CREATE TABLE placeholder_audit_snapshots (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER, open_count INTEGER, resolved_count INTEGER)"
         )
         conn.execute(
-            "CREATE TABLE unresolved_placeholders (file TEXT, line INTEGER)"
+            "CREATE TABLE placeholder_tasks (file_path TEXT, line_number INTEGER, status TEXT)"
         )
         conn.execute(
             "INSERT INTO placeholder_audit_snapshots(timestamp, open_count, resolved_count) VALUES (1,2,3)"
         )
         conn.execute(
-            "INSERT INTO unresolved_placeholders(file, line) VALUES ('file.py', 10)"
+            "INSERT INTO placeholder_tasks VALUES ('file.py', 10, 'open')"
         )
     monkeypatch.setattr(ed, "ANALYTICS_DB", db)
     client = ed.app.test_client()


### PR DESCRIPTION
## Summary
- replace `unresolved_placeholders` table usage with `placeholder_tasks`
- adjust dashboard and tests to read unresolved placeholders from `placeholder_tasks`
- document unified placeholder tracking

## Testing
- `ruff check scripts/code_placeholder_audit.py dashboard/enterprise_dashboard.py tests/test_dashboard.py tests/placeholder/test_code_placeholder_audit.py`
- `pytest --override-ini="addopts=" tests/test_dashboard.py tests/placeholder/test_code_placeholder_audit.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'flake8')*

------
https://chatgpt.com/codex/tasks/task_e_68985d4ebb588331a5f62650464b7973