### PR TITLE
fix: pin qiskit and guard backend provider imports

### DIFF
--- a/quantum/utils/backend_provider.py
+++ b/quantum/utils/backend_provider.py
@@ -7,21 +7,11 @@ import os
 from typing import Optional
 
 try:  # pragma: no cover - optional dependency
-    from qiskit import Aer
-except Exception:  # pragma: no cover - qiskit may be missing
-    try:  # fallback to BasicAer if available
-        from qiskit.providers.basicaer import QasmSimulator
-
-        class _AerShim:  # pragma: no cover - simple shim
-            @staticmethod
-            def get_backend(name: str):
-                if name == "qasm_simulator":
-                    return QasmSimulator()
-                raise ValueError("Backend not available")
-
-        Aer = _AerShim()
-    except Exception:
-        Aer = None
+    from qiskit_aer import Aer
+except Exception as exc:  # pragma: no cover - qiskit may be missing
+    raise ImportError(
+        "qiskit-aer is required for backend_provider; install qiskit==1.4.2"
+    ) from exc
 
 try:  # pragma: no cover - optional dependency
     from qiskit_ibm_provider import IBMProvider
@@ -60,11 +50,8 @@ def get_backend(
     Returns
     -------
     Any
-        The selected backend instance or ``None`` if Qiskit is unavailable.
+        The selected backend instance.
     """
-    if Aer is None:
-        LOGGER.warning("Qiskit Aer not available; no backend returned")
-        return None
 
     if use_hardware is None:
         use_hardware = os.getenv("QUANTUM_USE_HARDWARE", "0") == "1"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,10 +7,10 @@ tqdm
 numpy
 scikit-learn
 Flask==3.1.1
-qiskit>=1.4,<2.0
+qiskit==1.4.2
 qiskit-aer==0.17.1
 qiskit-machine-learning>=0.6.0
-qiskit-ibm-provider>=0.7.0
+qiskit-ibm-provider==0.7.0
 dill>=0.3.7
 py7zr
 schedule

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ requests==2.32.4            # HTTP orchestration and web hooks
 pandas==2.3.1               # Dataframe operations and analytics
 numpy==2.3.1                # Numerical optimization and simulation
 scikit-learn==1.7.0         # ML algorithms (e.g., clustering, MLP)
-qiskit>=1.4,<2.0            # Quantum optimizer backend
-qiskit-ibm-provider>=0.7.0  # IBM Quantum hardware access
+qiskit==1.4.2               # Quantum optimizer backend
+qiskit-ibm-provider==0.7.0  # IBM Quantum hardware access
 psutil==7.0.0               # System resource monitoring
 tqdm==4.67.1                # Progress bar for CLI and batch tasks
 PyYAML==6.0.2               # YAML config parsing

--- a/tests/quantum_tests/test_backend_provider_simulator.py
+++ b/tests/quantum_tests/test_backend_provider_simulator.py
@@ -1,0 +1,13 @@
+"""Smoke tests for the simulator backend provider."""
+
+import pytest
+
+pytest.importorskip("qiskit")
+
+from quantum.utils import backend_provider
+
+
+def test_simulator_backend_available():
+    backend = backend_provider.get_backend(use_hardware=False)
+    assert backend is not None
+


### PR DESCRIPTION
## Summary
- pin qiskit 1.4.2 and matching qiskit-ibm-provider in requirements
- raise clear error when qiskit-aer is missing in backend provider
- add simulator-only smoke test for backend provider

## Testing
- `ruff check quantum/utils/backend_provider.py tests/quantum_tests/test_backend_provider_simulator.py`
- `pytest tests/quantum_tests/test_backend_provider_simulator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6aea1a5083319acd0155e2e04308