### PR TITLE
fix: prioritize repository root on pytest path

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,9 @@
 [pytest]
+pythonpath = .
 addopts = --maxfail=10 --exitfirst --cov=. --cov-report=term
 # Enforce per-test timeouts via pytest-timeout (seconds)
 timeout = 120
 norecursedirs = builds
 python_files = test_*.py
-pythonpath = .
 markers =
     hardware: tests requiring IBM Quantum hardware


### PR DESCRIPTION
## Summary
- ensure repository root is prepended to `sys.path` by moving `pythonpath = .` to the top of `pytest.ini`

## Testing
- `pytest tests/monitoring_tests/anomaly/test_model.py -q`
- `pytest tests/quantum_tests/test_backend_provider.py -q`
- `ruff check pytest.ini`


------
https://chatgpt.com/codex/tasks/task_e_689b4fdea0a083318d181f66c3405ce5