### PR TITLE
feat: add placeholder history endpoint

### DIFF
--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -205,26 +205,38 @@ def audit_results_alias() -> Any:
 app.view_functions["dashboard.audit_results"] = audit_results_alias
 
 
+def _load_placeholder_history(limit: int = 50) -> List[Dict[str, Any]]:
+    """Return placeholder snapshot history."""
+
+    rows: List[Dict[str, Any]] = []
+    if ANALYTICS_DB.exists():
+        with sqlite3.connect(ANALYTICS_DB) as conn:
+            try:
+                cur = conn.execute(
+                    "SELECT timestamp, open_count, resolved_count "
+                    "FROM placeholder_audit_snapshots ORDER BY timestamp LIMIT ?",
+                    (limit,),
+                )
+                rows = [
+                    {
+                        "timestamp": int(r[0]),
+                        "open": int(r[1]),
+                        "resolved": int(r[2]),
+                    }
+                    for r in cur.fetchall()
+                ]
+            except sqlite3.Error:
+                pass
+    return rows
+
+
 def _load_placeholder_details(limit: int = 50) -> Dict[str, List[Dict[str, Any]]]:
     """Return placeholder snapshot history and unresolved placeholders."""
 
-    history: List[Dict[str, Any]] = []
+    history: List[Dict[str, Any]] = _load_placeholder_history(limit)
     unresolved: List[Dict[str, Any]] = []
     if ANALYTICS_DB.exists():
         with sqlite3.connect(ANALYTICS_DB) as conn:
-            cur = conn.execute(
-                "SELECT timestamp, open_count, resolved_count "
-                "FROM placeholder_audit_snapshots ORDER BY timestamp LIMIT ?",
-                (limit,),
-            )
-            history = [
-                {
-                    "timestamp": int(r[0]),
-                    "open": int(r[1]),
-                    "resolved": int(r[2]),
-                }
-                for r in cur.fetchall()
-            ]
             cur = conn.execute(
                 "SELECT file_path, line_number FROM placeholder_tasks WHERE status='open' ORDER BY file_path LIMIT ?",
                 (limit,),
@@ -240,6 +252,13 @@ def placeholder_details() -> Any:
     """Expose placeholder history and unresolved entries."""
 
     return jsonify(_load_placeholder_details())
+
+
+@app.route("/api/placeholder_history")
+def placeholder_history() -> Any:
+    """Expose placeholder snapshot history."""
+
+    return jsonify({"history": _load_placeholder_history()})
 
 
 def index() -> str:

--- a/dashboard/static/placeholder_chart.js
+++ b/dashboard/static/placeholder_chart.js
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     function refresh() {
-        fetch('/api/placeholder_details').then(r => r.json()).then(data => {
+        fetch('/api/placeholder_history').then(r => r.json()).then(data => {
             const history = data.history || [];
             chart.data.labels = history.map(h => new Date(h.timestamp * 1000).toLocaleString());
             chart.data.datasets[0].data = history.map(h => h.open);

--- a/tests/dashboard/test_placeholder_history_endpoint.py
+++ b/tests/dashboard/test_placeholder_history_endpoint.py
@@ -1,0 +1,21 @@
+import sqlite3
+
+import dashboard.enterprise_dashboard as ed
+
+
+def test_placeholder_history_endpoint(tmp_path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE placeholder_audit_snapshots (timestamp INTEGER, open_count INTEGER, resolved_count INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO placeholder_audit_snapshots VALUES (1, 2, 3)"
+        )
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+
+    client = ed.app.test_client()
+    resp = client.get("/api/placeholder_history")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["history"][0]["open"] == 2


### PR DESCRIPTION
## Summary
- expose `/api/placeholder_history` route reading snapshot data from `analytics.db`
- update placeholder chart to query new endpoint
- test placeholder history endpoint

## Testing
- `ruff check dashboard/enterprise_dashboard.py tests/dashboard/test_placeholder_history_endpoint.py`
- `pytest tests/dashboard/test_placeholder_history_endpoint.py`

------
https://chatgpt.com/codex/tasks/task_e_689863da46e08331971a9b51550afcfd