### PR TITLE
feat: enable IonQ backend provider with lazy loading

### DIFF
--- a/quantum/providers/__init__.py
+++ b/quantum/providers/__init__.py
@@ -1,39 +1,36 @@
-"""Backend provider registry.
-
-This module exposes a helper :func:`get_provider` that returns an instance of
-the requested backend provider. Providers implement
-``quantum.providers.base.BackendProvider``.
-"""
+"""Helper for retrieving quantum backend providers."""
 
 from __future__ import annotations
 
-from typing import Dict
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, Type
 
-from .base import BackendProvider
-from .ibm_provider import IBMBackendProvider
-from .ionq_provider import IonQProvider
-from .rigetti_provider import RigettiProvider
-from .simulator import SimulatorProvider
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .base import BackendProvider
 
-# Mapping of provider names to their classes. Additional providers can be added
-# here without modifying :func:`get_provider`.
-_PROVIDERS: Dict[str, type[BackendProvider]] = {
-    "simulator": SimulatorProvider,
-    "ibm": IBMBackendProvider,
-    "ionq": IonQProvider,
-    "rigetti": RigettiProvider,
+_PROVIDERS: Dict[str, str] = {
+    "simulator": "quantum.providers.simulator.SimulatorProvider",
+    "ibm": "quantum.providers.ibm_provider.IBMBackendProvider",
+    "ionq": "quantum.providers.ionq_provider.IonQProvider",
+    "rigetti": "quantum.providers.rigetti_provider.RigettiProvider",
 }
 
 
-def get_provider(name: str) -> BackendProvider:
-    """Return a provider instance by name.
-
-    Unknown names default to the :class:`SimulatorProvider`.
-    """
-
-    provider_cls = _PROVIDERS.get(name, SimulatorProvider)
+def _load_provider(path: str) -> "BackendProvider":
+    module_name, class_name = path.rsplit(".", 1)
+    module = import_module(module_name)
+    provider_cls: Type["BackendProvider"] = getattr(module, class_name)
     return provider_cls()
 
 
-__all__ = ["BackendProvider", "get_provider"]
+def get_provider(name: str) -> "BackendProvider":
+    """Return a provider instance by name.
 
+    Unknown names default to the simulator provider.
+    """
+
+    path = _PROVIDERS.get(name, _PROVIDERS["simulator"])
+    return _load_provider(path)
+
+
+__all__ = ["get_provider"]

--- a/quantum/providers/ionq_provider.py
+++ b/quantum/providers/ionq_provider.py
@@ -2,19 +2,63 @@
 
 from __future__ import annotations
 
+import os
+import warnings
+from typing import Any, TYPE_CHECKING
+
 from .base import BackendProvider
-from quantum.framework.backend import QuantumBackend
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from quantum.framework.backend import QuantumBackend
+
+
+try:  # pragma: no cover - optional dependency
+    from qiskit_ionq import IonQProvider as _IonQProvider  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    _IonQProvider = None  # type: ignore
 
 
 class IonQProvider(BackendProvider):
-    """Placeholder provider for IonQ backends."""
+    """Provide access to IonQ hardware when the SDK is installed."""
 
-    def get_backend(self) -> QuantumBackend:  # pragma: no cover - TODO
-        raise NotImplementedError("IonQ provider not implemented yet")
+    def __init__(self) -> None:
+        self._backend: "QuantumBackend" | None = None
 
-    def is_available(self) -> bool:  # pragma: no cover - TODO
-        # TODO: detect IonQ SDK availability
-        return False
+    def is_available(self) -> bool:
+        api_key = os.getenv("IONQ_API_KEY")
+        return _IonQProvider is not None and api_key is not None
+
+    def _build_backend(self) -> "QuantumBackend":
+        api_key = os.getenv("IONQ_API_KEY")
+        backend_name = os.getenv("IONQ_BACKEND")
+        if not self.is_available():
+            from quantum.framework.backend import SimulatorBackend
+
+            return SimulatorBackend()
+        try:
+            provider = _IonQProvider(api_key=api_key)
+            if backend_name:
+                backend = provider.get_backend(backend_name)
+            else:
+                hardware = provider.backends(simulator=False)
+                backend = hardware[0] if hardware else provider.get_backend("ionq.simulator")
+
+            class _Adapter(QuantumBackend):  # pragma: no cover - thin wrapper
+                def run(self, circuit: Any, **kwargs: Any) -> Any:
+                    job = backend.run(circuit, **kwargs)
+                    return job.result() if hasattr(job, "result") else job
+
+            return _Adapter()
+        except Exception as exc:  # pragma: no cover - provider issues
+            from quantum.framework.backend import SimulatorBackend
+
+            warnings.warn(f"IonQ backend unavailable: {exc}; using simulator")
+            return SimulatorBackend()
+
+    def get_backend(self) -> "QuantumBackend":
+        if self._backend is None:
+            self._backend = self._build_backend()
+        return self._backend
 
 
 __all__ = ["IonQProvider"]

--- a/tests/quantum/__init__.py
+++ b/tests/quantum/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for quantum providers."""

--- a/tests/quantum/test_ionq_provider.py
+++ b/tests/quantum/test_ionq_provider.py
@@ -1,0 +1,11 @@
+import pytest
+
+from quantum.providers.ionq_provider import IonQProvider
+from quantum.framework.backend import QuantumBackend
+
+
+@pytest.mark.skipif(not IonQProvider().is_available(), reason="IonQ SDK not available")
+def test_get_backend_returns_quantum_backend():
+    provider = IonQProvider()
+    backend = provider.get_backend()
+    assert isinstance(backend, QuantumBackend)


### PR DESCRIPTION
## Summary
- implement IonQProvider with simulator fallback and availability checks
- lazily load quantum backend providers to avoid circular imports
- add integration test for IonQ provider that skips when IonQ SDK is missing

## Testing
- `ruff check quantum/providers/__init__.py quantum/providers/ionq_provider.py tests/quantum/__init__.py tests/quantum/test_ionq_provider.py`
- `pytest tests/quantum/test_ionq_provider.py` (skipped: IonQ SDK not available)
- `pre-commit run --files quantum/providers/ionq_provider.py tests/quantum/test_ionq_provider.py tests/quantum/__init__.py` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_689b4d86d19083318e0230be48b53980