### PR TITLE
fix: import pid recursion guard in documentation ingestor

### DIFF
--- a/scripts/database/documentation_ingestor.py
+++ b/scripts/database/documentation_ingestor.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 
 from enterprise_modules.compliance import (
     enforce_anti_recursion,
+    pid_recursion_guard,
     validate_enterprise_operation,
 )
 from template_engine.learning_templates import get_dataset_sources

--- a/tests/database/test_documentation_ingestor.py
+++ b/tests/database/test_documentation_ingestor.py
@@ -1,7 +1,11 @@
 import sqlite3
 from pathlib import Path
 
-from scripts.database.documentation_ingestor import ingest_documentation
+from enterprise_modules.compliance import pid_recursion_guard as compliance_pid_guard
+from scripts.database.documentation_ingestor import (
+    ingest_documentation,
+    pid_recursion_guard,
+)
 
 
 def test_duplicate_detection(tmp_path: Path, monkeypatch) -> None:
@@ -55,3 +59,8 @@ def test_validator_invoked(tmp_path: Path, monkeypatch) -> None:
 
     ingest_documentation(workspace, docs_dir)
     assert called["files"] == [str(doc)]
+
+
+def test_pid_recursion_guard_exposed() -> None:
+    """Ensure the pid_recursion_guard decorator is imported correctly."""
+    assert pid_recursion_guard is compliance_pid_guard

--- a/tests/test_documentation_ingestor.py
+++ b/tests/test_documentation_ingestor.py
@@ -4,7 +4,11 @@ import os
 import sqlite3
 from pathlib import Path
 
-from scripts.database.documentation_ingestor import ingest_documentation
+from enterprise_modules.compliance import pid_recursion_guard as compliance_pid_guard
+from scripts.database.documentation_ingestor import (
+    ingest_documentation,
+    pid_recursion_guard,
+)
 from scripts.database.unified_database_initializer import initialize_database
 
 
@@ -120,3 +124,8 @@ def test_reingest_logs_duplicate(tmp_path: Path, caplog, monkeypatch) -> None:
     with sqlite3.connect(db_path) as conn:
         count = conn.execute("SELECT COUNT(*) FROM documentation_assets").fetchone()[0]
     assert count == 1
+
+
+def test_pid_recursion_guard_exposed() -> None:
+    """Ensure the pid_recursion_guard decorator is imported correctly."""
+    assert pid_recursion_guard is compliance_pid_guard

--- a/tests/test_documentation_ingestor_logging.py
+++ b/tests/test_documentation_ingestor_logging.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from enterprise_modules.compliance import pid_recursion_guard as compliance_pid_guard
 from scripts.database import documentation_ingestor as di
 
 
@@ -37,3 +38,8 @@ def test_ingest_documentation_logs_event(tmp_path, monkeypatch):
 
     assert logged["op"] == "documentation_ingestion"
     assert logged["db"] == workspace / "databases" / "enterprise_assets.db"
+
+
+def test_pid_recursion_guard_exposed() -> None:
+    """Ensure the pid_recursion_guard decorator is imported correctly."""
+    assert di.pid_recursion_guard is compliance_pid_guard

--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -3,8 +3,12 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
+from enterprise_modules.compliance import pid_recursion_guard as compliance_pid_guard
 from scripts.database.template_asset_ingestor import ingest_templates
-from scripts.database.documentation_ingestor import ingest_documentation
+from scripts.database.documentation_ingestor import (
+    ingest_documentation,
+    pid_recursion_guard,
+)
 from scripts.database.cross_database_sync_logger import _table_exists, log_sync_operation
 from scripts.database.ingestion_validator import IngestionValidator
 
@@ -20,6 +24,11 @@ def _create_unique_files(directory: Path) -> None:
     directory.mkdir(parents=True, exist_ok=True)
     (directory / "alpha.md").write_text("alpha", encoding="utf-8")
     (directory / "beta.md").write_text("beta", encoding="utf-8")
+
+
+def test_documentation_ingestor_decorator_exposed() -> None:
+    """Ensure the pid_recursion_guard decorator is imported correctly."""
+    assert pid_recursion_guard is compliance_pid_guard
 
 
 def test_ingestion_pipeline(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- import `pid_recursion_guard` in `documentation_ingestor`
- expose the decorator in associated tests
- verify decorator availability across ingestion pipeline tests

## Testing
- `ruff check scripts/database/documentation_ingestor.py tests/database/test_documentation_ingestor.py tests/test_documentation_ingestor.py tests/test_ingestion_pipeline.py tests/test_documentation_ingestor_logging.py`
- `pytest tests/database/test_documentation_ingestor.py tests/test_documentation_ingestor.py tests/test_ingestion_pipeline.py tests/test_documentation_ingestor_logging.py`
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689a72c74a788331b61f844080f496d1