### PR TITLE
fix: exclude gitkeep from lfs tracking

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@ codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text
 web_gui/assets/icons/** filter=lfs diff=lfs merge=lfs -text
 web_gui/assets/images/** filter=lfs diff=lfs merge=lfs -text
 web_gui/assets/fonts/** filter=lfs diff=lfs merge=lfs -text
+web_gui/assets/**/.gitkeep -filter -diff -merge text
 *.ttf filter=lfs diff=lfs merge=lfs -text
 *.otf filter=lfs diff=lfs merge=lfs -text
 *.woff filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- regenerate .gitattributes and exclude .gitkeep placeholders from LFS

## Testing
- `git lfs status`
- `bash tools/pre-commit-lfs.sh`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'monitoring.anomaly')*


------
https://chatgpt.com/codex/tasks/task_e_689a9f5fc49483319a663fa8345e00c6