### PR TITLE
docs: document rollback usage and test database backup invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,8 @@ Synchronization outcomes are logged to `databases/analytics.db`, allowing the da
 
 The compliance score is averaged from records in the `correction_logs` table.
 Correction history is summarized via `scripts/correction_logger_and_rollback.py`.
+Use `scripts/correction_logger_and_rollback.py --rollback-last` to undo the most
+recent correction when necessary.
 The `summarize_corrections()` routine now keeps only the most recent entries
 (configurable via the `max_entries` argument). Existing summary files are moved
 to `dashboard/compliance/archive/` before new summaries are written. The main
@@ -1014,6 +1016,7 @@ Set `GH_COPILOT_WORKSPACE` before running these utilities:
 export GH_COPILOT_WORKSPACE=$(pwd)
 python dashboard/compliance_metrics_updater.py
 python scripts/correction_logger_and_rollback.py
+python scripts/correction_logger_and_rollback.py --rollback-last  # undo last correction
 ```
 
 ---

--- a/tests/test_disaster_recovery_backup_validation.py
+++ b/tests/test_disaster_recovery_backup_validation.py
@@ -19,6 +19,7 @@ def test_schedule_backup_creates_checksum(tmp_path, monkeypatch):
     workspace = tmp_path / "ws"
     workspace.mkdir()
     backup_root = tmp_path / "backup"
+    backup_root.mkdir()
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
     system = UnifiedDisasterRecoverySystem(str(workspace))
@@ -29,3 +30,30 @@ def test_schedule_backup_creates_checksum(tmp_path, monkeypatch):
     assert hash_file.exists()
     digest = hashlib.sha256(backup_file.read_bytes()).hexdigest()
     assert hash_file.read_text().strip() == digest
+
+
+def test_backup_invocation_on_core_databases(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    db_dir = workspace / "databases"
+    db_dir.mkdir(parents=True)
+    (db_dir / "production.db").write_text("prod")
+    (db_dir / "analytics.db").write_text("analytics")
+    backup_root = tmp_path / "backup"
+    backup_root.mkdir()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+
+    calls = []
+
+    def fake_schedule(self, max_backups=None):  # noqa: ANN001
+        calls.append(True)
+        backup_file = backup_root / "dummy.bak"
+        backup_file.write_text("backup")
+        return backup_file
+
+    monkeypatch.setattr(
+        "unified_disaster_recovery_system.BackupScheduler.schedule", fake_schedule
+    )
+    system = UnifiedDisasterRecoverySystem(str(workspace))
+    backup_file = system.schedule_backups()
+    assert calls and backup_file.exists()


### PR DESCRIPTION
## Summary
- document rollback usage via `scripts/correction_logger_and_rollback.py --rollback-last`
- add unit test simulating backup invocation on core databases

## Testing
- `ruff check tests/test_disaster_recovery_backup_validation.py`
- `pytest --override-ini="addopts=" tests/test_disaster_recovery_backup_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689867d823ec8331a35837d01547c8c6