### PR TITLE
fix: ensure single snapshot per placeholder audit

### DIFF
--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -307,18 +307,6 @@ def log_placeholder_tasks(
                     ),
                 )
         conn.commit()
-
-        # Persist aggregate counts for dashboard consumers.
-        cur = conn.execute(
-            "SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='open'"
-        )
-        open_count = int(cur.fetchone()[0])
-        cur = conn.execute(
-            "SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='resolved'"
-        )
-        resolved_count = int(cur.fetchone()[0])
-        _record_placeholder_snapshot(conn, open_count, resolved_count)
-        conn.commit()
     return inserted
 
 
@@ -694,18 +682,6 @@ def log_findings(
                         values[:-1],
                     )
                     inserted += 1
-        conn.commit()
-
-        # Persist aggregate counts for dashboard consumers.
-        cur = conn.execute(
-            "SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='open'"
-        )
-        open_count = int(cur.fetchone()[0])
-        cur = conn.execute(
-            "SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='resolved'"
-        )
-        resolved_count = int(cur.fetchone()[0])
-        _record_placeholder_snapshot(conn, open_count, resolved_count)
         conn.commit()
     return inserted
 


### PR DESCRIPTION
## Summary
- avoid duplicate placeholder snapshot recordings by removing redundant calls
- test that placeholder audit inserts a single snapshot per run

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder_audit/test_snapshot_recording.py`
- `pytest tests/placeholder_audit/test_snapshot_recording.py tests/test_placeholder_audit_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68985d3f84348331b8b075d978f2c2a2