### PR TITLE
fix: resolve cross-package imports in monitoring recovery

### DIFF
--- a/monitoring/anomaly/__init__.py
+++ b/monitoring/anomaly/__init__.py
@@ -1,4 +1,33 @@
 """Anomaly detection utilities."""
+
+from typing import Dict, Tuple
+
 from .model import StatisticalAnomalyDetector
 
-__all__ = ["StatisticalAnomalyDetector"]
+# Type alias for mean and standard deviation per metric
+Model = Tuple[float, float]
+
+
+def detect_anomalies(
+    models: Dict[str, Model],
+    current_metrics: Dict[str, float],
+    *,
+    z_threshold: float = 3.0,
+) -> Dict[str, bool]:
+    """Detect anomalies given current metric values."""
+
+    anomalies: Dict[str, bool] = {}
+    for metric, value in current_metrics.items():
+        model = models.get(metric)
+        if model is None:
+            continue
+        mean, std = model
+        if std == 0:
+            anomalies[metric] = value != mean
+            continue
+        z_score = abs(value - mean) / std
+        anomalies[metric] = z_score > z_threshold
+    return anomalies
+
+
+__all__ = ["StatisticalAnomalyDetector", "Model", "detect_anomalies"]

--- a/monitoring/recovery.py
+++ b/monitoring/recovery.py
@@ -17,8 +17,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable
 import sqlite3
 
-from src.monitoring import anomaly
-from src.session import validators
+from monitoring import anomaly
+from session import validators
 
 
 def recover_system(

--- a/session/validators.py
+++ b/session/validators.py
@@ -1,0 +1,105 @@
+"""Simple validators used during session shutdown.
+
+This module mirrors the lightweight validation helpers from the `src.session`
+package so that modules outside the `src` tree can import them without relying
+on cross-package paths.  The functions intentionally avoid external
+dependencies and keep the checks very small. They return lists of offending
+items so callers can decide how to handle validation failures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+
+
+def check_open_connections(connections: list[sqlite3.Connection]) -> list[sqlite3.Connection]:
+    """Return connections that are still usable."""
+
+    open_conns: list[sqlite3.Connection] = []
+    for conn in connections:
+        try:
+            conn.execute("SELECT 1")
+        except Exception:
+            continue
+        else:
+            open_conns.append(conn)
+    return open_conns
+
+
+def check_temp_files(temp_dir: Path) -> list[Path]:
+    """Return ``*.tmp`` files located in ``temp_dir``."""
+
+    directory = Path(temp_dir)
+    return [p for p in directory.glob("*.tmp") if p.is_file()]
+
+
+def check_logs(log_dir: Path) -> list[Path]:
+    """Return empty ``*.log`` files present in ``log_dir``."""
+
+    directory = Path(log_dir)
+    offending: list[Path] = []
+    for log in directory.glob("*.log"):
+        if log.is_file() and log.stat().st_size == 0:
+            offending.append(log)
+    return offending
+
+
+def check_uncommitted_transactions(
+    connections: list[sqlite3.Connection],
+) -> list[sqlite3.Connection]:
+    """Return connections that have pending transactions."""
+
+    return [conn for conn in connections if conn.in_transaction]
+
+
+def check_orphaned_sessions(session_dir: Path) -> list[Path]:
+    """Return ``session-*.json`` files located in ``session_dir``."""
+
+    directory = Path(session_dir)
+    return [p for p in directory.glob("session-*.json") if p.is_file()]
+
+
+def validate_lifecycle(
+    connections: list[sqlite3.Connection],
+    *,
+    log_dir: Path,
+    temp_dir: Path,
+    session_dir: Path,
+) -> dict[str, list]:
+    """Run all validators and return a mapping of failures."""
+
+    issues: dict[str, list] = {}
+
+    open_conns = check_open_connections(connections)
+    if open_conns:
+        issues["open_connections"] = open_conns
+
+    uncommitted = check_uncommitted_transactions(connections)
+    if uncommitted:
+        issues["uncommitted_transactions"] = uncommitted
+
+    temp_files = check_temp_files(temp_dir)
+    if temp_files:
+        issues["temp_files"] = temp_files
+
+    empty_logs = check_logs(log_dir)
+    if empty_logs:
+        issues["empty_logs"] = empty_logs
+
+    orphaned = check_orphaned_sessions(session_dir)
+    if orphaned:
+        issues["orphaned_sessions"] = orphaned
+
+    return issues
+
+
+__all__ = [
+    "check_open_connections",
+    "check_temp_files",
+    "check_logs",
+    "check_uncommitted_transactions",
+    "check_orphaned_sessions",
+    "validate_lifecycle",
+]
+


### PR DESCRIPTION
## Summary
- import monitoring utilities without using `src` package paths
- expose anomaly detection helper and model alias in monitoring package
- provide standalone session validators to avoid brittle cross-package deps

## Testing
- `ruff check monitoring/recovery.py monitoring/anomaly/__init__.py session/validators.py tests/monitoring_tests/recovery/test_recovery.py`
- `pytest tests/monitoring_tests/recovery/test_recovery.py`
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689b4ea74d148331bf9b094107b32d40