### PR TITLE
docs: document safe ripgrep usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,22 @@ Thank you for considering a contribution to gh_COPILOT. Please follow these guid
 - Use conventional commit messages and reference these standards in your pull requests.
 - Follow the [Git LFS recovery guide](docs/git_lfs_recovery.md) when restoring large binary files.
 
+## Safe `rg` usage for large repositories
+
+Use [`rg`](https://github.com/BurntSushi/ripgrep) carefully to avoid overwhelming the console:
+
+- Limit scope with globs or directory exclusions and cap matches.
+  Example:
+  ```bash
+  set +o pipefail && rg "except\s*:" -g "*.py" --max-count 200 | head
+  ```
+- Ensure downstream tools read all input. Use `set +o pipefail`, `--no-buffer`, and viewers like `head`, `tail`, or `clw`.
+- When truncating output, capture the full results to a temporary log for later review:
+  ```bash
+  set +o pipefail && rg --no-buffer "TODO" -g "*.py" --max-count 200 \
+    | tee /tmp/rg_todo.log | head
+  ```
+
 ## Documentation Workflow Checklist
 
 For daily white-paper updates, ensure the following:


### PR DESCRIPTION
## Summary
- document safe ripgrep usage patterns for large repositories in CONTRIBUTING.md

## Testing
- `set +o pipefail && ruff check . | tee /tmp/ruff.log | tail -n 20`
- `set +o pipefail && pytest -q | tee /tmp/pytest.log | tail -n 20` *(fails: ModuleNotFoundError: No module named 'qiskit')*


------
https://chatgpt.com/codex/tasks/task_e_689a2c80ab588331bdc07daa4a65c724