### PR TITLE
feat: expose anomaly detection helpers under monitoring

### DIFF
--- a/monitoring/unified_monitoring_optimization_system.py
+++ b/monitoring/unified_monitoring_optimization_system.py
@@ -1,0 +1,83 @@
+"""Lightweight re-exports for monitoring utilities.
+
+This module exposes the anomaly detection helpers from
+``unified_monitoring_optimization_system`` inside the ``monitoring`` package.
+It provides a thin wrapper around :func:`detect_anomalies` and
+:func:`anomaly_detection_loop` so consumers can import them using
+``from monitoring.unified_monitoring_optimization_system import ...``.
+
+Only the two public helpers are exported via ``__all__``; other functions are
+re-exported solely for test purposes.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from unified_monitoring_optimization_system import (
+    auto_heal_session as _auto_heal_session,
+    collect_metrics as _collect_metrics,
+    detect_anomalies as _detect_impl,
+    push_metrics,  # noqa: F401 - re-exported for tests
+    train_anomaly_model,  # noqa: F401 - re-exported for tests
+)
+
+# re-exported for tests that patch these callables
+collect_metrics = _collect_metrics
+auto_heal_session = _auto_heal_session
+
+
+def detect_anomalies(
+    history: Iterable[Dict[str, float]],
+    *,
+    contamination: float = 0.1,
+    db_path: Optional[Path] = None,
+    model_path: Optional[Path] = None,
+    retrain_interval: float = 3600,
+) -> List[Dict[str, float]]:
+    """Delegate to the core implementation."""
+
+    return _detect_impl(
+        history,
+        contamination=contamination,
+        db_path=db_path,
+        model_path=model_path,
+        retrain_interval=retrain_interval,
+    )
+
+
+def anomaly_detection_loop(
+    interval: float = 5.0,
+    *,
+    iterations: Optional[int] = None,
+    contamination: float = 0.1,
+    threshold: float = 0.5,
+    manager=None,
+    db_path: Optional[Path] = None,
+    model_path: Optional[Path] = None,
+    collector=collect_metrics,
+) -> None:
+    """Continuously collect metrics and restart sessions on anomalies."""
+
+    history: List[Dict[str, float]] = []
+    count = 0
+    while iterations is None or count < iterations:
+        metrics = collector(db_path=db_path)
+        history.append(metrics)
+        anomalies = detect_anomalies(
+            history,
+            contamination=contamination,
+            db_path=db_path,
+            model_path=model_path,
+        )
+        filtered = [a for a in anomalies if a.get("anomaly_score", 0) > threshold]
+        if filtered:
+            auto_heal_session(anomalies=filtered, manager=manager, db_path=db_path)
+        count += 1
+        if iterations is None or count < iterations:
+            time.sleep(interval)
+
+
+__all__ = ["anomaly_detection_loop", "detect_anomalies"]

--- a/tests/monitoring_tests/test_anomaly_detection.py
+++ b/tests/monitoring_tests/test_anomaly_detection.py
@@ -5,7 +5,7 @@ from src.monitoring.anomaly import detect_anomalies, train_baseline_models
 from src.monitoring.anomaly_detector import detect_anomalies as db_detect_anomalies
 from src.monitoring.anomaly_detector import train_models as db_train_models
 
-import unified_monitoring_optimization_system as umos
+import monitoring.unified_monitoring_optimization_system as umos
 
 
 def _data_dir() -> Path:

--- a/tests/monitoring_tests/test_anomaly_pipeline.py
+++ b/tests/monitoring_tests/test_anomaly_pipeline.py
@@ -21,7 +21,7 @@ def _stub_quantum_module(monkeypatch):
         SimpleNamespace(quantum_score_stub=_stub_score),
     )
 
-from unified_monitoring_optimization_system import anomaly_detection_loop
+from monitoring.unified_monitoring_optimization_system import anomaly_detection_loop
 from monitoring.baseline_anomaly_detector import BaselineAnomalyDetector
 
 
@@ -91,13 +91,13 @@ def test_anomaly_pipeline_triggers_heal_and_reports_metrics(monkeypatch, tmp_pat
         return [dict(metrics, anomaly_score=1.0, composite_score=1.0)]
 
     monkeypatch.setattr(
-        "unified_monitoring_optimization_system.collect_metrics", fake_collect_metrics
+        "monitoring.unified_monitoring_optimization_system.collect_metrics", fake_collect_metrics
     )
     monkeypatch.setattr(
-        "unified_monitoring_optimization_system.detect_anomalies", fake_detect
+        "monitoring.unified_monitoring_optimization_system.detect_anomalies", fake_detect
     )
     monkeypatch.setattr(
-        "unified_monitoring_optimization_system.time.sleep", lambda _t: None
+        "monitoring.unified_monitoring_optimization_system.time.sleep", lambda _t: None
     )
     monkeypatch.setattr(BaselineAnomalyDetector, "_fetch_values", lambda self: [0.0])
 

--- a/tests/monitoring_tests/test_unified_monitoring_optimization_system.py
+++ b/tests/monitoring_tests/test_unified_monitoring_optimization_system.py
@@ -3,8 +3,8 @@ import sqlite3
 
 import pytest
 
+from monitoring.unified_monitoring_optimization_system import detect_anomalies
 from unified_monitoring_optimization_system import (
-    detect_anomalies,
     _ensure_table,
     push_metrics,
     train_anomaly_model,

--- a/tests/test_monitoring_ml.py
+++ b/tests/test_monitoring_ml.py
@@ -53,10 +53,10 @@ class _TqdmStub:
 
 sys.modules.setdefault("tqdm", types.SimpleNamespace(tqdm=_TqdmStub))
 
+from monitoring.unified_monitoring_optimization_system import detect_anomalies
 from unified_monitoring_optimization_system import (
     push_metrics,
     train_anomaly_model,
-    detect_anomalies,
     get_anomaly_summary,
 )
 

--- a/tests/test_unified_monitoring_optimization_system.py
+++ b/tests/test_unified_monitoring_optimization_system.py
@@ -33,8 +33,8 @@ def _stub_quantum_module(monkeypatch):
 
 quantum_score_stub = _stub_score
 
+from monitoring.unified_monitoring_optimization_system import detect_anomalies
 from unified_monitoring_optimization_system import (
-    detect_anomalies,
     push_metrics,
     auto_heal_session,
     record_quantum_score,


### PR DESCRIPTION
## Summary
- add `monitoring.unified_monitoring_optimization_system` module with wrapper exports for `detect_anomalies` and `anomaly_detection_loop`
- update tests to import anomaly detection helpers from the `monitoring` package

## Testing
- `pytest tests/monitoring_tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa73b34bc8331ab9bc15c4b8ae8fa