### PR TITLE
feat: expose monitoring package APIs

### DIFF
--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -13,15 +13,32 @@ except Exception:  # pragma: no cover - missing optional deps
 
 from .baseline_anomaly_detector import BaselineAnomalyDetector
 from .health_monitor import record_system_health
-from .performance_tracker import track_query_time, push_metrics
+from .performance_tracker import track_query_time
 from .compliance_monitor import check_compliance
 from .log_error_notifier import monitor_logs
+
+# Re-export key monitoring utilities from the consolidated module
+from unified_monitoring_optimization_system import (
+    anomaly_detection_loop,
+    auto_heal_session,
+    collect_metrics,
+    detect_anomalies,
+    push_metrics,
+    train_anomaly_model,
+    _ensure_table,
+)
 
 __all__ += [
     "BaselineAnomalyDetector",
     "record_system_health",
     "track_query_time",
-    "push_metrics",
     "check_compliance",
     "monitor_logs",
+    "collect_metrics",
+    "push_metrics",
+    "train_anomaly_model",
+    "detect_anomalies",
+    "anomaly_detection_loop",
+    "auto_heal_session",
+    "_ensure_table",
 ]

--- a/tests/monitoring_tests/test_anomaly_detection.py
+++ b/tests/monitoring_tests/test_anomaly_detection.py
@@ -5,7 +5,7 @@ from src.monitoring.anomaly import detect_anomalies, train_baseline_models
 from src.monitoring.anomaly_detector import detect_anomalies as db_detect_anomalies
 from src.monitoring.anomaly_detector import train_models as db_train_models
 
-import unified_monitoring_optimization_system as umos
+import monitoring as umos
 
 
 def _data_dir() -> Path:

--- a/tests/monitoring_tests/test_anomaly_pipeline.py
+++ b/tests/monitoring_tests/test_anomaly_pipeline.py
@@ -21,7 +21,7 @@ def _stub_quantum_module(monkeypatch):
         SimpleNamespace(quantum_score_stub=_stub_score),
     )
 
-from unified_monitoring_optimization_system import anomaly_detection_loop
+from monitoring import anomaly_detection_loop
 from monitoring.baseline_anomaly_detector import BaselineAnomalyDetector
 
 
@@ -90,12 +90,8 @@ def test_anomaly_pipeline_triggers_heal_and_reports_metrics(monkeypatch, tmp_pat
             conn.commit()
         return [dict(metrics, anomaly_score=1.0, composite_score=1.0)]
 
-    monkeypatch.setattr(
-        "unified_monitoring_optimization_system.collect_metrics", fake_collect_metrics
-    )
-    monkeypatch.setattr(
-        "unified_monitoring_optimization_system.detect_anomalies", fake_detect
-    )
+    monkeypatch.setattr("monitoring.collect_metrics", fake_collect_metrics)
+    monkeypatch.setattr("monitoring.detect_anomalies", fake_detect)
     monkeypatch.setattr(
         "unified_monitoring_optimization_system.time.sleep", lambda _t: None
     )

--- a/tests/monitoring_tests/test_unified_monitoring_optimization_system.py
+++ b/tests/monitoring_tests/test_unified_monitoring_optimization_system.py
@@ -3,7 +3,7 @@ import sqlite3
 
 import pytest
 
-from unified_monitoring_optimization_system import (
+from monitoring import (
     detect_anomalies,
     _ensure_table,
     push_metrics,


### PR DESCRIPTION
## Summary
- re-export unified monitoring utilities in `monitoring` and declare `__all__`
- update monitoring tests to consume package-level API

## Testing
- `ruff check monitoring tests/monitoring_tests tests/quantum_tests`
- `pytest tests/monitoring_tests tests/quantum_tests -q -o addopts=""` *(fails: KeyError and collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_689aa738abc48331be8f8ce5f162a1a7