### PR TITLE
fix: clean up imports and recursion guards

### DIFF
--- a/quantum/__init__.py
+++ b/quantum/__init__.py
@@ -7,11 +7,6 @@ and orchestration capabilities while maintaining backward compatibility.
 """
 
 from . import benchmarking, quantum_optimization
-from .quantum_database_search import (
-    quantum_search_sql,
-    quantum_search_nosql,
-    quantum_search_hybrid,
-)
 from .optimizers.quantum_optimizer import QuantumOptimizer
 
 # Import new modular components

--- a/scripts/backup_archiver.py
+++ b/scripts/backup_archiver.py
@@ -14,6 +14,7 @@ import py7zr
 from enterprise_modules.compliance import (
     enforce_anti_recursion,
     validate_enterprise_operation,
+    pid_recursion_guard,
 )
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.validation_utils import anti_recursion_guard

--- a/scripts/database/documentation_ingestor.py
+++ b/scripts/database/documentation_ingestor.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from enterprise_modules.compliance import (
     enforce_anti_recursion,
     validate_enterprise_operation,
+    pid_recursion_guard,
 )
 from template_engine.learning_templates import get_dataset_sources
 

--- a/scripts/utilities/phase6_comprehensive_elimination_system.py
+++ b/scripts/utilities/phase6_comprehensive_elimination_system.py
@@ -13,19 +13,15 @@ Enterprise-Grade Multi-Processor Violation Elimination Framework
 🏆 SUCCESS METRIC: 95%+ elimination rate across all categories
 """
 
-import os
 import re
-import sys
-import ast
 import json
 import time
-import shutil
 import logging
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, List, Any
 from dataclasses import dataclass
-from collections import defaultdict, Counter
+from collections import defaultdict
 
 # Configure enterprise logging
 logging.basicConfig(
@@ -119,8 +115,9 @@ class Phase6ComprehensiveEliminationSystem:
                 files_modified.update(getattr(result, 'modified_files', []))
 
                 logger.info(
-    f"# # # ✅ {processor_name}: {result.eliminated_count}/{result.initial_count} eliminated (
-    {result.elimination_rate:.1f}%)")
+                    f"# # # ✅ {processor_name}: {result.eliminated_count}/{result.initial_count} eliminated "
+                    f"({result.elimination_rate:.1f}%)"
+                )
 
             except Exception as e:
                 logger.error(f"❌ {processor_name} failed: {e}")
@@ -234,8 +231,9 @@ class E999SyntaxErrorProcessor:
         elimination_rate = (eliminated_count / initial_count * 100) if initial_count > 0 else 0
 
         logger.info(
-    f"# # # ✅ E999 Processor: {eliminated_count}/{initial_count} corrected (
-    {elimination_rate:.1f}%)")
+            f"# # # ✅ E999 Processor: {eliminated_count}/{initial_count} corrected "
+            f"({elimination_rate:.1f}%)"
+        )
 
         return ViolationMetrics(
             category=self.category,


### PR DESCRIPTION
## Summary
- remove unused quantum search imports
- ensure pid_recursion_guard imported before usage
- tidy phase6 elimination system imports and logging

## Testing
- `ruff check quantum/__init__.py scripts/backup_archiver.py scripts/database/documentation_ingestor.py scripts/utilities/phase6_comprehensive_elimination_system.py`
- `python -m py_compile quantum/__init__.py scripts/backup_archiver.py scripts/database/documentation_ingestor.py scripts/utilities/phase6_comprehensive_elimination_system.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'utils')*


------
https://chatgpt.com/codex/tasks/task_e_689a74b92ae483318072528fb74644dd