### PR TITLE
fix: expose monitoring APIs and align tests

### DIFF
--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -16,6 +16,10 @@ from .health_monitor import record_system_health
 from .performance_tracker import track_query_time, push_metrics
 from .compliance_monitor import check_compliance
 from .log_error_notifier import monitor_logs
+from .unified_monitoring_optimization_system import (
+    anomaly_detection_loop,
+    detect_anomalies,
+)
 
 __all__ += [
     "BaselineAnomalyDetector",
@@ -24,4 +28,6 @@ __all__ += [
     "push_metrics",
     "check_compliance",
     "monitor_logs",
+    "anomaly_detection_loop",
+    "detect_anomalies",
 ]

--- a/tests/monitoring_tests/test_anomaly_pipeline.py
+++ b/tests/monitoring_tests/test_anomaly_pipeline.py
@@ -21,7 +21,7 @@ def _stub_quantum_module(monkeypatch):
         SimpleNamespace(quantum_score_stub=_stub_score),
     )
 
-from monitoring.unified_monitoring_optimization_system import anomaly_detection_loop
+from monitoring import anomaly_detection_loop
 from monitoring.baseline_anomaly_detector import BaselineAnomalyDetector
 
 

--- a/tests/monitoring_tests/test_unified_monitoring_optimization_system.py
+++ b/tests/monitoring_tests/test_unified_monitoring_optimization_system.py
@@ -3,7 +3,7 @@ import sqlite3
 
 import pytest
 
-from monitoring.unified_monitoring_optimization_system import detect_anomalies
+from monitoring import detect_anomalies
 from unified_monitoring_optimization_system import (
     _ensure_table,
     push_metrics,

--- a/tests/quantum_tests/test_scoring.py
+++ b/tests/quantum_tests/test_scoring.py
@@ -21,7 +21,9 @@ def test_quantum_text_score_qiskit(tmp_path, monkeypatch):
     qal.ANALYTICS_DB = db
     db.touch()
     qal.QISKIT_AVAILABLE = True
-    monkeypatch.setattr(qal, "get_backend", lambda use_hardware=None: _DummyBackend())
+    monkeypatch.setattr(
+        qal, "get_backend", lambda backend_name, use_hardware=None: _DummyBackend()
+    )
     score = qal.quantum_text_score("hello")
     assert 0 <= score <= 1
     with sqlite3.connect(db) as conn:
@@ -48,7 +50,7 @@ def test_quantum_text_score_use_hardware_flag(tmp_path, monkeypatch):
     qal.QISKIT_AVAILABLE = True
     called = {}
 
-    def _fake_backend(use_hardware=None):
+    def _fake_backend(backend_name, use_hardware=None):
         called["flag"] = use_hardware
         return _DummyBackend()
 
@@ -66,7 +68,9 @@ def test_quantum_text_score_backend_none_fallback(tmp_path, monkeypatch):
     qal.ANALYTICS_DB = db
     db.touch()
     qal.QISKIT_AVAILABLE = True
-    monkeypatch.setattr(qal, "get_backend", lambda use_hardware=None: None)
+    monkeypatch.setattr(
+        qal, "get_backend", lambda backend_name, use_hardware=None: None
+    )
     score = qal.quantum_text_score("hi", use_hardware=True)
     assert 0 <= score <= 1
     with sqlite3.connect(db) as conn:

--- a/tests/test_monitoring_ml.py
+++ b/tests/test_monitoring_ml.py
@@ -31,10 +31,12 @@ class _IForestStub:
 
 
 sklearn_stub = types.SimpleNamespace(
-    ensemble=types.SimpleNamespace(IsolationForest=_IForestStub)
+    ensemble=types.SimpleNamespace(IsolationForest=_IForestStub),
+    cluster=types.SimpleNamespace(KMeans=lambda *args, **kwargs: None),
 )
 sys.modules.setdefault("sklearn", sklearn_stub)
 sys.modules.setdefault("sklearn.ensemble", sklearn_stub.ensemble)
+sys.modules.setdefault("sklearn.cluster", sklearn_stub.cluster)
 
 
 class _TqdmStub:
@@ -53,7 +55,7 @@ class _TqdmStub:
 
 sys.modules.setdefault("tqdm", types.SimpleNamespace(tqdm=_TqdmStub))
 
-from monitoring.unified_monitoring_optimization_system import detect_anomalies
+from monitoring import detect_anomalies
 from unified_monitoring_optimization_system import (
     push_metrics,
     train_anomaly_model,

--- a/tests/test_unified_monitoring_optimization_system.py
+++ b/tests/test_unified_monitoring_optimization_system.py
@@ -33,7 +33,7 @@ def _stub_quantum_module(monkeypatch):
 
 quantum_score_stub = _stub_score
 
-from monitoring.unified_monitoring_optimization_system import detect_anomalies
+from monitoring import detect_anomalies
 from unified_monitoring_optimization_system import (
     push_metrics,
     auto_heal_session,


### PR DESCRIPTION
## Summary
- export anomaly utilities directly from monitoring package
- update monitoring and quantum tests to use package-level imports
- harden quantum test stubs for backend and compliance engine

## Testing
- `ruff check monitoring tests/monitoring_tests/test_anomaly_pipeline.py tests/monitoring_tests/test_unified_monitoring_optimization_system.py tests/quantum_tests/test_scoring.py tests/quantum_tests/test_simulation_markers.py tests/test_monitoring_ml.py tests/test_unified_monitoring_optimization_system.py`
- `pytest tests/monitoring_tests tests/quantum_tests -q`
- `pytest tests/test_monitoring_ml.py tests/test_unified_monitoring_optimization_system.py -q` *(fails: ModuleNotFoundError: No module named 'sklearn.datasets'; 'sklearn' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689ad3aa92cc8331a5c069a290c487ec