### PR TITLE
fix: handle broken pipe in clw

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ The terminal enforces a **1600-byte per-line limit**. Lines longer than this wil
 * When unsure, redirect command output to a log file and inspect it using `clw` or chunked reads (`head`, `tail`).
 * If `clw` is missing, recreate it from `tools/clw.py`, place it at `/usr/local/bin/clw`, and make it executable.
 * On any line-length error, start a new session, re-run setup, and retry the command using `clw` or log chunking.
+* The wrapper now exits quietly if the downstream pipe closes (e.g., when piping into `head`), avoiding `BrokenPipeError` stack traces.
 
 ## Large Output Handling
 

--- a/tests/tools/test_clw.py
+++ b/tests/tools/test_clw.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def test_clw_silently_handles_broken_pipe():
+    cmd = "set -o pipefail; printf 'data\n' | /usr/local/bin/clw | head -n 0"
+    result = subprocess.run(
+        ["bash", "-c", cmd], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    assert b"Traceback" not in result.stderr

--- a/tools/clw.py
+++ b/tools/clw.py
@@ -52,10 +52,13 @@ def main() -> None:
 
     for line in sys.stdin.buffer:
         for wrapped, chunk in split_into_chunks(line, chunk_size):
-            sys.stdout.buffer.write(chunk)
-            if wrapped:
-                sys.stdout.buffer.write(mark)
-            sys.stdout.buffer.flush()
+            try:
+                sys.stdout.buffer.write(chunk)
+                if wrapped:
+                    sys.stdout.buffer.write(mark)
+                sys.stdout.buffer.flush()
+            except BrokenPipeError:
+                return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- handle BrokenPipeError in clw to avoid stack traces when downstream pipe closes
- add regression test simulating closed pipe
- document clw broken pipe behavior in AGENTS.md

## Testing
- `ruff check tools/clw.py tests/tools/test_clw.py`
- `pytest tests/test_clw.py tests/tools/test_clw.py`


------
https://chatgpt.com/codex/tasks/task_e_689a5994d8e48331893864eedc9d89f2