### PR TITLE
test: add simulator import test

### DIFF
--- a/tests/quantum_tests/test_simulator_import.py
+++ b/tests/quantum_tests/test_simulator_import.py
@@ -1,16 +1,20 @@
 import pytest
 
-pytest.importorskip("qiskit")
-pytest.importorskip("qiskit_aer")
+qiskit = pytest.importorskip("qiskit")
 from qiskit import QuantumCircuit
-from qiskit_aer import Aer
 
 
-def test_simulator_import_and_run():
-    circuit = QuantumCircuit(1, 1)
-    circuit.h(0)
-    circuit.measure(0, 0)
-    backend = Aer.get_backend("aer_simulator")
-    result = backend.run(circuit, shots=1).result()
+def test_simulator_import():
+    try:
+        from qiskit import Aer
+    except Exception:  # pragma: no cover - environment-dependent
+        pytest.skip("Qiskit Aer is not available")
+
+    qc = QuantumCircuit(1, 1)
+    qc.x(0)
+    qc.measure(0, 0)
+
+    backend = Aer.get_backend("qasm_simulator")
+    result = backend.run(qc, shots=1).result()
     counts = result.get_counts()
-    assert counts
+    assert counts == {"1": 1}


### PR DESCRIPTION
## Summary
- add test to verify QuantumCircuit runs on simulator when Qiskit Aer is available

## Testing
- `ruff check tests/quantum_tests/test_simulator_import.py`
- `pytest tests/quantum_tests/test_simulator_import.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689ade61d2a88331800987ed3f954c3b