### PR TITLE
ci: run pyright via npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,15 @@ jobs:
           echo "VIRTUAL_ENV=${{ github.workspace }}/.venv" >> $GITHUB_ENV
           echo "PATH=${{ github.workspace }}/.venv/bin:$PATH" >> $GITHUB_ENV
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
       - name: Install lint dependencies
-        run: pip install flake8 ruff==0.12.8 pyright
+        run: pip install flake8 ruff==0.12.8
+
+      - name: Install Pyright
+        run: npm install pyright
 
       - name: Verify Ruff version
         run: |
@@ -62,7 +69,7 @@ jobs:
         run: flake8 --config=.flake8 ${{ steps.changed.outputs.added_modified }}
 
       - name: Run pyright
-        run: pyright
+        run: npx pyright
 
       - name: Run combined checks
         env:


### PR DESCRIPTION
## Summary
- ensure CI installs Pyright via npm and invokes it using npx

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'monitoring.anomaly')*


------
https://chatgpt.com/codex/tasks/task_e_689a87a00b588331984deb3c58aa80a2