### PR TITLE
feat: add safe ripgrep wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ Ensure the development environment is correctly configured **before** making any
   ```bash
   grep -R "pattern" . | /usr/local/bin/clw
   ```
+* **Safe `rg` wrapper**: Search the repository with column limits and skip heavy directories.
+  ```bash
+  ./tools/safe_rg.sh "except\s*:"
+  ```
 * **Python & Tools**: Use **Python 3.8+** (already provided in Codex). The setup will install necessary system packages (development headers, build tools, SQLite, etc.) and Python packages as specified by the project. Do **not** install additional packages beyond those listed in `requirements.txt` (and optional `requirements-web.txt`, `requirements-ml.txt`, etc.). **Only use** the dependencies declared by the project. If you believe a new package is required, **do not install it yourself** – instead, mention the need in the PR description for maintainers.
 * **Virtual Environment**: Always activate the Python virtual environment after running setup. For example, use `source .venv/bin/activate` to ensure you’re using the project’s isolated environment and packages.
 * **Git LFS Pre-commit Hook**: Install `tools/pre-commit-lfs.sh` as a local pre-commit hook (e.g., `cp tools/pre-commit-lfs.sh .git/hooks/pre-commit-lfs && chmod +x .git/hooks/pre-commit-lfs`) and run it before committing to verify all `.db` files are tracked by Git LFS.

--- a/tools/safe_rg.sh
+++ b/tools/safe_rg.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper around ripgrep with sane defaults.
+# - Limits columns to avoid exceedingly long lines.
+# - Suppresses error messages.
+# - Skips heavy build directories by default.
+
+rg --max-columns=300 --no-messages --glob '!:builds/**' "$@" | cut -c1-300
+exit ${PIPESTATUS[0]}
+


### PR DESCRIPTION
## Summary
- add tools/safe_rg.sh wrapper around ripgrep with column limit and build dir exclusion
- document safe_rg usage in AGENTS.md

## Testing
- `ruff check .` (fails: F821 undefined name `pid_recursion_guard` in scripts/backup_archiver.py and scripts/database/documentation_ingestor.py)
- `pytest` (fails: unrecognized arguments --cov=. --cov-report=term)


------
https://chatgpt.com/codex/tasks/task_e_689a4169a80483319f6de3a217dadc24