### PR TITLE
fix: require qiskit 0.44.1 or newer

### DIFF
--- a/quantum/utils/backend_provider.py
+++ b/quantum/utils/backend_provider.py
@@ -10,7 +10,7 @@ try:  # pragma: no cover - optional dependency
     import qiskit  # noqa: F401
 except Exception as exc:  # pragma: no cover - qiskit may be missing
     raise ImportError(
-        "qiskit is required; install qiskit==0.44.0"
+        "qiskit is required; install qiskit>=0.44.1"
     ) from exc
 
 try:  # pragma: no cover - optional dependency
@@ -61,7 +61,7 @@ def get_backend(
 
     if Aer is None:
         raise ImportError(
-            "qiskit and qiskit-aer are required; install qiskit==0.44.0 and qiskit-aer==0.17.1"
+            "qiskit and qiskit-aer are required; install qiskit>=0.44.1 and qiskit-aer==0.17.1"
         ) from _AER_IMPORT_ERROR
 
     if use_hardware is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests==2.32.4            # HTTP orchestration and web hooks
 pandas==2.3.1               # Dataframe operations and analytics
 numpy==2.3.1                # Numerical optimization and simulation
 scikit-learn==1.7.0         # ML algorithms (e.g., clustering, MLP)
-qiskit==0.44.1              # Quantum optimizer backend
+ qiskit>=0.44.1              # Quantum optimizer backend
 qiskit-ibm-provider==0.7.0  # IBM Quantum hardware access
 psutil==7.0.0               # System resource monitoring
 tqdm==4.67.1                # Progress bar for CLI and batch tasks


### PR DESCRIPTION
## Summary
- allow newer qiskit versions by setting minimum to 0.44.1
- align backend provider guidance with updated qiskit requirement

## Testing
- `ruff check quantum/utils/backend_provider.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'monitoring.anomaly'; 'monitoring' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689ace41712883319b41d8f0820db82a