### PR TITLE
feat: centralize placeholder pattern configuration

### DIFF
--- a/config/audit_patterns.json
+++ b/config/audit_patterns.json
@@ -1,0 +1,12 @@
+{
+  "placeholder_patterns": [
+    "TODO",
+    "FIXME",
+    "pass\\b",
+    "NotImplementedError",
+    "placeholder",
+    "HACK",
+    "BUG",
+    "XXX"
+  ]
+}

--- a/docs/PLACEHOLDER_AUDIT_COMPLIANCE.md
+++ b/docs/PLACEHOLDER_AUDIT_COMPLIANCE.md
@@ -6,7 +6,7 @@ This guide outlines the procedure for running the placeholder audit and verifyin
 
 1. Activate the project virtual environment.
 2. Execute `python -m scripts.code_placeholder_audit --workspace-path <path> --analytics-db databases/analytics.db --production-db databases/production.db --dashboard-dir dashboard/compliance`.
-3. The script scans for TODO, FIXME, and related markers. Findings are written to `databases/analytics.db` and summarized under `dashboard/compliance`.
+3. The script scans for markers defined in `config/audit_patterns.json` (e.g., TODO, FIXME). Findings are written to `databases/analytics.db` and summarized under `dashboard/compliance`.
 
 ## Reviewing Results
 

--- a/tests/test_placeholder_pattern_consistency.py
+++ b/tests/test_placeholder_pattern_consistency.py
@@ -1,0 +1,26 @@
+from enterprise_modules import compliance
+from scripts import code_placeholder_audit as audit
+
+
+def test_placeholder_counts_consistent(tmp_path, monkeypatch):
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    sample = tmp_path / "example.py"
+    sample.write_text(
+        "\n".join(
+            [
+                "TODO",
+                "FIXME",
+                "pass",
+                "NotImplementedError",
+                "placeholder",
+                "HACK",
+                "BUG",
+                "XXX",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    audit_count = len(audit.scan_file_for_placeholders(sample))
+    compliance_count = compliance._count_placeholders()  # noqa: SLF001
+    assert audit_count == compliance_count

--- a/validation/compliance_report_generator.py
+++ b/validation/compliance_report_generator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from utils.log_utils import _log_plain
 from utils.validation_utils import calculate_composite_compliance_score
 import os
@@ -13,8 +14,9 @@ from pathlib import Path
 from typing import Dict, Any
 
 from tqdm import tqdm
+from enterprise_modules.compliance import load_placeholder_patterns
 
-PLACEHOLDER_PATTERNS = ["TODO", "FIXME"]
+PLACEHOLDER_PATTERNS = load_placeholder_patterns()
 
 DEFAULT_ANALYTICS_DB = Path("databases/analytics.db")
 LOGS_DIR = Path("artifacts/logs/template_rendering")
@@ -66,7 +68,7 @@ def _parse_pytest(path: Path) -> Dict[str, Any]:
 
 
 def _count_placeholders(workspace: Path) -> int:
-    """Return count of TODO/FIXME markers in ``workspace``."""
+    """Return count of placeholder markers in ``workspace``."""
     count = 0
     for file in workspace.rglob("*.py"):
         try:
@@ -74,7 +76,7 @@ def _count_placeholders(workspace: Path) -> int:
         except (OSError, UnicodeDecodeError):
             continue
         for pattern in PLACEHOLDER_PATTERNS:
-            count += text.count(pattern)
+            count += len(re.findall(pattern, text))
     return count
 
 


### PR DESCRIPTION
## Summary
- externalize placeholder regexes to `config/audit_patterns.json`
- load shared patterns in compliance, audit script, and report generator
- ensure placeholder counts match across audit and compliance modules

## Testing
- `ruff check enterprise_modules/compliance.py scripts/code_placeholder_audit.py validation/compliance_report_generator.py tests/test_placeholder_pattern_consistency.py`
- `pytest tests/test_placeholder_pattern_consistency.py`


------
https://chatgpt.com/codex/tasks/task_e_689a5ec8970c8331ab1b64de92a496c9