### PR TITLE
fix: ensure analytics tests import local modules

### DIFF
--- a/tests/test_analytics_modules.py
+++ b/tests/test_analytics_modules.py
@@ -1,3 +1,10 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from analytics import (
     calculate_throughput,
     detect_patterns,


### PR DESCRIPTION
## Summary
- ensure tests load the repository's analytics package by inserting the project root into `sys.path`

## Testing
- `pytest tests/test_analytics_modules.py`
- `ruff check tests/test_analytics_modules.py analytics/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_689a4154149c83318c1ff0cf28699ab3