### PR TITLE
feat: add pluggable quantum backend providers

### DIFF
--- a/quantum/framework/__init__.py
+++ b/quantum/framework/__init__.py
@@ -1,6 +1,6 @@
 """Core abstractions for quantum backend management."""
 
-from .backend import QuantumBackend, SimulatorBackend, get_backend
+from .backend import QuantumBackend, SimulatorBackend
 from .circuit import QuantumCircuit
 from .executor import QuantumExecutor
 from .hybrid import run_with_fallback
@@ -8,7 +8,6 @@ from .hybrid import run_with_fallback
 __all__ = [
     "QuantumBackend",
     "SimulatorBackend",
-    "get_backend",
     "QuantumCircuit",
     "QuantumExecutor",
     "run_with_fallback",

--- a/quantum/framework/backend.py
+++ b/quantum/framework/backend.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Tuple
-
-from quantum.ibm_backend import init_ibm_backend
+from typing import Any
 
 
 class QuantumBackend(ABC):
@@ -21,30 +19,4 @@ class SimulatorBackend(QuantumBackend):
         return {"simulated": True, "circuit": str(circuit)}
 
 
-def get_backend(token: str | None = None) -> Tuple[QuantumBackend, bool]:
-    """Return best available backend with hardware detection.
 
-    Parameters
-    ----------
-    token:
-        Optional IBM token passed through to :func:`init_ibm_backend`.
-
-    Returns
-    -------
-    tuple
-        ``(backend, use_hardware)`` where ``backend`` implements
-        :class:`QuantumBackend` and ``use_hardware`` indicates whether a real
-        device will be used.
-    """
-    backend, use_hardware = init_ibm_backend(token=token)
-    if backend is None:
-        return SimulatorBackend(), False
-    if hasattr(backend, "run"):
-        # Wrap existing provider object in an adapter so `run` can be called.
-        class _Adapter(QuantumBackend):  # pragma: no cover - thin wrapper
-            def run(self, circuit: Any, **kwargs: Any) -> Any:
-                job = backend.run(circuit, **kwargs)
-                return job.result() if hasattr(job, "result") else job
-
-        return _Adapter(), use_hardware
-    return SimulatorBackend(), False

--- a/quantum/providers/__init__.py
+++ b/quantum/providers/__init__.py
@@ -1,0 +1,39 @@
+"""Backend provider registry.
+
+This module exposes a helper :func:`get_provider` that returns an instance of
+the requested backend provider. Providers implement
+``quantum.providers.base.BackendProvider``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .base import BackendProvider
+from .ibm import IBMBackendProvider
+from .ionq import IonQProvider
+from .rigetti import RigettiProvider
+from .simulator import SimulatorProvider
+
+# Mapping of provider names to their classes. Additional providers can be added
+# here without modifying :func:`get_provider`.
+_PROVIDERS: Dict[str, type[BackendProvider]] = {
+    "simulator": SimulatorProvider,
+    "ibm": IBMBackendProvider,
+    "ionq": IonQProvider,
+    "rigetti": RigettiProvider,
+}
+
+
+def get_provider(name: str) -> BackendProvider:
+    """Return a provider instance by name.
+
+    Unknown names default to the :class:`SimulatorProvider`.
+    """
+
+    provider_cls = _PROVIDERS.get(name, SimulatorProvider)
+    return provider_cls()
+
+
+__all__ = ["BackendProvider", "get_provider"]
+

--- a/quantum/providers/base.py
+++ b/quantum/providers/base.py
@@ -1,0 +1,21 @@
+"""Protocol for quantum backend providers."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from quantum.framework.backend import QuantumBackend
+
+
+class BackendProvider(Protocol):
+    """Interface implemented by all backend providers."""
+
+    def get_backend(self) -> QuantumBackend:  # pragma: no cover - protocol
+        """Return a :class:`~quantum.framework.backend.QuantumBackend` instance."""
+
+    def is_available(self) -> bool:  # pragma: no cover - protocol
+        """Return ``True`` if the provider can supply a backend."""
+
+
+__all__ = ["BackendProvider"]
+

--- a/quantum/providers/ibm.py
+++ b/quantum/providers/ibm.py
@@ -1,0 +1,64 @@
+"""IBM Quantum backend provider."""
+
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Any
+
+from .base import BackendProvider
+from quantum.framework.backend import QuantumBackend, SimulatorBackend
+
+try:  # pragma: no cover - optional dependency
+    from qiskit_ibm_provider import IBMProvider  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    IBMProvider = None  # type: ignore
+
+
+try:  # pragma: no cover - optional dependency
+    from qiskit import Aer  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Aer = None  # type: ignore
+
+
+class IBMBackendProvider(BackendProvider):
+    """Provide access to IBM Quantum hardware when available."""
+
+    def __init__(self) -> None:
+        self._backend: QuantumBackend | None = None
+
+    def is_available(self) -> bool:
+        token = os.getenv("QISKIT_IBM_TOKEN")
+        return IBMProvider is not None and token is not None
+
+    def _build_backend(self) -> QuantumBackend:
+        token = os.getenv("QISKIT_IBM_TOKEN")
+        backend_name = os.getenv("IBM_BACKEND")
+        if not self.is_available():
+            return SimulatorBackend()
+        try:
+            provider = IBMProvider(token=token)
+            if backend_name:
+                backend = provider.get_backend(backend_name)
+            else:
+                hardware = provider.backends(simulator=False, operational=True)
+                backend = hardware[0] if hardware else provider.get_backend("aer_simulator")
+
+            class _Adapter(QuantumBackend):  # pragma: no cover - thin wrapper
+                def run(self, circuit: Any, **kwargs: Any) -> Any:
+                    job = backend.run(circuit, **kwargs)
+                    return job.result() if hasattr(job, "result") else job
+
+            return _Adapter()
+        except Exception as exc:  # pragma: no cover - provider issues
+            warnings.warn(f"IBM backend unavailable: {exc}; using simulator")
+            return SimulatorBackend()
+
+    def get_backend(self) -> QuantumBackend:
+        if self._backend is None:
+            self._backend = self._build_backend()
+        return self._backend
+
+
+__all__ = ["IBMBackendProvider"]
+

--- a/quantum/providers/ionq.py
+++ b/quantum/providers/ionq.py
@@ -1,0 +1,21 @@
+"""IonQ backend provider (stub)."""
+
+from __future__ import annotations
+
+from .base import BackendProvider
+from quantum.framework.backend import QuantumBackend
+
+
+class IonQProvider(BackendProvider):
+    """Placeholder provider for IonQ backends."""
+
+    def get_backend(self) -> QuantumBackend:  # pragma: no cover - TODO
+        raise NotImplementedError("IonQ provider not implemented yet")
+
+    def is_available(self) -> bool:  # pragma: no cover - TODO
+        # TODO: detect IonQ SDK availability
+        return False
+
+
+__all__ = ["IonQProvider"]
+

--- a/quantum/providers/rigetti.py
+++ b/quantum/providers/rigetti.py
@@ -1,0 +1,21 @@
+"""Rigetti backend provider (stub)."""
+
+from __future__ import annotations
+
+from .base import BackendProvider
+from quantum.framework.backend import QuantumBackend
+
+
+class RigettiProvider(BackendProvider):
+    """Placeholder provider for Rigetti backends."""
+
+    def get_backend(self) -> QuantumBackend:  # pragma: no cover - TODO
+        raise NotImplementedError("Rigetti provider not implemented yet")
+
+    def is_available(self) -> bool:  # pragma: no cover - TODO
+        # TODO: detect Rigetti SDK availability
+        return False
+
+
+__all__ = ["RigettiProvider"]
+

--- a/quantum/providers/simulator.py
+++ b/quantum/providers/simulator.py
@@ -1,0 +1,20 @@
+"""Provider for the built-in simulator backend."""
+
+from __future__ import annotations
+
+from .base import BackendProvider
+from quantum.framework.backend import SimulatorBackend
+
+
+class SimulatorProvider(BackendProvider):
+    """Always-available provider that returns :class:`SimulatorBackend`."""
+
+    def get_backend(self) -> SimulatorBackend:
+        return SimulatorBackend()
+
+    def is_available(self) -> bool:
+        return True
+
+
+__all__ = ["SimulatorProvider"]
+

--- a/tests/quantum_tests/test_framework_models.py
+++ b/tests/quantum_tests/test_framework_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from quantum.framework import QuantumExecutor, SimulatorBackend, backend as fw_backend
+from quantum.framework import QuantumExecutor, SimulatorBackend
+from quantum.providers import ibm as ibm_provider
 from quantum.models import QuantumModel
 
 try:  # pragma: no cover - optional demo model
@@ -12,9 +13,9 @@ import pytest
 
 def test_executor_falls_back_to_simulator(monkeypatch):
     monkeypatch.setattr(
-        fw_backend, "init_ibm_backend", lambda token=None, backend_name=None: (None, False)
+        ibm_provider.IBMBackendProvider, "is_available", lambda self: False
     )
-    executor = QuantumExecutor()
+    executor = QuantumExecutor(provider="ibm")
     assert isinstance(executor.backend, SimulatorBackend)
     assert executor.use_hardware is False
 
@@ -26,8 +27,9 @@ class _DummyModel(QuantumModel):
 
 def test_model_run_uses_simulator(monkeypatch):
     monkeypatch.setattr(
-        fw_backend, "init_ibm_backend", lambda token=None, backend_name=None: (None, False)
+        ibm_provider.IBMBackendProvider, "is_available", lambda self: False
     )
+    monkeypatch.setenv("QUANTUM_PROVIDER", "ibm")
     model = _DummyModel()
     result = model.run()
     assert result == {"simulated": True, "circuit": "test-circuit"}
@@ -38,8 +40,9 @@ def test_demo_model(monkeypatch):
     """DemoModel should execute using the simulator backend."""
 
     monkeypatch.setattr(
-        fw_backend, "init_ibm_backend", lambda token=None, backend_name=None: (None, False)
+        ibm_provider.IBMBackendProvider, "is_available", lambda self: False
     )
+    monkeypatch.setenv("QUANTUM_PROVIDER", "ibm")
     model = DemoModel()
     result = model.run()
     assert result["simulated"] is True

--- a/tests/quantum_tests/test_provider_selection.py
+++ b/tests/quantum_tests/test_provider_selection.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from quantum.framework import QuantumExecutor, SimulatorBackend
+from quantum.providers import ibm as ibm_provider
+from quantum.framework.backend import QuantumBackend
+
+
+class _DummyBackend(QuantumBackend):
+    def run(self, circuit, **kwargs):  # pragma: no cover - simple stub
+        return {"dummy": True}
+
+
+def test_env_selects_simulator(monkeypatch):
+    monkeypatch.setenv("QUANTUM_PROVIDER", "simulator")
+    exec_ = QuantumExecutor()
+    assert isinstance(exec_.backend, SimulatorBackend)
+    assert exec_.use_hardware is False
+
+
+def test_env_requests_ibm_but_falls_back(monkeypatch):
+    monkeypatch.setenv("QUANTUM_PROVIDER", "ibm")
+    monkeypatch.setattr(
+        ibm_provider.IBMBackendProvider, "is_available", lambda self: False
+    )
+    exec_ = QuantumExecutor()
+    assert isinstance(exec_.backend, SimulatorBackend)
+    assert exec_.use_hardware is False
+
+
+def test_ibm_selected_when_available(monkeypatch):
+    monkeypatch.setenv("QUANTUM_PROVIDER", "ibm")
+
+    def _avail(self):
+        return True
+
+    def _get(self):
+        return _DummyBackend()
+
+    monkeypatch.setattr(ibm_provider.IBMBackendProvider, "is_available", _avail)
+    monkeypatch.setattr(ibm_provider.IBMBackendProvider, "get_backend", _get)
+
+    exec_ = QuantumExecutor()
+    assert isinstance(exec_.backend, _DummyBackend)
+    assert exec_.use_hardware is True
+


### PR DESCRIPTION
## Summary
- introduce BackendProvider protocol and provider registry
- implement IBM and simulator providers with IonQ and Rigetti stubs
- refactor framework QuantumExecutor to choose provider via env or argument
- add tests for provider selection and fallback

## Testing
- `ruff check quantum/providers quantum/framework tests/quantum_tests/test_framework_models.py tests/quantum_tests/test_provider_selection.py`
- `pytest tests/quantum_tests/test_framework_models.py tests/quantum_tests/test_provider_selection.py tests/quantum_tests/test_hybrid_routines.py`


------
https://chatgpt.com/codex/tasks/task_e_689a7aaba7dc8331bbba44e455f79339