### PR TITLE
feat: log integration progress and requirement mappings

### DIFF
--- a/tests/template_engine/test_integration_progress_mapping.py
+++ b/tests/template_engine/test_integration_progress_mapping.py
@@ -1,0 +1,55 @@
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import template_engine.db_first_code_generator as dbgen
+from template_engine.db_first_code_generator import DBFirstCodeGenerator
+
+
+def test_progress_and_requirement_mapping_logged(tmp_path: Path) -> None:
+    prod_db = tmp_path / "production.db"
+    doc_db = tmp_path / "documentation.db"
+    tpl_db = tmp_path / "template.db"
+    analytics = tmp_path / "analytics.db"
+
+    os.environ["GH_COPILOT_WORKSPACE"] = str(tmp_path)
+    os.environ["GH_COPILOT_DISABLE_VALIDATION"] = "1"
+
+    with sqlite3.connect(prod_db) as conn:
+        conn.execute(
+            "CREATE TABLE template_placeholders (placeholder_name TEXT, default_value TEXT)"
+        )
+        conn.execute("INSERT INTO template_placeholders VALUES ('{{NAME}}', 'World')")
+
+    def fake_log(event: dict, *, table: str, db_path: Path, **_: object) -> None:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(f"CREATE TABLE IF NOT EXISTS {table} (data TEXT)")
+            conn.execute(
+                f"INSERT INTO {table} (data) VALUES (?)",
+                (json.dumps(event),),
+            )
+            conn.commit()
+
+    dbgen._log_event = fake_log
+
+    gen = DBFirstCodeGenerator(prod_db, doc_db, tpl_db, analytics)
+
+    def select_template(*_: object) -> str:
+        return "print('{{NAME}}')"
+
+    gen.select_best_template = select_template
+
+    path = gen.generate_integration_ready_code("REQ-1")
+    assert path.exists()
+
+    with sqlite3.connect(analytics) as conn:
+        events = [json.loads(r[0]) for r in conn.execute("SELECT data FROM generator_events")]
+
+    phases = {e.get("phase") for e in events if e.get("event") == "integration_progress"}
+    assert phases == {"template_selection", "token_replacement", "file_write"}
+
+    mapping = next(e for e in events if e.get("event") == "requirement_mapping")
+    assert mapping["requirement_id"] == "REQ-1"
+    assert mapping["generated_path"] == str(path)
+


### PR DESCRIPTION
## Summary
- add progress indicators to integration-ready code generation
- record requirement-to-file mapping in analytics events
- test progress and requirement mapping logging

## Testing
- `ruff check template_engine/db_first_code_generator.py tests/template_engine/test_integration_progress_mapping.py`
- `pytest tests/test_db_first_code_generator.py tests/test_db_first_codegen_analytics.py tests/template_engine/test_integration_progress_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4f7bb4a4833186c1230637c19d57