### PR TITLE
feat: add ripgrep safety wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,16 @@ jobs:
               importlib.import_module(m)
           PY
 
-      - name: Check for zero-byte files
-        run: bash scripts/check_zero_logs.sh .
+    - name: Check for zero-byte files
+      run: bash scripts/check_zero_logs.sh .
 
-      - name: Import template_engine
-        run: |
-          python - <<'PY'
-          import template_engine.auto_generator
+    - name: Scan repository TODOs
+      run: ./scripts/rg_safe.sh TODO -g "*.py" --max-count 100 | head || true
+
+    - name: Import template_engine
+      run: |
+        python - <<'PY'
+        import template_engine.auto_generator
           import template_engine.template_synchronizer
           PY
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,19 +7,19 @@ Thank you for considering a contribution to gh_COPILOT. Please follow these guid
 - Use conventional commit messages and reference these standards in your pull requests.
 - Follow the [Git LFS recovery guide](docs/git_lfs_recovery.md) when restoring large binary files.
 
-## Safe `rg` usage for large repositories
+## Safe ripgrep usage for large repositories
 
-Use [`rg`](https://github.com/BurntSushi/ripgrep) carefully to avoid overwhelming the console:
+Use the wrapper `./scripts/rg_safe.sh` (which invokes [`rg`](https://github.com/BurntSushi/ripgrep) with sensible limits) to avoid overwhelming the console:
 
 - Limit scope with globs or directory exclusions and cap matches.
   Example:
   ```bash
-  set +o pipefail && rg "except\s*:" -g "*.py" --max-count 200 | head
+  set +o pipefail && ./scripts/rg_safe.sh "except\s*:" -g "*.py" --max-count 200 | head
   ```
 - Ensure downstream tools read all input. Use `set +o pipefail`, `--no-buffer`, and viewers like `head`, `tail`, or `clw`.
 - When truncating output, capture the full results to a temporary log for later review:
   ```bash
-  set +o pipefail && rg --no-buffer "TODO" -g "*.py" --max-count 200 \
+  set +o pipefail && ./scripts/rg_safe.sh --no-buffer "TODO" -g "*.py" --max-count 200 \
     | tee /tmp/rg_todo.log | head
   ```
 

--- a/docs/troubleshooting/large-output.md
+++ b/docs/troubleshooting/large-output.md
@@ -38,10 +38,10 @@ This guide outlines how to safely inspect or store command output without exceed
 
 ```bash
 # search repository for TODOs and wrap output
-rg TODO | /usr/local/bin/clw
+./scripts/rg_safe.sh TODO | /usr/local/bin/clw
 
 # or log and review in chunks
-rg TODO > /tmp/todo.log
+./scripts/rg_safe.sh TODO > /tmp/todo.log
 head -n 50 /tmp/todo.log
 rm /tmp/todo.log
 ```

--- a/scripts/rg_safe.sh
+++ b/scripts/rg_safe.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper around ripgrep enforcing sane defaults to avoid runaway line sizes.
+exec rg --max-columns=200 --max-columns-preview "$@"
+


### PR DESCRIPTION
## Summary
- add scripts/rg_safe.sh wrapper enforcing safer ripgrep defaults
- recommend the wrapper in contributing and troubleshooting docs
- call the wrapper from CI to limit search output

## Testing
- `ruff check .`
- `pytest -q --disable-warnings --maxfail=10 --exitfirst tests` *(fails: ModuleNotFoundError: No module named 'monitoring.anomaly')*


------
https://chatgpt.com/codex/tasks/task_e_689a302d08648331afee698809ca32a0