### PR TITLE
fix: handle missing tracking entries when applying suggestions

### DIFF
--- a/scripts/code_placeholder_audit.py
+++ b/scripts/code_placeholder_audit.py
@@ -34,16 +34,21 @@ from enterprise_modules.compliance import (
     validate_enterprise_operation,
 )
 from scripts.database.add_code_audit_log import ensure_code_audit_log
+
 # ``template_engine`` is optional; fall back to a no-op if missing.
 try:
     from template_engine.template_placeholder_remover import remove_unused_placeholders
 except ModuleNotFoundError:
+
     def remove_unused_placeholders(text: str, *args, **kwargs) -> str:  # type: ignore[no-redef]
         """Return text unchanged when placeholder remover is unavailable."""
         return text
+
+
 from scripts.correction_logger_and_rollback import CorrectionLoggerRollback
 import secondary_copilot_validator
 from utils.log_utils import log_message
+
 try:  # pragma: no cover - optional dependency for dashboard integration
     from dashboard.compliance_metrics_updater import ComplianceMetricsUpdater
 except Exception:  # pragma: no cover - allow absence during unit tests
@@ -150,9 +155,7 @@ def generate_removal_tasks(
 
     tasks: List[Dict[str, str]] = []
     for item in results:
-        description = (
-            f"Remove {item['pattern']} in {item['file']}:{item['line']} - {item['context']}"
-        )
+        description = f"Remove {item['pattern']} in {item['file']}:{item['line']} - {item['context']}"
         suggestion = _suggest_fix(item["context"])
         if production_db and analytics_db:
             try:
@@ -190,9 +193,7 @@ def write_tasks_report(tasks: List[Dict[str, str]], report_path: Path) -> None:
         report_path.write_text(json.dumps(tasks, indent=2), encoding="utf-8")
 
 
-def log_placeholder_tasks(
-    tasks: List[Dict[str, str]], analytics_db: Path, simulate: bool = False
-) -> int:
+def log_placeholder_tasks(tasks: List[Dict[str, str]], analytics_db: Path, simulate: bool = False) -> int:
     """Persist placeholder removal tasks to tracking tables.
 
     Findings are written to both the legacy ``todo_fixme_tracking`` table
@@ -279,12 +280,8 @@ def log_placeholder_tasks(
                 )
         conn.commit()
         # Record snapshot and metrics
-        open_count = conn.execute(
-            "SELECT COUNT(*) FROM placeholder_tasks WHERE status='open'"
-        ).fetchone()[0]
-        resolved_count = conn.execute(
-            "SELECT COUNT(*) FROM placeholder_tasks WHERE status='resolved'"
-        ).fetchone()[0]
+        open_count = conn.execute("SELECT COUNT(*) FROM placeholder_tasks WHERE status='open'").fetchone()[0]
+        resolved_count = conn.execute("SELECT COUNT(*) FROM placeholder_tasks WHERE status='resolved'").fetchone()[0]
         try:
             auto_removal_count = conn.execute(
                 "SELECT COUNT(*) FROM corrections WHERE rationale='Auto placeholder cleanup'"
@@ -346,19 +343,13 @@ def verify_task_completion(analytics_db: Path, workspace: Path) -> int:
     resolved = 0
     with sqlite3.connect(analytics_db) as conn:
         tables = []
-        if conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='placeholder_tasks'"
-        ).fetchone():
+        if conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='placeholder_tasks'").fetchone():
             tables.append(("placeholder_tasks", "pattern"))
-        if conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='todo_fixme_tracking'"
-        ).fetchone():
+        if conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='todo_fixme_tracking'").fetchone():
             tables.append(("todo_fixme_tracking", "placeholder_type"))
 
         for table, col in tables:
-            cur = conn.execute(
-                f"SELECT rowid, file_path, line_number, {col} FROM {table} WHERE status='open'"
-            )
+            cur = conn.execute(f"SELECT rowid, file_path, line_number, {col} FROM {table} WHERE status='open'")
             rows = cur.fetchall()
             for rowid, fpath, line, pattern in rows:
                 path = Path(fpath)
@@ -466,10 +457,7 @@ def record_unresolved_placeholders(
     suppress duplicates.
     """
 
-    rows = [
-        (r["file"], int(r["line"]), r.get("pattern", ""), r.get("context", ""))
-        for r in results
-    ]
+    rows = [(r["file"], int(r["line"]), r.get("pattern", ""), r.get("context", "")) for r in results]
     with sqlite3.connect(analytics_db) as conn:
         conn.execute(
             """
@@ -482,12 +470,10 @@ def record_unresolved_placeholders(
             """
         )
         conn.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_unresolved_file_line"
-            " ON unresolved_placeholders(file, line)"
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_unresolved_file_line ON unresolved_placeholders(file, line)"
         )
         conn.executemany(
-            "INSERT OR IGNORE INTO unresolved_placeholders"
-            " (file, line, pattern, context) VALUES (?, ?, ?, ?)",
+            "INSERT OR IGNORE INTO unresolved_placeholders (file, line, pattern, context) VALUES (?, ?, ?, ?)",
             rows,
         )
         conn.commit()
