### PR TITLE
fix: import pid_recursion_guard decorator

### DIFF
--- a/scripts/backup_archiver.py
+++ b/scripts/backup_archiver.py
@@ -13,6 +13,7 @@ import py7zr
 
 from enterprise_modules.compliance import (
     enforce_anti_recursion,
+    pid_recursion_guard,
     validate_enterprise_operation,
 )
 from utils.cross_platform_paths import CrossPlatformPathManager

--- a/scripts/database/documentation_ingestor.py
+++ b/scripts/database/documentation_ingestor.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 
 from enterprise_modules.compliance import (
     enforce_anti_recursion,
+    pid_recursion_guard,
     validate_enterprise_operation,
 )
 from template_engine.learning_templates import get_dataset_sources


### PR DESCRIPTION
## Summary
- import `pid_recursion_guard` before use in backup and documentation ingest scripts

## Testing
- `ruff check scripts/backup_archiver.py scripts/database/documentation_ingestor.py`
- `pytest -q tests/test_pid_recursion_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_689a777776ec83319eac6a38cf240950