### PR TITLE
fix: handle empty placeholder sets as fully compliant

### DIFF
--- a/scripts/compliance/update_compliance_metrics.py
+++ b/scripts/compliance/update_compliance_metrics.py
@@ -142,11 +142,10 @@ def _compute(c: ComplianceComponents) -> Tuple[float, float, float, float]:
     L = min(100.0, max(0.0, 100.0 - float(c.ruff_issues)))
     T = (float(c.tests_passed) / c.tests_total * 100.0) if c.tests_total else 0.0
     denom = c.placeholders_open + c.placeholders_resolved
-    placeholder_score = (
-        float(c.placeholders_resolved) / denom * 100.0
-        if denom
-        else 100.0
-    )
+    if denom == 0:
+        placeholder_score = 100.0
+    else:
+        placeholder_score = float(c.placeholders_resolved) / denom * 100.0
     composite = 0.3 * L + 0.5 * T + 0.2 * placeholder_score
     return L, T, placeholder_score, composite
 

--- a/tests/compliance/test_composite_bounds.py
+++ b/tests/compliance/test_composite_bounds.py
@@ -33,7 +33,7 @@ def _compute(c: ComplianceComponents) -> Tuple[float, float, float, float]:
 
 def test_composite_bounds_extremes():
     """Test extreme values for composite score bounds."""
-    # ruff_issues = 0 (best), no tests executed, no placeholders -> P fallback 0
+    # ruff_issues = 0 (best), no tests executed, no placeholders -> P defaults to 100
     c = ComplianceComponents(
         ruff_issues=0,
         tests_passed=0,

--- a/tests/compliance/test_update_compliance_metrics.py
+++ b/tests/compliance/test_update_compliance_metrics.py
@@ -333,6 +333,11 @@ class TestUpdateComplianceMetrics:
             with patch.dict(os.environ, {"GH_COPILOT_WORKSPACE": str(workspace)}):
                 score = update_compliance_metrics()
                 assert score == 50.0  # Expected default score with no placeholders
+                with _connect(analytics_db) as conn:
+                    cur = conn.execute(
+                        "SELECT P FROM compliance_scores ORDER BY id DESC LIMIT 1"
+                    )
+                    assert cur.fetchone()[0] == 100.0
 
     def test_update_compliance_metrics_custom_db_path(self, temp_workspace):
         """Test update with custom database path."""
@@ -344,6 +349,11 @@ class TestUpdateComplianceMetrics:
         
         score = update_compliance_metrics(str(temp_workspace), custom_db)
         assert score == 50.0  # Expected default score with no placeholders
+        with _connect(custom_db) as conn:
+            cur = conn.execute(
+                "SELECT P FROM compliance_scores ORDER BY id DESC LIMIT 1"
+            )
+            assert cur.fetchone()[0] == 100.0
 
 
 class TestEdgeCases:


### PR DESCRIPTION
## Summary
- ensure compliance metrics treat zero placeholders as a perfect placeholder score
- verify databases record placeholder_score=100 when no placeholders exist
- clarify composite bounds test for no placeholders

## Testing
- `ruff check scripts/compliance/update_compliance_metrics.py tests/compliance/test_update_compliance_metrics.py tests/compliance/test_composite_bounds.py`
- `pytest tests/compliance` *(fails: tests/compliance/test_session_lifecycle_metrics.py::TestSessionLifecycle::test_session_duration_calculation)*
- `pytest tests/compliance/test_update_compliance_metrics.py tests/compliance/test_composite_bounds.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a1d465a488331aa88a4cab79fe7ca