### PR TITLE
feat: enforce governance standards across docs and CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Pull Request
+
+## Summary
+- _Provide a brief summary of the changes._
+
+## Checklist
+- [ ] Tests added or updated
+- [ ] Documentation updated
+- [ ] I adhere to the [Governance Standards](../docs/GOVERNANCE_STANDARDS.md)
+

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -12,3 +12,4 @@ jobs:
           test -f docs/GOVERNANCE_STANDARDS.md
           test -f docs/REPOSITORY_GUIDELINES.md
           grep -q "GOVERNANCE_STANDARDS.md" README.md
+          grep -q "GOVERNANCE_STANDARDS.md" .github/pull_request_template.md

--- a/docs/GOVERNANCE_STANDARDS.md
+++ b/docs/GOVERNANCE_STANDARDS.md
@@ -46,3 +46,9 @@ A composite score below **85** blocks merges until issues are corrected.
 
 ## ML Monitoring and Placeholder Audits
 Machine-learning components must log performance and drift metrics to `analytics.db` via the unified monitoring interfaces. Placeholder audits run after each session and their results are stored in `placeholder_audit_snapshots` to satisfy enterprise governance requirements. Deviations from expected model behaviour or unresolved placeholders trigger compliance reviews and must be addressed before deployment.
+
+## Session Lifecycle Requirements
+- Invoke `start_session` at the beginning of every workflow and `end_session` upon completion.
+- Persist session metadata, compliance scores, and audit results to `analytics.db` for traceability.
+- Run zero-byte file checks and placeholder audits during `end_session` to confirm integrity.
+- Mark sessions that fail integrity checks or leave placeholders unresolved as non‑compliant until corrected.

--- a/docs/executive_guides/README.md
+++ b/docs/executive_guides/README.md
@@ -8,11 +8,15 @@ Quick references for leadership teams using the enterprise dashboard.
   – launches the executive dashboard
 - [web_gui/documentation/user_guides/README.md](../../web_gui/documentation/user_guides/README.md)
   – general user documentation
+- [Governance Standards](../GOVERNANCE_STANDARDS.md)
+  – compliance policies and scoring rules
 
 ## Overview
 
 The executive dashboard surfaces compliance summaries, performance
-metrics, and certification status. Run the dashboard script and navigate
+metrics, and certification status. It displays the composite compliance
+score (30% lint, 40% tests, 20% placeholders, 10% session success) and
+highlights placeholder audit results. Run the dashboard script and navigate
 to the highlighted sections to review system health at a glance.
 
 ## Related Modules

--- a/docs/white-paper.md
+++ b/docs/white-paper.md
@@ -2,17 +2,15 @@
 
 ## Compliance Formula Implementation
 
-The compliance formula is now **100% implemented** and drives enforcement across the toolkit. The composite score blends lint results, test outcomes, and placeholder resolution metrics to provide a single indicator of repository health and feeds the `/api/refresh_compliance` and `/api/compliance_scores` endpoints.
+The compliance formula is now **100% implemented** and drives enforcement across the toolkit. The composite score blends lint results, test outcomes, placeholder resolution metrics, and session lifecycle success to provide a single indicator of repository health and feeds the `/api/refresh_compliance` and `/api/compliance_scores` endpoints. For full policy details see the [Governance Standards](GOVERNANCE_STANDARDS.md).
 
 The weighted composite is defined as:
 
 ```
-score = 0.3 * L + 0.5 * T + 0.2 * P
+score = 0.3 * L + 0.4 * T + 0.2 * P + 0.1 * S
 ```
 
-Where **L** is the lint score, **T** the test pass rate and **P** the
-placeholder resolution percentage. Scores below `0.8` trigger dashboard
-alerts and notification hooks.
+Where **L** is the lint score, **T** the test pass rate, **P** the placeholder resolution percentage, and **S** the session success rate. Scores below `0.85` trigger dashboard alerts and notification hooks.
 
 ```python
 from enterprise_modules.compliance import calculate_compliance_score
@@ -22,6 +20,7 @@ score = calculate_compliance_score(
     tests_failed,
     placeholders_open,
     placeholders_resolved,
+    session_success_rate,
 )
 ```
 

--- a/tests/documentation/test_governance_links.py
+++ b/tests/documentation/test_governance_links.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import pytest
+
+
+DOCS = [
+    Path("docs/white-paper.md"),
+    Path("docs/executive_guides/README.md"),
+]
+
+
+@pytest.mark.parametrize("path", DOCS)
+def test_docs_reference_governance_standards(path: Path) -> None:
+    content = path.read_text(encoding="utf-8")
+    assert "GOVERNANCE_STANDARDS.md" in content, f"{path} missing governance reference"
+


### PR DESCRIPTION
## Summary
- expand governance standards with session lifecycle policies
- update white paper and executive guide to reference final compliance formula
- add PR template, CI check, and documentation test for governance links

## Testing
- `ruff check tests/documentation/test_governance_links.py`
- `pytest tests/documentation/test_governance_links.py`


------
https://chatgpt.com/codex/tasks/task_e_68985e5ac810833183c5f2b7ada632c8