### PR TITLE
fix: enable linting for utilities and clean imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,21 +37,19 @@ extend-exclude = [
     "misc",
     "scripts/enterprise/*",
     "scripts/optimization/*",
-    "scripts/utilities/*",
     "scripts/quantum_placeholders/*",
     "copilot_qiskit_stubs/*",
     "db_tools/*",
     "enterprise_modules/*",
     "quantum_optimizer.py",
-    "scripts/utilities/comprehensive_e999_repair.py",
-    "scripts/utilities/phase6_comprehensive_elimination_system.py",
-    "scripts/utilities/phase8_final_cleanup_specialist.py",
-    "scripts/utilities/phase9_ultimate_violation_eliminator.py",
-    "scripts/utilities/phase10_precision_violation_eliminator.py",
-    "scripts/utilities/main.py",
     "databases/*.db",
     "*.log",
     "recovered_files_*",
+]
+
+extend-include = [
+    "quantum",
+    "scripts/utilities",
 ]
 
 [tool.ruff.lint]

--- a/scripts/backup_archiver.py
+++ b/scripts/backup_archiver.py
@@ -15,7 +15,6 @@ from enterprise_modules.compliance import (
     enforce_anti_recursion,
     pid_recursion_guard,
     validate_enterprise_operation,
-    pid_recursion_guard,
 )
 from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.validation_utils import anti_recursion_guard

--- a/scripts/database/documentation_ingestor.py
+++ b/scripts/database/documentation_ingestor.py
@@ -18,7 +18,6 @@ from enterprise_modules.compliance import (
     enforce_anti_recursion,
     pid_recursion_guard,
     validate_enterprise_operation,
-    pid_recursion_guard,
 )
 from template_engine.learning_templates import get_dataset_sources
 

--- a/scripts/utilities/main.py
+++ b/scripts/utilities/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+
 from copilot.orchestrators.final_enterprise_orchestrator import (
-import logging
-    FinalEnterpriseOrchestrator
+    FinalEnterpriseOrchestrator,
 )
 
 

--- a/scripts/utilities/phase10_precision_violation_eliminator.py
+++ b/scripts/utilities/phase10_precision_violation_eliminator.py
@@ -463,8 +463,12 @@ class Phase10PrecisionViolationEliminator:
             100 if target_violations > 0 else 0
 
         print(f"   📈 Elimination Rate: {elimination_rate:.1f}%")
-        print(f"   # # 🎯 Status: {'PRECISION SUCCESS' if \
-             elimination_rate > 60 else 'SIGNIFICANT PROGRESS'}")
+        status = (
+            "PRECISION SUCCESS"
+            if elimination_rate > 60
+            else "SIGNIFICANT PROGRESS"
+        )
+        print(f"   # # 🎯 Status: {status}")
 
         # Save detailed report
         report_file = f"phase10_precision_elimination_ \

--- a/scripts/utilities/phase8_final_cleanup_specialist.py
+++ b/scripts/utilities/phase8_final_cleanup_specialist.py
@@ -450,9 +450,14 @@ class Phase8FinalCleanupSpecialist:
             target_violations > 0 else 0
 
         print(f"   📈 Elimination Rate: {elimination_rate:.1f}%")
-        print(f"   # # 🎯 Status: {'EXCEPTIONAL SUCCESS' if \
-            elimination_rate > 50 else 'SIGNIFICANT PROGR \
-                ESS' if elimination_rate > 25 else 'MODERATE PROGRESS'}")
+        status = (
+            "EXCEPTIONAL SUCCESS"
+            if elimination_rate > 50
+            else "SIGNIFICANT PROGRESS"
+            if elimination_rate > 25
+            else "MODERATE PROGRESS"
+        )
+        print(f"   # # 🎯 Status: {status}")
 
         # Save detailed report
         report_file = f"phase8_final_cleanup_report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"

--- a/scripts/utilities/phase9_ultimate_violation_eliminator.py
+++ b/scripts/utilities/phase9_ultimate_violation_eliminator.py
@@ -504,9 +504,14 @@ class Phase9UltimateViolationEliminator:
             target_violations > 0 else 0
 
         print(f"   📈 Elimination Rate: {elimination_rate:.1f}%")
-        print(f"   # # 🎯 Status: {'ULTIMATE SUCCESS' if \
-            elimination_rate > 70 else 'EXCEPTIONAL SUCCES \
-                S' if elimination_rate > 50 else 'SIGNIFICANT PROGRESS'}")
+        status = (
+            "ULTIMATE SUCCESS"
+            if elimination_rate > 70
+            else "EXCEPTIONAL SUCCESS"
+            if elimination_rate > 50
+            else "SIGNIFICANT PROGRESS"
+        )
+        print(f"   # # 🎯 Status: {status}")
 
         # Save detailed report
         report_file = \

--- a/tests/dashboard/test_corrections_stream.py
+++ b/tests/dashboard/test_corrections_stream.py
@@ -7,9 +7,19 @@ import websockets
 import dashboard.enterprise_dashboard as ed
 from flask import Flask
 
-@pytest.fixture
-def client():
-    return app.test_client()
+
+def _create_db(tmp_path: Path) -> Path:
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE correction_logs(timestamp TEXT, path TEXT, status TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO correction_logs VALUES (?,?,?)",
+            ("2024-01-01", "file1.py", "pending"),
+        )
+        conn.commit()
+    return db
 
 
 def test_corrections_stream_once(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- re-enable ruff checks for `quantum/` and `scripts/utilities/`
- resolve syntax issues in phase cleanup utilities and tidy imports
- add helper for corrections stream tests

## Testing
- `ruff check .`
- `pytest tests/compliance/test_ingestion_edge_cases.py tests/dashboard/test_score_serialization.py tests/dashboard/test_corrections_stream.py`


------
https://chatgpt.com/codex/tasks/task_e_689a7c1a19b48331928ad4cffb182ab0