### PR TITLE
feat: add scoped safe rg wrapper with diagnostics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,18 +9,16 @@ Thank you for considering a contribution to gh_COPILOT. Please follow these guid
 
 ## Safe ripgrep usage for large repositories
 
-Use the wrapper `./scripts/rg_safe.sh` (which invokes [`rg`](https://github.com/BurntSushi/ripgrep) with sensible limits) to avoid overwhelming the console:
+Use the wrapper `./tools/safe_rg.sh` to search without flooding the console. It limits line widths, skips heavy directories, and saves full results when matches exceed a safe size.
 
-- Limit scope with globs or directory exclusions and cap matches.
-  Example:
+- **Limit scope** with globs or directory exclusions and cap matches (default 200 via `SAFE_RG_MAX_COUNT`):
   ```bash
-  set +o pipefail && ./scripts/rg_safe.sh "except\s*:" -g "*.py" --max-count 200 | head
+  set +o pipefail && ./tools/safe_rg.sh "except\s*:" -g "*.py"
   ```
-- Ensure downstream tools read all input. Use `set +o pipefail`, `--no-buffer`, and viewers like `head`, `tail`, or `clw`.
-- When truncating output, capture the full results to a temporary log for later review:
+- **Control downstream consumption** using `set +o pipefail` and viewers like `head`, `tail`, or `clw` to consume the output safely.
+- **Diagnostics**: when results are truncated, the script stores the complete output under `$GH_COPILOT_BACKUP_ROOT` and prints the file path for manual review. Adjust the limit with `SAFE_RG_MAX_COUNT` if needed:
   ```bash
-  set +o pipefail && ./scripts/rg_safe.sh --no-buffer "TODO" -g "*.py" --max-count 200 \
-    | tee /tmp/rg_todo.log | head
+  SAFE_RG_MAX_COUNT=100 set +o pipefail && ./tools/safe_rg.sh "TODO" -g "*.py"
   ```
 
 ## Documentation Workflow Checklist

--- a/scripts/rg_safe.sh
+++ b/scripts/rg_safe.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+# Delegate to the central safe ripgrep wrapper.
 set -euo pipefail
 
-# Wrapper around ripgrep enforcing sane defaults to avoid runaway line sizes.
-exec rg --max-columns=200 --max-columns-preview "$@"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/../tools/safe_rg.sh" "$@"
 

--- a/tools/safe_rg.sh
+++ b/tools/safe_rg.sh
@@ -1,11 +1,33 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+# Safe ripgrep wrapper with output throttling and diagnostics.
+# - Limits columns to prevent exceedingly long lines.
+# - Excludes heavy directories.
+# - Captures full results to a temp file when truncated.
+
 set -euo pipefail
 
-# Wrapper around ripgrep with sane defaults.
-# - Limits columns to avoid exceedingly long lines.
-# - Suppresses error messages.
-# - Skips heavy build directories by default.
+MAX_COUNT=${SAFE_RG_MAX_COUNT:-200}
+BACKUP_ROOT=${GH_COPILOT_BACKUP_ROOT:-/tmp}
+TMP_FILE="$(mktemp "${BACKUP_ROOT%/}/safe_rg.XXXXXX.log")"
 
-rg --max-columns=300 --no-messages --glob '!:builds/**' "$@" | cut -c1-300
-exit ${PIPESTATUS[0]}
+rg --max-columns=300 --no-messages \
+  --max-count=$((MAX_COUNT+1)) \
+  --glob '!:builds/**' --glob '!:artifacts/**' --glob '!:archive/**' --glob '!:logs/**' \
+  "$@" >"$TMP_FILE" || true
+
+TOTAL_LINES=$(wc -l <"$TMP_FILE")
+
+set +o pipefail
+head -n "$MAX_COUNT" "$TMP_FILE" | cut -c1-300
+set -o pipefail
+
+if [ "$TOTAL_LINES" -gt "$MAX_COUNT" ]; then
+  echo "Result truncated to ${MAX_COUNT} lines. Full output saved to $TMP_FILE" >&2
+else
+  rm -f "$TMP_FILE"
+fi
+
+exit 0
 


### PR DESCRIPTION
## Summary
- add temp-file logging and directory exclusions to safe_rg.sh
- delegate scripts/rg_safe.sh to central wrapper
- document safe ripgrep usage with examples

## Testing
- `ruff check .` *(fails: F821 in backup_archiver.py, documentation_ingestor.py)*
- `ruff format tools/safe_rg.sh scripts/rg_safe.sh CONTRIBUTING.md` *(fails: Failed to parse non-Python files)*
- `pyright` *(execution interrupted: KeyboardInterrupt)*
- `pytest` *(fails: NameError in tests/database/test_documentation_ingestor.py)*


------
https://chatgpt.com/codex/tasks/task_e_689a5ed96b908331a42c4b6b0f195417