### PR TITLE
feat: add compliance summary API

### DIFF
--- a/databases/migrations/0002_compliance_views.sql
+++ b/databases/migrations/0002_compliance_views.sql
@@ -1,0 +1,17 @@
+-- gh_COPILOT: compliance summary read-optimized views
+PRAGMA foreign_keys=ON;
+
+-- expects tables score_snapshots and placeholder_tasks exist (see initial migration)
+CREATE VIEW IF NOT EXISTS vw_latest_snapshot AS
+SELECT s1.*
+FROM score_snapshots s1
+JOIN (
+    SELECT branch, MAX(ts) AS max_ts
+    FROM score_snapshots
+    GROUP BY branch
+) s2 ON s1.branch = s2.branch AND s1.ts = s2.max_ts;
+
+CREATE VIEW IF NOT EXISTS vw_placeholders_open AS
+SELECT COUNT(*) AS open_count
+FROM placeholder_tasks
+WHERE status = 'open';

--- a/src/gh_copilot/compliance/__init__.py
+++ b/src/gh_copilot/compliance/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["models", "dao", "api"]

--- a/src/gh_copilot/compliance/api.py
+++ b/src/gh_copilot/compliance/api.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import AsyncIterator
+
+from fastapi import FastAPI, Query
+from starlette.responses import JSONResponse, StreamingResponse
+
+from .dao import ComplianceDAO
+
+DB_PATH = Path(os.getenv("GH_COPILOT_ANALYTICS_DB", "analytics.db"))
+_dao = ComplianceDAO(DB_PATH)
+_dao.ensure_views()
+
+app = FastAPI(title="gh_COPILOT — Compliance Summary API", version="0.1.0")
+
+
+@app.get("/api/v1/compliance/summary")
+def get_compliance_summary(branch: str = Query("main"), min_score: float | None = Query(None)) -> JSONResponse:
+    summary = _dao.compliance_summary(branch, target_min_score=min_score)
+    return JSONResponse(summary.model_dump())
+
+
+async def _sse_event_stream(branch: str, min_score: float | None) -> AsyncIterator[bytes]:
+    last_ts: str | None = None
+    while True:
+        snap = _dao.latest_snapshot(branch)
+        if snap is not None:
+            if last_ts is None or snap.ts.isoformat() > last_ts:
+                last_ts = snap.ts.isoformat()
+                summary = _dao.compliance_summary(branch, target_min_score=min_score)
+                payload = json.dumps(summary.model_dump())
+                yield f"data: {payload}\n\n".encode("utf-8")
+        else:
+            if last_ts is None:
+                payload = json.dumps(_dao.compliance_summary(branch, target_min_score=min_score).model_dump())
+                yield f"data: {payload}\n\n".encode("utf-8")
+                last_ts = "sent-initial"
+        # keep-alive
+        yield b": ping\n\n"
+        await asyncio.sleep(10)
+
+
+@app.get("/api/v1/events")
+def sse_events(branch: str = Query("main"), min_score: float | None = Query(None)) -> StreamingResponse:
+    gen = _sse_event_stream(branch=branch, min_score=min_score)
+    return StreamingResponse(gen, media_type="text/event-stream")
+
+
+@app.get("/api/v1/health")
+def health() -> dict[str, bool]:
+    return {"ok": True}
+
+
+def run(host: str = "127.0.0.1", port: int = 8001) -> None:
+    import uvicorn
+
+    uvicorn.run(app, host=host, port=port)

