### PR TITLE
test: add simulator import test

### DIFF
--- a/tests/quantum_tests/test_simulator_import.py
+++ b/tests/quantum_tests/test_simulator_import.py
@@ -1,0 +1,16 @@
+import pytest
+
+pytest.importorskip("qiskit")
+pytest.importorskip("qiskit_aer")
+from qiskit import QuantumCircuit
+from qiskit_aer import Aer
+
+
+def test_simulator_import_and_run():
+    circuit = QuantumCircuit(1, 1)
+    circuit.h(0)
+    circuit.measure(0, 0)
+    backend = Aer.get_backend("aer_simulator")
+    result = backend.run(circuit, shots=1).result()
+    counts = result.get_counts()
+    assert counts


### PR DESCRIPTION
## Summary
- add QuantumCircuit simulator test that skips when Qiskit isn't installed

## Testing
- `ruff check tests/quantum_tests/test_simulator_import.py`
- `pytest tests/quantum_tests/test_simulator_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689aaedb8084833196f6e06d4da9136e