### PR TITLE
feat: add MFA validation to dashboard sessions

### DIFF
--- a/src/dashboard/auth.py
+++ b/src/dashboard/auth.py
@@ -46,11 +46,32 @@ def _check_rate_limit(identifier: str = "global", limit: int = 5, window: int = 
     events.append(now)
     _RATE_LIMIT[identifier] = events
 
-# TODO: integrate multi-factor authentication mechanisms
 
-def _check_mfa() -> None:
-    """Placeholder for future multi-factor authentication logic."""
-    pass
+def _check_mfa(token: str | None) -> None:
+    """Validate a user-provided TOTP code.
+
+    Parameters
+    ----------
+    token:
+        The one-time password supplied by the user.  The secret used to
+        validate the token is read from ``DASHBOARD_MFA_SECRET``.
+    """
+
+    if token is None:
+        raise ValueError("MFA token required")
+
+    secret = os.environ.get("DASHBOARD_MFA_SECRET")
+    if not secret:
+        raise ValueError("MFA secret not configured")
+
+    try:  # pragma: no cover - optional dependency
+        import pyotp
+    except Exception as exc:  # pragma: no cover - dependency issue
+        raise ValueError("pyotp library is required for MFA") from exc
+
+    totp = pyotp.TOTP(secret)
+    if not totp.verify(token):
+        raise ValueError("Invalid MFA token")
 
 
 @dataclass
@@ -72,8 +93,8 @@ class SessionManager:
             session_timeout=session_timeout,
         )
 
-    def start_session(self, token: str) -> str:
-        """Start a session if the token matches the expected value."""
+    def start_session(self, token: str, mfa_token: str | None = None) -> str:
+        """Start a session if both auth token and MFA code are valid."""
 
         _check_rate_limit("start_session")
         now = time.time()
@@ -88,7 +109,7 @@ class SessionManager:
             raise ValueError("Invalid token")
         self.failed_attempts = 0
         self.lock_until = 0
-        _check_mfa()
+        _check_mfa(mfa_token)
         session_id = str(uuid.uuid4())
         csrf_token = secrets.token_hex(16)
         self.active_sessions[session_id] = _Session(

--- a/tests/dashboard/auth/test_security.py
+++ b/tests/dashboard/auth/test_security.py
@@ -3,6 +3,11 @@ import pytest
 from src.dashboard import auth
 
 
+@pytest.fixture(autouse=True)
+def _mock_mfa(monkeypatch):
+    monkeypatch.setattr(auth, "_check_mfa", lambda *_: None)
+
+
 @pytest.fixture()
 def manager():
     auth._RATE_LIMIT.clear()

--- a/tests/dashboard/integration/test_auth_flow.py
+++ b/tests/dashboard/integration/test_auth_flow.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request
 
 from src.dashboard.auth import SessionManager
+from src.dashboard import auth
 
 
 def create_app() -> Flask:
@@ -32,6 +33,7 @@ def create_app() -> Flask:
 
 def test_auth_end_to_end(monkeypatch):
     monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    monkeypatch.setattr(auth, "_check_mfa", lambda *_: None)
     app = create_app()
     client = app.test_client()
 

--- a/tests/dashboard/integration/test_dashboard_workflow.py
+++ b/tests/dashboard/integration/test_dashboard_workflow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from flask import Flask, jsonify, request
 
 from src.dashboard.auth import SessionManager
+from src.dashboard import auth
 from dashboard import compliance_metrics_updater as cmu
 
 
@@ -32,6 +33,7 @@ def create_app(summary_path: Path) -> Flask:
 
 def test_dashboard_workflow(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    monkeypatch.setattr(auth, "_check_mfa", lambda *_: None)
     summary = tmp_path / "correction_summary.json"
     summary.write_text(json.dumps({"corrections": [{"file_path": "file.py"}]}))
 

--- a/tests/dashboard/test_auth.py
+++ b/tests/dashboard/test_auth.py
@@ -3,6 +3,11 @@ import pytest
 from src.dashboard import auth
 
 
+@pytest.fixture(autouse=True)
+def _mock_mfa(monkeypatch):
+    monkeypatch.setattr(auth, "_check_mfa", lambda *_: None)
+
+
 @pytest.fixture()
 def manager():
     return auth.SessionManager.create()

--- a/tests/dashboard/test_auth_mfa.py
+++ b/tests/dashboard/test_auth_mfa.py
@@ -1,0 +1,29 @@
+import pytest
+
+from src.dashboard import auth
+
+pyotp = pytest.importorskip("pyotp")
+
+
+@pytest.fixture()
+def manager() -> auth.SessionManager:
+    return auth.SessionManager.create()
+
+
+def test_session_requires_valid_mfa(monkeypatch, manager):
+    monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    secret = pyotp.random_base32()
+    monkeypatch.setenv("DASHBOARD_MFA_SECRET", secret)
+    valid = pyotp.TOTP(secret).now()
+    session = manager.start_session("secret", valid)
+    assert manager.validate("secret", session)
+    with pytest.raises(ValueError):
+        manager.start_session("secret", "000000")
+
+
+def test_start_session_without_mfa(monkeypatch, manager):
+    monkeypatch.setenv("DASHBOARD_AUTH_TOKEN", "secret")
+    secret = pyotp.random_base32()
+    monkeypatch.setenv("DASHBOARD_MFA_SECRET", secret)
+    with pytest.raises(ValueError):
+        manager.start_session("secret")

--- a/tests/dashboard/test_auth_security.py
+++ b/tests/dashboard/test_auth_security.py
@@ -7,6 +7,11 @@ from src.dashboard import auth
 from src.dashboard.api import logs as logs_api
 
 
+@pytest.fixture(autouse=True)
+def _mock_mfa(monkeypatch):
+    monkeypatch.setattr(auth, "_check_mfa", lambda *_: None)
+
+
 @pytest.fixture()
 def manager() -> auth.SessionManager:
     return auth.SessionManager.create(max_attempts=3)


### PR DESCRIPTION
## Summary
- validate TOTP codes for dashboard logins and require MFA token when starting sessions
- add MFA unit tests and update existing dashboard tests to mock MFA

## Testing
- `ruff check src/dashboard/auth.py tests/dashboard/test_auth_mfa.py tests/dashboard/test_auth.py tests/dashboard/auth/test_security.py tests/dashboard/test_auth_security.py tests/dashboard/integration/test_dashboard_workflow.py tests/dashboard/integration/test_auth_flow.py`
- `pytest -q tests/dashboard/test_auth.py tests/dashboard/auth/test_security.py tests/dashboard/test_auth_mfa.py tests/monitoring_tests/recovery/test_recovery.py -o addopts=""` *(fails: ModuleNotFoundError: No module named 'monitoring.recovery'; 'monitoring' is not a package)*


------
https://chatgpt.com/codex/tasks/task_e_689b5f6239788331ad57fa18d77a11a1