### PR TITLE
chore: add ripgrep ignore for build artifacts

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,3 @@
+builds/
+reports/
+deployment/


### PR DESCRIPTION
## Summary
- add .rgignore to ignore build and deployment artifacts

## Testing
- `ruff check .` *(fails: F821 Undefined name `pid_recursion_guard`)*
- `pytest -q` *(fails: unrecognized arguments: --cov=. --cov-report=term)*
- `python scripts/wlc_session_manager.py --help` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_689a6555d09083319ae0f42974d65d77