### PR TITLE
feat: expose placeholder audit trends and totals

### DIFF
--- a/dashboard/static/placeholder_chart.js
+++ b/dashboard/static/placeholder_chart.js
@@ -41,10 +41,9 @@ document.addEventListener('DOMContentLoaded', () => {
             chart.data.datasets[0].data = history.map(h => h.open);
             chart.data.datasets[1].data = history.map(h => h.resolved);
             chart.update();
-            if (history.length && openCount && resolvedCount) {
-                const latest = history[history.length - 1];
-                openCount.textContent = latest.open;
-                resolvedCount.textContent = latest.resolved;
+            if (openCount && resolvedCount) {
+                openCount.textContent = (data.totals && data.totals.open) || 0;
+                resolvedCount.textContent = (data.totals && data.totals.resolved) || 0;
             }
             if (tableBody) {
                 tableBody.innerHTML = '';

--- a/tests/dashboard/test_placeholder_audit_endpoint.py
+++ b/tests/dashboard/test_placeholder_audit_endpoint.py
@@ -9,9 +9,7 @@ def test_placeholder_audit_endpoint(tmp_path, monkeypatch):
         conn.execute(
             "CREATE TABLE placeholder_audit_snapshots (timestamp INTEGER, open_count INTEGER, resolved_count INTEGER)"
         )
-        conn.execute(
-            "INSERT INTO placeholder_audit_snapshots VALUES (1, 5, 3)"
-        )
+        conn.execute("INSERT INTO placeholder_audit_snapshots VALUES (1, 5, 3)")
         conn.execute(
             "CREATE TABLE placeholder_audit (id INTEGER PRIMARY KEY, file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT)"
         )
@@ -25,4 +23,6 @@ def test_placeholder_audit_endpoint(tmp_path, monkeypatch):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["history"][0]["open"] == 5
+    assert data["totals"]["open"] == 5
+    assert data["totals"]["resolved"] == 3
     assert data["unresolved"][0]["type"] == "TODO"


### PR DESCRIPTION
## Summary
- extend placeholder snapshot loader with recent history and totals
- add `/api/placeholder_audit` endpoint and dashboard chart updates
- cover placeholder audit JSON structure with integration tests

## Testing
- `ruff check dashboard/enterprise_dashboard.py tests/dashboard/test_placeholder_audit_endpoint.py`
- `pyright dashboard/enterprise_dashboard.py tests/dashboard/test_placeholder_audit_endpoint.py`
- `pytest tests/dashboard/test_placeholder_audit_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_689a4143f114833192ecc4e6a135c714