### PR TITLE
feat: add progress tracking with requirement mapping

### DIFF
--- a/template_engine/db_first_code_generator.py
+++ b/template_engine/db_first_code_generator.py
@@ -407,6 +407,17 @@ class DBFirstCodeGenerator(TemplateAutoGenerator):
                 template = self.generate(objective)
             _log_event(
                 {
+                    "event": "template_selected",
+                    "objective": objective,
+                    "template_snippet": template[:100],
+                    "requirement_map": {objective: template[:100]},
+                },
+                table="generator_events",
+                db_path=self.analytics_db,
+                test_mode=False,
+            )
+            _log_event(
+                {
                     "event": "integration_progress",
                     "phase": "template_selection",
                     "objective": objective,
@@ -418,7 +429,12 @@ class DBFirstCodeGenerator(TemplateAutoGenerator):
                 test_mode=False,
             )
             bar.update(1)
-            bar.set_postfix({"phase": "template_selection"})
+            bar.set_postfix(
+                {
+                    "phase": "template_selection",
+                    "eta": f"{bar.format_dict.get('remaining', 0):.1f}s",
+                }
+            )
 
             # Phase 2: token replacement
             stub = apply_tokens(
@@ -434,6 +450,17 @@ class DBFirstCodeGenerator(TemplateAutoGenerator):
             )
             _log_event(
                 {
+                    "event": "tokens_replaced",
+                    "objective": objective,
+                    "code_snippet": stub[:100],
+                    "requirement_map": {objective: stub[:100]},
+                },
+                table="generator_events",
+                db_path=self.analytics_db,
+                test_mode=False,
+            )
+            _log_event(
+                {
                     "event": "integration_progress",
                     "phase": "token_replacement",
                     "objective": objective,
@@ -445,7 +472,12 @@ class DBFirstCodeGenerator(TemplateAutoGenerator):
                 test_mode=False,
             )
             bar.update(1)
-            bar.set_postfix({"phase": "token_replacement"})
+            bar.set_postfix(
+                {
+                    "phase": "token_replacement",
+                    "eta": f"{bar.format_dict.get('remaining', 0):.1f}s",
+                }
+            )
 
             # Phase 3: file write
             path = Path(f"{objective}.py")
@@ -549,6 +581,12 @@ class DBFirstCodeGenerator(TemplateAutoGenerator):
                 test_mode=False,
             )
             bar.update(1)
+            bar.set_postfix(
+                {
+                    "phase": "file_write",
+                    "eta": f"{bar.format_dict.get('remaining', 0):.1f}s",
+                }
+            )
 
         return path
 

--- a/tests/template_engine/test_integration_progress_mapping.py
+++ b/tests/template_engine/test_integration_progress_mapping.py
@@ -49,6 +49,12 @@ def test_progress_and_requirement_mapping_logged(tmp_path: Path) -> None:
     phases = {e.get("phase") for e in events if e.get("event") == "integration_progress"}
     assert phases == {"template_selection", "token_replacement", "file_write"}
 
+    tpl_evt = next(e for e in events if e.get("event") == "template_selected")
+    assert tpl_evt["requirement_map"]["REQ-1"].startswith("print")
+
+    token_evt = next(e for e in events if e.get("event") == "tokens_replaced")
+    assert token_evt["requirement_map"]["REQ-1"].startswith("print")
+
     mapping_event = next(e for e in events if e.get("event") == "requirement_mapping")
     assert mapping_event["mapping"]["REQ-1"]["path"] == str(path)
 


### PR DESCRIPTION
## Summary
- track template selection, token replacement, and file write phases with tqdm progress bars and ETA
- log requirement mappings for selected templates and replaced tokens
- test analytics logging of progress phases and requirement mappings

## Testing
- `ruff check template_engine/db_first_code_generator.py tests/template_engine/test_integration_progress_mapping.py`
- `pytest --override-ini addopts='' tests/template_engine/test_integration_progress_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_689b65763b34833194500f9565c87688