### PR TITLE
feat: log session lifecycle in reclone script

### DIFF
--- a/scripts/reclone_repo.py
+++ b/scripts/reclone_repo.py
@@ -18,6 +18,7 @@ import uuid
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from session.session_lifecycle_metrics import start_session, end_session
+from utils.logging_utils import log_session_event
 
 from enterprise_modules.compliance import (
     anti_recursion_guard,
@@ -110,6 +111,7 @@ def main() -> None:
     session_id = os.getenv("SESSION_ID_SOURCE", str(uuid.uuid4()))
     workspace = os.getenv("GH_COPILOT_WORKSPACE")
     start_session(session_id, workspace=workspace)
+    log_session_event(session_id, "start")
     try:
         ensure_git_installed()
         if args.backup_existing and args.clean:
@@ -130,8 +132,10 @@ def main() -> None:
 
         commit = clone_repository(args.repo_url, args.dest, args.branch)
         print(commit)
+        log_session_event(session_id, "success")
         end_session(session_id, status="success", workspace=workspace)
     except Exception as exc:  # pragma: no cover - broad exception for CLI user feedback
+        log_session_event(session_id, "failure")
         end_session(session_id, status="failure", workspace=workspace)
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/tests/scripts/test_reclone_repo_session.py
+++ b/tests/scripts/test_reclone_repo_session.py
@@ -86,17 +86,24 @@ def test_session_logged_on_success(monkeypatch, tmp_path: Path) -> None:
 
     starts: list[tuple[str | None]] = []
     ends: list[tuple[str, str | None]] = []
+    events: list[tuple[str, str]] = []
     monkeypatch.setattr(rr, "start_session", lambda sid, workspace=None: starts.append((sid, workspace)))
     monkeypatch.setattr(
         rr,
         "end_session",
         lambda sid, *, status, workspace=None: ends.append((sid, status, workspace)),
     )
+    monkeypatch.setattr(
+        rr,
+        "log_session_event",
+        lambda sid, event: events.append((sid, event)),
+    )
 
     rr.main()
     assert len(starts) == 1
     assert len(ends) == 1
     assert ends[0][1] == "success"
+    assert events == [(starts[0][0], "start"), (starts[0][0], "success")]
 
 
 def test_session_logged_on_failure(monkeypatch, tmp_path: Path) -> None:
@@ -108,11 +115,17 @@ def test_session_logged_on_failure(monkeypatch, tmp_path: Path) -> None:
 
     starts: list[tuple[str | None]] = []
     ends: list[tuple[str, str | None]] = []
+    events: list[tuple[str, str]] = []
     monkeypatch.setattr(rr, "start_session", lambda sid, workspace=None: starts.append((sid, workspace)))
     monkeypatch.setattr(
         rr,
         "end_session",
         lambda sid, *, status, workspace=None: ends.append((sid, status, workspace)),
+    )
+    monkeypatch.setattr(
+        rr,
+        "log_session_event",
+        lambda sid, event: events.append((sid, event)),
     )
 
     with pytest.raises(SystemExit):
@@ -120,3 +133,4 @@ def test_session_logged_on_failure(monkeypatch, tmp_path: Path) -> None:
     assert len(starts) == 1
     assert len(ends) == 1
     assert ends[0][1] == "failure"
+    assert events == [(starts[0][0], "start"), (starts[0][0], "failure")]


### PR DESCRIPTION
## Summary
- log session start and completion status to analytics in `scripts/reclone_repo.py`
- exercise session lifecycle logging in `test_reclone_repo_session`

## Testing
- `ruff check scripts/reclone_repo.py tests/scripts/test_reclone_repo_session.py`
- `pytest -o addopts='' tests/scripts/test_reclone_repo_session.py`


------
https://chatgpt.com/codex/tasks/task_e_689a396df380833192b17ecc81cba83c