### PR TITLE
fix: expose pid recursion guard decorators

### DIFF
--- a/scripts/backup_archiver.py
+++ b/scripts/backup_archiver.py
@@ -23,6 +23,8 @@ from secondary_copilot_validator import (
     run_dual_copilot_validation,
 )
 
+__all__ = ["archive_backups", "pid_recursion_guard"]
+
 _RECURSION_CTX = SimpleNamespace()
 
 @pid_recursion_guard

--- a/scripts/database/documentation_ingestor.py
+++ b/scripts/database/documentation_ingestor.py
@@ -28,6 +28,8 @@ from .cross_database_sync_logger import _table_exists, log_sync_operation
 from .size_compliance_checker import check_database_sizes
 from .unified_database_initializer import initialize_database
 
+__all__ = ["ingest_documentation", "pid_recursion_guard"]
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- re-export `pid_recursion_guard` in backup and documentation scripts
- ensure modules provide `archive_backups` and `ingest_documentation` via `__all__`

## Testing
- `ruff check scripts/backup_archiver.py scripts/database/documentation_ingestor.py`
- `pytest tests/test_backup_archiver.py tests/test_documentation_ingestor.py tests/database/test_documentation_ingestor.py tests/test_ingestion_pipeline.py tests/test_documentation_ingestor_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_689aa21c583483318dcd22352e2f890c