--- a/src/gh_copilot/compliance/dao.py
+++ b/src/gh_copilot/compliance/dao.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from .models import ComplianceSummary, GaugeBreakdown, ScoreInputs, ScoreSnapshot
+
+PRAGMAS: tuple[str, ...] = (
+    "PRAGMA journal_mode=WAL;",
+    "PRAGMA synchronous=NORMAL;",
+    "PRAGMA foreign_keys=ON;",
+)
+
+
+def get_conn(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    for p in PRAGMAS:
+        conn.execute(p)
+    return conn
+
+
+class ComplianceDAO:
+    """Read-optimized DAO for compliance summary and gauges."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+
+    @contextmanager
+    def _conn(self) -> Iterable[sqlite3.Connection]:
+        c = get_conn(self.db_path)
+        try:
+            yield c
+        finally:
+            c.close()
+
+    def ensure_views(self) -> None:
+        """Create views if missing."""
+        with self._conn() as c, c:
+            c.executescript(
+                """
+                CREATE VIEW IF NOT EXISTS vw_latest_snapshot AS
+                SELECT s1.*
+                FROM score_snapshots s1
+                JOIN (
+                    SELECT branch, MAX(ts) AS max_ts
+                    FROM score_snapshots
+                    GROUP BY branch
+                ) s2 ON s1.branch = s2.branch AND s1.ts = s2.max_ts;
+
+                CREATE VIEW IF NOT EXISTS vw_placeholders_open AS
+                SELECT COUNT(*) AS open_count
+                FROM placeholder_tasks
+                WHERE status = 'open';
+                """
+            )
+
+    def latest_snapshot(self, branch: str) -> ScoreSnapshot | None:
+        with self._conn() as c:
+            row = c.execute(
+                "SELECT branch, score, model_id, inputs_json, ts FROM vw_latest_snapshot WHERE branch=?",
+                (branch,),
+            ).fetchone()
+        if not row:
+            return None
+        inputs = ScoreInputs.model_validate_json(row["inputs_json"])  # pydantic v2
+        return ScoreSnapshot(
+            branch=row["branch"],
+            score=float(row["score"]),
+            model_id=row["model_id"],
+            inputs=inputs,
+            ts=datetime.fromisoformat(row["ts"]),
+        )
+
+    def open_placeholders(self) -> int:
+        with self._conn() as c:
+            row = c.execute("SELECT open_count FROM vw_placeholders_open").fetchone()
+        return int(row["open_count"]) if row else 0
+
+    def compliance_summary(self, branch: str, target_min_score: float | None = None) -> ComplianceSummary:
+        snap = self.latest_snapshot(branch)
+        placeholders_open = self.open_placeholders()
+        if snap is None:
+            return ComplianceSummary(branch=branch, score=None, placeholders_open=placeholders_open, gauges=[])
+        target = target_min_score if target_min_score is not None else (0.90 if branch == "main" else 0.80)
+        gauges = [
+            GaugeBreakdown(name="compliance_score", value=snap.score, target=target),
+            GaugeBreakdown(name="open_placeholders", value=float(placeholders_open), target=0.0),
+        ]
+        return ComplianceSummary(
+            branch=branch,
+            score=snap.score,
+            model_id=snap.model_id,
+            placeholders_open=placeholders_open,
+            gauges=gauges,
+        )

--- a/src/gh_copilot/compliance/models.py
+++ b/src/gh_copilot/compliance/models.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+
+class GaugeBreakdown(BaseModel):
+    name: str
+    value: float
+    target: float | None = None
+    ts: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ComplianceSummary(BaseModel):
+    branch: str
+    score: float | None
+    model_id: str | None = None
+    placeholders_open: int = 0
+    gauges: list[GaugeBreakdown] = Field(default_factory=list)
+    ts: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ScoreInputs(BaseModel):
+    run_id: str
+    lint: float
+    tests: float
+    placeholders: float
+    sessions: float
+    model_id: str
+    ts: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ScoreSnapshot(BaseModel):
+    branch: str
+    score: float
+    model_id: str
+    inputs: ScoreInputs
+    ts: datetime = Field(default_factory=datetime.utcnow)

--- a/tests/test_compliance_summary.py
+++ b/tests/test_compliance_summary.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import sqlite3
+
+from gh_copilot.compliance.dao import ComplianceDAO
+from gh_copilot.compliance.models import ScoreInputs
+
+
+def seed_minimal(db: Path) -> None:
+    con = sqlite3.connect(db)
+    con.executescript(
+        """
+        PRAGMA foreign_keys=ON;
+        CREATE TABLE IF NOT EXISTS score_snapshots (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          branch TEXT NOT NULL,
+          score REAL NOT NULL,
+          model_id TEXT NOT NULL,
+          inputs_json TEXT NOT NULL,
+          ts TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS placeholder_tasks (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          file TEXT NOT NULL,
+          line INTEGER NOT NULL,
+          kind TEXT NOT NULL,
+          sha TEXT,
+          ts TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'open'
+        );
+        """
+    )
+    con.commit()
+    con.close()
+
+
+def test_summary_without_data(tmp_path: Path) -> None:
+    db = tmp_path / "analytics.db"
+    seed_minimal(db)
+    dao = ComplianceDAO(db)
+    dao.ensure_views()
+
+    s = dao.compliance_summary("main")
+    assert s.score is None
+    assert s.placeholders_open == 0
+    assert s.gauges == []
+
+
+def test_summary_with_snapshot_and_placeholder(tmp_path: Path) -> None:
+    db = tmp_path / "analytics.db"
+    seed_minimal(db)
+
+    # Insert one snapshot and one open placeholder
+    con = sqlite3.connect(db)
+    inputs = ScoreInputs(
+        run_id="t1", lint=0.9, tests=0.9, placeholders=0.9, sessions=0.9, model_id="main-default"
+    )
+    con.execute(
+        "INSERT INTO score_snapshots(branch, score, model_id, inputs_json, ts) VALUES (?,?,?,?,?)",
+        ("main", 0.92, "main-default", inputs.model_dump_json(), datetime.utcnow().isoformat()),
+    )
+    con.execute(
+        "INSERT INTO placeholder_tasks(file, line, kind, sha, ts, status) VALUES (?,?,?,?,?, 'open')",
+        ("a.py", 1, "TODO", "deadbeef", datetime.utcnow().isoformat()),
+    )
+    con.commit()
+    con.close()
+
+    dao = ComplianceDAO(db)
+    dao.ensure_views()
+
+    s = dao.compliance_summary("main")
+    assert s.score == 0.92
+    assert s.placeholders_open == 1
+    assert any(g.name == "compliance_score" for g in s.gauges)
+    assert any(g.name == "open_placeholders" for g in s.gauges)


### PR DESCRIPTION
## Summary
- add compliance summary models and DAO with snapshot and placeholder views
- expose FastAPI endpoints with SSE event stream and health check
- cover summary logic with unit tests and SQL migration

## Testing
- `ruff check src/gh_copilot/compliance tests/test_compliance_summary.py`
- `python -m pytest tests/test_compliance_summary.py -q --override-ini="addopts="`
- `timeout 5s python -c "from gh_copilot.compliance.api import run; run()"`


------
https://chatgpt.com/codex/tasks/task_e_689ae0e804bc8331b5acd412cb1c40df