### PR TITLE
feat: add placeholder audit API and dashboard visuals

### DIFF
--- a/dashboard/static/placeholder_chart.js
+++ b/dashboard/static/placeholder_chart.js
@@ -1,6 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
     const canvas = document.getElementById('placeholderChart');
     const tableBody = document.getElementById('unresolvedBody');
+    const openCount = document.getElementById('placeholderOpenCount');
+    const resolvedCount = document.getElementById('placeholderResolvedCount');
     if (!canvas || typeof Chart === 'undefined') {
         return;
     }
@@ -33,12 +35,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     function refresh() {
-        fetch('/api/placeholder_history').then(r => r.json()).then(data => {
+        fetch('/api/placeholder_audit').then(r => r.json()).then(data => {
             const history = data.history || [];
             chart.data.labels = history.map(h => new Date(h.timestamp * 1000).toLocaleString());
             chart.data.datasets[0].data = history.map(h => h.open);
             chart.data.datasets[1].data = history.map(h => h.resolved);
             chart.update();
+            if (history.length && openCount && resolvedCount) {
+                const latest = history[history.length - 1];
+                openCount.textContent = latest.open;
+                resolvedCount.textContent = latest.resolved;
+            }
             if (tableBody) {
                 tableBody.innerHTML = '';
                 (data.unresolved || []).forEach(row => {
@@ -47,8 +54,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     fileTd.textContent = row.file;
                     const lineTd = document.createElement('td');
                     lineTd.textContent = row.line;
+                    const typeTd = document.createElement('td');
+                    typeTd.textContent = row.type;
                     tr.appendChild(fileTd);
                     tr.appendChild(lineTd);
+                    tr.appendChild(typeTd);
+                    if (row.context) {
+                        tr.title = row.context;
+                    }
                     tableBody.appendChild(tr);
                 });
             }

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -258,10 +258,14 @@
     <h3>Compliance Trend</h3>
     <ul id="compliance_trend"></ul>
     <h3>Placeholder History</h3>
+    <div>
+        Open: <span id="placeholderOpenCount">0</span>
+        Resolved: <span id="placeholderResolvedCount">0</span>
+    </div>
     <canvas id="placeholderChart"></canvas>
     <h3>Unresolved Placeholders</h3>
     <table id="unresolvedTable">
-        <thead><tr><th>File</th><th>Line</th></tr></thead>
+        <thead><tr><th>File</th><th>Line</th><th>Type</th></tr></thead>
         <tbody id="unresolvedBody"></tbody>
     </table>
 

--- a/tests/dashboard/test_placeholder_audit_endpoint.py
+++ b/tests/dashboard/test_placeholder_audit_endpoint.py
@@ -1,0 +1,28 @@
+import sqlite3
+
+import dashboard.enterprise_dashboard as ed
+
+
+def test_placeholder_audit_endpoint(tmp_path, monkeypatch):
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE placeholder_audit_snapshots (timestamp INTEGER, open_count INTEGER, resolved_count INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO placeholder_audit_snapshots VALUES (1, 5, 3)"
+        )
+        conn.execute(
+            "CREATE TABLE placeholder_audit (id INTEGER PRIMARY KEY, file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO placeholder_audit (file_path, line_number, placeholder_type, context) VALUES ('file.py', 10, 'TODO', 'fix this')"
+        )
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+
+    client = ed.app.test_client()
+    resp = client.get("/api/placeholder_audit")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["history"][0]["open"] == 5
+    assert data["unresolved"][0]["type"] == "TODO"

--- a/tests/dashboard/test_placeholder_audit_rendering.py
+++ b/tests/dashboard/test_placeholder_audit_rendering.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def test_placeholder_chart_uses_new_endpoint():
+    content = Path("dashboard/static/placeholder_chart.js").read_text()
+    assert "/api/placeholder_audit" in content
+    assert "placeholderOpenCount" in content
+    assert "title" in content  # tooltip support
+
+
+def test_dashboard_template_includes_counts():
+    content = Path("dashboard/templates/dashboard.html").read_text()
+    assert 'id="placeholderOpenCount"' in content
+    assert '<th>Type</th>' in content


### PR DESCRIPTION
## Summary
- expose `/api/placeholder_audit` with snapshot history and unresolved placeholder details
- render placeholder audit counts, trend chart, and tooltip context on dashboard
- test endpoint and front-end wiring

## Testing
- `ruff check dashboard/enterprise_dashboard.py tests/dashboard/test_placeholder_audit_endpoint.py tests/dashboard/test_placeholder_audit_rendering.py`
- `pytest tests/dashboard/test_placeholder_audit_endpoint.py tests/dashboard/test_placeholder_audit_rendering.py`
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689867dc15ac8331b4373ade9929e82c