### PR TITLE
fix: restrict placeholder suggestions to workspace

### DIFF
--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -695,9 +695,12 @@ def apply_suggestions_to_files(
     workspace: Path,
     simulate: bool = False,
 ) -> List[Dict[str, str]]:
-    """Apply generated suggestions to source files.
+    """Apply generated suggestions to source files within ``workspace``.
 
-    Returns a list of tasks that could not be applied and remain unresolved."""
+    Any task whose path resolves outside the provided ``workspace`` is skipped
+    and logged. Returns a list of tasks that could not be applied and remain
+    unresolved.
+    """
 
     if simulate:
         return tasks
@@ -714,7 +717,11 @@ def apply_suggestions_to_files(
             resolved = path.resolve()
             resolved.relative_to(ws_resolved)
         except Exception:
-            log_message(__name__, f"{TEXT['warn']} skipping outside workspace: {path}")
+            log_message(
+                __name__,
+                f"{TEXT['warn']} skipping outside workspace: {path}",
+                level=logging.WARNING,
+            )
             unresolved.append(task)
             continue
         try:

--- a/tests/placeholder/test_code_placeholder_audit.py
+++ b/tests/placeholder/test_code_placeholder_audit.py
@@ -172,7 +172,7 @@ def test_apply_suggestions_updates_file_and_db(tmp_path, monkeypatch):
     assert unresolved == 0
 
 
-def test_apply_suggestions_ignores_files_outside_workspace(tmp_path):
+def test_apply_suggestions_ignores_files_outside_workspace(tmp_path, capsys):
     workspace = tmp_path / "ws"
     workspace.mkdir()
     outside = tmp_path / "outside.py"
@@ -188,8 +188,10 @@ def test_apply_suggestions_ignores_files_outside_workspace(tmp_path):
         }
     ]
     unresolved = audit.apply_suggestions_to_files(tasks, analytics_db, workspace)
+    out, _ = capsys.readouterr()
     assert unresolved == tasks
     assert outside.read_text(encoding="utf-8") == "# FIXME: adjust\n"
+    assert "outside workspace" in out
 
 
 def test_placeholder_tasks_logged(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure `apply_suggestions_to_files` only edits files inside the workspace and warn otherwise
- test that out-of-tree files are skipped when applying suggestions

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder/test_code_placeholder_audit.py`
- `pytest tests/placeholder/test_code_placeholder_audit.py::test_apply_suggestions_ignores_files_outside_workspace -q`

------
https://chatgpt.com/codex/tasks/task_e_68993c9a4c8c8331bf4cf18d15dda013