### PR TITLE
fix: add robust error handling for Codex log database

### DIFF
--- a/tests/test_codex_log_database.py
+++ b/tests/test_codex_log_database.py
@@ -5,14 +5,42 @@ from __future__ import annotations
 from pathlib import Path
 import tempfile
 
-from utils.codex_log_database import fetch_codex_events, log_codex_event
+import sqlite3
+import pytest
+from utils import codex_log_database as cldb
 
 
 def test_log_and_fetch() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         db_path = Path(tmp) / "codex_test.db"
-        log_codex_event("action", "statement", session_id="s1", db_path=db_path)
-        events = fetch_codex_events(session_id="s1", db_path=db_path)
+        cldb.log_codex_event("action", "statement", session_id="s1", db_path=db_path)
+        events = cldb.fetch_codex_events(session_id="s1", db_path=db_path)
         assert events and events[0]["action"] == "action"
         assert events[0]["statement"] == "statement"
+
+
+def test_log_codex_event_db_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = tmp_path / "db.sqlite"
+    cldb._ensure_db(db_path)
+
+    def boom(*args, **kwargs):
+        raise sqlite3.DatabaseError("fail")
+
+    monkeypatch.setattr(sqlite3, "connect", boom)
+    monkeypatch.setattr(cldb, "_ensure_db", lambda _db_path: None)
+    with pytest.raises(RuntimeError, match="Failed to log Codex event"):
+        cldb.log_codex_event("a", "b", db_path=db_path)
+
+
+def test_fetch_codex_events_db_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = tmp_path / "db.sqlite"
+    cldb._ensure_db(db_path)
+
+    def boom(*args, **kwargs):
+        raise sqlite3.DatabaseError("fail")
+
+    monkeypatch.setattr(sqlite3, "connect", boom)
+    monkeypatch.setattr(cldb, "_ensure_db", lambda _db_path: None)
+    with pytest.raises(RuntimeError, match="Failed to fetch Codex events"):
+        cldb.fetch_codex_events(db_path=db_path)
 


### PR DESCRIPTION
## Summary
- guard Codex log database initialization against filesystem and SQLite failures
- raise RuntimeError when logging or fetching Codex events encounters database errors
- test error paths for logging and fetching Codex events

## Testing
- `ruff check utils/codex_log_database.py tests/test_codex_log_database.py`
- `pytest tests/test_codex_log_database.py`


------
https://chatgpt.com/codex/tasks/task_e_689b662587f88331bc83bc8bb59a9c20