### PR TITLE
fix: export quantum database search helpers

### DIFF
--- a/quantum/__init__.py
+++ b/quantum/__init__.py
@@ -8,6 +8,11 @@ and orchestration capabilities while maintaining backward compatibility.
 
 from . import benchmarking, quantum_optimization
 from .optimizers.quantum_optimizer import QuantumOptimizer
+from .quantum_database_search import (
+    quantum_search_hybrid,
+    quantum_search_nosql,
+    quantum_search_sql,
+)
 
 # Import new modular components
 from .algorithms.base import QuantumAlgorithmBase
@@ -33,4 +38,7 @@ __all__ = [
     "QuantumExecutor",
     "QuantumIntegrationOrchestrator",
     "QuantumOptimizer",
+    "quantum_search_sql",
+    "quantum_search_nosql",
+    "quantum_search_hybrid",
 ]


### PR DESCRIPTION
## Summary
- re-export quantum_search_sql, quantum_search_nosql, and quantum_search_hybrid from package init

## Testing
- `ruff check quantum/__init__.py`
- `pytest -q` *(fails: NameError: name 'pytest' is not defined in tests/dashboard/test_corrections_stream.py)*

------
https://chatgpt.com/codex/tasks/task_e_689a7c4e485c8331b77e104dc0ad3546