### PR TITLE
fix: restrict suggestion application to workspace

### DIFF
--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -713,6 +713,8 @@ def apply_suggestions_to_files(
             unresolved.append(task)
             continue
         path = Path(task["file"])
+        if not path.is_absolute():
+            path = ws_resolved / path
         try:
             resolved = path.resolve()
             resolved.relative_to(ws_resolved)

--- a/tests/placeholder/test_code_placeholder_audit.py
+++ b/tests/placeholder/test_code_placeholder_audit.py
@@ -194,6 +194,28 @@ def test_apply_suggestions_ignores_files_outside_workspace(tmp_path, capsys):
     assert "outside workspace" in out
 
 
+def test_apply_suggestions_ignores_relative_paths_outside_workspace(tmp_path, capsys):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("# TODO: keep\n", encoding="utf-8")
+    analytics_db = tmp_path / "analytics.db"
+    tasks = [
+        {
+            "file": "../outside.py",
+            "line": 1,
+            "pattern": "TODO",
+            "context": "# TODO: keep",
+            "suggestion": "# done",
+        }
+    ]
+    unresolved = audit.apply_suggestions_to_files(tasks, analytics_db, workspace)
+    out, _ = capsys.readouterr()
+    assert unresolved == tasks
+    assert outside.read_text(encoding="utf-8") == "# TODO: keep\n"
+    assert "outside workspace" in out
+
+
 def test_placeholder_tasks_logged(tmp_path, monkeypatch):
     workspace = tmp_path / "ws"
     workspace.mkdir()


### PR DESCRIPTION
## Summary
- guard `apply_suggestions_to_files` against relative paths escaping the workspace
- test suggestion application skips relative paths outside workspace

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder/test_code_placeholder_audit.py`
- `pytest tests/placeholder/test_code_placeholder_audit.py`


------
https://chatgpt.com/codex/tasks/task_e_689a2627be008331b0865522df4941c6