### PR TITLE
docs: remove outdated analytics test reference

### DIFF
--- a/docs/testing/failing_modules.md
+++ b/docs/testing/failing_modules.md
@@ -1,7 +1,5 @@
 # Failing Test Modules
 
-The following test modules encountered errors:
-
-- `tests/test_analytics_modules.py` – collection error
-
-Source: `failing_tests.log`
+The test suite currently reports 39 collection errors, primarily within
+monitoring and quantum-related modules. See `failing_tests.log` for a detailed
+listing of the affected tests.

--- a/docs/testing/failing_tests.md
+++ b/docs/testing/failing_tests.md
@@ -1,7 +1,4 @@
 # Failing Tests Summary
 
-The following modules reported errors during the latest test run:
-
-- `tests/test_analytics_modules.py` – ImportError: cannot import name `track_active_users` from `analytics.user_behavior`
-
-See `failing_tests.log` for details.
+Recent test runs report numerous collection errors across monitoring and quantum
+modules. Refer to `failing_tests.log` for the complete output and module list.

--- a/failing_tests.log
+++ b/failing_tests.log
@@ -2,11 +2,11 @@
 platform linux -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0
 rootdir: /workspace/gh_COPILOT
 configfile: pytest.ini
-plugins: anyio-4.10.0, cov-6.2.1, timeout-2.4.0
+plugins: timeout-2.4.0, anyio-4.10.0, cov-6.2.1
 timeout: 120.0s
 timeout method: signal
 timeout func_only: False
-collected 1383 items / 39 errors / 2 skipped
+collected 1384 items / 39 errors / 2 skipped
 
 ============================================================ ERRORS ============================================================
 ___________________________________ ERROR collecting tests/monitoring/anomaly/test_model.py ____________________________________
@@ -533,4 +533,4 @@ ERROR tests/test_unified_monitoring_optimization_system.py
 ERROR tests/test_unified_wrapup_orchestrator_postinit.py
 ERROR tests/test_unified_wrapup_orchestrator_validation.py
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 39 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-========================================= 2 skipped, 46 warnings, 39 errors in 22.71s ==========================================
+========================================== 2 skipped, 46 warnings, 39 errors in 9.52s ==========================================


### PR DESCRIPTION
## Summary
- document current failing test suite without outdated `tests/test_analytics_modules.py` mention
- refresh `failing_tests.log` with latest pytest run

## Testing
- `pytest -o addopts="--maxfail=1000" >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`
- `ruff check tests/test_analytics_modules.py`

------
https://chatgpt.com/codex/tasks/task_e_68992dc1b0708331b90136c6206bba3a