### PR TITLE
feat: add compliance route and git sha footer

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -4,10 +4,27 @@ from __future__ import annotations
 
 import csv
 import io
+import subprocess
 from flask import Response
 
 from .enterprise_dashboard import app
+from .routes import register_routes
 from scripts.compliance.update_compliance_metrics import fetch_recent_compliance
+
+
+GIT_SHA = (
+    subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
+)
+
+
+@app.context_processor
+def inject_git_sha() -> dict[str, str]:
+    """Expose current Git SHA to all templates."""
+    return {"git_sha": GIT_SHA}
+
+
+# Register additional blueprint routes such as compliance page
+register_routes(app)
 
 
 @app.route("/api/compliance_scores.csv")

--- a/dashboard/routes/__init__.py
+++ b/dashboard/routes/__init__.py
@@ -1,1 +1,18 @@
 """Flask route blueprints for dashboard."""
+
+from __future__ import annotations
+
+from flask import Flask
+
+from .corrections import bp as corrections_bp
+from .compliance import bp as compliance_bp
+
+
+def register_routes(app: Flask) -> None:
+    """Register dashboard blueprints on the given Flask app."""
+    app.register_blueprint(corrections_bp)
+    app.register_blueprint(compliance_bp)
+
+
+__all__ = ["register_routes", "corrections_bp", "compliance_bp"]
+

--- a/dashboard/routes/compliance.py
+++ b/dashboard/routes/compliance.py
@@ -1,0 +1,22 @@
+"""Serve compliance metrics page for the dashboard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from flask import Blueprint, render_template
+
+bp = Blueprint(
+    "dashboard_compliance",
+    __name__,
+    template_folder=str(Path(__file__).resolve().parents[1] / "templates"),
+)
+
+
+@bp.route("/compliance")
+def compliance_page() -> str:
+    """Render the compliance metrics page."""
+    return render_template("compliance.html")
+
+
+__all__ = ["bp"]
+

--- a/dashboard/templates/audit_results.html
+++ b/dashboard/templates/audit_results.html
@@ -12,5 +12,6 @@
       <li>{{ row.placeholder_type }}: {{ row.count }}</li>
     {% endfor %}
     </ul>
+  {% include 'footer.html' %}
   </body>
 </html>

--- a/dashboard/templates/compliance.html
+++ b/dashboard/templates/compliance.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+    <title>Compliance Metrics</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <script>
+        function loadCompliance() {
+            fetch('/api/compliance_scores').then(r => r.json()).then(data => {
+                const scores = data.scores || [];
+                if (!scores.length) return;
+                const latest = scores[0];
+                const ts = latest.timestamp;
+                const composite = document.getElementById('composite');
+                composite.textContent = latest.composite;
+                composite.title = `Definition: composite compliance score. Units: points. Cadence: periodic. Last update: ${ts}`;
+                const lint = document.getElementById('lint_score');
+                lint.textContent = latest.lint_score;
+                lint.title = `Definition: percentage of files passing lint checks. Units: percent. Cadence: periodic. Last update: ${ts}`;
+                const test = document.getElementById('test_score');
+                test.textContent = latest.test_score;
+                test.title = `Definition: percentage of tests passing. Units: percent. Cadence: periodic. Last update: ${ts}`;
+                const placeholder = document.getElementById('placeholder_score');
+                placeholder.textContent = latest.placeholder_score;
+                placeholder.title = `Definition: progress removing placeholders. Units: percent. Cadence: periodic. Last update: ${ts}`;
+            });
+        }
+        document.addEventListener('DOMContentLoaded', loadCompliance);
+    </script>
+</head>
+<body>
+<h1>Compliance Metrics</h1>
+<table>
+    <tr><th>Metric</th><th>Value</th></tr>
+    <tr><td>Composite</td><td id="composite" title="Definition: composite compliance score. Units: points. Cadence: periodic. Last update: unknown">--</td></tr>
+    <tr><td>Lint Score</td><td id="lint_score" title="Definition: percentage of files passing lint checks. Units: percent. Cadence: periodic. Last update: unknown">--</td></tr>
+    <tr><td>Test Score</td><td id="test_score" title="Definition: percentage of tests passing. Units: percent. Cadence: periodic. Last update: unknown">--</td></tr>
+    <tr><td>Placeholder Score</td><td id="placeholder_score" title="Definition: progress removing placeholders. Units: percent. Cadence: periodic. Last update: unknown">--</td></tr>
+</table>
+{% include 'footer.html' %}
+</body>
+</html>
+

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -223,6 +223,7 @@
 <h1>Compliance Dashboard</h1>
 <nav>
     <a href="/corrections/view">Corrections</a>
+    <a href="/compliance">Compliance</a>
 </nav>
 <div>
     <strong>Placeholder Removals:</strong> <span id="placeholder_removal">{{ metrics.placeholder_removal | default(0) }}</span><br>
@@ -311,5 +312,6 @@
     <li>{{ row.placeholder_type }}: {{ row.count }}</li>
 {% endfor %}
 </ul>
+{% include 'footer.html' %}
 </body>
 </html>

--- a/dashboard/templates/footer.html
+++ b/dashboard/templates/footer.html
@@ -1,0 +1,4 @@
+<footer>
+    <small>Git SHA: {{ git_sha }}</small>
+</footer>
+

--- a/dashboard/templates/metrics.html
+++ b/dashboard/templates/metrics.html
@@ -34,6 +34,7 @@
     </li>
 {% endfor %}
 </ul>
+{% include 'footer.html' %}
 
 </body>
 </html>

--- a/dashboard/templates/rollback_logs.html
+++ b/dashboard/templates/rollback_logs.html
@@ -11,6 +11,7 @@
     <li>{{ log.timestamp }} - {{ log.target }}{% if log.backup %} ({{ log.backup }}){% endif %}</li>
 {% endfor %}
 </ul>
+{% include 'footer.html' %}
 </body>
 </html>
 

--- a/dashboard/templates/sync_events.html
+++ b/dashboard/templates/sync_events.html
@@ -11,5 +11,6 @@
     <li>{{ event.timestamp }} - {{ event.source_db }} -> {{ event.target_db }} ({{ event.action }})</li>
 {% endfor %}
 </ul>
+{% include 'footer.html' %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add compliance dashboard page with tooltip metrics
- expose current git SHA to templates via footer
- register dashboard blueprints and add navigation link

## Testing
- `ruff check dashboard tests/test_dashboard.py`
- `pytest tests/test_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_689a05d676fc8331a8c653df7a547ce0