@@ -509,25 +495,15 @@ def snapshot_placeholder_counts(db: Path) -> Tuple[int, int]:
 
     with sqlite3.connect(db) as conn:
         _ensure_placeholder_tables(conn)
-        if conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='placeholder_tasks'"
-        ).fetchone():
-            cur = conn.execute(
-                "SELECT COUNT(*) FROM placeholder_tasks WHERE status='open'"
-            )
+        if conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='placeholder_tasks'").fetchone():
+            cur = conn.execute("SELECT COUNT(*) FROM placeholder_tasks WHERE status='open'")
             open_count = int(cur.fetchone()[0])
-            cur = conn.execute(
-                "SELECT COUNT(*) FROM placeholder_tasks WHERE status='resolved'"
-            )
+            cur = conn.execute("SELECT COUNT(*) FROM placeholder_tasks WHERE status='resolved'")
             resolved_count = int(cur.fetchone()[0])
         else:
-            cur = conn.execute(
-                "SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='open'"
-            )
+            cur = conn.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='open'")
             open_count = int(cur.fetchone()[0])
-            cur = conn.execute(
-                "SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='resolved'"
-            )
+            cur = conn.execute("SELECT COUNT(*) FROM todo_fixme_tracking WHERE status='resolved'")
             resolved_count = int(cur.fetchone()[0])
         return open_count, resolved_count
 
