### PR TITLE
feat: expose anomaly utilities via monitoring package

### DIFF
--- a/monitoring/unified_monitoring_optimization_system.py
+++ b/monitoring/unified_monitoring_optimization_system.py
@@ -24,6 +24,9 @@ from unified_monitoring_optimization_system import (
     train_anomaly_model,  # noqa: F401 - re-exported for tests
 )
 
+# Exported public helpers
+__all__ = ["anomaly_detection_loop", "detect_anomalies"]
+
 # re-exported for tests that patch these callables
 collect_metrics = _collect_metrics
 auto_heal_session = _auto_heal_session
@@ -80,4 +83,3 @@ def anomaly_detection_loop(
             time.sleep(interval)
 
 
-__all__ = ["anomaly_detection_loop", "detect_anomalies"]

--- a/tests/monitoring_tests/test_anomaly_detection.py
+++ b/tests/monitoring_tests/test_anomaly_detection.py
@@ -5,6 +5,7 @@ from src.monitoring.anomaly import detect_anomalies, train_baseline_models
 from src.monitoring.anomaly_detector import detect_anomalies as db_detect_anomalies
 from src.monitoring.anomaly_detector import train_models as db_train_models
 
+from monitoring import anomaly_detection_loop
 import monitoring.unified_monitoring_optimization_system as umos
 
 
@@ -77,7 +78,7 @@ def test_anomaly_loop_triggers_auto_heal(tmp_path, monkeypatch):
     def collector(*, db_path=None):
         return {"cpu": 999.0, "memory": 999.0}
 
-    umos.anomaly_detection_loop(
+    anomaly_detection_loop(
         interval=0,
         iterations=1,
         db_path=db_file,


### PR DESCRIPTION
## Summary
- ensure monitoring.unified_monitoring_optimization_system defines `__all__` and re-exports anomaly utilities
- update tests to import `anomaly_detection_loop` from monitoring package

## Testing
- `ruff check monitoring/unified_monitoring_optimization_system.py tests/monitoring_tests/test_anomaly_detection.py`
- `pytest tests/monitoring_tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689adcaec264833198ce2af54c46d9d1