### PR TITLE
feat: enable IBM hardware backend in QuantumExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > Compliance: run `python secondary_copilot_validator.py --validate` after critical changes to enforce dual-copilot and EnterpriseComplianceValidator checks.
 > Docs: run `python scripts/docs_status_reconciler.py` to refresh `docs/task_stubs.md` and `docs/status_index.json` before committing documentation changes.
 > CI: pipeline pins Ruff, enforces a 90% test pass rate, and fails if coverage regresses relative to `main`.
-> Quantum modules run exclusively in simulation mode; hardware flags are currently ignored. Documentation and guides now clearly mark these components as simulation-only. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Module completion status is tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics.db`.
+> Quantum modules default to simulation but can target IBM hardware when `QISKIT_IBM_TOKEN` and `IBM_BACKEND` are set. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Module completion status is tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics.db`.
 > Integration plan: [docs/quantum_integration_plan.md](docs/quantum_integration_plan.md) outlines staged hardware enablement while current builds remain simulator-only.
 > Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards. New compliance routines and monitoring capabilities are detailed in [docs/white-paper.md](docs/white-paper.md).
 > Security: updated protocols and configuration files reside under `security/` including `security/enterprise_security_policy.json`, `security/access_control_matrix.json`, `security/encryption_standards.json`, and `security/security_audit_framework.json`.
@@ -31,10 +31,10 @@
 
 The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality operates solely through simulators; hardware execution is not yet available.
 
-> **Note**
-> Modules accept backend-selection environment variables such as `QUANTUM_USE_HARDWARE`, `QUANTUM_BACKEND`, and `QISKIT_IBM_TOKEN`, but these flags are ignored and the simulator is always used.
-> **Roadmap**
-> Hardware integration is planned for future phases; current builds forcibly select simulator backends regardless of configuration.
+ > **Note**
+ > Set `QISKIT_IBM_TOKEN` and `IBM_BACKEND` (or pass `use_hardware=True`) to run quantum routines on IBM hardware when available; otherwise the simulator is used.
+ > **Roadmap**
+ > Hardware support is evolving and falls back to simulation if initialization fails.
 > **Phase 5 AI**
 > Advanced AI integration features operate in simulation mode by default and ignore hardware execution flags.
 
@@ -1320,9 +1320,9 @@ Set these variables in your `.env` file or shell before running scripts:
 - `OPENAI_API_KEY` – enables optional OpenAI features.
 - `FLASK_SECRET_KEY` – Flask dashboard secret.
 - `FLASK_RUN_PORT` – dashboard port (default `5000`).
- - `QISKIT_IBM_TOKEN` – placeholder for a future IBM Quantum API token; currently ignored.
- - `IBM_BACKEND` – preferred hardware backend for future use; defaults to `ibmq_qasm_simulator`.
- - `QUANTUM_USE_HARDWARE` – no-op flag reserved for eventual hardware execution.
+ - `QISKIT_IBM_TOKEN` – IBM Quantum API token enabling hardware execution.
+ - `IBM_BACKEND` – hardware backend name; defaults to `ibmq_qasm_simulator`.
+ - `QUANTUM_USE_HARDWARE` – set to `1` to prefer hardware when credentials are available.
 - `LOG_WEBSOCKET_ENABLED` – set to `1` to stream logs.
 - `CLW_MAX_LINE_LENGTH` – max line length for the `clw` wrapper (default `1550`).
 

--- a/quantum/README.md
+++ b/quantum/README.md
@@ -4,10 +4,11 @@ This package provides experimental quantum-inspired utilities used across the
 gh_COPILOT toolkit.
 
 > **Note**
-> All utilities currently run **exclusively** on local Qiskit simulators.
-> Environment variables such as `QISKIT_IBM_TOKEN`, `QUANTUM_USE_HARDWARE`, and
-> `IBM_BACKEND` are accepted for future compatibility but are treated as
-> no-ops. Hardware execution is not yet supported.
+> Utilities default to local Qiskit simulators. When
+> `use_hardware=True` and a valid IBM Quantum token is supplied via
+> the `QISKIT_IBM_TOKEN` environment variable (or constructor argument),
+> `QuantumExecutor` will attempt to initialize the backend named by
+> `IBM_BACKEND`.
 
 ## Framework and Models
 
@@ -38,15 +39,17 @@ local simulator and ignores hardware-specific settings.
 - `quantum.quantum_database_search` – lightweight helpers for SQL, NoSQL and
   hybrid search. All queries are logged to `analytics.db` for compliance.
 
-These modules always execute on simulators regardless of command-line flags or
-environment variables. The `--hardware` flag in
-`quantum_integration_orchestrator.py` and the `QUANTUM_USE_HARDWARE` environment
-variable are placeholders for future hardware support.
+These modules default to simulators when no IBM credentials are available.
+The `--hardware` flag in `quantum_integration_orchestrator.py` and the
+`QUANTUM_USE_HARDWARE` environment variable enable hardware execution when
+`QISKIT_IBM_TOKEN` and a usable backend are supplied.
 
 ## IBM Quantum Access
 
