### PR TITLE
feat: track session latency and enforce path safety

### DIFF
--- a/analytics/session_correlator.py
+++ b/analytics/session_correlator.py
@@ -1,0 +1,64 @@
+"""Correlate session provenance and compliance data."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import os
+import sqlite3
+from typing import Optional
+
+
+__all__ = ["correlate_session"]
+
+
+def _db_paths(workspace: Optional[str] = None) -> tuple[Path, Path]:
+    ws = Path(workspace or os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    db_dir = ws / "databases"
+    return db_dir / "production.db", db_dir / "analytics.db"
+
+
+def correlate_session(session_id: str, *, workspace: Optional[str] = None) -> Path:
+    """Join production and analytics data for ``session_id`` and flag anomalies.
+
+    Any mismatches or compliance issues are written to
+    ``monitoring/session_anomalies.log``.
+    """
+
+    prod_db, analytics_db = _db_paths(workspace)
+    ws = Path(workspace or os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))
+    monitor_dir = ws / "monitoring"
+    monitor_dir.mkdir(parents=True, exist_ok=True)
+    log_file = monitor_dir / "session_anomalies.log"
+
+    with sqlite3.connect(prod_db) as p_conn, sqlite3.connect(analytics_db) as a_conn:
+        p_conn.row_factory = sqlite3.Row
+        a_conn.row_factory = sqlite3.Row
+        p_row = p_conn.execute(
+            "SELECT status, p50_latency, p90_latency, p99_latency, retry_trace FROM session_lifecycle WHERE session_id=?",
+            (session_id,),
+        ).fetchone()
+        a_row = a_conn.execute(
+            "SELECT zero_byte_files, status FROM wrap_up_metrics WHERE session_id=?",
+            (session_id,),
+        ).fetchone()
+
+    anomalies: list[str] = []
+    if not p_row or not a_row:
+        anomalies.append("missing_records")
+    else:
+        if a_row["status"] != p_row["status"]:
+            anomalies.append("status_mismatch")
+        if a_row["zero_byte_files"]:
+            anomalies.append("zero_byte_files_present")
+        if p_row["p99_latency"] and p_row["p99_latency"] > 1.0:
+            anomalies.append("high_latency")
+        if p_row["retry_trace"]:
+            anomalies.append("retries_detected")
+
+    if anomalies:
+        with open(log_file, "a", encoding="utf-8") as fh:
+            fh.write(
+                f"{datetime.utcnow().isoformat()} {session_id} {';'.join(anomalies)}\n"
+            )
+    return log_file

--- a/tests/test_session_correlation.py
+++ b/tests/test_session_correlation.py
@@ -1,0 +1,64 @@
+import sqlite3
+
+import pytest
+
+from session.session_lifecycle_metrics import (
+    end_session,
+    record_latency,
+    record_retry,
+    start_session,
+)
+from unified_session_management_system import ensure_no_zero_byte_files
+from analytics.session_correlator import correlate_session
+
+
+def test_latency_capture_and_correlation(tmp_path):
+    workspace = tmp_path
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+    prod_db = db_dir / "production.db"
+    analytics_db = db_dir / "analytics.db"
+    sqlite3.connect(prod_db).close()
+    sqlite3.connect(analytics_db).close()
+
+    session_id = "s1"
+    start_session(session_id, workspace=str(workspace))
+    for val in (0.1, 0.2, 0.4):
+        record_latency(session_id, val, workspace=str(workspace))
+    record_retry(session_id, "retry1", workspace=str(workspace))
+
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            """CREATE TABLE wrap_up_metrics (
+            session_id TEXT, zero_byte_files INTEGER, status TEXT, duration_seconds REAL)
+            """
+        )
+        conn.execute(
+            "INSERT INTO wrap_up_metrics VALUES (?, ?, ?, ?)",
+            (session_id, 1, "failed", 0.5),
+        )
+        conn.commit()
+
+    end_session(session_id, workspace=str(workspace))
+
+    with sqlite3.connect(prod_db) as conn:
+        row = conn.execute(
+            "SELECT p50_latency, p90_latency, p99_latency, retry_trace FROM session_lifecycle WHERE session_id=?",
+            (session_id,),
+        ).fetchone()
+    assert row[0] == pytest.approx(0.2)
+    assert row[1] == pytest.approx(0.4)
+    assert row[2] == pytest.approx(0.4)
+    assert "retry1" in row[3]
+
+    bad_dir = workspace / "backup"
+    bad_dir.mkdir()
+    with pytest.raises(RuntimeError):
+        with ensure_no_zero_byte_files(bad_dir, session_id):
+            pass
+
+    log_file = correlate_session(session_id, workspace=str(workspace))
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert session_id in content
+    assert "status_mismatch" in content


### PR DESCRIPTION
## Summary
- capture p50/p90/p99 latencies and retry traces in `production.db`
- harden session management with allow/deny path checks
- correlate session provenance across production and analytics databases
- add integration test for latency metrics, anti-recursion, and correlation

## Testing
- `ruff check session/session_lifecycle_metrics.py unified_session_management_system.py analytics/session_correlator.py tests/test_session_correlation.py`
- `pytest tests/test_session_correlation.py`

------
https://chatgpt.com/codex/tasks/task_e_689a2c3f8eec8331a42951b41a98cdfa