### PR TITLE
feat: add backup orchestrator with rollback logging

### DIFF
--- a/dr/__init__.py
+++ b/dr/__init__.py
@@ -1,0 +1,1 @@
+"""Disaster recovery utilities."""

--- a/dr/backup_orchestrator.py
+++ b/dr/backup_orchestrator.py
@@ -1,0 +1,89 @@
+"""Simple backup orchestrator for pre-operation backups and restores."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable
+
+from utils.log_utils import DEFAULT_ANALYTICS_DB, log_event
+
+
+class BackupOrchestrator:
+    """Handle backups before write operations and perform restores.
+
+    Parameters
+    ----------
+    backup_root:
+        Directory where backups and manifests are stored. Falls back to the
+        ``GH_COPILOT_BACKUP_ROOT`` environment variable or ``/tmp`` when not
+        provided.
+    analytics_db:
+        Path to ``analytics.db`` for logging rollback events.
+    """
+
+    def __init__(self, backup_root: Path | None = None, analytics_db: Path = DEFAULT_ANALYTICS_DB) -> None:
+        self.backup_root = Path(backup_root or os.getenv("GH_COPILOT_BACKUP_ROOT", "/tmp/gh_copilot_backups"))
+        self.analytics_db = analytics_db
+        self.backup_root.mkdir(parents=True, exist_ok=True)
+        (self.backup_root / "manifests").mkdir(exist_ok=True)
+
+    def pre_op_backup(self, paths: Iterable[Path]) -> Path:
+        """Backup ``paths`` before a write operation.
+
+        Each existing path is copied to a timestamped folder under
+        ``backup_root``. A manifest mapping original paths to backup copies is
+        written and a ``rollback_logs`` entry is recorded for each file.
+
+        Parameters
+        ----------
+        paths:
+            Iterable of file paths that will be written to.
+
+        Returns
+        -------
+        Path
+            Location of the created manifest file.
+        """
+
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S%f")
+        backup_dir = self.backup_root / timestamp
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        manifest: Dict[str, str] = {}
+        for p in paths:
+            src = Path(p)
+            if not src.exists():
+                continue
+            dest = backup_dir / src.name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+            manifest[str(src)] = str(dest)
+            log_event(
+                {"event": "pre_op_backup", "target": str(src), "backup": str(dest)},
+                table="rollback_logs",
+                db_path=self.analytics_db,
+            )
+        manifest_path = self.backup_root / "manifests" / f"{timestamp}.json"
+        with open(manifest_path, "w", encoding="utf-8") as fh:
+            json.dump(manifest, fh, indent=2)
+        return manifest_path
+
+    def restore(self, manifest_path: Path) -> None:
+        """Restore files from ``manifest_path`` backups."""
+
+        with open(manifest_path, "r", encoding="utf-8") as fh:
+            manifest: Dict[str, str] = json.load(fh)
+        for target, backup in manifest.items():
+            src = Path(backup)
+            dest = Path(target)
+            if not src.exists():
+                continue
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+            log_event(
+                {"event": "restore", "target": str(dest), "backup": str(src)},
+                table="rollback_logs",
+                db_path=self.analytics_db,
+            )

--- a/tests/dr/test_backup_restore.py
+++ b/tests/dr/test_backup_restore.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from dr.backup_orchestrator import BackupOrchestrator
+
+
+def test_backup_and_restore(tmp_path, monkeypatch):
+    backup_root = tmp_path / "backups"
+    analytics_db = tmp_path / "analytics.db"
+    monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(backup_root))
+    monkeypatch.setenv("ANALYTICS_DB", str(analytics_db))
+
+    target = tmp_path / "data.txt"
+    target.write_text("original", encoding="utf-8")
+
+    orchestrator = BackupOrchestrator(analytics_db=analytics_db)
+    manifest = orchestrator.pre_op_backup([target])
+
+    target.write_text("modified", encoding="utf-8")
+    orchestrator.restore(manifest)
+
+    assert target.read_text(encoding="utf-8") == "original"
+
+    with sqlite3.connect(analytics_db) as conn:
+        rows = conn.execute("SELECT target, backup FROM rollback_logs").fetchall()
+
+    assert len(rows) == 2
+    assert any(r[0] == str(target) for r in rows)
+
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    assert data[str(target)]


### PR DESCRIPTION
## Summary
- add backup orchestrator that snapshots write targets, records manifests, and logs to `rollback_logs`
- test backup and restore workflow with analytics logging

## Testing
- `ruff check dr tests/dr`
- `pytest tests/dr/test_backup_restore.py`


------
https://chatgpt.com/codex/tasks/task_e_689a38a9107c8331ae4da72a5d7c3873