### PR TITLE
fix: clarify placeholder audit insert counters

### DIFF
--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -242,7 +242,7 @@ def log_placeholder_tasks(
         if "suggestion" not in cols:
             conn.execute("ALTER TABLE todo_fixme_tracking ADD COLUMN suggestion TEXT")
         author = os.getenv("GH_COPILOT_USER", getpass.getuser())
-        inserted = 0
+        tasks_inserted = 0
         for task in tasks:
             key = (task["file"], int(task["line"]), task["pattern"], task["context"])
 
@@ -275,7 +275,7 @@ def log_placeholder_tasks(
                         author,
                     ),
                 )
-                inserted += 1
+                tasks_inserted += 1
 
             # Mirror entry in legacy todo_fixme_tracking table
             cur = conn.execute(
@@ -307,7 +307,7 @@ def log_placeholder_tasks(
                     ),
                 )
         conn.commit()
-    return inserted
+    return tasks_inserted
 
 
 def verify_task_completion(analytics_db: Path, workspace: Path) -> int:
@@ -578,7 +578,7 @@ def log_findings(
             "[TEST MODE] Simulation enabled: not writing to analytics.db",
         )
         return 0
-    inserted = 0
+    findings_inserted = 0
     with sqlite3.connect(analytics_db) as conn:
         _ensure_placeholder_tables(conn)
         conn.execute(
@@ -681,9 +681,9 @@ def log_findings(
                         " VALUES (?, ?, ?, ?, ?, 'open')",
                         values[:-1],
                     )
-                    inserted += 1
+                    findings_inserted += 1
         conn.commit()
-    return inserted
+    return findings_inserted
 
 
 

--- a/tests/placeholder_audit/test_metrics_logging.py
+++ b/tests/placeholder_audit/test_metrics_logging.py
@@ -180,3 +180,44 @@ def test_metrics_updater_runs_without_task_insertion(tmp_path, monkeypatch):
     )
 
     assert updates == ["called"]
+
+
+def test_metrics_logged_without_task_insertion(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "d.py").write_text("# TODO\n")
+
+    analytics = tmp_path / "analytics.db"
+    dash_dir = tmp_path / "dashboard"
+
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    monkeypatch.setattr(secondary_copilot_validator, "run_flake8", lambda *a, **k: True)
+    monkeypatch.setattr(
+        secondary_copilot_validator,
+        "SecondaryCopilotValidator",
+        lambda: SimpleNamespace(validate_corrections=lambda *a, **k: True),
+    )
+    monkeypatch.setattr("scripts.code_placeholder_audit.log_placeholder_tasks", lambda *a, **k: 0)
+    monkeypatch.setattr("scripts.code_placeholder_audit.collect_metrics", _fake_collect_metrics)
+    monkeypatch.setattr("scripts.code_placeholder_audit.push_metrics", _fake_push_metrics)
+    monkeypatch.setattr(
+        "scripts.code_placeholder_audit.ComplianceMetricsUpdater",
+        lambda *a, **k: SimpleNamespace(
+            update=lambda *a, **k: None, validate_update=lambda *a, **k: True
+        ),
+    )
+
+    main(
+        workspace_path=str(workspace),
+        analytics_db=str(analytics),
+        production_db=None,
+        dashboard_dir=str(dash_dir / "compliance"),
+    )
+
+    with sqlite3.connect(analytics) as conn:
+        cur = conn.execute(
+            "SELECT metrics_json FROM monitoring_metrics ORDER BY id DESC LIMIT 1"
+        )
+        row = cur.fetchone()
+        data = json.loads(row[0])
+        assert "placeholder_open" in data


### PR DESCRIPTION
## Summary
- clarify logging counts in placeholder audit functions
- ensure metrics updates run even when no tasks are inserted

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder_audit/test_metrics_logging.py`
- `pytest tests/placeholder_audit/test_metrics_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_689924e3c3bc8331ac4993e045335821