### PR TITLE
feat: add WebSocket corrections broadcast

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -142,7 +142,7 @@ immediately.
 | `/api/health`             | System health check API                                                          |
 | `/metrics_stream`         | Server-Sent Events stream of live metrics                                       |
 | `/corrections_stream`     | SSE stream of recent correction logs                                            |
-| `/ws/corrections`         | WebSocket stream of correction logs (SSE fallback)                              |
+| `/ws/corrections`         | WebSocket broadcast of correction logs (same data as `/corrections_stream`)     |
 | `/dashboard/compliance`   | Returns compliance metrics, rollback and audit trail as JSON                     |
 | `/overview`               | Consolidated dashboard with metrics, rollbacks, sync events, and audit results   |
 #### Example `/dashboard/compliance` Response

--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -7,6 +7,7 @@ import sqlite3
 import threading
 import asyncio
 from typing import Any, Callable, Dict, List
+import queue
 
 from monitoring import BaselineAnomalyDetector
 
@@ -191,36 +192,45 @@ def _load_corrections(limit: int = 10) -> List[Dict[str, Any]]:
     return rows
 
 
-_ws_server_started = False
+_sse_subscribers: list["queue.Queue[str]"] = []
+_ws_clients: list[Any] = []
+_last_corrections_payload = ""
+_broadcast_thread_started = False
 
 
-def _run_corrections_ws_server() -> None:
-    """Start a background WebSocket server for corrections."""
-    global _ws_server_started
-    if _ws_server_started:
+def _broadcast_corrections(payload: str | None = None) -> None:
+    """Broadcast ``payload`` to SSE and WebSocket clients."""
+    global _last_corrections_payload
+    if payload is None:
+        payload = json.dumps(_load_corrections())
+    if payload == _last_corrections_payload:
         return
-    try:  # pragma: no cover - optional dependency
-        import websockets
-    except Exception:  # pragma: no cover - quietly skip if missing
-        return
-
-    async def handler(ws):
+    _last_corrections_payload = payload
+    for q in list(_sse_subscribers):
         try:
-            while True:
-                await ws.send(json.dumps(_load_corrections()))
-                await asyncio.sleep(5)
-        except websockets.ConnectionClosed:  # pragma: no cover - network errors
-            pass
-
-    async def main() -> None:
-        async with websockets.serve(handler, "localhost", CORRECTIONS_WS_PORT):
-            await asyncio.Event().wait()
-
-    threading.Thread(target=lambda: asyncio.run(main()), daemon=True).start()
-    _ws_server_started = True
+            q.put_nowait(payload)
+        except Exception:
+            _sse_subscribers.remove(q)
+    for ws in list(_ws_clients):
+        try:
+            ws.send(payload)
+        except Exception:
+            _ws_clients.remove(ws)
 
 
-_run_corrections_ws_server()
+def _corrections_broadcast_loop(interval: int = 5) -> None:
+    """Periodically load corrections and broadcast to subscribers."""
+    while True:
+        _broadcast_corrections()
+        time.sleep(interval)
+
+
+def _ensure_corrections_thread() -> None:
+    """Start the corrections broadcast thread if not already running."""
+    global _broadcast_thread_started
+    if not _broadcast_thread_started:
+        threading.Thread(target=_corrections_broadcast_loop, daemon=True).start()
+        _broadcast_thread_started = True
 
 
 def _load_audit_results(limit: int = 50) -> List[Dict[str, Any]]:
@@ -299,34 +309,42 @@ def metrics_stream() -> Response:
 def corrections_stream() -> Response:
     """Stream recent correction logs via SSE."""
     once = request.args.get("once") == "1"
-    interval = int(request.args.get("interval", "5"))
+    if once:
+        payload = json.dumps(_load_corrections())
+        def generate_once() -> Any:
+            yield f"data: {payload}\n\n"
+        return Response(generate_once(), mimetype="text/event-stream")
 
     def generate() -> Any:
-        while True:
-            payload = json.dumps(_load_corrections())
-            yield f"data: {payload}\n\n"
-            if once:
-                break
-            time.sleep(interval)
+        q: "queue.Queue[str]" = queue.Queue()
+        _sse_subscribers.append(q)
+        _ensure_corrections_thread()
+        try:
+            while True:
+                data = q.get()
+                yield f"data: {data}\n\n"
+        finally:
+            _sse_subscribers.remove(q)
 
     return Response(generate(), mimetype="text/event-stream")
 
 
 @app.route("/ws/corrections")
 def corrections_ws() -> Any:
-    """WebSocket endpoint for streaming corrections with SSE fallback."""
+    """WebSocket endpoint for correction broadcasts with SSE fallback."""
     ws = request.environ.get("wsgi.websocket")
-    if ws is not None:
-        interval = int(request.args.get("interval", "5"))
+    if ws is None:
+        return corrections_stream()
+    _ws_clients.append(ws)
+    _ensure_corrections_thread()
+    try:
         while True:
-            payload = json.dumps(_load_corrections())
-            try:
-                ws.send(payload)
-            except Exception:
+            if ws.receive() is None:
                 break
-            time.sleep(interval)
-        return ""
-    return corrections_stream()
+    finally:
+        if ws in _ws_clients:
+            _ws_clients.remove(ws)
+    return ""
 
 
 app.view_functions["dashboard.metrics"] = metrics


### PR DESCRIPTION
## Summary
- add centralized corrections broadcaster to stream updates to WebSocket and SSE clients
- expose `/ws/corrections` endpoint with WebSocket handling and SSE fallback
- document real-time corrections endpoints and add regression tests

## Testing
- `ruff check dashboard/enterprise_dashboard.py tests/dashboard/test_corrections_stream.py`
- `PYTEST_ADDOPTS="--no-cov" pytest tests/dashboard/test_corrections_stream.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ae3c97d1483319032b1d2334344b3