### PR TITLE
feat: add enterprise compliance validator

### DIFF
--- a/secondary_copilot_validator.py
+++ b/secondary_copilot_validator.py
@@ -1,7 +1,12 @@
-"""Compatibility wrapper exposing secondary validation utilities."""
+"""Compatibility wrapper exposing validation utilities.
+
+This module now also provides access to the enterprise compliance validator
+which aggregates analytics metrics into a composite score.
+"""
 
 from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
 from utils.validation_utils import run_dual_copilot_validation
+from validation.enterprise_compliance_validator import EnterpriseComplianceValidator
 
 
 def run_flake8(files: list[str]) -> bool:
@@ -16,8 +21,22 @@ def run_flake8(files: list[str]) -> bool:
     return validator.validate_corrections(files)
 
 
+def record_compliance_metrics() -> float:
+    """Collect and persist a composite compliance score.
+
+    The returned value represents the composite score computed from lint,
+    test, placeholder, and session metrics stored in ``analytics.db``.
+    """
+
+    validator = EnterpriseComplianceValidator()
+    result = validator.evaluate()
+    return result["composite_score"]
+
+
 __all__ = [
     "SecondaryCopilotValidator",
     "run_dual_copilot_validation",
     "run_flake8",
+    "EnterpriseComplianceValidator",
+    "record_compliance_metrics",
 ]