-Setting `QISKIT_IBM_TOKEN` or providing a token argument has no effect today;
-the system always runs in simulation mode.
+Provide an IBM Quantum token via `QISKIT_IBM_TOKEN` (or the ``token`` argument)
+to allow `QuantumExecutor` to run circuits on real hardware. If the provider or
+backend cannot be loaded, the executor automatically falls back to the local
+simulator.
 
 ## Algorithms
 

--- a/quantum/ibm_backend.py
+++ b/quantum/ibm_backend.py
@@ -31,6 +31,7 @@ def init_ibm_backend(
     token: str | None = None,
     token_env: str = "QISKIT_IBM_TOKEN",
     backend_env: str = "IBM_BACKEND",
+    backend_name: str | None = None,
 ) -> Tuple[Any, bool]:
     """Initialize an IBM quantum backend.
 
@@ -43,6 +44,8 @@ def init_ibm_backend(
         Name of the environment variable that may contain the token.
     backend_env:
         Environment variable for selecting a specific backend.
+    backend_name:
+        Optional explicit backend name. Overrides ``backend_env`` when provided.
 
     Returns
     -------
@@ -52,7 +55,7 @@ def init_ibm_backend(
         hardware execution will be used.
     """
     token = token or os.getenv(token_env) or _load_token_from_config()
-    backend_name = os.getenv(backend_env)
+    backend_name = backend_name or os.getenv(backend_env)
 
     if IBMProvider is None or Aer is None:
         warnings.warn(

--- a/tests/quantum/test_framework_models.py
+++ b/tests/quantum/test_framework_models.py
@@ -11,7 +11,9 @@ import pytest
 
 
 def test_executor_falls_back_to_simulator(monkeypatch):
-    monkeypatch.setattr(fw_backend, "init_ibm_backend", lambda token=None: (None, False))
+    monkeypatch.setattr(
+        fw_backend, "init_ibm_backend", lambda token=None, backend_name=None: (None, False)
+    )
     executor = QuantumExecutor()
     assert isinstance(executor.backend, SimulatorBackend)
     assert executor.use_hardware is False
@@ -23,7 +25,9 @@ class _DummyModel(QuantumModel):
 
 
 def test_model_run_uses_simulator(monkeypatch):
-    monkeypatch.setattr(fw_backend, "init_ibm_backend", lambda token=None: (None, False))
+    monkeypatch.setattr(
+        fw_backend, "init_ibm_backend", lambda token=None, backend_name=None: (None, False)
+    )
     model = _DummyModel()
     result = model.run()
     assert result == {"simulated": True, "circuit": "test-circuit"}
@@ -33,7 +37,9 @@ def test_model_run_uses_simulator(monkeypatch):
 def test_demo_model(monkeypatch):
     """DemoModel should execute using the simulator backend."""
 
-    monkeypatch.setattr(fw_backend, "init_ibm_backend", lambda token=None: (None, False))
+    monkeypatch.setattr(
+        fw_backend, "init_ibm_backend", lambda token=None, backend_name=None: (None, False)
+    )
     model = DemoModel()
     result = model.run()
     assert result["simulated"] is True

--- a/tests/quantum/test_provider_fallback.py
+++ b/tests/quantum/test_provider_fallback.py
@@ -30,7 +30,9 @@ def _setup_db(path: Path) -> None:
 
 
 def test_executor_falls_back_without_ibm(monkeypatch):
-    monkeypatch.setattr(qexec, "HAS_IBM_PROVIDER", False)
+    monkeypatch.setattr(
+        qexec, "init_ibm_backend", lambda token=None, backend_name=None: (None, False)
+    )
     exec_ = QuantumExecutor(use_hardware=True)
     assert exec_.use_hardware is False
     if qexec.QISKIT_AVAILABLE:


### PR DESCRIPTION
## Summary
- allow `QuantumExecutor` to initialize IBM hardware backends when credentials are supplied
- accept explicit backend names in `init_ibm_backend`
- document `QISKIT_IBM_TOKEN` and `IBM_BACKEND` usage and add hardware/simulator tests

## Testing
- `ruff check quantum/orchestration/executor.py quantum/ibm_backend.py tests/quantum/test_executor_hardware.py tests/quantum/test_provider_fallback.py tests/quantum/test_framework_models.py`
- `pytest --override-ini=addopts= tests/quantum/test_executor_hardware.py::test_env_token_and_backend -q` *(fails: ModuleNotFoundError: No module named 'qiskit')*

------
https://chatgpt.com/codex/tasks/task_e_689a417c6f308331aac01237c55e6ee8