### PR TITLE
feat: add compliance drill-down and version info

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -60,6 +60,16 @@ This module is designed to meet enterprise auditability and compliance standards
 
 ---
 
+## Metric Sources and Tooltips
+
+Metrics shown in the dashboard are queried from `/api/compliance_scores`,
+which reads composite and component scores from `analytics.db`. The
+frontend updates the `title` attribute for each metric, enabling native
+browser tooltips with definitions and timestamps. Clicking a gauge
+reveals these descriptions in an inline panel for quick drill-down.
+
+---
+
 ## MODULE DIRECTORY STRUCTURE
 
 ```

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import io
+import os
 import subprocess
 from flask import Response
 
@@ -12,8 +13,10 @@ from .routes import register_routes
 from scripts.compliance.update_compliance_metrics import fetch_recent_compliance
 
 
-GIT_SHA = (
-    subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip()
+# Prefer build-time environment variable for versioning; fall back to git.
+GIT_SHA = os.getenv(
+    "GIT_SHA",
+    subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode().strip(),
 )
 
 

--- a/dashboard/static/main.js
+++ b/dashboard/static/main.js
@@ -1,4 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
     console.log('Dashboard assets loaded');
+    const details = document.getElementById('metric-details');
+    document.querySelectorAll('#score_gauges canvas').forEach((canvas) => {
+        canvas.addEventListener('click', () => {
+            const id = canvas.dataset.metric;
+            const target = document.getElementById(id);
+            if (!target) return;
+            details.textContent = `${target.title} Current value: ${target.textContent}`;
+            details.removeAttribute('hidden');
+        });
+    });
 });
 

--- a/dashboard/templates/compliance.html
+++ b/dashboard/templates/compliance.html
@@ -4,6 +4,7 @@
     <title>Compliance Metrics</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <script>
+        // Pull metrics from /api/compliance_scores and populate tooltip titles
         function loadCompliance() {
             fetch('/api/compliance_scores').then(r => r.json()).then(data => {
                 const scores = data.scores || [];

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -35,6 +35,7 @@
             chart.data.datasets[0].data = [value, 100 - value];
             chart.update();
         }
+        // Metrics sourced from /api/compliance_scores (analytics.db)
         function updateMetrics(data){
         document.getElementById('placeholder_removal').textContent = data.placeholder_removal;
         document.getElementById('compliance_score').textContent = data.compliance_score.toFixed(3);
@@ -44,9 +45,16 @@
             document.getElementById('ruff_issues').textContent = data.ruff_issues || 0;
             document.getElementById('tests_passed').textContent = data.tests_passed || 0;
             document.getElementById('tests_failed').textContent = data.tests_failed || 0;
-        document.getElementById('lint_score').textContent = (data.lint_score ?? 0).toFixed(2);
-        document.getElementById('test_score').textContent = (data.test_score ?? 0).toFixed(2);
-        document.getElementById('placeholder_score').textContent = (data.placeholder_score ?? 0).toFixed(2);
+        const ts = data.timestamp || new Date().toISOString();
+        const lintEl = document.getElementById('lint_score');
+        const testEl = document.getElementById('test_score');
+        const placeholderEl = document.getElementById('placeholder_score');
+        lintEl.textContent = (data.lint_score ?? 0).toFixed(2);
+        testEl.textContent = (data.test_score ?? 0).toFixed(2);
+        placeholderEl.textContent = (data.placeholder_score ?? 0).toFixed(2);
+        lintEl.title = `Definition: percentage of files passing lint checks. Units: percent. Cadence: periodic. Last update: ${ts}`;
+        testEl.title = `Definition: percentage of tests passing. Units: percent. Cadence: periodic. Last update: ${ts}`;
+        placeholderEl.title = `Definition: progress removing placeholders. Units: percent. Cadence: periodic. Last update: ${ts}`;
         updateGauge(lintGauge, data.lint_score ?? 0);
         updateGauge(testGauge, data.test_score ?? 0);
         updateGauge(placeholderGauge, data.placeholder_score ?? 0);
@@ -223,7 +231,7 @@
 <h1>Compliance Dashboard</h1>
 <nav>
     <a href="/corrections/view">Corrections</a>
-    <a href="/compliance">Compliance</a>
+    <a href="/api/compliance_scores">Compliance</a>
 </nav>
 <div>
     <strong>Placeholder Removals:</strong> <span id="placeholder_removal">{{ metrics.placeholder_removal | default(0) }}</span><br>
@@ -236,10 +244,13 @@
     <strong title="Percentage of tests passing">Test Score:</strong> <span id="test_score">{{ metrics.test_score | default(0) }}</span><br>
     <strong title="Progress removing TODO/FIXME placeholders">Placeholder Score:</strong> <span id="placeholder_score">{{ metrics.placeholder_score | default(0) }}</span><br>
     <div id="score_gauges">
-        <canvas id="lintGauge" class="gauge" title="Lint score gauge"></canvas>
-        <canvas id="testGauge" class="gauge" title="Test score gauge"></canvas>
-        <canvas id="placeholderGauge" class="gauge" title="Placeholder score gauge"></canvas>
+        <!-- Gauges support click drill-down via main.js -->
+        <canvas id="lintGauge" class="gauge" data-metric="lint_score" title="Lint score gauge"></canvas>
+        <canvas id="testGauge" class="gauge" data-metric="test_score" title="Test score gauge"></canvas>
+        <canvas id="placeholderGauge" class="gauge" data-metric="placeholder_score" title="Placeholder score gauge"></canvas>
     </div>
+    <!-- Details panel populated when a gauge is clicked -->
+    <div id="metric-details" class="metric-details" hidden></div>
     <div class="exports">
         <a href="/api/compliance_scores" id="export-json">Download JSON</a> |
         <a href="/api/compliance_scores.csv" id="export-csv">Download CSV</a>

--- a/dashboard/templates/footer.html
+++ b/dashboard/templates/footer.html
@@ -1,4 +1,5 @@
 <footer>
+    <!-- git_sha provided via app context; derived from GIT_SHA env var or git commit -->
     <small>Git SHA: {{ git_sha }}</small>
 </footer>
 

--- a/tests/dashboard/test_git_sha_injection.py
+++ b/tests/dashboard/test_git_sha_injection.py
@@ -1,0 +1,11 @@
+import importlib
+import sys
+
+
+def test_git_sha_env_injection(monkeypatch):
+    monkeypatch.setenv("GIT_SHA", "testsha")
+    sys.modules.pop("dashboard.app", None)
+    app_module = importlib.import_module("dashboard.app")
+    assert app_module.GIT_SHA == "testsha"
+    assert app_module.inject_git_sha()["git_sha"] == "testsha"
+

--- a/tests/dashboard/test_nav_links.py
+++ b/tests/dashboard/test_nav_links.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_compliance_tab_links_api():
+    html = Path("dashboard/templates/dashboard.html").read_text()
+    assert "/api/compliance_scores" in html
+


### PR DESCRIPTION
## Summary
- link dashboard navigation to compliance score API and support drill-down tooltips
- expose build version via `GIT_SHA` and document metric sources

## Testing
- `ruff check dashboard/app.py tests/dashboard/test_nav_links.py tests/dashboard/test_git_sha_injection.py`
- `pytest tests/dashboard/test_nav_links.py tests/dashboard/test_git_sha_injection.py -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_689a345d59fc83318bf0c03f3d2a9d86