### PR TITLE
feat: stream corrections and metrics via SSE

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -44,7 +44,7 @@ This module is designed to meet enterprise auditability and compliance standards
 - **Correction Log UI:** Vue component (`web/dashboard/components/CorrectionLog.vue`) fetches
   `/corrections/logs` and supports client-side filtering and pagination.
 - **Data Sources:** `production.db`, `analytics.db`, `monitoring.db`
-- **Primary Endpoints:** `/`, `/database`, `/backup`, `/migration`, `/deployment`, `/api/scripts`, `/api/health`, `/metrics_stream`, `/dashboard/compliance`
+- **Primary Endpoints:** `/`, `/database`, `/backup`, `/migration`, `/deployment`, `/api/scripts`, `/api/health`, `/metrics_stream`, `/corrections_stream`, `/dashboard/compliance`
 - **Session Logging:** All actions are recorded in `production.db` and mirrored in `analytics.db`
 - **Compliance Display:** DUAL COPILOT validation and compliance events visible in dashboard sidebar and `/dashboard/compliance`
 
@@ -118,12 +118,12 @@ Example screenshot:
 
 ### Live Metrics
 
-The dashboard templates consume `/metrics_stream` via Server-Sent Events (SSE).
-Metrics are retrieved from `analytics.db` and include placeholder removal totals,
-open placeholder counts, and the average compliance score. If SSE is
-unavailable, a JavaScript fallback polls `/dashboard/compliance` every five
-seconds. Alerts combine rollback and violation logs so operators can react to
-compliance issues immediately.
+The dashboard templates consume `/metrics_stream` and `/corrections_stream` via
+Server-Sent Events (SSE). Metrics and correction logs are retrieved from
+`analytics.db`. If SSE is unavailable, a JavaScript fallback polls
+`/dashboard/compliance` and `/corrections` every five seconds. Alerts combine
+rollback and violation logs so operators can react to compliance issues
+immediately.
 
 ---
 
@@ -139,6 +139,7 @@ compliance issues immediately.
 | `/api/scripts`            | Run and monitor scripts via API                                                  |
 | `/api/health`             | System health check API                                                          |
 | `/metrics_stream`         | Server-Sent Events stream of live metrics                                       |
+| `/corrections_stream`     | SSE stream of recent correction logs                                            |
 | `/dashboard/compliance`   | Returns compliance metrics, rollback and audit trail as JSON                     |
 | `/overview`               | Consolidated dashboard with metrics, rollbacks, sync events, and audit results   |
 #### Example `/dashboard/compliance` Response

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -195,7 +195,6 @@
         function pollExtras(){
             fetch('/sync_events').then(r=>r.json()).then(updateSyncEvents);
             fetch('/audit_results').then(r=>r.json()).then(updateAuditResults);
-            fetch('/corrections').then(r=>r.json()).then(updateCorrections);
         }
         window.onload = function(){
             initGauges();
@@ -208,6 +207,10 @@
                         window.updatePlaceholderChart(payload.placeholder_history || []);
                     }
                 };
+                const cs = new EventSource('/corrections_stream');
+                cs.onmessage = function(evt){
+                    updateCorrections(JSON.parse(evt.data));
+                };
             }else{
                 setInterval(function(){
                     fetch('/metrics').then(r=>r.json()).then(payload => {
@@ -216,6 +219,9 @@
                             window.updatePlaceholderChart(payload.placeholder_history || []);
                         }
                     });
+                },5000);
+                setInterval(function(){
+                    fetch('/corrections').then(r=>r.json()).then(updateCorrections);
                 },5000);
             }
             pollCompliance();

--- a/tests/dashboard/test_corrections_stream.py
+++ b/tests/dashboard/test_corrections_stream.py
@@ -1,0 +1,46 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import dashboard.enterprise_dashboard as ed
+
+
+def _create_db(tmp_path: Path) -> Path:
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE correction_logs(timestamp TEXT, path TEXT, status TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO correction_logs VALUES ('t1', 'file1.py', 'fixed')"
+        )
+    return db
+
+
+def test_corrections_stream_once(tmp_path, monkeypatch):
+    db = _create_db(tmp_path)
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+    client = ed.app.test_client()
+    resp = client.get("/corrections_stream?once=1")
+    assert resp.status_code == 200
+    line = resp.data.decode().split("\n")[0]
+    assert line.startswith("data:")
+    logs = json.loads(line.split("data: ")[1])
+    assert logs[0]["path"] == "file1.py"
+
+
+def test_corrections_stream_live(tmp_path, monkeypatch):
+    db = _create_db(tmp_path)
+    monkeypatch.setattr(ed, "ANALYTICS_DB", db)
+    client = ed.app.test_client()
+    resp = client.get("/corrections_stream?interval=0", buffered=False)
+    first = next(resp.response).decode().strip()
+    assert first.startswith("data:")
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "INSERT INTO correction_logs VALUES ('t2', 'file2.py', 'pending')"
+        )
+    second = next(resp.response).decode().strip()
+    data = json.loads(second.split("data: ")[1])
+    assert any(entry["path"] == "file2.py" for entry in data)
+


### PR DESCRIPTION
## Summary
- expose `/metrics_stream` and new `/corrections_stream` SSE endpoints
- update dashboard template to consume correction stream in real time
- document streaming endpoints and add integration tests

## Testing
- `ruff check dashboard/enterprise_dashboard.py tests/dashboard/test_corrections_stream.py`
- `pytest tests/dashboard/test_corrections_stream.py tests/dashboard/test_metrics_stream_fallback.py tests/dashboard/test_live_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_689a52d0b9fc83318912dcc2c937e654