--- a/tests/validation/test_enterprise_compliance_validator.py
+++ b/tests/validation/test_enterprise_compliance_validator.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from validation.enterprise_compliance_validator import (
+    EnterpriseComplianceValidator,
+)
+import secondary_copilot_validator as wrapper
+
+
+def _setup_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE ruff_issue_log(run_timestamp INTEGER, issues INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO ruff_issue_log(run_timestamp, issues) VALUES(1, 5)"
+        )
+        conn.execute(
+            "CREATE TABLE test_run_stats(run_timestamp INTEGER, passed INTEGER, total INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO test_run_stats(run_timestamp, passed, total) VALUES(1, 8, 10)"
+        )
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking(id INTEGER PRIMARY KEY, status TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO todo_fixme_tracking(status) VALUES (?)",
+            [("open",), ("resolved",)],
+        )
+        conn.execute(
+            "CREATE TABLE session_lifecycle(session_id TEXT, status TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO session_lifecycle(session_id, status) VALUES (?, ?)",
+            [("a", "success"), ("b", "failed")],
+        )
+
+
+def test_evaluate_success(tmp_path: Path) -> None:
+    db = tmp_path / "analytics.db"
+    _setup_db(db)
+    validator = EnterpriseComplianceValidator(db)
+    metrics = validator.evaluate()
+    assert metrics["lint_issues"] == 5
+    assert metrics["tests_passed"] == 8
+    assert metrics["tests_failed"] == 2
+    assert metrics["placeholders_open"] == 1
+    assert metrics["placeholders_resolved"] == 1
+    assert metrics["composite_score"] > 0
+    with sqlite3.connect(db) as conn:
+        cur = conn.execute(
+            "SELECT COUNT(*) FROM enterprise_compliance_scores"
+        )
+        assert cur.fetchone()[0] == 1
+
+
+def test_missing_database(tmp_path: Path) -> None:
+    db = tmp_path / "missing.db"
+    validator = EnterpriseComplianceValidator(db)
+    with pytest.raises(FileNotFoundError):
+        validator.evaluate()
+
+
+def test_wrapper_function(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "analytics.db"
+    _setup_db(db)
+
+    def _factory() -> EnterpriseComplianceValidator:
+        return EnterpriseComplianceValidator(db)
+
+    monkeypatch.setattr(wrapper, "EnterpriseComplianceValidator", _factory)
+    score = wrapper.record_compliance_metrics()
+    assert score > 0
+

--- a/validation/enterprise_compliance_validator.py
+++ b/validation/enterprise_compliance_validator.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from utils.validation_utils import calculate_composite_compliance_score
+
+DEFAULT_DB_PATH = Path("databases/analytics.db")
+
+
+class EnterpriseComplianceValidator:
+    """Aggregate compliance metrics and persist a composite score.
+
+    The validator gathers lint, test, placeholder, and session metrics from
+    ``analytics.db``. It computes a composite compliance score using existing
+    project utilities and stores the result in the database for later
+    consumption by other components.
+    """
+
+    def __init__(self, db_path: Path | str = DEFAULT_DB_PATH) -> None:
+        self.db_path = Path(db_path)
+
+    # ------------------------------------------------------------------
+    # database helpers
+    # ------------------------------------------------------------------
+    def _table_exists(self, cur: sqlite3.Cursor, table: str) -> bool:
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        )
+        return cur.fetchone() is not None
+
+    def _fetch_latest(self, cur: sqlite3.Cursor, table: str, columns: str) -> Tuple[int, ...]:
+        try:
+            cur.execute(
+                f"SELECT {columns} FROM {table} ORDER BY 1 DESC LIMIT 1"
+            )
+            row = cur.fetchone()
+            if row:
+                return tuple(int(x or 0) for x in row)
+        except sqlite3.Error:
+            pass
+        return tuple(0 for _ in columns.split(","))
+
+    def _count(self, cur: sqlite3.Cursor, table: str, where: str) -> int:
+        try:
+            cur.execute(f"SELECT COUNT(*) FROM {table} WHERE {where}")
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+        except sqlite3.Error:
+            return 0
+
+    # ------------------------------------------------------------------
+    def aggregate_metrics(self) -> Dict[str, int]:
+        """Return aggregated metrics from ``analytics.db``.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the analytics database does not exist.
+        """
+
+        if not self.db_path.exists():
+            raise FileNotFoundError(f"analytics database not found: {self.db_path}")
+
+        metrics: Dict[str, int] = {
+            "lint_issues": 0,
+            "tests_passed": 0,
+            "tests_failed": 0,
+            "placeholders_open": 0,
+            "placeholders_resolved": 0,
+            "sessions": 0,
+        }
+
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+
+            # lint issues from ruff_issue_log
+            lint, = self._fetch_latest(cur, "ruff_issue_log", "issues")
+            metrics["lint_issues"] = lint
+
+            # test results from test_run_stats
+            passed, total = self._fetch_latest(cur, "test_run_stats", "passed,total")
+            metrics["tests_passed"] = passed
+            metrics["tests_failed"] = max(0, total - passed)
+
+            # placeholder metrics from todo_fixme_tracking if available
+            if self._table_exists(cur, "todo_fixme_tracking"):
+                metrics["placeholders_open"] = self._count(
+                    cur, "todo_fixme_tracking", "status='open'"
+                )
+                metrics["placeholders_resolved"] = self._count(
+                    cur, "todo_fixme_tracking", "status='resolved'"
+                )
+
+            # session metrics from session_lifecycle
+            if self._table_exists(cur, "session_lifecycle"):
+                cur.execute(
+                    "SELECT COUNT(*) FROM session_lifecycle WHERE status='success'"
+                )
+                row = cur.fetchone()
+                metrics["sessions"] = int(row[0]) if row else 0
+
+        return metrics
+
+    def persist_score(self, metrics: Dict[str, int]) -> float:
+        """Persist composite compliance score and return it."""
+
+        scores = calculate_composite_compliance_score(
+            metrics["lint_issues"],
+            metrics["tests_passed"],
+            metrics["tests_failed"],
+            metrics["placeholders_open"],
+            metrics["placeholders_resolved"],
+        )
+        composite = scores["composite"]
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS enterprise_compliance_scores (
+                    timestamp TEXT,
+                    lint_issues INTEGER,
+                    tests_passed INTEGER,
+                    tests_failed INTEGER,
+                    placeholders_open INTEGER,
+                    placeholders_resolved INTEGER,
+                    composite_score REAL
+                )
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO enterprise_compliance_scores (
+                    timestamp, lint_issues, tests_passed, tests_failed,
+                    placeholders_open, placeholders_resolved, composite_score
+                ) VALUES (?,?,?,?,?,?,?)
+                """,
+                (
+                    datetime.utcnow().isoformat(),
+                    metrics["lint_issues"],
+                    metrics["tests_passed"],
+                    metrics["tests_failed"],
+                    metrics["placeholders_open"],
+                    metrics["placeholders_resolved"],
+                    composite,
+                ),
+            )
+            conn.commit()
+        return composite
+
+    def evaluate(self) -> Dict[str, Any]:
+        """Aggregate metrics, persist composite score, and return details."""
+        metrics = self.aggregate_metrics()
+        metrics["composite_score"] = self.persist_score(metrics)
+        return metrics
+
+
+__all__ = ["EnterpriseComplianceValidator"]


### PR DESCRIPTION
## Summary
- add EnterpriseComplianceValidator to gather analytics metrics and persist composite scores
- expose compliance metric API via secondary_copilot_validator wrapper
- test aggregation, failure case, and wrapper integration

## Testing
- `ruff check validation/enterprise_compliance_validator.py secondary_copilot_validator.py tests/validation/test_enterprise_compliance_validator.py`
- `pytest tests/validation/test_enterprise_compliance_validator.py -q --no-cov --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_689a1e034a0483319bb9c4a2de291873