### PR TITLE
fix: remove backslash escapes in utility f-strings

### DIFF
--- a/scripts/utilities/phase8_final_cleanup_specialist.py
+++ b/scripts/utilities/phase8_final_cleanup_specialist.py
@@ -168,8 +168,10 @@ class Phase8FinalCleanupSpecialist:
                 indent = len(line) - len(line.lstrip())
                 base_indent = ' ' * indent
                 continuation_indent = ' ' * (indent + 4)
-                return f"{parts[0]} and \
-                    \\\n{continuation_indent}" + f" and \\\n{continuation_indent}".join(parts[1:])
+                return (
+                    f"{parts[0]} and\n{continuation_indent}"
+                    + f" and\n{continuation_indent}".join(parts[1:])
+                )
 
         # Strategy 2: Break at commas in function calls
         if '(' in line and ')' in line and ',' in line:
@@ -190,10 +192,12 @@ class Phase8FinalCleanupSpecialist:
                         indent = len(before_func)
                         param_indent = ' ' * (indent + len(func_name) + 1)
 
-                        broken_params = f"\n{param_indent}".join(param_list)
+                        broken_params = ("\n" + param_indent).join(param_list)
                         return (
-                            f"{before_func}{func_name}(\n"
-                            f"{param_indent}{broken_params}\n"
+                            f"{before_func}{func_name}("
+                            "\n"
+                            f"{param_indent}{broken_params}"
+                            "\n"
                             f"{' ' * indent}){after_func}"
                         )
 
@@ -203,8 +207,10 @@ class Phase8FinalCleanupSpecialist:
             if len(parts) >= 2:
                 indent = len(line) - len(line.lstrip())
                 continuation_indent = ' ' * (indent + 4)
-                return f"{parts[0]} + \
-                    \\\n{continuation_indent}" + f" + \\\n{continuation_indent}".join(parts[1:])
+                return (
+                    f"{parts[0]} +\n{continuation_indent}"
+                    + f" +\n{continuation_indent}".join(parts[1:])
+                )
 
         # Strategy 4: Break at logical points in conditionals
         if (' or ' in line or ' and ' in line) and 'if ' in line:
@@ -222,7 +228,7 @@ class Phase8FinalCleanupSpecialist:
                     parts = condition.split(' and ')
                     indent = len(before_if) + len(if_keyword)
                     continuation_indent = ' ' * (indent + 4)
-                    broken_condition = f" and \\\n{continuation_indent}".join(parts)
+                    broken_condition = (" and\n" + continuation_indent).join(parts)
                     return f"{before_if}{if_keyword}{broken_condition}{colon}{after_if}"
 
         return line  # Return original if no breaking strategy worked
@@ -483,7 +489,7 @@ def main():
     specialist = Phase8FinalCleanupSpecialist()
     results = specialist.execute_final_cleanup()
 
-    print(f"\n# # ✅ PHASE 8 FINAL CLEANUP COMPLETED")
+    print("\n# # ✅ PHASE 8 FINAL CLEANUP COMPLETED")
     print(f"Total Violations Eliminated: {results['total_violations_eliminated']}")
     print(f"Files Processed: {results['files_processed']}")
 

--- a/scripts/utilities/phase9_ultimate_violation_eliminator.py
+++ b/scripts/utilities/phase9_ultimate_violation_eliminator.py
@@ -449,28 +449,38 @@ class Phase9UltimateViolationEliminator:
                         before = line[:func_match.start()]
                         after = line[func_match.end():]
 
-                        broken_params = f",\n{cont_indent}".join(param_list)
-                        return f"{before}{func_name}( \
-                            \n{cont_indent}{broken_params}\n{base_indent}){after}"
+                        broken_params = (",\n" + cont_indent).join(param_list)
+                        return (
+                            f"{before}{func_name}("
+                            "\n"
+                            f"{cont_indent}{broken_params}"
+                            "\n"
+                            f"{base_indent}){after}"
+                        )
 
         # Strategy 2: String concatenation
         if ' + ' in line and ('"' in line or "'" in line) and len(line) > 100:
             parts = line.split(' + ')
             if len(parts) > 1:
-                return f"{parts[0]} + \\\n{cont_indent}" + f" + \\\n{cont_indent}".join(parts[1:])
+                return (
+                    f"{parts[0]} +\n{cont_indent}"
+                    + f" +\n{cont_indent}".join(parts[1:])
+                )
 
         # Strategy 3: Logical operators
         if ' and ' in line and len(line) > 100:
             parts = line.split(' and ')
             if len(parts) > 1:
-                return f"{parts[0]} and \
-                    \\\n{cont_indent}" + f" and \\\n{cont_indent}".join(parts[1:])
+                return (
+                    f"{parts[0]} and\n{cont_indent}"
+                    + f" and\n{cont_indent}".join(parts[1:])
+                )
 
         # Strategy 4: Dictionary/list literals
         if ('{' in line or '[' in line) and len(line) > 100:
             # Break after commas in data structures
             if ', ' in line:
-                return line.replace(', ', f',\n{cont_indent}')
+                return line.replace(', ', ",\n" + cont_indent)
 
         return original_line
 
@@ -538,7 +548,7 @@ def main():
     eliminator = Phase9UltimateViolationEliminator()
     results = eliminator.execute_ultimate_elimination()
 
-    print(f"\n# # ✅ PHASE 9 ULTIMATE ELIMINATION COMPLETED")
+    print("\n# # ✅ PHASE 9 ULTIMATE ELIMINATION COMPLETED")
     print(f"Total Violations Eliminated: {results['total_violations_eliminated']}")
     print(f"Files Processed: {results['files_processed']}")
 


### PR DESCRIPTION
## Summary
- refactor Phase 8 and Phase 9 utilities to avoid backslash escapes inside f-strings
- use newline concatenation and `.join` patterns for compatibility with Python 3.8+

## Testing
- `ruff check scripts/utilities/phase8_final_cleanup_specialist.py scripts/utilities/phase9_ultimate_violation_eliminator.py`
- `python -m py_compile scripts/utilities/phase8_final_cleanup_specialist.py scripts/utilities/phase9_ultimate_violation_eliminator.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'monitoring.anomaly')*

------
https://chatgpt.com/codex/tasks/task_e_689aa21dbc508331ba00a972eec846d3