@@ -550,11 +526,10 @@ def get_latest_placeholder_snapshot(
     """
 
     _ensure_placeholder_tables(conn)
-    cur = conn.execute(
-        "SELECT open_count, resolved_count FROM placeholder_audit_snapshots ORDER BY id DESC LIMIT 1"
-    )
+    cur = conn.execute("SELECT open_count, resolved_count FROM placeholder_audit_snapshots ORDER BY id DESC LIMIT 1")
     row = cur.fetchone()
     return (int(row[0]), int(row[1])) if row else (0, 0)
+
 
 # Insert findings into analytics.db.code_audit_log
 def log_findings(
@@ -564,7 +539,7 @@ def log_findings(
     *,
     update_resolutions: bool = False,
     auto_remove_resolved: bool = False,
-    ) -> int:
+) -> int:
     """Log audit results to analytics.db.
 
     Parameters
@@ -748,8 +723,6 @@ def log_findings(
     return findings_inserted
 
 
-
-
 def apply_suggestions_to_files(
     tasks: List[Dict[str, str]],
     analytics_db: Path,
@@ -794,21 +767,33 @@ def apply_suggestions_to_files(
             continue
         idx = int(task["line"]) - 1
         if 0 <= idx < len(lines):
-            lines[idx] = suggestion
-            resolved.write_text("\n".join(lines) + "\n", encoding="utf-8")
             with sqlite3.connect(analytics_db) as conn:
-                conn.execute(
-                    "UPDATE todo_fixme_tracking SET resolved=1, resolved_timestamp=?, resolved_by=?, status='resolved' WHERE file_path=? AND line_number=? AND placeholder_type=? AND context=?",
+                cur = conn.execute(
+                    "SELECT 1 FROM todo_fixme_tracking WHERE file_path=? AND line_number=? AND placeholder_type=? AND context=?",
                     (
-                        datetime.now().isoformat(),
-                        author,
                         task["file"],
                         int(task["line"]),
                         task["pattern"],
                         task["context"],
                     ),
                 )
-                conn.commit()
+                if cur.fetchone():
+                    lines[idx] = suggestion
+                    resolved.write_text("\n".join(lines) + "\n", encoding="utf-8")
+                    conn.execute(
+                        "UPDATE todo_fixme_tracking SET resolved=1, resolved_timestamp=?, resolved_by=?, status='resolved' WHERE file_path=? AND line_number=? AND placeholder_type=? AND context=?",
+                        (
+                            datetime.now().isoformat(),
+                            author,
+                            task["file"],
+                            int(task["line"]),
+                            task["pattern"],
+                            task["context"],
+                        ),
+                    )
+                    conn.commit()
+                else:
+                    unresolved.append(task)
         else:
             unresolved.append(task)
     return unresolved
@@ -904,19 +889,14 @@ def update_dashboard(
         "resolved": resolved,
         "timestamp": timestamp,
     }
-    (dashboard_dir / "placeholder_counts.json").write_text(
-        json.dumps(counts_payload, indent=2), encoding="utf-8"
-    )
+    (dashboard_dir / "placeholder_counts.json").write_text(json.dumps(counts_payload, indent=2), encoding="utf-8")
     history: List[Dict[str, int]] = []
     if analytics_db.exists():
         with sqlite3.connect(analytics_db) as conn:
             cur = conn.execute(
                 "SELECT timestamp, open_count, resolved_count FROM placeholder_audit_snapshots ORDER BY timestamp"
             )
-            history = [
-                {"timestamp": row[0], "open_count": row[1], "resolved_count": row[2]}
-                for row in cur.fetchall()
-            ]
+            history = [{"timestamp": row[0], "open_count": row[1], "resolved_count": row[2]} for row in cur.fetchall()]
     (dashboard_dir / "placeholder_history.json").write_text(
         json.dumps({"history": history}, indent=2), encoding="utf-8"
     )
@@ -941,9 +921,7 @@ def export_resolved_placeholders(analytics_db: Path, dashboard_dir: Path) -> Non
             }
             for row in cur.fetchall()
         ]
-    (dashboard_dir / "resolved_placeholders.json").write_text(
-        json.dumps(rows, indent=2), encoding="utf-8"
-    )
+    (dashboard_dir / "resolved_placeholders.json").write_text(json.dumps(rows, indent=2), encoding="utf-8")
 
 
 # Scan a single file for placeholder patterns
@@ -1412,6 +1390,7 @@ def main(
             )
         try:
             from scripts.compliance.update_compliance_metrics import update_compliance_metrics
+
             update_compliance_metrics(str(workspace))
         except Exception as exc:
             log_message(

--- a/tests/placeholder/test_code_placeholder_audit.py
+++ b/tests/placeholder/test_code_placeholder_audit.py
@@ -22,9 +22,7 @@ def test_record_unresolved_placeholders_ignores_duplicates(tmp_path):
     audit.record_unresolved_placeholders(rows, analytics)
     audit.record_unresolved_placeholders(rows, analytics)
     with sqlite3.connect(analytics) as conn:
-        count = conn.execute(
-            "SELECT COUNT(*) FROM unresolved_placeholders"
-        ).fetchone()[0]
+        count = conn.execute("SELECT COUNT(*) FROM unresolved_placeholders").fetchone()[0]
     assert count == 1
 
 
@@ -109,24 +107,12 @@ def test_apply_fixes_updates_db_and_file(tmp_path, monkeypatch):
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
     monkeypatch.setenv("GH_COPILOT_BACKUP_ROOT", str(tmp_path / "backups"))
     monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
-    monkeypatch.setattr(
-        "scripts.database.add_violation_logs.ensure_violation_logs", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        "enterprise_modules.compliance.ensure_violation_logs", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        "scripts.correction_logger_and_rollback.ensure_violation_logs", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        "scripts.database.add_rollback_logs.ensure_rollback_logs", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        "enterprise_modules.compliance.ensure_rollback_logs", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        "scripts.correction_logger_and_rollback.ensure_rollback_logs", lambda *a, **k: None
-    )
+    monkeypatch.setattr("scripts.database.add_violation_logs.ensure_violation_logs", lambda *a, **k: None)
+    monkeypatch.setattr("enterprise_modules.compliance.ensure_violation_logs", lambda *a, **k: None)
+    monkeypatch.setattr("scripts.correction_logger_and_rollback.ensure_violation_logs", lambda *a, **k: None)
+    monkeypatch.setattr("scripts.database.add_rollback_logs.ensure_rollback_logs", lambda *a, **k: None)
+    monkeypatch.setattr("enterprise_modules.compliance.ensure_rollback_logs", lambda *a, **k: None)
+    monkeypatch.setattr("scripts.correction_logger_and_rollback.ensure_rollback_logs", lambda *a, **k: None)
     audit.main(
         workspace_path=str(workspace),
         analytics_db=str(analytics_db),
@@ -144,9 +130,7 @@ def test_apply_fixes_updates_db_and_file(tmp_path, monkeypatch):
     )
     assert "TODO" not in src.read_text()
     with sqlite3.connect(analytics_db) as conn:
-        cur = conn.execute(
-            "SELECT status, resolved FROM todo_fixme_tracking"
-        )
+        cur = conn.execute("SELECT status, resolved FROM todo_fixme_tracking")
         status, resolved = cur.fetchone()
     assert status == "resolved" and resolved == 1
     resolved_file = dashboard / "resolved_placeholders.json"
@@ -181,9 +165,7 @@ def test_apply_suggestions_updates_file_and_db(tmp_path, monkeypatch):
     )
     assert "FIXME" not in src.read_text()
     with sqlite3.connect(analytics_db) as conn:
-        unresolved = conn.execute(
-            "SELECT COUNT(*) FROM placeholder_tasks WHERE status='open'"
-        ).fetchone()[0]
+        unresolved = conn.execute("SELECT COUNT(*) FROM placeholder_tasks WHERE status='open'").fetchone()[0]
     assert unresolved == 0
 
 
@@ -231,6 +213,34 @@ def test_apply_suggestions_ignores_relative_paths_outside_workspace(tmp_path, ca
     assert "outside workspace" in out
 
 
+def test_apply_suggestions_skips_missing_tracking_entry(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    src = workspace / "foo.py"
+    src.write_text("# TODO: fix\n", encoding="utf-8")
+    analytics_db = tmp_path / "analytics.db"
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            "CREATE TABLE todo_fixme_tracking (file_path TEXT, line_number INTEGER, placeholder_type TEXT, context TEXT, suggestion TEXT, resolved INTEGER, resolved_timestamp TEXT, resolved_by TEXT, status TEXT)"
+        )
+        conn.commit()
+    tasks = [
+        {
+            "file": str(src),
+            "line": 1,
+            "pattern": "TODO",
+            "context": "# TODO: fix",
+            "suggestion": "# done",
+        }
+    ]
+    unresolved = audit.apply_suggestions_to_files(tasks, analytics_db, workspace)
+    assert unresolved == tasks
+    assert src.read_text(encoding="utf-8") == "# TODO: fix\n"
+    with sqlite3.connect(analytics_db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM todo_fixme_tracking").fetchone()[0]
+    assert count == 0
+
+
 def test_placeholder_tasks_logged(tmp_path, monkeypatch):
     workspace = tmp_path / "ws"
     workspace.mkdir()
@@ -258,11 +268,7 @@ def test_placeholder_tasks_logged(tmp_path, monkeypatch):
         fail_on_findings=False,
     )
     with sqlite3.connect(analytics_db) as conn:
-        row = conn.execute(
-            "SELECT file_path, line_number FROM placeholder_tasks"
-        ).fetchone()
-        metrics_rows = conn.execute(
-            "SELECT COUNT(*) FROM placeholder_metrics"
-        ).fetchone()[0]
+        row = conn.execute("SELECT file_path, line_number FROM placeholder_tasks").fetchone()
+        metrics_rows = conn.execute("SELECT COUNT(*) FROM placeholder_metrics").fetchone()[0]
     assert row == (str(src), 1)
     assert metrics_rows == 1


### PR DESCRIPTION
## Summary
- verify todo_fixme_tracking contains placeholder before applying suggestion
- skip file update and mark task unresolved if tracking entry is missing
- add regression test for missing tracking records

## Testing
- `ruff check scripts/code_placeholder_audit.py tests/placeholder/test_code_placeholder_audit.py`
- `pytest tests/placeholder/test_code_placeholder_audit.py`
- `pyright scripts/code_placeholder_audit.py tests/placeholder/test_code_placeholder_audit.py`
- `pytest tests/placeholder/test_code_placeholder_audit.py --json-report --maxfail=1` *(fails: unrecognized arguments: --json-report)*
- `python scripts/ingest_test_and_lint_results.py` *(fails: ModuleNotFoundError: No module named 'scripts')*
- `python -m scripts.compliance.update_compliance_metrics` *(fails: sqlite3.OperationalError: no such column: ts)*

------
https://chatgpt.com/codex/tasks/task_e_689a5273f7c88331ad3ecb1b974d87a8