### PR TITLE
refactor: consolidate compliance scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,8 +603,10 @@ validation through the `SecondaryCopilotValidator`. It records each session in
 Each run inserts a row into the `unified_wrapup_sessions` table with a
 compliance score for audit purposes. Ensure all command output is piped through
 `/usr/local/bin/clw` to avoid exceeding the line length limit.
-The scoring formula blends Ruff issues, pytest pass ratios and placeholder
-resolution statistics. See
+The scoring formula blends Ruff issues, pytest pass ratios, placeholder
+resolution, and session lifecycle success via
+`enterprise_modules.compliance.calculate_compliance_score` and the
+`SCORE_WEIGHTS` constants. See
 [docs/COMPLIANCE_METRICS.md](docs/COMPLIANCE_METRICS.md) for details.
 The table stores `session_id`, timestamps, status, compliance score, and
 optional error details so administrators can audit every session.

--- a/dashboard/compliance_metrics_updater.py
+++ b/dashboard/compliance_metrics_updater.py
@@ -29,7 +29,7 @@ from enterprise_modules.compliance import (
     _run_ruff,
     _run_pytest,
     pid_recursion_guard,
-    calculate_code_quality_score,
+    calculate_compliance_score,
 )
 from disaster_recovery_orchestrator import DisasterRecoveryOrchestrator
 from unified_monitoring_optimization_system import (
@@ -397,7 +397,7 @@ class ComplianceMetricsUpdater:
             ruff_issues = _run_ruff()
             tests_passed, tests_failed = _run_pytest()
 
-        score, breakdown = calculate_code_quality_score(
+        score, breakdown = calculate_compliance_score(
             ruff_issues,
             tests_passed,
             tests_failed,

--- a/dashboard/integrated_dashboard.py
+++ b/dashboard/integrated_dashboard.py
@@ -21,7 +21,7 @@ from tqdm import tqdm
 from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
 from database_first_synchronization_engine import list_events
 from enterprise_modules.compliance import (
-    calculate_composite_score,
+    calculate_compliance_score,
     get_latest_compliance_score,
 )
 from utils.validation_utils import calculate_composite_compliance_score
@@ -83,12 +83,14 @@ def _load_metrics() -> dict[str, Any]:
                     )
                     row = cur.fetchone()
                     if row:
-                        score, breakdown = calculate_composite_score(
+                        score, breakdown = calculate_compliance_score(
                             row["ruff_issues"],
                             row["tests_passed"],
                             row["tests_failed"],
                             row["placeholders_open"],
                             row["placeholders_resolved"],
+                            0,
+                            0,
                         )
                         metrics["code_quality_score"] = score
                         metrics["composite_score"] = score

--- a/docs/COMPLIANCE_METRICS.md
+++ b/docs/COMPLIANCE_METRICS.md
@@ -31,11 +31,11 @@ reported alongside compliance metrics.
 ## Code Quality Composite Score
 
 Lint, test, placeholder, and session lifecycle outcomes are combined into a single score using
-``enterprise_modules.compliance.calculate_code_quality_score`` with weights of 30%, 40%, 20%, and 10% respectively:
+``enterprise_modules.compliance.calculate_compliance_score`` with weights defined in ``SCORE_WEIGHTS`` (30%, 40%, 20%, 10):
 
 ```python
-from enterprise_modules.compliance import calculate_code_quality_score
-score, breakdown = calculate_code_quality_score(
+from enterprise_modules.compliance import calculate_compliance_score, SCORE_WEIGHTS
+score, breakdown = calculate_compliance_score(
     ruff_issues,
     tests_passed,
     tests_failed,
@@ -53,8 +53,8 @@ The helper returns the composite ``score`` along with the ratios used to derive 
 - ``placeholder_resolution_ratio`` – ``placeholders_resolved / total_placeholders``
 - ``session_success_ratio`` – ``sessions_successful / (sessions_successful + sessions_failed)``
 
-The final ``score`` weights ``lint_score`` (30%), ``test_pass_ratio * 100`` (40%),
-``placeholder_resolution_ratio * 100`` (20%), and ``session_success_ratio * 100`` (10%).
+The final ``score`` applies ``SCORE_WEIGHTS`` to ``lint_score``, ``test_pass_ratio * 100``,
+``placeholder_resolution_ratio * 100``, and ``session_success_ratio * 100``.
 
 ### Session Lifecycle Requirements
 

--- a/documentation/phase5_tasks.md
+++ b/documentation/phase5_tasks.md
@@ -1,17 +1,18 @@
 # Phase 5 Composite Compliance Score
 
-The composite compliance score blends linting, tests, and placeholder hygiene into a single 0–100 metric.
+The composite compliance score blends linting, tests, placeholder hygiene, and session health into a single 0–100 metric.
 
 ## Components
 
 - **Lint (L):** `L = max(0, 100 - issues)` where *issues* is the number of ruff findings.
 - **Tests (T):** `T = passed / (passed + failed) * 100`; defaults to `0` if no tests run.
 - **Placeholders (P):** `P = resolved / (open + resolved) * 100`; defaults to `100` when no placeholders exist.
+- **Sessions (S):** `S = successful / (successful + failed) * 100`; defaults to `100` when no sessions recorded.
 
 ## Formula
 
 ```
-score = 0.3 * L + 0.5 * T + 0.2 * P
+score = 0.3 * L + 0.4 * T + 0.2 * P + 0.1 * S
 ```
 
-The function `calculate_composite_score` in `enterprise_modules/compliance.py` returns the overall score and a breakdown of each weighted component, allowing dashboards to surface detailed compliance metrics.
+The function `calculate_compliance_score` in `enterprise_modules/compliance.py` returns the overall score and a breakdown of each weighted component, allowing dashboards to surface detailed compliance metrics.

--- a/phase5_tasks.md
+++ b/phase5_tasks.md
@@ -1,17 +1,16 @@
 # Phase 5 Compliance Scoring
 
-The compliance score blends linting, testing, and placeholder hygiene:
+The compliance score blends linting, testing, placeholder hygiene, and session health:
 
 - **Lint component (L):** `L = max(0, 100 - issues)` where `issues` is the number of Ruff findings.
 - **Test component (T):** `T = passed / (passed + failed) * 100` from pytest results.
 - **Placeholder component (P):** `P = (resolved / (open + resolved)) * 100` with a default of `100` when no placeholders exist.
+- **Session component (S):** `S = successful / (successful + failed) * 100` defaulting to `100` when no sessions recorded.
 
-The weighted composite score is:
+The weighted composite score uses ``SCORE_WEIGHTS`` (30%, 40%, 20%, 10):
 
 ```
-score = 0.3 * L + 0.5 * T + 0.2 * P
+score = 0.3 * L + 0.4 * T + 0.2 * P + 0.1 * S
 ```
 
-This applies weights of **30%** to lint results, **50%** to tests, and **20%** to placeholder cleanup. The score is stored in `analytics.db` and surfaced at `/dashboard/compliance`.
-
-Implemented in [`calculate_composite_score`](enterprise_modules/compliance.py), the function returns the overall score and a breakdown of each weighted component for dashboard use.
+Implemented in [`calculate_compliance_score`](enterprise_modules/compliance.py), the function returns the overall score and a breakdown of each weighted component for dashboard use.

--- a/tests/compliance/test_ingestion_edge_cases.py
+++ b/tests/compliance/test_ingestion_edge_cases.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
-import tempfile
 from pathlib import Path
-from unittest.mock import patch
 import sys
 import pytest
 

--- a/tests/dashboard/test_compliance_metrics.py
+++ b/tests/dashboard/test_compliance_metrics.py
@@ -5,7 +5,7 @@ from validation import compliance_report_generator as crg
 from dashboard import integrated_dashboard as gui
 import dashboard.enterprise_dashboard as ed
 from enterprise_modules.compliance import (
-    calculate_composite_score,
+    calculate_compliance_score,
     persist_compliance_score,
 )
 
@@ -32,7 +32,7 @@ def test_compliance_metrics_breakdown(tmp_path, monkeypatch):
     db = tmp_path / "analytics.db"
     monkeypatch.setattr(ed, "ANALYTICS_DB", db)
 
-    score, breakdown = calculate_composite_score(1, 4, 1, 0, 0)
+    score, breakdown = calculate_compliance_score(1, 4, 1, 0, 0, 0, 0)
     persist_compliance_score(score, breakdown, db)
 
     client = ed.app.test_client()

--- a/tests/dashboard/test_compliance_metrics_updater.py
+++ b/tests/dashboard/test_compliance_metrics_updater.py
@@ -81,7 +81,7 @@ def test_violation_and_rollback_counts_affect_composite(tmp_path, monkeypatch):
     assert metrics["rollback_count"] == 1
     assert metrics["score_breakdown"]["violation_penalty"] == 10
     assert metrics["score_breakdown"]["rollback_penalty"] == 5
-    expected_base = calculate_compliance_score(0, 1, 0, 1, 1)
+    expected_base, _ = calculate_compliance_score(0, 1, 0, 1, 1, 0, 0)
     assert metrics["composite_score"] == pytest.approx(
         expected_base - 15, rel=1e-3
     )

--- a/tests/dashboard/test_composite_score_persistence.py
+++ b/tests/dashboard/test_composite_score_persistence.py
@@ -5,7 +5,7 @@ import pytest
 import dashboard.enterprise_dashboard as ed
 import dashboard.integrated_dashboard as gui
 from enterprise_modules.compliance import (
-    calculate_composite_score,
+    calculate_compliance_score,
     persist_compliance_score,
     record_code_quality_metrics,
 )
@@ -19,7 +19,7 @@ def test_composite_score_persisted_and_served(tmp_path, monkeypatch):
     monkeypatch.setattr(gui, "ANALYTICS_DB", db)
     monkeypatch.setattr(ed, "ANALYTICS_DB", db)
 
-    score, breakdown = calculate_composite_score(5, 8, 2, 1, 4)
+    score, breakdown = calculate_compliance_score(5, 8, 2, 1, 4, 0, 0)
     persist_compliance_score(score, breakdown, db_path=db)
     # ensure persist_compliance_score wrote placeholder_score to history
     with sqlite3.connect(db) as conn:
@@ -28,7 +28,7 @@ def test_composite_score_persisted_and_served(tmp_path, monkeypatch):
         ).fetchone()
         assert row == (pytest.approx(breakdown["placeholder_score"], rel=1e-3), pytest.approx(score, rel=1e-3))
 
-    record_code_quality_metrics(5, 8, 2, 1, 4, db_path=db)
+    record_code_quality_metrics(5, 8, 2, 1, 4, 0, 0, db_path=db)
 
     client = ed.app.test_client()
     resp = client.get("/dashboard/compliance")

--- a/tests/dashboard/test_score_serialization.py
+++ b/tests/dashboard/test_score_serialization.py
@@ -4,7 +4,8 @@ import sqlite3
 import pytest
 
 import dashboard.enterprise_dashboard as ed
-import dashboard.app  # ensure CSV export routes are registered
+# ensure CSV export routes are registered
+import dashboard.app  # noqa: F401
 
 
 def _prepare_metrics(tmp_path, monkeypatch):

--- a/tests/test_code_quality_score.py
+++ b/tests/test_code_quality_score.py
@@ -1,8 +1,8 @@
-from enterprise_modules.compliance import calculate_code_quality_score
+from enterprise_modules.compliance import calculate_compliance_score
 
 
 def test_score_returns_ratios_and_score():
-    score, breakdown = calculate_code_quality_score(0, 10, 0, 0, 5, 1, 0)
+    score, breakdown = calculate_compliance_score(0, 10, 0, 0, 5, 1, 0)
     assert score == 100.0
     assert breakdown["lint_score"] == 100.0
     assert breakdown["test_pass_ratio"] == 1.0
@@ -11,7 +11,7 @@ def test_score_returns_ratios_and_score():
 
 
 def test_score_handles_mixed_inputs():
-    score, breakdown = calculate_code_quality_score(10, 8, 2, 3, 7, 5, 5)
+    score, breakdown = calculate_compliance_score(10, 8, 2, 3, 7, 5, 5)
     assert score == 78.0
     assert breakdown["test_pass_ratio"] == 0.8
     assert breakdown["placeholder_resolution_ratio"] == 0.7
@@ -19,6 +19,6 @@ def test_score_handles_mixed_inputs():
 
 
 def test_score_handles_zero_tests():
-    score, breakdown = calculate_code_quality_score(5, 0, 0, 2, 8, 1, 1)
+    score, breakdown = calculate_compliance_score(5, 0, 0, 2, 8, 1, 1)
     assert breakdown["test_pass_ratio"] == 0.0
     assert round(score, 2) == 49.5

--- a/tests/test_compliance_score.py
+++ b/tests/test_compliance_score.py
@@ -7,15 +7,15 @@ from enterprise_modules import compliance
 
 def test_score_persistence_and_fetch(tmp_path: Path) -> None:
     db = tmp_path / "analytics.db"
-    score = compliance.calculate_compliance_score(1, 2, 0, 0, 0)
-    _, breakdown = compliance.calculate_composite_score(1, 2, 0, 0, 0)
+    score, breakdown = compliance.calculate_compliance_score(1, 2, 0, 0, 0, 0, 0)
     compliance.persist_compliance_score(score, breakdown, db_path=db)
     assert compliance.get_latest_compliance_score(db_path=db) == score
 
 
 def test_composite_score_breakdown() -> None:
-    score, breakdown = compliance.calculate_composite_score(10, 8, 2, 1, 3)
-    assert score == pytest.approx(82.0, rel=1e-3)
+    score, breakdown = compliance.calculate_compliance_score(10, 8, 2, 1, 3, 0, 0)
+    assert score == pytest.approx(84.0, rel=1e-3)
     assert breakdown["lint_score"] == pytest.approx(90.0, rel=1e-3)
     assert breakdown["test_score"] == pytest.approx(80.0, rel=1e-3)
     assert breakdown["placeholder_score"] == pytest.approx(75.0, rel=1e-3)
+    assert breakdown["session_score"] == pytest.approx(100.0, rel=1e-3)

--- a/tests/validation/test_compliance_scoring.py
+++ b/tests/validation/test_compliance_scoring.py
@@ -1,70 +1,74 @@
 """Tests for compliance scoring helpers."""
 
-from enterprise_modules.compliance import (
-    calculate_compliance_score,
-    calculate_composite_score,
-)
+from enterprise_modules.compliance import calculate_compliance_score
 
 
 def test_calculate_compliance_score_matches_phase5_tasks() -> None:
     """Compliance score should match the weighted formula in phase5_tasks.md."""
 
-    score = calculate_compliance_score(
+    score, _ = calculate_compliance_score(
         ruff_issues=10,
         tests_passed=80,
         tests_failed=20,
         placeholders_open=5,
         placeholders_resolved=5,
+        sessions_successful=0,
+        sessions_failed=0,
     )
-    assert score == 77.0
+    assert score == 79.0
 
 
-def test_calculate_composite_score_surfaces_weighted_components() -> None:
+def test_calculate_compliance_score_surfaces_weighted_components() -> None:
     """Composite score should expose individual weighted contributions."""
 
-    score, breakdown = calculate_composite_score(10, 80, 20, 5, 5)
+    score, breakdown = calculate_compliance_score(10, 80, 20, 5, 5, 0, 0)
 
-    assert score == 77.0
+    assert score == 79.0
     assert breakdown["lint_score"] == 90.0
     assert breakdown["test_score"] == 80.0
     assert breakdown["placeholder_score"] == 50.0
+    assert breakdown["session_score"] == 100.0
     assert breakdown["lint_weighted"] == 27.0
-    assert breakdown["test_weighted"] == 40.0
+    assert breakdown["test_weighted"] == 32.0
     assert breakdown["placeholder_weighted"] == 10.0
+    assert breakdown["session_weighted"] == 10.0
     assert (
         breakdown["lint_weighted"]
         + breakdown["test_weighted"]
         + breakdown["placeholder_weighted"]
+        + breakdown["session_weighted"]
         == score
     )
 
 
-def test_calculate_composite_score_handles_no_tests_or_placeholders() -> None:
-    """Score should fall back to lint and placeholder defaults when data missing."""
+def test_calculate_compliance_score_handles_no_tests_or_placeholders() -> None:
+    """Score should fall back to defaults when data missing."""
 
-    score, breakdown = calculate_composite_score(0, 0, 0, 0, 0)
+    score, breakdown = calculate_compliance_score(0, 0, 0, 0, 0, 0, 0)
 
-    assert score == 50.0
+    assert score == 60.0
     assert breakdown["lint_weighted"] == 30.0
     assert breakdown["test_weighted"] == 0.0
     assert breakdown["placeholder_weighted"] == 20.0
+    assert breakdown["session_weighted"] == 10.0
 
 
-def test_calculate_composite_score_perfect_results() -> None:
+def test_calculate_compliance_score_perfect_results() -> None:
     """A spotless run should yield a perfect composite score."""
 
-    score, breakdown = calculate_composite_score(0, 10, 0, 0, 0)
+    score, breakdown = calculate_compliance_score(0, 10, 0, 0, 0, 0, 0)
 
     assert score == 100.0
     assert breakdown["lint_weighted"] == 30.0
-    assert breakdown["test_weighted"] == 50.0
+    assert breakdown["test_weighted"] == 40.0
     assert breakdown["placeholder_weighted"] == 20.0
+    assert breakdown["session_weighted"] == 10.0
 
 
-def test_resolved_placeholders_affect_composite_score() -> None:
+def test_resolved_placeholders_affect_score() -> None:
     """Resolved placeholders should improve the overall composite score."""
 
-    score_unresolved, _ = calculate_composite_score(0, 10, 0, 5, 0)
-    score_resolved, _ = calculate_composite_score(0, 10, 0, 5, 5)
+    score_unresolved, _ = calculate_compliance_score(0, 10, 0, 5, 0, 0, 0)
+    score_resolved, _ = calculate_compliance_score(0, 10, 0, 5, 5, 0, 0)
     assert score_resolved > score_unresolved
 


### PR DESCRIPTION
## Summary
- centralize compliance scoring via `calculate_compliance_score`
- expose shared `SCORE_WEIGHTS` constants for lint, tests, placeholders, and session stats
- align docs and helpers with unified scoring API

## Testing
- `ruff check .`
- `pytest` *(fails: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_689a2c54cb8c8331b28975062199f62d