### PR TITLE
feat: add Rigetti provider with environment detection

### DIFF
--- a/quantum/providers/rigetti_provider.py
+++ b/quantum/providers/rigetti_provider.py
@@ -1,20 +1,66 @@
-"""Rigetti backend provider (stub)."""
+"""Rigetti backend provider."""
 
 from __future__ import annotations
 
+import os
+import warnings
+from typing import Any
+
 from .base import BackendProvider
-from quantum.framework.backend import QuantumBackend
+from quantum.framework.backend import QuantumBackend, SimulatorBackend
+
+try:  # pragma: no cover - optional dependency
+    from pyquil.api import WavefunctionSimulator  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    WavefunctionSimulator = None  # type: ignore
 
 
 class RigettiProvider(BackendProvider):
-    """Placeholder provider for Rigetti backends."""
+    """Provide access to Rigetti backends via the `pyquil` SDK.
 
-    def get_backend(self) -> QuantumBackend:  # pragma: no cover - TODO
-        raise NotImplementedError("Rigetti provider not implemented yet")
+    The provider checks for the presence of the Rigetti SDK and two
+    environment variables:
 
-    def is_available(self) -> bool:  # pragma: no cover - TODO
-        # TODO: detect Rigetti SDK availability
-        return False
+    - ``RIGETTI_API_KEY`` – API key for authentication.
+    - ``RIGETTI_CLUSTER_URL`` – URL of the target cluster.
+
+    If the SDK or required environment variables are missing, a
+    :class:`~quantum.framework.backend.SimulatorBackend` is returned
+    instead.
+    """
+
+    def __init__(self) -> None:
+        self._backend: QuantumBackend | None = None
+
+    def is_available(self) -> bool:
+        """Return ``True`` when the Rigetti SDK and credentials are present."""
+
+        return (
+            WavefunctionSimulator is not None
+            and os.getenv("RIGETTI_API_KEY") is not None
+            and os.getenv("RIGETTI_CLUSTER_URL") is not None
+        )
+
+    def _build_backend(self) -> QuantumBackend:
+        if not self.is_available():
+            return SimulatorBackend()
+
+        try:
+            simulator = WavefunctionSimulator()
+
+            class _RigettiBackend(QuantumBackend):  # pragma: no cover - thin wrapper
+                def run(self, circuit: Any, **kwargs: Any) -> Any:
+                    return simulator.wavefunction(circuit, **kwargs).amplitudes
+
+            return _RigettiBackend()
+        except Exception as exc:  # pragma: no cover - provider issues
+            warnings.warn(f"Rigetti backend unavailable: {exc}; using simulator")
+            return SimulatorBackend()
+
+    def get_backend(self) -> QuantumBackend:
+        if self._backend is None:
+            self._backend = self._build_backend()
+        return self._backend
 
 
 __all__ = ["RigettiProvider"]

--- a/tests/quantum/test_rigetti_provider.py
+++ b/tests/quantum/test_rigetti_provider.py
@@ -1,0 +1,25 @@
+"""Tests for the :mod:`quantum.providers.rigetti_provider` module."""
+
+import pytest
+
+pytest.importorskip("pyquil")
+
+from quantum.framework.backend import QuantumBackend
+from quantum.providers.rigetti_provider import RigettiProvider
+
+
+def test_rigetti_provider_unavailable_without_env(monkeypatch):
+    monkeypatch.delenv("RIGETTI_API_KEY", raising=False)
+    monkeypatch.delenv("RIGETTI_CLUSTER_URL", raising=False)
+    provider = RigettiProvider()
+    assert provider.is_available() is False
+
+
+def test_rigetti_provider_backend(monkeypatch):
+    monkeypatch.setenv("RIGETTI_API_KEY", "dummy")
+    monkeypatch.setenv("RIGETTI_CLUSTER_URL", "http://example.com")
+    provider = RigettiProvider()
+    assert provider.is_available()
+    backend = provider.get_backend()
+    assert isinstance(backend, QuantumBackend)
+


### PR DESCRIPTION
## Summary
- implement RigettiProvider with pyquil-based backend and env var checks
- add tests validating Rigetti provider availability and backend retrieval

## Testing
- `ruff check quantum/providers/rigetti_provider.py tests/quantum/test_rigetti_provider.py`
- `pytest tests/quantum/test_rigetti_provider.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689b4e47224483319790adf45b03fb05