### PR TITLE
fix: regenerate Git LFS attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,5 +14,9 @@ web_gui/documentation/deployment/screenshots/*.png filter=lfs diff=lfs merge=lfs
 web_gui/assets/icons/** filter=lfs diff=lfs merge=lfs -text
 web_gui/assets/images/** filter=lfs diff=lfs merge=lfs -text
 web_gui/assets/fonts/** filter=lfs diff=lfs merge=lfs -text
+web_gui/assets/icons/.gitkeep -filter -diff -merge -text
+web_gui/assets/images/.gitkeep -filter -diff -merge -text
+web_gui/assets/fonts/.gitkeep -filter -diff -merge -text
+deployment/package/deployment_package_20250710_183234.zip -filter -diff -merge -text
 # End of LFS patterns
 codex-session_20250811_185201.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- regenerate `.gitattributes` and exclude directory placeholders from LFS

## Testing
- `git lfs status`
- `ruff check .` *(fails: `.quantum_database_search.quantum_search_sql` imported but unused; scripts/utilities/main.py:2:66: invalid-syntax)*
- `pytest` *(fails: tests/database/test_documentation_ingestor.py::NameError: name 'pid_recursion_guard' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689a73b44fec8331853e4a59090dfd0b