### PR TITLE
feat: add db-first analytics skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,15 @@ archive/*.tar
 archive/*.tar.gz
 *.bak
 *.tmp
+# Additional tooling caches
+.dist/
+.build/
+.mypy_cache/
+.pyright/
+.ruff_cache/
+# Project artifacts
+artifacts/
+*.ndjson
 # Test artifacts
 tmp/
 # Git LFS temporary files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.6
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: ["pydantic>=2.6"]

--- a/README.md
+++ b/README.md
@@ -1428,3 +1428,16 @@ See [Continuous Improvement Roadmap](docs/continuous_improvement_roadmap.md),
 [Stakeholder Roadmap](documentation/continuous_improvement_roadmap.md) and
 [Project Roadmap](documentation/ROADMAP.md) for detailed milestones and
 status tracking.
+
+## gh_copilot skeleton
+
+The `src/gh_copilot` package provides a minimal database-first service with a FastAPI app and Typer CLI.
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+gh-copilot migrate
+gh-copilot seed-models
+gh-copilot compute-score --lint 0.9 --tests 0.8 --placeholders 0.95 --sessions 1.0
+gh-copilot serve  # http://127.0.0.1:8000/docs
+```

--- a/databases/gh_copilot_migrations/0001_init.sql
+++ b/databases/gh_copilot_migrations/0001_init.sql
@@ -1,0 +1,43 @@
+-- gh_COPILOT: initial schema for analytics/compliance
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS compliance_models (
+  model_id TEXT PRIMARY KEY,
+  weights_json TEXT NOT NULL,
+  min_score REAL NOT NULL,
+  effective_from TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS score_inputs (
+  run_id TEXT PRIMARY KEY,
+  lint REAL NOT NULL,
+  tests REAL NOT NULL,
+  placeholders REAL NOT NULL,
+  sessions REAL NOT NULL,
+  model_id TEXT NOT NULL,
+  ts TEXT NOT NULL,
+  FOREIGN KEY (model_id) REFERENCES compliance_models(model_id)
+);
+CREATE INDEX IF NOT EXISTS idx_score_inputs_ts ON score_inputs(ts);
+
+CREATE TABLE IF NOT EXISTS score_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  branch TEXT NOT NULL,
+  score REAL NOT NULL,
+  model_id TEXT NOT NULL,
+  inputs_json TEXT NOT NULL,
+  ts TEXT NOT NULL,
+  FOREIGN KEY (model_id) REFERENCES compliance_models(model_id)
+);
+CREATE INDEX IF NOT EXISTS idx_score_snapshots_branch_ts ON score_snapshots(branch, ts DESC);
+
+CREATE TABLE IF NOT EXISTS placeholder_tasks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  file TEXT NOT NULL,
+  line INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  sha TEXT,
+  ts TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open'
+);
+CREATE INDEX IF NOT EXISTS idx_placeholder_tasks_status_ts ON placeholder_tasks(status, ts DESC);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,22 @@ authors = [{name = "gh_COPILOT Team"}]
 requires-python = ">=3.8"
 dependencies = [
     "PyPDF2==3.0.1",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.23",
+    "pydantic>=2.6",
+    "typer[all]>=0.12",
 ]
 
 [project.scripts]
 final-enterprise-orchestrator = "copilot.orchestrators.final_enterprise_orchestrator:main"
 unified-deployment-orchestrator = "copilot.orchestrators.unified_deployment_orchestrator:main"
+gh-copilot = "gh_copilot.cli:app"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
+where = ["src"]
 exclude = ["scripts.quantum_placeholders"]
 
 [tool.ruff]

--- a/src/gh_copilot/__init__.py
+++ b/src/gh_copilot/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["models", "dao", "api"]

--- a/src/gh_copilot/api.py
+++ b/src/gh_copilot/api.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from fastapi import FastAPI, Query
+
+from .dao import SQLiteAnalyticsDAO
+
+app = FastAPI(title="gh_COPILOT API", version="0.0.1")
+
+_DB = Path(os.getenv("GH_COPILOT_ANALYTICS_DB", "analytics.db"))
+_dao = SQLiteAnalyticsDAO(_DB)
+
+
+@app.get("/api/v1/health")
+def health() -> dict[str, bool]:
+    return {"ok": True}
+
+
+@app.get("/api/v1/placeholders")
+def get_placeholders(status: str = Query("open")):
+    return [p.model_dump() for p in _dao.fetch_placeholders(status=status)]
+
+
+@app.get("/api/v1/compliance")
+def get_compliance(branch: str = Query("main")):
+    snap = _dao.fetch_score(branch)
+    return snap.model_dump() if snap else {"branch": branch, "score": None}

--- a/src/gh_copilot/cli.py
+++ b/src/gh_copilot/cli.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+import typer
+
+from .api import _dao
+from .models import ScoreInputs, ScoreSnapshot
+
+app = typer.Typer(help="gh_COPILOT command-line tools")
+
+
+def _db_path() -> Path:
+    return Path(os.getenv("GH_COPILOT_ANALYTICS_DB", "analytics.db"))
+
+
+@app.command()
+def migrate(migrations_dir: Path = typer.Option(Path("databases/gh_copilot_migrations"), exists=True)) -> None:
+    """Apply all SQL migrations in order."""
+    import sqlite3
+
+    db = _db_path()
+    conn = sqlite3.connect(db)
+    try:
+        for sql_file in sorted(migrations_dir.glob("*.sql")):
+            sql = sql_file.read_text(encoding="utf-8")
+            conn.executescript(sql)
+            conn.commit()
+            typer.echo(f"applied: {sql_file}")
+    finally:
+        conn.close()
+
+
+@app.command("seed-models")
+def seed_models() -> None:
+    """Insert default compliance model rows if missing."""
+    import sqlite3
+    import datetime
+
+    db = _db_path()
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO compliance_models(model_id, weights_json, min_score, effective_from)
+        VALUES
+        ('main-default', '{"lint":0.3,"tests":0.4,"placeholders":0.2,"sessions":0.1}', 0.90, ?),
+        ('dev-default',  '{"lint":0.3,"tests":0.4,"placeholders":0.2,"sessions":0.1}', 0.80, ?)
+        """,
+        (
+            datetime.datetime.utcnow().isoformat(),
+            datetime.datetime.utcnow().isoformat(),
+        ),
+    )
+    conn.commit()
+    conn.close()
+    typer.echo("seeded default models (main/dev)")
+
+
+@app.command("compute-score")
+def compute_score(
+    branch: str = typer.Option("main"),
+    lint: float = typer.Option(..., min=0, max=1),
+    tests: float = typer.Option(..., min=0, max=1),
+    placeholders: float = typer.Option(..., min=0, max=1),
+    sessions: float = typer.Option(..., min=0, max=1),
+) -> None:
+    """Compute and store a score snapshot for a branch."""
+    model = _dao.fetch_active_model(branch)
+    inputs = ScoreInputs(
+        run_id=str(uuid.uuid4()),
+        lint=lint,
+        tests=tests,
+        placeholders=placeholders,
+        sessions=sessions,
+        model_id=model.model_id,
+    )
+    score = model.lint * lint + model.tests * tests + model.placeholders * placeholders + model.sessions * sessions
+    snap = ScoreSnapshot(branch=branch, score=score, model_id=model.model_id, inputs=inputs)
+
+    _dao.store_score_inputs(inputs)
+    _dao.store_score_snapshot(snap)
+
+    result = {"branch": branch, "score": score, "model": model.model_id}
+    typer.echo(json.dumps(result, indent=2))
+
+
+@app.command("serve")
+def serve(host: str = "127.0.0.1", port: int = 8000) -> None:
+    import uvicorn
+
+    uvicorn.run("gh_copilot.api:app", host=host, port=port, reload=True)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/gh_copilot/dao.py
+++ b/src/gh_copilot/dao.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator, Optional, Protocol
+
+from .models import PlaceholderTask, ScoreInputs, ScoreModel, ScoreSnapshot
+
+
+class AnalyticsDAO(Protocol):
+    def log_placeholder(self, task: PlaceholderTask) -> None: ...
+    def fetch_placeholders(self, status: str = "open", limit: int = 1000) -> list[PlaceholderTask]: ...
+    def store_score_inputs(self, inputs: ScoreInputs) -> None: ...
+    def fetch_active_model(self, branch: str) -> ScoreModel: ...
+    def store_score_snapshot(self, snap: ScoreSnapshot) -> None: ...
+    def fetch_score(self, branch: str) -> Optional[ScoreSnapshot]: ...
+
+
+PRAGMAS = (
+    "PRAGMA journal_mode=WAL;",
+    "PRAGMA synchronous=NORMAL;",
+    "PRAGMA foreign_keys=ON;",
+)
+
+
+def get_conn(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    for p in PRAGMAS:
+        conn.execute(p)
+    return conn
+
+
+class SQLiteAnalyticsDAO:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+
+    @contextmanager
+    def _conn(self) -> Iterator[sqlite3.Connection]:
+        conn = get_conn(self.db_path)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def log_placeholder(self, task: PlaceholderTask) -> None:
+        with self._conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO placeholder_tasks(file, line, kind, sha, ts, status)
+                VALUES (?, ?, ?, ?, ?, 'open')
+                """,
+                (task.file, task.line, task.kind.value, task.sha, task.ts.isoformat()),
+            )
+            conn.commit()
+
+    def fetch_placeholders(self, status: str = "open", limit: int = 1000) -> list[PlaceholderTask]:
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT file, line, kind, sha, ts FROM placeholder_tasks WHERE status=? ORDER BY ts DESC LIMIT ?",
+                (status, limit),
+            ).fetchall()
+        return [
+            PlaceholderTask(
+                file=r["file"],
+                line=r["line"],
+                kind=r["kind"],
+                sha=r["sha"],
+                ts=datetime.fromisoformat(r["ts"]),
+            )
+            for r in rows
+        ]
+
+    def store_score_inputs(self, inputs: ScoreInputs) -> None:
+        with self._conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO score_inputs(run_id, lint, tests, placeholders, sessions, model_id, ts)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    inputs.run_id,
+                    inputs.lint,
+                    inputs.tests,
+                    inputs.placeholders,
+                    inputs.sessions,
+                    inputs.model_id,
+                    inputs.ts.isoformat(),
+                ),
+            )
+            conn.commit()
+
+    def fetch_active_model(self, branch: str) -> ScoreModel:
+        min_score = 0.90 if branch == "main" else 0.80
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT model_id, weights_json, min_score, effective_from FROM compliance_models ORDER BY effective_from DESC LIMIT 1"
+            ).fetchone()
+        if row:
+            import json
+            import datetime
+
+            weights = json.loads(row["weights_json"])
+            return ScoreModel(
+                model_id=row["model_id"],
+                lint=weights.get("lint", 0.30),
+                tests=weights.get("tests", 0.40),
+                placeholders=weights.get("placeholders", 0.20),
+                sessions=weights.get("sessions", 0.10),
+                min_score=min_score,
+                effective_from=datetime.datetime.fromisoformat(row["effective_from"]),
+            )
+        import datetime
+
+        return ScoreModel(model_id="default", effective_from=datetime.datetime.utcnow(), min_score=min_score)
+
+    def store_score_snapshot(self, snap: ScoreSnapshot) -> None:
+        with self._conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO score_snapshots(branch, score, model_id, inputs_json, ts)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    snap.branch,
+                    snap.score,
+                    snap.model_id,
+                    snap.inputs.model_dump_json(),
+                    snap.ts.isoformat(),
+                ),
+            )
+            conn.commit()
+
+    def fetch_score(self, branch: str) -> Optional[ScoreSnapshot]:
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT score, model_id, inputs_json, ts FROM score_snapshots WHERE branch=? ORDER BY ts DESC LIMIT 1",
+                (branch,),
+            ).fetchone()
+        if not row:
+            return None
+        from .models import ScoreInputs, ScoreSnapshot
+        import datetime
+
+        inputs = ScoreInputs.model_validate_json(row["inputs_json"])
+        return ScoreSnapshot(
+            branch=branch,
+            score=row["score"],
+            model_id=row["model_id"],
+            inputs=inputs,
+            ts=datetime.datetime.fromisoformat(row["ts"]),
+        )

--- a/src/gh_copilot/models.py
+++ b/src/gh_copilot/models.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from enum import Enum
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class PlaceholderKind(str, Enum):
+    TODO = "TODO"
+    FIXME = "FIXME"
+    TBD = "TBD"
+
+
+class PlaceholderTask(BaseModel):
+    file: str
+    line: int
+    kind: PlaceholderKind
+    sha: Optional[str] = None
+    ts: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ScoreModel(BaseModel):
+    model_id: str
+    lint: float = 0.30
+    tests: float = 0.40
+    placeholders: float = 0.20
+    sessions: float = 0.10
+    min_score: float = 0.85
+    effective_from: datetime
+
+
+class ScoreInputs(BaseModel):
+    run_id: str
+    lint: float
+    tests: float
+    placeholders: float
+    sessions: float
+    model_id: str
+    ts: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ScoreSnapshot(BaseModel):
+    branch: str
+    score: float
+    model_id: str
+    inputs: ScoreInputs
+    ts: datetime = Field(default_factory=datetime.utcnow)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_smoke_layout():
+    assert Path("src/gh_copilot/models.py").exists()
+    assert Path("src/gh_copilot/dao.py").exists()
+    assert Path("src/gh_copilot/api.py").exists()
+    assert Path("src/gh_copilot/cli.py").exists()


### PR DESCRIPTION
## Summary
- scaffold minimal `gh_copilot` package with models, DAO, FastAPI API and Typer CLI
- add SQLite migrations and smoke test
- configure project tooling with pre-commit and new dependencies

## Testing
- `pre-commit run --files .gitignore README.md pyproject.toml src/gh_copilot/__init__.py src/gh_copilot/models.py src/gh_copilot/dao.py src/gh_copilot/api.py src/gh_copilot/cli.py tests/test_smoke.py`
- `pytest tests/test_smoke.py`
- `gh-copilot migrate`
- `gh-copilot seed-models`
- `gh-copilot compute-score --lint 0.9 --tests 0.8 --placeholders 0.95 --sessions 1.0`
- `gh-copilot serve`

------
https://chatgpt.com/codex/tasks/task_e_689ad7848f5883318244bb405ebd3d15