### PR TITLE
refactor: remove unused quantum search exports

### DIFF
--- a/quantum/__init__.py
+++ b/quantum/__init__.py
@@ -8,11 +8,6 @@ and orchestration capabilities while maintaining backward compatibility.
 
 from . import benchmarking, quantum_optimization
 from .optimizers.quantum_optimizer import QuantumOptimizer
-from .quantum_database_search import (
-    quantum_search_hybrid,
-    quantum_search_nosql,
-    quantum_search_sql,
-)
 
 # Import new modular components
 from .algorithms.base import QuantumAlgorithmBase
@@ -38,7 +33,4 @@ __all__ = [
     "QuantumExecutor",
     "QuantumIntegrationOrchestrator",
     "QuantumOptimizer",
-    "quantum_search_sql",
-    "quantum_search_nosql",
-    "quantum_search_hybrid",
 ]


### PR DESCRIPTION
## Summary
- remove unused quantum search exports from `quantum.__init__`

## Testing
- `ruff check quantum/__init__.py`
- `pytest tests/quantum_tests/test_provider_fallback.py::test_quantum_search_sql_fallback -q` *(fails: unrecognized arguments: --cov=. --cov-report=term)*

------
https://chatgpt.com/codex/tasks/task_e_689aa21c54c08331be39c028cbb8aa7e