### PR TITLE
docs: migrate main README to reStructuredText

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,33 +1,51 @@
-# 🎯 gh_COPILOT Toolkit v4.0 Enterprise
-## High-Performance HTTP Archive (HAR) Analysis with Advanced Enterprise Integration
+🎯 gh_COPILOT Toolkit v4.0 Enterprise
+====================================
 
-![GitHub Copilot Integration](https://img.shields.io/badge/GitHub_Copilot-Enterprise_Integration-green)
-![Learning Patterns](https://img.shields.io/badge/Learning_Patterns-ongoing-yellow)
-![DUAL COPILOT](https://img.shields.io/badge/DUAL_COPILOT-Pattern_Validated-orange)
-![Database First](https://img.shields.io/badge/Database_First-Architecture_Complete-purple)
-![Coverage](https://img.shields.io/badge/coverage-automated-blue)
-![Ruff](https://img.shields.io/badge/ruff-linted-blue)
+High-Performance HTTP Archive (HAR) Analysis with Advanced Enterprise Integration
+---------------------------------------------------------------------------------
+
+
+.. image:: https://img.shields.io/badge/GitHub_Copilot-Enterprise_Integration-green
+   :alt: GitHub Copilot Integration
+
+.. image:: https://img.shields.io/badge/Learning_Patterns-ongoing-yellow
+   :alt: Learning Patterns
+
+.. image:: https://img.shields.io/badge/DUAL_COPILOT-Pattern_Validated-orange
+   :alt: DUAL COPILOT
+
+.. image:: https://img.shields.io/badge/Database_First-Architecture_Complete-purple
+   :alt: Database First
+
+.. image:: https://img.shields.io/badge/coverage-automated-blue
+   :alt: Coverage
+
+.. image:: https://img.shields.io/badge/ruff-linted-blue
+   :alt: Ruff
+
 
 **Status:** Active development with incremental improvements. Disaster recovery now enforces external backup roots with verified restore tests, and session-management lifecycle APIs (`start_session` / `end_session`) are now available. Monitoring modules expose a unified metrics API via `UnifiedMonitoringOptimizationSystem.collect_metrics` with optional quantum scoring hooks, and Git LFS rules are auto-synced from `.codex_lfs_policy.yaml` to ensure binary assets are tracked. The compliance metrics feature is fully implemented, combining lint, test, placeholder, and session lifecycle audits into a composite score persisted to `analytics.db` and exposed through `/api/refresh_compliance` (recalculate) and `/api/compliance_scores` (fetch recent scores). Dashboard gauges now include tooltips explaining lint, test, placeholder, and session success scores, and session wrap-ups log these metrics for every run.
 
-> Combined checks: run `python scripts/run_checks.py` to execute `ruff` and `pytest` sequentially.
-> Tests: run `pytest` before committing. Current repository tests report multiple failures.
-> Lint: run `ruff check .` before committing.
-> Compliance: run `python secondary_copilot_validator.py --validate` after critical changes to enforce dual-copilot and EnterpriseComplianceValidator checks.
-> Docs: run `python scripts/docs_status_reconciler.py` to refresh `docs/task_stubs.md` and `docs/status_index.json` before committing documentation changes.
-> CI: pipeline pins Ruff, enforces a 90% test pass rate, and fails if coverage regresses relative to `main`.
-> Quantum modules default to simulation but can target IBM hardware when `QISKIT_IBM_TOKEN` and `IBM_BACKEND` are set. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) and [docs/PHASE5_TASKS_STARTED.md](docs/PHASE5_TASKS_STARTED.md) for progress details. Module completion status is tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics.db`.
-> Integration plan: [docs/quantum_integration_plan.md](docs/quantum_integration_plan.md) outlines staged hardware enablement while current builds remain simulator-only.
-> Governance: see [docs/GOVERNANCE_STANDARDS.md](docs/GOVERNANCE_STANDARDS.md) for organizational rules and coding standards. New compliance routines and monitoring capabilities are detailed in [docs/white-paper.md](docs/white-paper.md).
-> Security: updated protocols and configuration files reside under `security/` including `security/enterprise_security_policy.json`, `security/access_control_matrix.json`, `security/encryption_standards.json`, and `security/security_audit_framework.json`.
-> Documentation: quantum preparation, executive guides, and certification workflows live under `docs/` — see [docs/quantum_preparation/README.md](docs/quantum_preparation/README.md), [docs/executive_guides/README.md](docs/executive_guides/README.md), and [docs/certification/README.md](docs/certification/README.md) for details and related module links.
-> White-paper summary: [documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_Summary_(2025-08-06).md](documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_Summary_(2025-08-06).md)
+Combined checks: run `python scripts/run_checks.py` to execute `ruff` and `pytest` sequentially.
+Tests: run `pytest` before committing. Current repository tests report multiple failures.
+Lint: run `ruff check .` before committing.
+Compliance: run `python secondary_copilot_validator.py --validate` after critical changes to enforce dual-copilot and EnterpriseComplianceValidator checks.
+Docs: run `python scripts/docs_status_reconciler.py` to refresh `docs/task_stubs.md` and `docs/status_index.json` before committing documentation changes.
+CI: pipeline pins Ruff, enforces a 90% test pass rate, and fails if coverage regresses relative to `main`.
+Quantum modules default to simulation but can target IBM hardware when `QISKIT_IBM_TOKEN` and `IBM_BACKEND` are set. See `docs/QUANTUM_PLACEHOLDERS.md <docs/QUANTUM_PLACEHOLDERS.md>`_ and `docs/PHASE5_TASKS_STARTED.md <docs/PHASE5_TASKS_STARTED.md>`_ for progress details. Module completion status is tracked in `docs/STUB_MODULE_STATUS.md <docs/STUB_MODULE_STATUS.md>`_. Compliance auditing is enforced via `EnterpriseComplianceValidator`, and composite scores combine lint, test, and placeholder metrics stored in `analytics.db`.
+Integration plan: `docs/quantum_integration_plan.md <docs/quantum_integration_plan.md>`_ outlines staged hardware enablement while current builds remain simulator-only.
+Governance: see `docs/GOVERNANCE_STANDARDS.md <docs/GOVERNANCE_STANDARDS.md>`_ for organizational rules and coding standards. New compliance routines and monitoring capabilities are detailed in `docs/white-paper.md <docs/white-paper.md>`_.
+Security: updated protocols and configuration files reside under `security/` including `security/enterprise_security_policy.json`, `security/access_control_matrix.json`, `security/encryption_standards.json`, and `security/security_audit_framework.json`.
+Documentation: quantum preparation, executive guides, and certification workflows live under `docs/` — see `docs/quantum_preparation/README.md <docs/quantum_preparation/README.md>`_, `docs/executive_guides/README.md <docs/executive_guides/README.md>`_, and `docs/certification/README.md <docs/certification/README.md>`_ for details and related module links.
+White-paper summary: `documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_Summary_(2025-08-06).md <documentation/generated/daily_state_update/gh_COPILOT_Project_White-Paper_Blueprint_Summary_(2025-08-06>`_.md)
 
-> **Validation:** Real-time streaming, correction logs, and the synchronization engine are active. Run `python scripts/generate_docs_metrics.py` followed by `python -m scripts.docs_metrics_validator` to verify documentation metrics.
+**Validation:** Real-time streaming, correction logs, and the synchronization engine are active. Run `python scripts/generate_docs_metrics.py` followed by `python -m scripts.docs_metrics_validator` to verify documentation metrics.
 
 ---
 
-## 📊 SYSTEM OVERVIEW
+📊 SYSTEM OVERVIEW
+-----------------
+
 
 The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file analysis with comprehensive learning pattern integration, autonomous operations, and advanced GitHub Copilot collaboration capabilities. Many core modules are implemented, while others remain in development. Quantum functionality operates solely through simulators; hardware execution is not yet available.
 
@@ -35,10 +53,12 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
  > Set `QISKIT_IBM_TOKEN` and `IBM_BACKEND` (or pass `use_hardware=True`) to run quantum routines on IBM hardware when available; otherwise the simulator is used.
  > **Roadmap**
  > Hardware support is evolving and falls back to simulation if initialization fails.
-> **Phase 5 AI**
-> Advanced AI integration features operate in simulation mode by default and ignore hardware execution flags.
+**Phase 5 AI**
+Advanced AI integration features operate in simulation mode by default and ignore hardware execution flags.
 
-### 🎯 **Recent Milestones**
+🎯 **Recent Milestones**
+^^^^^^^^^^^^^^^^^^^^^^^
+
 - **Lessons Learned Integration:** sessions automatically apply lessons from `learning_monitor.db`
 - **Database-First Architecture:** `databases/production.db` used as primary reference
 - **DUAL COPILOT Pattern:** primary/secondary validation framework available
@@ -77,22 +97,25 @@ The gh_COPILOT toolkit is an enterprise-grade system for HTTP Archive (HAR) file
 - **Monitoring Pipeline:** anomaly detection results stored in `analytics.db` appear on the dashboard's monitoring panels and stream through `/metrics_stream` when the dashboard is enabled.
 - **Dashboard Tooltips:** lint, test, and placeholder gauges now provide explanatory titles for quick reference.
 
-- **Quantum Placeholder Utilities:** see [quantum/README.md](quantum/README.md) for simulated optimizer and search helpers. `quantum_optimizer.run_quantum_routine` includes placeholder hooks for annealing and search routines; entanglement correction is not implemented. These stubs run on Qiskit simulators and ignore `use_hardware=True` until real hardware integration lands. See [docs/QUANTUM_PLACEHOLDERS.md](docs/QUANTUM_PLACEHOLDERS.md) for current status.
+- **Quantum Placeholder Utilities:** see `quantum/README.md <quantum/README.md>`_ for simulated optimizer and search helpers. `quantum_optimizer.run_quantum_routine` includes placeholder hooks for annealing and search routines; entanglement correction is not implemented. These stubs run on Qiskit simulators and ignore `use_hardware=True` until real hardware integration lands. See `docs/QUANTUM_PLACEHOLDERS.md <docs/QUANTUM_PLACEHOLDERS.md>`_ for current status.
 - **Phase 6 Quantum Demo:** `quantum_integration_orchestrator.py` demonstrates a simulated quantum
   database search. Hardware backend flags are accepted but remain no-ops until
   future phases implement real execution.
 
-### Compliance Scoring
+Compliance Scoring
+^^^^^^^^^^^^^^^^^^
+
 
 The fully implemented compliance metrics engine computes an overall code quality score by combining lint issues, test results, placeholder resolution rates, and session lifecycle success:
 
-```
-L = max(0, 100 - ruff_issues)
-T = (tests_passed / total_tests) * 100
-P = (placeholders_resolved / (placeholders_open + placeholders_resolved)) * 100
-S = (sessions_successful / (sessions_successful + sessions_failed)) * 100
-score = 0.3 * L + 0.4 * T + 0.2 * P + 0.1 * S
-```
+.. code-block:: text
+
+   L = max(0, 100 - ruff_issues)
+   T = (tests_passed / total_tests) * 100
+   P = (placeholders_resolved / (placeholders_open + placeholders_resolved)) * 100
+   S = (sessions_successful / (sessions_successful + sessions_failed)) * 100
+   score = 0.3 * L + 0.4 * T + 0.2 * P + 0.1 * S
+
 
 Sessions must call `start_session` and `end_session`; runs that fail to close cleanly reduce `S` and therefore the composite score.
 
@@ -118,33 +141,41 @@ Compliance enforcement also blocks destructive commands (`rm -rf`, `mkfs`,
 placeholders in accordance with `enterprise_modules/compliance.py` and the
 Phase 5 scoring guidelines.
 
-### 🏆 **Enterprise Achievements**
+🏆 **Enterprise Achievements**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
  - ✅ **Script Validation**: 1,679 scripts synchronized
  - **30 Synchronized Databases**: Enterprise data management
 
 ---
 
-## 🏗️ CORE ARCHITECTURE
+🏗️ CORE ARCHITECTURE
+--------------------
 
-### **Enterprise Systems**
+
+**Enterprise Systems**
+^^^^^^^^^^^^^^^^^^^^^^
+
 - **Multiple SQLite Databases:** `databases/production.db`, `databases/analytics.db`, `databases/monitoring.db`, `databases/codex_logs.db`
-  - [ER Diagrams](docs/ER_DIAGRAMS.md) for key databases
+  - `ER Diagrams <docs/ER_DIAGRAMS.md>`_ for key databases
 - **Flask Enterprise Dashboard:** run `python web_gui_integration_system.py` to launch the metrics and compliance dashboard
 - **Template Intelligence Platform:** tracks generated scripts
 - **Enterprise HTML Templates:** reusable base layouts, components, mobile views, and email templates under `templates/`
 - **Documentation logs:** rendered templates saved under `logs/template_rendering/`
 - **Script Validation**: automated checks available
 - **Self-Healing Systems:** correction scripts
-- **Autonomous File Management:** see [Using AutonomousFileManager](docs/USING_AUTONOMOUS_FILE_MANAGER.md)
+- **Autonomous File Management:** see `Using AutonomousFileManager <docs/USING_AUTONOMOUS_FILE_MANAGER.md>`_
 - **Quantum Modules:** all quantum features execute on Qiskit simulators; hardware
   backends are currently disabled.
 - **Continuous Operation Mode:** optional monitoring utilities
    - **Simulated Quantum Monitoring Scripts:** `scripts/monitoring/continuous_operation_monitor.py`,
     `scripts/monitoring/enterprise_compliance_monitor.py`, and
     `scripts/monitoring/unified_monitoring_optimization_system.py`.
-    See [monitoring/README.md](monitoring/README.md) for details.
+    See `monitoring/README.md <monitoring/README.md>`_ for details.
 
-### **Learning Pattern Integration**
+**Learning Pattern Integration**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 - **Database-First Logic:** Production.db is consulted before generating output
 - **DUAL COPILOT Pattern:** Primary executor and secondary validator scripts
 - **Visual Processing:** Progress indicators via `tqdm`
@@ -153,9 +184,13 @@ Phase 5 scoring guidelines.
 
 ---
 
-## 🚀 QUICK START
+🚀 QUICK START
+-------------
 
-### **Prerequisites**
+
+**Prerequisites**
+^^^^^^^^^^^^^^^^^
+
 - Python 3.8+
 - PowerShell (for Windows automation)
 - SQLite3
@@ -163,59 +198,69 @@ Phase 5 scoring guidelines.
 - Quantum routines run on Qiskit simulators; hardware execution is not
   yet supported, and any provider credentials are ignored
 
-### **Installation & Setup**
-```bash
-# 1. Clone and setup
-git clone https://github.com/your-org/gh_COPILOT.git
-cd gh_COPILOT
+**Installation & Setup**
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-# 1b. Copy environment template
-cp .env.example .env
-# Edit `.env` to add `FLASK_SECRET_KEY`, `API_SECRET_KEY`, and `OPENAI_API_KEY` values.
-# The `OPENAI_API_KEY` variable enables modules in `github_integration/openai_connector.py`.
-# Generate strong secrets with `python -c "import secrets; print(secrets.token_hex(32))"`.
+.. code-block:: bash
 
-# 2. Set the external backup directory and run the setup script
-export GH_COPILOT_BACKUP_ROOT=/path/to/external/backups
-bash setup.sh            # installs core and test dependencies
-# Or include optional extras
-GH_COPILOT_BACKUP_ROOT=/path/to/external/backups bash setup.sh --with-optional
-# Always run this script before executing tests or automation tasks.
-# The script installs `requirements.txt` and `requirements-test.txt` by default,
-# runs `scripts/run_migrations.py`, and prepares environment variables.
-# Passing `--with-optional` additionally installs `requirements-a.txt` and
-# `requirements-quantum.txt` when present.
-# If package installation fails due to network restrictions,
-# update the environment to permit outbound connections to PyPI.
+   # 1. Clone and setup
+   git clone https://github.com/your-org/gh_COPILOT.git
+   cd gh_COPILOT
+   
+   # 1b. Copy environment template
+   cp .env.example .env
+   # Edit `.env` to add `FLASK_SECRET_KEY`, `API_SECRET_KEY`, and `OPENAI_API_KEY` values.
+   # The `OPENAI_API_KEY` variable enables modules in `github_integration/openai_connector.py`.
+   # Generate strong secrets with `python -c "import secrets; print(secrets.token_hex(32))"`.
+   
+   # 2. Set the external backup directory and run the setup script
+   export GH_COPILOT_BACKUP_ROOT=/path/to/external/backups
+   bash setup.sh            # installs core and test dependencies
+   # Or include optional extras
+   GH_COPILOT_BACKUP_ROOT=/path/to/external/backups bash setup.sh --with-optional
+   # Always run this script before executing tests or automation tasks.
+   # The script installs `requirements.txt` and `requirements-test.txt` by default,
+   # runs `scripts/run_migrations.py`, and prepares environment variables.
+   # Passing `--with-optional` additionally installs `requirements-a.txt` and
+   # `requirements-quantum.txt` when present.
+   # If package installation fails due to network restrictions,
+   # update the environment to permit outbound connections to PyPI.
+   
+   # 2b. Install the line-wrapping utility
+   # The repository ships a `tools/clw.py` script and a helper installer.
+   # If `/usr/local/bin/clw` is missing, run the installer and verify it.
+   tools/install_clw.sh
+   # Verify clw exists and view usage
+   ls -l /usr/local/bin/clw
+   /usr/local/bin/clw --help
+   
 
-# 2b. Install the line-wrapping utility
-# The repository ships a `tools/clw.py` script and a helper installer.
-# If `/usr/local/bin/clw` is missing, run the installer and verify it.
-tools/install_clw.sh
-# Verify clw exists and view usage
-ls -l /usr/local/bin/clw
-/usr/local/bin/clw --help
 
-```
+Reclone a Repository
+^^^^^^^^^^^^^^^^^^^^
 
-### Reclone a Repository
 Use `scripts/reclone_repo.py` to create a fresh clone of any Git repository.
 This is helpful when a working copy becomes corrupted or when a clean
 re-clone is required. The utility can back up or remove an existing
 destination directory before cloning. See
-[docs/RECLONE_REPO_GUIDE.md](docs/RECLONE_REPO_GUIDE.md) for detailed
+`docs/RECLONE_REPO_GUIDE.md <docs/RECLONE_REPO_GUIDE.md>`_ for detailed
 instructions and examples.
 
-### Add Lessons After a Run
+Add Lessons After a Run
+^^^^^^^^^^^^^^^^^^^^^^^
+
 Store new insights directly from the gap analyzer:
 
-```bash
-python -m scripts.analysis.lessons_learned_gap_analyzer --lesson "use temp dirs"
-```
+.. code-block:: bash
+
+   python -m scripts.analysis.lessons_learned_gap_analyzer --lesson "use temp dirs"
+
 
 Lessons are written to `learning_monitor.db` and automatically applied in future sessions.
 
-### OpenAI Connector
+OpenAI Connector
+^^^^^^^^^^^^^^^^
+
 The repository provides `github_integration/openai_connector.py` for OpenAI API
 calls using the `OpenAIClient` helper in
 `third_party/openai_client.py`. Set `OPENAI_API_KEY` in your `.env` to enable
@@ -225,84 +270,89 @@ rate limiting and retry behavior. The client now respects `Retry-After` headers
 for HTTP 429 responses and surfaces the message from 4xx errors like invalid
 credentials.
 
-```bash
-# 3. Initialize databases
-python scripts/database/unified_database_initializer.py
+.. code-block:: bash
 
-# Add analytics tables and run migrations
-python scripts/database/add_code_audit_log.py
-# If `analytics.db` is missing required tables, run the SQL migrations manually
-sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
-sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
-sqlite3 databases/analytics.db < databases/migrations/add_code_audit_history.sql
-# Initialize codex log database
-python scripts/codex_log_db.py --init
-sqlite3 databases/analytics.db < databases/migrations/add_violation_logs.sql
-sqlite3 databases/analytics.db < databases/migrations/add_rollback_logs.sql
-sqlite3 databases/analytics.db < databases/migrations/create_todo_fixme_tracking.sql
-sqlite3 databases/analytics.db < databases/migrations/extend_todo_fixme_tracking.sql
-# Or run all migrations sequentially
-python scripts/run_migrations.py
-# Verify creation
-sqlite3 databases/analytics.db ".schema code_audit_log"
-sqlite3 databases/analytics.db ".schema code_audit_history"
-python scripts/database/size_compliance_checker.py
+   # 3. Initialize databases
+   python scripts/database/unified_database_initializer.py
+   
+   # Add analytics tables and run migrations
+   python scripts/database/add_code_audit_log.py
+   # If `analytics.db` is missing required tables, run the SQL migrations manually
+   sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
+   sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
+   sqlite3 databases/analytics.db < databases/migrations/add_code_audit_history.sql
+   # Initialize codex log database
+   python scripts/codex_log_db.py --init
+   sqlite3 databases/analytics.db < databases/migrations/add_violation_logs.sql
+   sqlite3 databases/analytics.db < databases/migrations/add_rollback_logs.sql
+   sqlite3 databases/analytics.db < databases/migrations/create_todo_fixme_tracking.sql
+   sqlite3 databases/analytics.db < databases/migrations/extend_todo_fixme_tracking.sql
+   # Or run all migrations sequentially
+   python scripts/run_migrations.py
+   # Verify creation
+   sqlite3 databases/analytics.db ".schema code_audit_log"
+   sqlite3 databases/analytics.db ".schema code_audit_history"
+   python scripts/database/size_compliance_checker.py
+   
+   # 3b. Synchronize databases
+   python scripts/database/database_sync_scheduler.py \
+       --workspace . \
+       --add-documentation-sync documentation/EXTRA_DATABASES.md \
+   #    Optional: --timeout 300
+       --target staging.db
+   # Progress bars display elapsed time and estimated completion while operations
+   # are logged with start time and duration in `cross_database_sync_operations`.
+   
+   # 3c. Consolidate databases with compression
+   python scripts/database/complete_consolidation_orchestrator.py \
+       --input-databases db1.db db2.db db3.db \
+       --output-database consolidated.db \
+       --compression-level 5  # specify 7z compression level
+   
+   # The `complete_consolidation_orchestrator.py` script consolidates multiple databases into a single compressed database.
+   # 
+   # **Parameters:**
+   # - `--input-databases`: A list of input database files to consolidate.
+   # - `--output-database`: The name of the output consolidated database file.
+   # - `--compression-level`: Compression level for the 7z archives (default: 5).
+   #
+   # **Example Usage:**
+   # ```bash
+   # python scripts/database/complete_consolidation_orchestrator.py \
+   #     --input-databases databases/production.db databases/analytics.db databases/monitoring.db \
+   #     --output-database enterprise_consolidated.db \
+   #     --compression-level 7
+   # ```
+   # 4. Validate enterprise compliance
+   python scripts/validation/enterprise_dual_copilot_validator.py --validate-all
+   
+   # 5. Start enterprise dashboard
+   python dashboard/enterprise_dashboard.py  # imports app from web_gui package
+   \n+# 6. (Optional) Ingest lint/test results & update composite compliance score
+   ruff check . --output-format json > ruff_report.json
+   pytest --json-report --maxfail=1 || true
+   python scripts/ingest_test_and_lint_results.py
+   python -m scripts.compliance.update_compliance_metrics
 
-# 3b. Synchronize databases
-python scripts/database/database_sync_scheduler.py \
-    --workspace . \
-    --add-documentation-sync documentation/EXTRA_DATABASES.md \
-#    Optional: --timeout 300
-    --target staging.db
-# Progress bars display elapsed time and estimated completion while operations
-# are logged with start time and duration in `cross_database_sync_operations`.
 
-# 3c. Consolidate databases with compression
-python scripts/database/complete_consolidation_orchestrator.py \
-    --input-databases db1.db db2.db db3.db \
-    --output-database consolidated.db \
-    --compression-level 5  # specify 7z compression level
+**Documentation Update Workflow**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-# The `complete_consolidation_orchestrator.py` script consolidates multiple databases into a single compressed database.
-# 
-# **Parameters:**
-# - `--input-databases`: A list of input database files to consolidate.
-# - `--output-database`: The name of the output consolidated database file.
-# - `--compression-level`: Compression level for the 7z archives (default: 5).
-#
-# **Example Usage:**
-# ```bash
-# python scripts/database/complete_consolidation_orchestrator.py \
-#     --input-databases databases/production.db databases/analytics.db databases/monitoring.db \
-#     --output-database enterprise_consolidated.db \
-#     --compression-level 7
-# ```
-# 4. Validate enterprise compliance
-python scripts/validation/enterprise_dual_copilot_validator.py --validate-all
-
-# 5. Start enterprise dashboard
-python dashboard/enterprise_dashboard.py  # imports app from web_gui package
-\n+# 6. (Optional) Ingest lint/test results & update composite compliance score
-ruff check . --output-format json > ruff_report.json
-pytest --json-report --maxfail=1 || true
-python scripts/ingest_test_and_lint_results.py
-python -m scripts.compliance.update_compliance_metrics
-```
-
-### **Documentation Update Workflow**
 After modifying files in `docs/`, regenerate and validate metrics:
 
-```bash
-python scripts/generate_docs_metrics.py
-python -m scripts.docs_metrics_validator
-python scripts/wlc_session_manager.py --db-path databases/production.db
-```
+.. code-block:: bash
+
+   python scripts/generate_docs_metrics.py
+   python -m scripts.docs_metrics_validator
+   python scripts/wlc_session_manager.py --db-path databases/production.db
+
 The session manager logs the documentation update to `production.db` and writes a log file under `$GH_COPILOT_BACKUP_ROOT/logs`.
 To regenerate enterprise documentation directly from the production database use:
 
-```bash
-python archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py
-```
+.. code-block:: bash
+
+   python archive/consolidated_scripts/enterprise_database_driven_documentation_manager.py
+
 This script pulls templates from both `documentation.db` and `production.db` and outputs Markdown, HTML and JSON files under `logs/template_rendering/`. Each render is logged to `analytics.db` and progress appears under `dashboard/compliance`.
 Both ``session_protocol_validator.py`` and ``session_management_consolidation_executor.py``
 are stable CLI wrappers. They delegate to the core implementations under
@@ -318,42 +368,49 @@ helper to ensure each session concludes cleanly and raises a
 - ``unified_session_management_system.py`` starts new sessions via enterprise compliance checks.
 - ``continuous_operation_monitor.py`` records uptime and resource usage to ``analytics.db``.
 Import these modules directly in your own scripts for easier maintenance.
-### **Output Safety with `clw`**
+**Output Safety with `clw`**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Commands that generate large output **must** be piped through `/usr/local/bin/clw` to avoid the 1600-byte line limit. If `clw` is missing, run `tools/install_clw.sh` and verify with `clw --help`.
 
 Once installed, wrap high-volume output like so:
 
-```bash
-ls -R | /usr/local/bin/clw
-```
+.. code-block:: bash
+
+   ls -R | /usr/local/bin/clw
+
 
 The script is bundled as `tools/clw.py` and installed via `tools/install_clw.sh` if needed.
 
 If you hit the limit error, restart the shell and rerun with `clw` or log to a file and inspect chunks.
 Set `CLW_MAX_LINE_LENGTH=1550` in your environment (e.g. in `.env`) before invoking the wrapper to keep output safe.
-> **Note**: The Codex terminal enforces a strict 1600-byte *per-line* limit. Wrapping output with
+**Note**: The Codex terminal enforces a strict 1600-byte *per-line* limit. Wrapping output with
 `clw` prevents session resets by ensuring no line exceeds this limit. When in doubt, redirect long
 output to a file and view it with `clw` in small chunks.
 
-### Additional Output Management Tools
+Additional Output Management Tools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 
 For cases where you need to execute a command and automatically truncate overly
 long lines, use `tools/shell_output_manager.sh`. Wrap any command with
 `safe_execute` to ensure lines longer than 4000 characters are redirected to a
 temporary log while a truncated preview is printed.
 
-```bash
-source tools/shell_output_manager.sh
-safe_execute "some_command producing huge output"
-```
+.. code-block:: bash
+
+   source tools/shell_output_manager.sh
+   safe_execute "some_command producing huge output"
+
 
 When streaming data from other processes or needing structured chunking, the
 Python utility `tools/output_chunker.py` can be used as a filter to split long
 lines intelligently, preserving ANSI color codes and JSON boundaries.
 
-```bash
-some_command | python tools/output_chunker.py
-```
+.. code-block:: bash
+
+   some_command | python tools/output_chunker.py
+
 
 For pattern-aware splitting, `tools/output_pattern_chunker.py` provides
 customizable boundary detection while maintaining ANSI sequences. To wrap
@@ -365,100 +422,122 @@ examples.
 
 
 
-### **Basic Usage**
-```python
-# Database-first pattern with visual processing
-from scripts.utilities.unified_script_generation_system import UnifiedScriptGenerator
-from scripts.validation.enterprise_dual_copilot_validator import DualCopilotValidator
+**Basic Usage**
+^^^^^^^^^^^^^^^
 
-# Initialize with autonomous capabilities
-generator = UnifiedScriptGenerator()
-validator = DualCopilotValidator()
+.. code-block:: python
 
-# Execute with DUAL COPILOT pattern
-result = generator.generate_with_validation(
-    objective="HAR file analysis",
-    validation_level="enterprise"
-)
+   # Database-first pattern with visual processing
+   from scripts.utilities.unified_script_generation_system import UnifiedScriptGenerator
+   from scripts.validation.enterprise_dual_copilot_validator import DualCopilotValidator
+   
+   # Initialize with autonomous capabilities
+   generator = UnifiedScriptGenerator()
+   validator = DualCopilotValidator()
+   
+   # Execute with DUAL COPILOT pattern
+   result = generator.generate_with_validation(
+       objective="HAR file analysis",
+       validation_level="enterprise"
+   )
+   
+   print(f"[SUCCESS] Generated with {result.confidence_score}% confidence")
 
-print(f"[SUCCESS] Generated with {result.confidence_score}% confidence")
-```
 
-### Run Simplified Quantum Integration Orchestrator
-```bash
-python simplified_quantum_integration_orchestrator.py
-```
+Run Simplified Quantum Integration Orchestrator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   python simplified_quantum_integration_orchestrator.py
+
 
 The orchestrator always uses the simulator. Flags `--hardware` and
 `--backend` are placeholders for future IBM Quantum device selection and are
 currently ignored.
 
-```bash
-# hardware flags are no-ops; simulator always used
-python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
-```
+.. code-block:: bash
+
+   # hardware flags are no-ops; simulator always used
+   python quantum_integration_orchestrator.py --hardware --backend ibm_oslo
+
 
 IBM Quantum tokens and the `--token` flag are currently ignored; hardware
 execution is not implemented. See
-[docs/QUANTUM_HARDWARE_SETUP.md](docs/QUANTUM_HARDWARE_SETUP.md) for future
-configuration notes and [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md)
+`docs/QUANTUM_HARDWARE_SETUP.md <docs/QUANTUM_HARDWARE_SETUP.md>`_ for future
+configuration notes and `docs/STUB_MODULE_STATUS.md <docs/STUB_MODULE_STATUS.md>`_
 for module status.
 
-### Quantum Placeholder Modules
+Quantum Placeholder Modules
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 
 The `scripts/quantum_placeholders` package offers simulation-only stubs that reserve
 future quantum interfaces. These modules are excluded from production import paths
 and only load in development or test environments.
 
-#### Roadmap
+Roadmap
+~~~~~~~
 
-- [quantum_placeholder_algorithm](scripts/quantum_placeholders/quantum_placeholder_algorithm.py)
+
+- `quantum_placeholder_algorithm <scripts/quantum_placeholders/quantum_placeholder_algorithm.py>`_
   → will evolve into a full optimizer engine.
-- [quantum_annealing](scripts/quantum_placeholders/quantum_annealing.py)
+- `quantum_annealing <scripts/quantum_placeholders/quantum_annealing.py>`_
   → planned hardware-backed annealing routine.
-- [quantum_superposition_search](scripts/quantum_placeholders/quantum_superposition_search.py)
+- `quantum_superposition_search <scripts/quantum_placeholders/quantum_superposition_search.py>`_
   → future superposition search module.
-- [quantum_entanglement_correction](scripts/quantum_placeholders/quantum_entanglement_correction.py)
+- `quantum_entanglement_correction <scripts/quantum_placeholders/quantum_entanglement_correction.py>`_
   → slated for robust entanglement error correction.
 
-### Run Template Matcher
-```bash
-echo "def foo(): pass" | python scripts/template_matcher.py
-```
+Run Template Matcher
+^^^^^^^^^^^^^^^^^^^^
 
-### Data Backup Feature
+.. code-block:: bash
+
+   echo "def foo(): pass" | python scripts/template_matcher.py
+
+
+Data Backup Feature
+^^^^^^^^^^^^^^^^^^^
+
 The toolkit includes an enterprise-grade data backup feature. Set the
 `GH_COPILOT_BACKUP_ROOT` environment variable to an external directory and
-follow the steps in [docs/enterprise_backup_guide.md](docs/enterprise_backup_guide.md)
+follow the steps in `docs/enterprise_backup_guide.md <docs/enterprise_backup_guide.md>`_
 to create and manage backups. This variable ensures backups never reside in the
 workspace, maintaining anti-recursion compliance.
 The `validate_enterprise_environment` helper enforces these settings at script startup.
 
 Run scheduled backups and restore them with:
 
-```bash
-python scripts/utilities/unified_disaster_recovery_system.py --schedule
-python scripts/utilities/unified_disaster_recovery_system.py --restore /path/to/backup.bak
-```
+.. code-block:: bash
 
-### Session Management
+   python scripts/utilities/unified_disaster_recovery_system.py --schedule
+   python scripts/utilities/unified_disaster_recovery_system.py --restore /path/to/backup.bak
+
+
+Session Management
+^^^^^^^^^^^^^^^^^^
+
 
 Codex sessions record start/end markers and actions in
 `databases/codex_log.db`. The `COMPREHENSIVE_WORKSPACE_MANAGER.py` CLI can
 launch and wrap up sessions:
 
-```bash
-python scripts/session/COMPREHENSIVE_WORKSPACE_MANAGER.py --SessionStart -AutoFix
-python scripts/session/COMPREHENSIVE_WORKSPACE_MANAGER.py --SessionEnd
-```
+.. code-block:: bash
+
+   python scripts/session/COMPREHENSIVE_WORKSPACE_MANAGER.py --SessionStart -AutoFix
+   python scripts/session/COMPREHENSIVE_WORKSPACE_MANAGER.py --SessionEnd
+
 
 Set `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT` before running. Use
 `SESSION_ID_SOURCE` if you supply your own session identifier. The log database
 is Git LFS-tracked; ensure `ALLOW_AUTOLFS=1` and verify with `git lfs status`
-before committing. See [docs/codex_logging.md](docs/codex_logging.md) for the
+before committing. See `docs/codex_logging.md <docs/codex_logging.md>`_ for the
 schema and commit workflow.
 
-### Codex Log Database
+Codex Log Database
+^^^^^^^^^^^^^^^^^^
+
 
 Session tooling records actions in `databases/codex_log.db`. When
 `finalize_codex_log_db()` runs, the log is copied to
@@ -469,7 +548,9 @@ helper stores timestamped `action` and `statement` entries in
 session and `codex_logger.finalize_db()` to stage the database for
 commit.
 
-#### Environment variables
+Environment variables
+~~~~~~~~~~~~~~~~~~~~~
+
 
 - `GH_COPILOT_WORKSPACE` – path to the repository root.
 - `GH_COPILOT_BACKUP_ROOT` – external backup directory.
@@ -477,74 +558,92 @@ commit.
 - `SESSION_ID_SOURCE` – optional custom session identifier.
 - `TEST_MODE` – set to `1` to disable writes during tests.
 
-#### Commit workflow
+Commit workflow
+~~~~~~~~~~~~~~~
+
 
 After calling `finalize_codex_log_db()` include the databases in your commit:
 
-```bash
-git add databases/codex_log.db databases/codex_session_logs.db
-git lfs status databases/codex_log.db
-```
+.. code-block:: bash
 
-See [docs/codex_logging.md](docs/codex_logging.md) for full API usage and
+   git add databases/codex_log.db databases/codex_session_logs.db
+   git lfs status databases/codex_log.db
+
+
+See `docs/codex_logging.md <docs/codex_logging.md>`_ for full API usage and
 workflow details.
 
-### Unified Deployment Orchestrator CLI
+Unified Deployment Orchestrator CLI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Manage orchestration tasks with start/stop controls:
 
-```bash
-python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --start
-python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --status
-python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --stop
-```
+.. code-block:: bash
+
+   python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --start
+   python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --status
+   python scripts/orchestration/UNIFIED_DEPLOYMENT_ORCHESTRATOR_CONSOLIDATED.py --stop
+
 Set `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT` before invoking to ensure logs and databases are found.
 
-### Workspace Optimizer CLI
+Workspace Optimizer CLI
+^^^^^^^^^^^^^^^^^^^^^^^
+
 Archive rarely used files and log metrics:
 
-```bash
-export GH_COPILOT_WORKSPACE=$(pwd)
-export GH_COPILOT_BACKUP_ROOT=/path/to/backups
-python scripts/file_management/workspace_optimizer.py
-```
+.. code-block:: bash
 
-### Git LFS workflow
+   export GH_COPILOT_WORKSPACE=$(pwd)
+   export GH_COPILOT_BACKUP_ROOT=/path/to/backups
+   python scripts/file_management/workspace_optimizer.py
+
+
+Git LFS workflow
+^^^^^^^^^^^^^^^^
+
 Use the helper scripts to automatically track binary or large files with Git LFS. Both variants accept `-h/--help` for usage information.
 
-```bash
-export GH_COPILOT_BACKUP_ROOT=/path/to/backups
-export ALLOW_AUTOLFS=1
-tools/git_safe_add_commit.py "your commit message" --push
-```
+.. code-block:: bash
+
+   export GH_COPILOT_BACKUP_ROOT=/path/to/backups
+   export ALLOW_AUTOLFS=1
+   tools/git_safe_add_commit.py "your commit message" --push
+
 
 The shell version `tools/git_safe_add_commit.sh` behaves the same and can push
 when invoked with `--push`. See
-[docs/GIT_LFS_WORKFLOW.md](docs/GIT_LFS_WORKFLOW.md) for details.
+`docs/GIT_LFS_WORKFLOW.md <docs/GIT_LFS_WORKFLOW.md>`_ for details.
 
-### Syncing `.gitattributes`
+Syncing `.gitattributes`
+^^^^^^^^^^^^^^^^^^^^^^^^
+
 Whenever you modify `.codex_lfs_policy.yaml`—for example to change
 `session_artifact_dir` or adjust LFS rules—regenerate `.gitattributes`:
 
-```bash
-python artifact_manager.py --sync-gitattributes
-```
+.. code-block:: bash
+
+   python artifact_manager.py --sync-gitattributes
+
 
 The script rebuilds `.gitattributes` from `gitattributes_template`, adds any
 missing patterns for session archives and `binary_extensions`, and should be run
 before committing policy changes.
 
-### Docker Usage
+Docker Usage
+^^^^^^^^^^^^
+
 Build and run the container with Docker:
 
-```bash
-docker build -t gh_copilot .
-docker run -p 5000:5000 \
-  -e GH_COPILOT_BACKUP_ROOT=/path/to/backups \
-  -e FLASK_SECRET_KEY=<generated_secret> \
-  gh_copilot
-```
+.. code-block:: bash
 
-See [docs/Docker_Usage.md](docs/Docker_Usage.md) for details on all environment
+   docker build -t gh_copilot .
+   docker run -p 5000:5000 \
+     -e GH_COPILOT_BACKUP_ROOT=/path/to/backups \
+     -e FLASK_SECRET_KEY=<generated_secret> \
+     gh_copilot
+
+
+See `docs/Docker_Usage.md <docs/Docker_Usage.md>`_ for details on all environment
 variables and the ports exposed by `docker-compose.yml`.
 
 `entrypoint.sh` expects `GH_COPILOT_WORKSPACE` and `GH_COPILOT_BACKUP_ROOT` to already be defined. The Docker image sets them to `/app` and `/backup`, but override these when running locally. The script initializes `enterprise_assets.db` only if missing, launches the background workers, and then `exec`s the dashboard command provided via `CMD`. Map `/backup` to a host directory so logs persist.
@@ -552,50 +651,60 @@ variables and the ports exposed by `docker-compose.yml`.
 When launching with Docker Compose, the provided `docker-compose.yml` mounts `${GH_COPILOT_BACKUP_ROOT:-/backup}` at `/backup` and passes environment variables from `.env`. Ensure `GH_COPILOT_BACKUP_ROOT` is configured on the host so backups survive container restarts.
 `FLASK_SECRET_KEY` must also be provided—either via `.env` or by setting the variable when invoking Docker commands.
 
-### Wrapping, Logging, and Compliance (WLC)
+Wrapping, Logging, and Compliance (WLC)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Run the session manager after setting the workspace and backup paths:
 
-```bash
-export GH_COPILOT_WORKSPACE=$(pwd)
-export GH_COPILOT_BACKUP_ROOT=/path/to/backups
-export API_SECRET_KEY=<generated_secret>
-python scripts/wlc_session_manager.py
-```
+.. code-block:: bash
+
+   export GH_COPILOT_WORKSPACE=$(pwd)
+   export GH_COPILOT_BACKUP_ROOT=/path/to/backups
+   export API_SECRET_KEY=<generated_secret>
+   python scripts/wlc_session_manager.py
+
 
 Major scripts should conclude by invoking the session manager to record
 final compliance results and generate a log file:
 
-```bash
-python <your_script>.py
-python scripts/wlc_session_manager.py --db-path databases/production.db
-```
+.. code-block:: bash
+
+   python <your_script>.py
+   python scripts/wlc_session_manager.py --db-path databases/production.db
+
 
 Each run writes a timestamped log to `$GH_COPILOT_BACKUP_ROOT/logs/`.
 
-For more information see [docs/WLC_SESSION_MANAGER.md](docs/WLC_SESSION_MANAGER.md).
-See [docs/WLC_QUICKSTART.md](docs/WLC_QUICKSTART.md) for a quickstart guide.
+For more information see `docs/WLC_SESSION_MANAGER.md <docs/WLC_SESSION_MANAGER.md>`_.
+See `docs/WLC_QUICKSTART.md <docs/WLC_QUICKSTART.md>`_ for a quickstart guide.
 
-Additional module overviews are available in [quantum/README.md](quantum/README.md)
-and [monitoring/README.md](monitoring/README.md).
+Additional module overviews are available in `quantum/README.md <quantum/README.md>`_
+and `monitoring/README.md <monitoring/README.md>`_.
 
-### Workspace Detection
+Workspace Detection
+^^^^^^^^^^^^^^^^^^^
+
 Most scripts read the workspace path from the `GH_COPILOT_WORKSPACE` environment variable. If the variable is not set, the current working directory is used by default.
 The helper `CrossPlatformPathManager.get_workspace_path()` now prioritizes this environment variable and falls back to searching for a `gh_COPILOT` folder starting from the current directory. If no workspace is found, it defaults to `/workspace/gh_COPILOT` when available.
 
-### WLC Session Manager
-The [WLC Session Manager](docs/WLC_SESSION_MANAGER.md) implements the **Wrapping, Logging, and Compliance** methodology. Run it with:
+WLC Session Manager
+^^^^^^^^^^^^^^^^^^^
 
-```bash
-python scripts/wlc_session_manager.py --steps 2 --db-path databases/production.db --verbose
-```
+The `WLC Session Manager <docs/WLC_SESSION_MANAGER.md>`_ implements the **Wrapping, Logging, and Compliance** methodology. Run it with:
+
+.. code-block:: bash
+
+   python scripts/wlc_session_manager.py --steps 2 --db-path databases/production.db --verbose
+
 Before running, set the required environment variables so session data is logged correctly:
 
-```bash
-export GH_COPILOT_WORKSPACE=$(pwd)
-export GH_COPILOT_BACKUP_ROOT=/path/to/backups
-export API_SECRET_KEY=<generated_secret>
-python scripts/wlc_session_manager.py --steps 2 --db-path databases/production.db --verbose
-```
+.. code-block:: bash
+
+   export GH_COPILOT_WORKSPACE=$(pwd)
+   export GH_COPILOT_BACKUP_ROOT=/path/to/backups
+   export API_SECRET_KEY=<generated_secret>
+   python scripts/wlc_session_manager.py --steps 2 --db-path databases/production.db --verbose
+
 
 The manager validates required environment variables, executes the
 `UnifiedWrapUpOrchestrator` for comprehensive cleanup, and performs dual
@@ -608,76 +717,87 @@ The scoring formula blends Ruff issues, pytest pass ratios, placeholder
 resolution, and session lifecycle success via
 `enterprise_modules.compliance.calculate_compliance_score` and the
 `SCORE_WEIGHTS` constants. See
-[docs/COMPLIANCE_METRICS.md](docs/COMPLIANCE_METRICS.md) for details.
+`docs/COMPLIANCE_METRICS.md <docs/COMPLIANCE_METRICS.md>`_ for details.
 The table stores `session_id`, timestamps, status, compliance score, and
 optional error details so administrators can audit every session.
 The test suite includes `tests/test_wlc_session_manager.py` to verify this behavior.
-See [docs/WLC_SESSION_MANAGER.md](docs/WLC_SESSION_MANAGER.md) for a full example showing environment variable setup, CLI options, log file location, and database updates.
+See `docs/WLC_SESSION_MANAGER.md <docs/WLC_SESSION_MANAGER.md>`_ for a full example showing environment variable setup, CLI options, log file location, and database updates.
 
 ---
 
-## 🗄️ DATABASE-FIRST ARCHITECTURE
+🗄️ DATABASE-FIRST ARCHITECTURE
+------------------------------
 
-### **Primary Databases**
+
+**Primary Databases**
+^^^^^^^^^^^^^^^^^^^^^
+
 
 The repository currently maintains **24** active SQLite databases under
 `databases/`:
 
-```text
-analytics.db
-autonomous_decisions.db
-capability_scaler.db
-consolidation_analysis.db
-continuous_innovation.db
-deployment_logs.db
-development.db
-documentation.db
-documentation_templates.db
-enhanced_deployment_tracking.db
-enhanced_intelligence.db
-enterprise_builds.db
-enterprise_ml_engine.db
-flake8_violations.db
-learning_monitor.db
-logs.db
-ml_deployment_engine.db
-monitoring.db
-performance_analysis.db
-production.db
-quantum_consolidated.db
-scaling_innovation.db
-template_consolidated.db
-template_documentation.db
-testing.db
-v3_self_learning_engine.db
-```
+.. code-block:: text
+
+   analytics.db
+   autonomous_decisions.db
+   capability_scaler.db
+   consolidation_analysis.db
+   continuous_innovation.db
+   deployment_logs.db
+   development.db
+   documentation.db
+   documentation_templates.db
+   enhanced_deployment_tracking.db
+   enhanced_intelligence.db
+   enterprise_builds.db
+   enterprise_ml_engine.db
+   flake8_violations.db
+   learning_monitor.db
+   logs.db
+   ml_deployment_engine.db
+   monitoring.db
+   performance_analysis.db
+   production.db
+   quantum_consolidated.db
+   scaling_innovation.db
+   template_consolidated.db
+   template_documentation.db
+   testing.db
+   v3_self_learning_engine.db
+
 
 The previously referenced `optimization_metrics.db` is deprecated and no longer
 included in the repository.
 
-### Analytics Database Test Protocol
+Analytics Database Test Protocol
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 You must never create or modify the `analytics.db` file automatically. Use the commands below for manual migrations.
 To create or migrate the file manually, run:
 
-```bash
-sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
-sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
-sqlite3 databases/analytics.db < databases/migrations/add_code_audit_history.sql
-sqlite3 databases/analytics.db < databases/migrations/add_violation_logs.sql
-sqlite3 databases/analytics.db < databases/migrations/add_rollback_logs.sql
-sqlite3 databases/analytics.db < databases/migrations/create_todo_fixme_tracking.sql
-sqlite3 databases/analytics.db < databases/migrations/extend_todo_fixme_tracking.sql
-```
+.. code-block:: bash
+
+   sqlite3 databases/analytics.db < databases/migrations/add_code_audit_log.sql
+   sqlite3 databases/analytics.db < databases/migrations/add_correction_history.sql
+   sqlite3 databases/analytics.db < databases/migrations/add_code_audit_history.sql
+   sqlite3 databases/analytics.db < databases/migrations/add_violation_logs.sql
+   sqlite3 databases/analytics.db < databases/migrations/add_rollback_logs.sql
+   sqlite3 databases/analytics.db < databases/migrations/create_todo_fixme_tracking.sql
+   sqlite3 databases/analytics.db < databases/migrations/extend_todo_fixme_tracking.sql
+
 
 Alternatively, run all migrations sequentially:
-```bash
-python scripts/run_migrations.py
-```
+.. code-block:: bash
+
+   python scripts/run_migrations.py
+
 
 Automated tests perform these migrations in-memory with progress bars and DUAL
 COPILOT validation, leaving the on-disk database untouched.
 
-### **Database-First Workflow**
+**Database-First Workflow**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 1. **Connect Safely:** Use `get_validated_production_db_connection()` from
    `utils.database_utils` before performing filesystem changes.
 2. **Query First:** Check production.db for existing solutions
@@ -688,7 +808,9 @@ COPILOT validation, leaving the on-disk database untouched.
 
 ---
 
-### Template Engine Modules
+Template Engine Modules
+^^^^^^^^^^^^^^^^^^^^^^^
+
 Several helper scripts under `template_engine` implement the database-first
 workflow. They provide progress indicators, DUAL COPILOT validation and
 compliance logging. The main modules are:
@@ -724,106 +846,123 @@ compliance logging. The main modules are:
   `.gitattributes` can be regenerated with `--sync-gitattributes`.
 
 
-```python
-from pathlib import Path
-from template_engine import auto_generator, template_synchronizer
+.. code-block:: python
 
-gen = auto_generator.TemplateAutoGenerator()
-template = gen.generate_template({"action": "print"})
+   from pathlib import Path
+   from template_engine import auto_generator, template_synchronizer
+   
+   gen = auto_generator.TemplateAutoGenerator()
+   template = gen.generate_template({"action": "print"})
+   
+   sync_count = template_synchronizer.synchronize_templates([Path("databases/production.db")])
 
-sync_count = template_synchronizer.synchronize_templates([Path("databases/production.db")])
-```
 
 Run in real mode to persist changes and log analytics. Pass `--cluster` to
 enable KMeans grouping before synchronization:
 
-```bash
-python template_engine/template_synchronizer.py --real --cluster
-```
+.. code-block:: bash
 
-#### Unified Logging Helper
+   python template_engine/template_synchronizer.py --real --cluster
+
+
+Unified Logging Helper
+~~~~~~~~~~~~~~~~~~~~~~
+
 The `_log_event` function records structured events with progress bars and
 real-time status. It accepts a dictionary payload, optional table name, and the
 database path. The default table is `sync_events_log`.
 
-```python
-from utils.log_utils import _log_event
-_log_event({"event": "sync_start"})
-_log_event({"event": "complete"}, table="sync_status")
-```
+.. code-block:: python
+
+   from utils.log_utils import _log_event
+   _log_event({"event": "sync_start"})
+   _log_event({"event": "complete"}, table="sync_status")
 
 
-## 🤖 DUAL COPILOT PATTERN
 
-### **Architecture**
-```
-User Request
-     ↓
-Primary Executor COPILOT (A)
-├── Execute with visual indicators
-├── Database-first logic
-├── Anti-recursion validation
-└── Generate comprehensive output
-     ↓
-Secondary Validator COPILOT (B)
-├── Validate execution quality
-├── Check enterprise compliance
-├── Verify visual processing
-└── Approve or reject with feedback
-     ↓
-Toward Enterprise-Grade Output (tests pending)
-```
+🤖 DUAL COPILOT PATTERN
+----------------------
+
+
+**Architecture**
+^^^^^^^^^^^^^^^^
+
+.. code-block:: text
+
+   User Request
+        ↓
+   Primary Executor COPILOT (A)
+   ├── Execute with visual indicators
+   ├── Database-first logic
+   ├── Anti-recursion validation
+   └── Generate comprehensive output
+        ↓
+   Secondary Validator COPILOT (B)
+   ├── Validate execution quality
+   ├── Check enterprise compliance
+   ├── Verify visual processing
+   └── Approve or reject with feedback
+        ↓
+   Toward Enterprise-Grade Output (tests pending)
+
 
 Optimization and security scripts must invoke their main logic via
 `DualCopilotOrchestrator` so that a `SecondaryCopilotValidator` review
 follows every primary execution and runtime metrics are captured for
 analytics.
 
-### **Implementation Example**
-```python
-class PrimaryExecutorCopilot:
-    """Primary COPILOT: Executes main workflow with enterprise standards"""
-    
-    def execute_with_monitoring(self, task):
-        # MANDATORY: Visual processing indicators
-        with tqdm(total=100, desc=f"[START] {task.name}") as pbar:
-            # Database-first query
-            patterns = self.query_production_db(task.requirements)
-            pbar.update(25)
-            
-            # Execute with anti-recursion validation
-            result = self.execute_safe_operation(patterns)
-            pbar.update(50)
-            
-            # Enterprise compliance check
-            validated_result = self.validate_enterprise_standards(result)
-            pbar.update(25)
-            
-        return validated_result
+**Implementation Example**
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-class SecondaryValidatorCopilot:
-    """Secondary COPILOT: Quality validation and compliance"""
-    
-    def validate_execution(self, result):
-        validation = ValidationResult()
-        
-        # Check visual indicators present
-        validation.check_visual_processing(result)
-        
-        # Verify database-first logic used
-        validation.check_database_integration(result)
-        
-        # Confirm enterprise compliance
-        validation.check_enterprise_standards(result)
-        
-        return validation
-```
+.. code-block:: python
+
+   class PrimaryExecutorCopilot:
+       """Primary COPILOT: Executes main workflow with enterprise standards"""
+       
+       def execute_with_monitoring(self, task):
+           # MANDATORY: Visual processing indicators
+           with tqdm(total=100, desc=f"[START] {task.name}") as pbar:
+               # Database-first query
+               patterns = self.query_production_db(task.requirements)
+               pbar.update(25)
+               
+               # Execute with anti-recursion validation
+               result = self.execute_safe_operation(patterns)
+               pbar.update(50)
+               
+               # Enterprise compliance check
+               validated_result = self.validate_enterprise_standards(result)
+               pbar.update(25)
+               
+           return validated_result
+   
+   class SecondaryValidatorCopilot:
+       """Secondary COPILOT: Quality validation and compliance"""
+       
+       def validate_execution(self, result):
+           validation = ValidationResult()
+           
+           # Check visual indicators present
+           validation.check_visual_processing(result)
+           
+           # Verify database-first logic used
+           validation.check_database_integration(result)
+           
+           # Confirm enterprise compliance
+           validation.check_enterprise_standards(result)
+           
+           return validation
+
 
 ---
 
-## 🎬 VISUAL PROCESSING INDICATORS
+🎬 VISUAL PROCESSING INDICATORS
+------------------------------
 
-### **Enterprise Standards**
+
+**Enterprise Standards**
+^^^^^^^^^^^^^^^^^^^^^^^^
+
 All operations MUST include:
 - ✅ **Progress Bars:** tqdm with percentage and ETC
 - ✅ **Start Time Logging:** Timestamp and process ID tracking
@@ -831,21 +970,26 @@ All operations MUST include:
 - ✅ **Phase Indicators:** Clear status updates for each phase
 - ✅ **Completion Summary:** Comprehensive execution metrics
 
-### **TEXT Indicators (Cross-Platform Compatible)**
-```python
-TEXT_INDICATORS = {
-    'start': '[START]',
-    'progress': '[PROGRESS]',
-    'success': '[SUCCESS]',
-    'error': '[ERROR]',
-    'warning': '[WARNING]',
-    'info': '[INFO]',
-    'validation': '[VALIDATION]',
-    'completion': '[COMPLETION]'
-}
-```
+**TEXT Indicators (Cross-Platform Compatible)**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-### **Unified Logging Utility**
+.. code-block:: python
+
+   TEXT_INDICATORS = {
+       'start': '[START]',
+       'progress': '[PROGRESS]',
+       'success': '[SUCCESS]',
+       'error': '[ERROR]',
+       'warning': '[WARNING]',
+       'info': '[INFO]',
+       'validation': '[VALIDATION]',
+       'completion': '[COMPLETION]'
+   }
+
+
+**Unified Logging Utility**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The toolkit provides a shared `_log_event` helper in
 `utils/log_utils.py`. This function writes events to a chosen table
 `utils/log_utils.py`. This function writes events to a chosen table
@@ -864,35 +1008,41 @@ with `SchemaMapper` and `SyncManager` helpers. Synchronization runs use
 explicit transactions, support conflict-resolution callbacks and log a row to
 `analytics.db`'s `synchronization_events` table.
 
-```python
-from utils.log_utils import _log_event
-from utils.log_utils import _log_event
+.. code-block:: python
 
-_log_event({"event": "sync_start"}, table="sync_events_log")
-```
+   from utils.log_utils import _log_event
+   from utils.log_utils import _log_event
+   
+   _log_event({"event": "sync_start"}, table="sync_events_log")
+
 
 `setup_enterprise_logging()` accepts an optional `log_file` parameter. When
 omitted, logs are saved under `logs/` relative to the workspace. Provide a path
 to store logs in a custom directory:
 
-```python
-from utils.logging_utils import setup_enterprise_logging
+.. code-block:: python
 
-# Default logs directory (logs/)
-logger = setup_enterprise_logging()
+   from utils.logging_utils import setup_enterprise_logging
+   
+   # Default logs directory (logs/)
+   logger = setup_enterprise_logging()
+   
+   # Custom directory
+   logger = setup_enterprise_logging(log_file="/var/log/gh_copilot/custom.log")
 
-# Custom directory
-logger = setup_enterprise_logging(log_file="/var/log/gh_copilot/custom.log")
-```
 The underlying `FileHandler` uses delayed creation so log files aren't created
 until the first message, preventing empty logs. Tests verify this logging
 mechanism as part of the DUAL COPILOT pattern.
 
 ---
 
-## ⚡ AUTONOMOUS SYSTEMS
+⚡ AUTONOMOUS SYSTEMS
+--------------------
 
-### **Self-Healing Capabilities**
+
+**Self-Healing Capabilities**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 - **Automatic Error Detection:** Real-time issue identification
 - **Autonomous Correction:** Self-fixing common problems
 - **Learning Integration:** ML-powered pattern recognition
@@ -905,38 +1055,45 @@ mechanism as part of the DUAL COPILOT pattern.
   automate self-healing and monitoring cycles. Job history is recorded in
   `analytics.db` and session entries in `production.db`.
 
-### **Autonomous System Architecture**
-```python
-class SelfHealingSelfLearningSystem:
-    """Autonomous system with self-healing and learning capabilities"""
-    
-    def __init__(self):
-        self.system_id = f"AUTONOMOUS_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-        self.learning_patterns = self.load_learning_patterns()
-        self.healing_protocols = self.initialize_healing_protocols()
-        
-    def continuous_operation(self):
-        """24/7 autonomous operation with self-healing"""
-        while True:
-            # Monitor system health
-            health_status = self.assess_system_health()
-            
-            # Apply autonomous corrections
-            if health_status.requires_intervention:
-                self.apply_autonomous_healing(health_status)
-            
-            # Learn from operations
-            self.update_learning_patterns()
-            
-            # Optimize performance
-            self.optimize_system_performance()
-```
+**Autonomous System Architecture**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   class SelfHealingSelfLearningSystem:
+       """Autonomous system with self-healing and learning capabilities"""
+       
+       def __init__(self):
+           self.system_id = f"AUTONOMOUS_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+           self.learning_patterns = self.load_learning_patterns()
+           self.healing_protocols = self.initialize_healing_protocols()
+           
+       def continuous_operation(self):
+           """24/7 autonomous operation with self-healing"""
+           while True:
+               # Monitor system health
+               health_status = self.assess_system_health()
+               
+               # Apply autonomous corrections
+               if health_status.requires_intervention:
+                   self.apply_autonomous_healing(health_status)
+               
+               # Learn from operations
+               self.update_learning_patterns()
+               
+               # Optimize performance
+               self.optimize_system_performance()
+
 
 ---
 
-## 🌐 ENTERPRISE WEB DASHBOARD
+🌐 ENTERPRISE WEB DASHBOARD
+--------------------------
 
-### **Flask Dashboard (8 Endpoints)**
+
+**Flask Dashboard (8 Endpoints)**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 - **`/`** - Executive dashboard with real-time metrics
 - **`/database`** - Database management interface
 - **`/backup`** - Backup and restore operations
@@ -948,22 +1105,30 @@ class SelfHealingSelfLearningSystem:
 - **`/summary`** - JSON summary of metrics and alerts
 - **`/corrections`** - Correction history overview
 
-### **Access Dashboard**
-```bash
-# Start enterprise dashboard
-python dashboard/enterprise_dashboard.py  # wrapper for web_gui Flask app
+**Access Dashboard**
+^^^^^^^^^^^^^^^^^^^^
 
-# Access at: http://localhost:5000
-# Features: Real-time metrics, database visualization, system monitoring
-```
+.. code-block:: bash
 
-### Staging Deployment
-```bash
-bash deploy/dashboard_deploy.sh staging
-```
+   # Start enterprise dashboard
+   python dashboard/enterprise_dashboard.py  # wrapper for web_gui Flask app
+   
+   # Access at: http://localhost:5000
+   # Features: Real-time metrics, database visualization, system monitoring
+
+
+Staging Deployment
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   bash deploy/dashboard_deploy.sh staging
+
 This script builds the dashboard, runs migrations, applies WebSocket settings, starts the service, and performs a smoke test.
 
-### Enable Streaming
+Enable Streaming
+^^^^^^^^^^^^^^^^
+
 
 Set the environment variable `LOG_WEBSOCKET_ENABLED=1` to allow real-time
 log broadcasting over WebSockets. Install the optional `websockets` package
@@ -973,18 +1138,21 @@ uses Server-Sent Events by default and works with Flask's ``Response`` when
 
 Compliance metrics are generated with `dashboard/compliance_metrics_updater.py`.
 This script reads from `analytics.db` and writes `dashboard/compliance/metrics.json`.
-### SyncEngine WebSocket Configuration
+SyncEngine WebSocket Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 
 Real-time data synchronization is provided by `src.sync.engine.SyncEngine`.
 To enable WebSocket-based propagation, start a broadcast WebSocket server and
 set `SYNC_ENGINE_WS_URL` to its endpoint (for example, `ws://localhost:8765`).
 
-```python
-from src.sync.engine import SyncEngine
+.. code-block:: python
 
-engine = SyncEngine()
-await engine.open_websocket(os.environ["SYNC_ENGINE_WS_URL"], apply_callback)
-```
+   from src.sync.engine import SyncEngine
+   
+   engine = SyncEngine()
+   await engine.open_websocket(os.environ["SYNC_ENGINE_WS_URL"], apply_callback)
+
 
 `apply_callback` should apply incoming changes locally. See `docs/realtime_sync.md` for more details.
 
@@ -999,73 +1167,91 @@ The `summarize_corrections()` routine now keeps only the most recent entries
 to `dashboard/compliance/archive/` before new summaries are written. The main
 report remains `dashboard/compliance/correction_summary.json`.
 
-### Composite Compliance Score
+Composite Compliance Score
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 
 Lint warnings, test results, and remaining placeholders are combined into a
 single weighted score:
 
-```
-L = max(0, 100 - lint_warnings)
-T = passed / (passed + failed) * 100
-P = max(0, 100 - 10 * placeholders)
-score = 0.3 * L + 0.5 * T + 0.2 * P
-```
+.. code-block:: text
+
+   L = max(0, 100 - lint_warnings)
+   T = passed / (passed + failed) * 100
+   P = max(0, 100 - 10 * placeholders)
+   score = 0.3 * L + 0.5 * T + 0.2 * P
+
 
 The composite score is stored in `code_quality_metrics` within `analytics.db`
 and displayed on the dashboard.
 Set `GH_COPILOT_WORKSPACE` before running these utilities:
 
-```bash
-export GH_COPILOT_WORKSPACE=$(pwd)
-python dashboard/compliance_metrics_updater.py
-python scripts/correction_logger_and_rollback.py
-python scripts/correction_logger_and_rollback.py --rollback-last  # undo last correction
-```
+.. code-block:: bash
+
+   export GH_COPILOT_WORKSPACE=$(pwd)
+   python dashboard/compliance_metrics_updater.py
+   python scripts/correction_logger_and_rollback.py
+   python scripts/correction_logger_and_rollback.py --rollback-last  # undo last correction
+
 
 ---
 
-## 🛡️ ENTERPRISE COMPLIANCE
+🛡️ ENTERPRISE COMPLIANCE
+------------------------
 
-### **Zero Tolerance Protocols**
+
+**Zero Tolerance Protocols**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 - **Anti-Recursion:** Mandatory recursive backup prevention
 - **Session Integrity:** Comprehensive session validation
 - **Visual Processing:** progress indicators used where applicable
 - **Database Validation:** Real-time database integrity monitoring
 
-### **Compliance Validation**
-```bash
-# Comprehensive enterprise validation
-python scripts/validation/enterprise_dual_copilot_validator.py --enterprise-compliance
+**Compliance Validation**
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-# Session integrity check
-python scripts/validation/comprehensive_session_integrity_validator.py --full-check
+.. code-block:: bash
 
-# Anti-recursion validation
-python scripts/utilities/emergency_c_temp_violation_prevention.py --emergency-cleanup
-```
+   # Comprehensive enterprise validation
+   python scripts/validation/enterprise_dual_copilot_validator.py --enterprise-compliance
+   
+   # Session integrity check
+   python scripts/validation/comprehensive_session_integrity_validator.py --full-check
+   
+   # Anti-recursion validation
+   python scripts/utilities/emergency_c_temp_violation_prevention.py --emergency-cleanup
+
 
 ---
 
-## 📁 FILE ORGANIZATION
+📁 FILE ORGANIZATION
+-------------------
 
-### **Core Structure**
-```
-gh_COPILOT/
-├── scripts/
-│   ├── utilities/           # Core utility scripts
-│   ├── validation/          # Enterprise validation framework
-│   ├── database/            # Database management
-│   └── automation/          # Autonomous operations
-├── databases/               # 27 synchronized databases
-├── web_gui/                 # Flask enterprise dashboard
-│   ├── assets/              # Static CSS/JS resources
-│   └── monitoring/          # Web GUI monitoring utilities
-├── documentation/           # Comprehensive documentation
-├── .github/instructions/    # GitHub Copilot instruction modules
-└── docs/                   # Learning pattern integration docs
-```
 
-### **Key Files**
+**Core Structure**
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: text
+
+   gh_COPILOT/
+   ├── scripts/
+   │   ├── utilities/           # Core utility scripts
+   │   ├── validation/          # Enterprise validation framework
+   │   ├── database/            # Database management
+   │   └── automation/          # Autonomous operations
+   ├── databases/               # 27 synchronized databases
+   ├── web_gui/                 # Flask enterprise dashboard
+   │   ├── assets/              # Static CSS/JS resources
+   │   └── monitoring/          # Web GUI monitoring utilities
+   ├── documentation/           # Comprehensive documentation
+   ├── .github/instructions/    # GitHub Copilot instruction modules
+   └── docs/                   # Learning pattern integration docs
+
+
+**Key Files**
+^^^^^^^^^^^^^
+
 - **`scripts/utilities/self_healing_self_learning_system.py`** - Autonomous operations
 - **`scripts/validation/enterprise_dual_copilot_validator.py`** - DUAL COPILOT validation
 - **`scripts/utilities/unified_script_generation_system.py`** - Database-first generation
@@ -1079,70 +1265,84 @@ gh_COPILOT/
 
 ---
 
-## 🎯 LEARNING PATTERNS INTEGRATION
+🎯 LEARNING PATTERNS INTEGRATION
+-------------------------------
 
-### **Validation Report**
+
+**Validation Report**
+^^^^^^^^^^^^^^^^^^^^^
+
 The project tracks several learning patterns. Current integration status:
 
 - **Database-First Architecture:** 98.5% implementation score
 **DUAL COPILOT Pattern:** 100% implementation score
-**Visual Processing Indicators:** 94.7% implementation score [[docs](docs/GITHUB_COPILOT_INTEGRATION_NOTES.md#visual-processing)]
-**Autonomous Systems:** 97.2% implementation score [[scheduler](documentation/SYSTEM_OVERVIEW.md#database-synchronization)]
-**Enterprise Compliance:** automated tests run `pytest` and `ruff`. Recent runs show failing tests while `ruff` reports no lint errors. [[validation helper](docs/DATABASE_FIRST_USAGE_GUIDE.md#database-first-enforcement)]
+**Visual Processing Indicators:** 94.7% implementation score `[docs <docs/GITHUB_COPILOT_INTEGRATION_NOTES.md#visual-processing>`_]
+**Autonomous Systems:** 97.2% implementation score `[scheduler <documentation/SYSTEM_OVERVIEW.md#database-synchronization>`_]
+**Enterprise Compliance:** automated tests run `pytest` and `ruff`. Recent runs show failing tests while `ruff` reports no lint errors. `[validation helper <docs/DATABASE_FIRST_USAGE_GUIDE.md#database-first-enforcement>`_]
 
 **Overall Integration Score: 97.4%** ✅
 
-### **Learning Pattern Categories**
+**Learning Pattern Categories**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 1. **Process Learning Patterns** (90% effectiveness)
-2. **Communication Excellence** (85% effectiveness) – see [Communication Excellence Guide](docs/COMMUNICATION_EXCELLENCE_GUIDE.md)
+2. **Communication Excellence** (85% effectiveness) – see `Communication Excellence Guide <docs/COMMUNICATION_EXCELLENCE_GUIDE.md>`_
 3. **Technical Implementation** (88% effectiveness)
 4. **Enterprise Standards** (95% effectiveness)
 5. **Autonomous Operations** (92% effectiveness)
 
 ---
 
-## 🔧 DEVELOPMENT WORKFLOW
+🔧 DEVELOPMENT WORKFLOW
+----------------------
 
-### **Standard Development Pattern**
-```python
-# 1. Database-first query
-existing_solutions = query_production_db(requirements)
 
-# 2. DUAL COPILOT validation
-primary_result = PrimaryExecutor().execute(requirements)
-validation_result = SecondaryValidator().validate(primary_result)
+**Standard Development Pattern**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-# 3. Visual processing compliance
-with tqdm(total=100, desc="[PROGRESS] Development") as pbar:
-    # Implementation with monitoring
-    pass
+.. code-block:: python
 
-# 4. Enterprise compliance check
-validate_enterprise_standards(final_result)
-```
+   # 1. Database-first query
+   existing_solutions = query_production_db(requirements)
+   
+   # 2. DUAL COPILOT validation
+   primary_result = PrimaryExecutor().execute(requirements)
+   validation_result = SecondaryValidator().validate(primary_result)
+   
+   # 3. Visual processing compliance
+   with tqdm(total=100, desc="[PROGRESS] Development") as pbar:
+       # Implementation with monitoring
+       pass
+   
+   # 4. Enterprise compliance check
+   validate_enterprise_standards(final_result)
 
-### **Testing & Validation**
-```bash
-# Contributors must execute `bash setup.sh` before running tests.
-# Ensure environment setup
-bash setup.sh
-source .venv/bin/activate
 
-# Run comprehensive test suite
-make test  # runs `pytest -q --disable-warnings tests` (defaults: --maxfail=10 --exitfirst)
+**Testing & Validation**
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-# Run linter
-ruff format .
-ruff check .
-# `.flake8` is the canonical lint configuration. Update it first and mirror any
-# changes in `pyproject.toml` to keep `ruff` and `flake8` consistent.
+.. code-block:: bash
 
-# Enterprise validation
-python -m pytest tests/enterprise/ -v
+   # Contributors must execute `bash setup.sh` before running tests.
+   # Ensure environment setup
+   bash setup.sh
+   source .venv/bin/activate
+   
+   # Run comprehensive test suite
+   make test  # runs `pytest -q --disable-warnings tests` (defaults: --maxfail=10 --exitfirst)
+   
+   # Run linter
+   ruff format .
+   ruff check .
+   # `.flake8` is the canonical lint configuration. Update it first and mirror any
+   # changes in `pyproject.toml` to keep `ruff` and `flake8` consistent.
+   
+   # Enterprise validation
+   python -m pytest tests/enterprise/ -v
+   
+   # DUAL COPILOT pattern validation
+   python scripts/validation/dual_copilot_pattern_tester.py
 
-# DUAL COPILOT pattern validation
-python scripts/validation/dual_copilot_pattern_tester.py
-```
 
 Tests enforce a default 120 s timeout via `pytest-timeout` (`timeout = 120` in
 `pytest.ini`) and fail fast with `--maxfail=10 --exitfirst`. For modules that
@@ -1151,16 +1351,22 @@ split heavy tests into smaller pieces to keep the suite responsive.
 
 ---
 
-## 📊 PERFORMANCE METRICS
+📊 PERFORMANCE METRICS
+---------------------
 
-### **System Performance**
+
+**System Performance**
+^^^^^^^^^^^^^^^^^^^^^^
+
 - **Database Query Speed:** <10ms average
 - **Script Generation:** <30s for integration-ready output
 - **Template Matching:** >85% accuracy rate
 - **Autonomous Healing:** scripts run in simulation; avoid using them in production
 - **Visual Processing:** progress indicators implemented
 
-### **Enterprise KPIs**
+**Enterprise KPIs**
+^^^^^^^^^^^^^^^^^^^
+
 - **Uptime:** 99.9% continuous operation
 - **Error Rate:** <0.1% across all systems
 - **Learning Integration:** 97.4% comprehensive integration
@@ -1168,15 +1374,21 @@ split heavy tests into smaller pieces to keep the suite responsive.
 
 ---
 
-## 🚀 FUTURE ROADMAP
+🚀 FUTURE ROADMAP
+----------------
 
-### **Phase 6: Quantum Enhancement (placeholder, not implemented)**
+
+**Phase 6: Quantum Enhancement (placeholder, not implemented)**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 - Advanced quantum algorithm integration
 - Quantum-enhanced database processing
 - Next-generation AI capabilities
 - Quantum-classical hybrid architectures
 
-### **Continuous Improvement**
+**Continuous Improvement**
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 - ML-powered pattern recognition enhancement
 - Autonomous system capability expansion
 - Enterprise compliance framework evolution
@@ -1184,17 +1396,23 @@ split heavy tests into smaller pieces to keep the suite responsive.
 
 ---
 
-## 📚 DOCUMENTATION
+📚 DOCUMENTATION
+---------------
 
-### **Core Documentation**
-- **[Lessons Learned Integration Report](docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md)** - Comprehensive validation
-- **[DUAL COPILOT Pattern Guide](.github/instructions/DUAL_COPILOT_PATTERN.instructions.md)** - Implementation guide
-- **[Enterprise Context Guide](.github/instructions/ENTERPRISE_CONTEXT.instructions.md)** - System overview
-- **[Instruction Module Index](docs/INSTRUCTION_INDEX.md)** - Complete instruction listing
+
+**Core Documentation**
+^^^^^^^^^^^^^^^^^^^^^^
+
+- **`Lessons Learned Integration Report <docs/LESSONS_LEARNED_INTEGRATION_VALIDATION_REPORT.md>`_** - Comprehensive validation
+- **`DUAL COPILOT Pattern Guide <.github/instructions/DUAL_COPILOT_PATTERN.instructions.md>`_** - Implementation guide
+- **`Enterprise Context Guide <.github/instructions/ENTERPRISE_CONTEXT.instructions.md>`_** - System overview
+- **`Instruction Module Index <docs/INSTRUCTION_INDEX.md>`_** - Complete instruction listing
 - **Quantum Template Generator** `docs/quantum_template_generator.py` - database-first template engine with optional quantum ranking
-- **[ChatGPT Bot Integration Guide](docs/chatgpt_bot_integration_guide.md)** - webhook and Copilot license setup
+- **`ChatGPT Bot Integration Guide <docs/chatgpt_bot_integration_guide.md>`_** - webhook and Copilot license setup
 
-### **GitHub Copilot Integration**
+**GitHub Copilot Integration**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The toolkit includes 16 specialized instruction modules for GitHub Copilot integration:
 - Visual Processing Standards
 - Database-First Architecture
@@ -1203,21 +1421,29 @@ The toolkit includes 16 specialized instruction modules for GitHub Copilot integ
 - Dual Copilot validation logs recorded in `copilot_interactions` database
 - Continuous Operation Protocols
 
-### GitHub Bot Integration
-See [ChatGPT Bot Integration Guide](docs/chatgpt_bot_integration_guide.md) for environment variables and usage of the webhook server and license assignment script.
+GitHub Bot Integration
+^^^^^^^^^^^^^^^^^^^^^^
+
+See `ChatGPT Bot Integration Guide <docs/chatgpt_bot_integration_guide.md>`_ for environment variables and usage of the webhook server and license assignment script.
 
 ---
 
-## 🤝 CONTRIBUTING
+🤝 CONTRIBUTING
+--------------
 
-### **Development Standards**
+
+**Development Standards**
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
 - Database-first logic required
 - DUAL COPILOT pattern implementation
 - Visual processing indicator compliance
 - Enterprise validation standards
 - Comprehensive test coverage
 
-### **Getting Started**
+**Getting Started**
+^^^^^^^^^^^^^^^^^^^
+
 1. Review learning pattern integration documentation
 2. Understand DUAL COPILOT pattern requirements
 3. Follow visual processing indicator standards
@@ -1226,91 +1452,104 @@ See [ChatGPT Bot Integration Guide](docs/chatgpt_bot_integration_guide.md) for e
 
 ---
 
-## 📄 LICENSE
+📄 LICENSE
+---------
 
-This project is licensed under the [MIT License](LICENSE).
+
+This project is licensed under the `MIT License <LICENSE>`_.
 © 2025 - Enterprise Excellence Framework
 
 ---
 
-## 🎯 QUICK REFERENCE
+🎯 QUICK REFERENCE
+-----------------
 
-### **Key Commands**
-```bash
-# Start enterprise systems
-python scripts/utilities/self_healing_self_learning_system.py --continuous
 
-# Validate learning integration
-python scripts/validation/lessons_learned_integration_validator.py
+**Key Commands**
+^^^^^^^^^^^^^^^^
 
-# Enterprise dashboard
-python dashboard/enterprise_dashboard.py  # wrapper for web_gui Flask app
+.. code-block:: bash
 
-# DUAL COPILOT validation
-python scripts/validation/enterprise_dual_copilot_validator.py --validate-all
+   # Start enterprise systems
+   python scripts/utilities/self_healing_self_learning_system.py --continuous
+   
+   # Validate learning integration
+   python scripts/validation/lessons_learned_integration_validator.py
+   
+   # Enterprise dashboard
+   python dashboard/enterprise_dashboard.py  # wrapper for web_gui Flask app
+   
+   # DUAL COPILOT validation
+   python scripts/validation/enterprise_dual_copilot_validator.py --validate-all
+   
+   # Repository-wide placeholder audit
+   python scripts/code_placeholder_audit.py \
+       --workspace $GH_COPILOT_WORKSPACE \
+       --analytics-db databases/analytics.db \
+       --production-db databases/production.db \
+       --exclude-dir builds --exclude-dir archive
+   # Automatically clean placeholders:
+   python scripts/code_placeholder_audit.py --cleanup
+   # Specify a custom summary path:
+   python scripts/code_placeholder_audit.py --summary-json results/placeholder_summary.json
+   # CI runs the audit via GitHub Actions using `actions/setup-python` and
+   # `pip install -r requirements.txt` to ensure dependencies are present.
+   
+   # The audit automatically populates `code_audit_log` in analytics.db for
+   # compliance reporting. After fixing issues, run:
+   python scripts/code_placeholder_audit.py --update-resolutions
+   # to mark resolved entries in `todo_fixme_tracking`.
+   # Run in test mode without database writes:
+   python scripts/code_placeholder_audit.py --test-mode
+   # `scripts/correction_logger_and_rollback.py` records final corrections.
+   # Check `/dashboard/compliance` to verify the placeholder count reaches zero.
+   # Run `scripts/database/add_code_audit_log.py` if the table is missing.
+   The `compliance-audit.yml` workflow now installs dependencies, including
+   `tqdm`, using Python 3.11 before invoking this script.
+   
+   # Generate scored documentation templates
+   python docs/quantum_template_generator.py
+   
+   # Safely commit staged changes with Git LFS auto-tracking
+   export GH_COPILOT_BACKUP_ROOT=/path/to/backups
+   ALLOW_AUTOLFS=1 tools/git_safe_add_commit.py "<commit message>" [--push]
+   # Bash fallback:
+   ALLOW_AUTOLFS=1 tools/git_safe_add_commit.sh "<commit message>" [--push]
+   
+   The audit results are used by the `/dashboard/compliance` endpoint to
+   report ongoing placeholder removal progress and overall compliance
+   metrics. A machine-readable summary is also written to
+   `dashboard/compliance/placeholder_summary.json`. This file tracks total
+   findings, resolved counts, and the current compliance score (0–100%). Refer to
+   the JSON schema in [dashboard/README.md](dashboard/README.md#placeholder_summaryjson-schema).
 
-# Repository-wide placeholder audit
-python scripts/code_placeholder_audit.py \
-    --workspace $GH_COPILOT_WORKSPACE \
-    --analytics-db databases/analytics.db \
-    --production-db databases/production.db \
-    --exclude-dir builds --exclude-dir archive
-# Automatically clean placeholders:
-python scripts/code_placeholder_audit.py --cleanup
-# Specify a custom summary path:
-python scripts/code_placeholder_audit.py --summary-json results/placeholder_summary.json
-# CI runs the audit via GitHub Actions using `actions/setup-python` and
-# `pip install -r requirements.txt` to ensure dependencies are present.
 
-# The audit automatically populates `code_audit_log` in analytics.db for
-# compliance reporting. After fixing issues, run:
-python scripts/code_placeholder_audit.py --update-resolutions
-# to mark resolved entries in `todo_fixme_tracking`.
-# Run in test mode without database writes:
-python scripts/code_placeholder_audit.py --test-mode
-# `scripts/correction_logger_and_rollback.py` records final corrections.
-# Check `/dashboard/compliance` to verify the placeholder count reaches zero.
-# Run `scripts/database/add_code_audit_log.py` if the table is missing.
-The `compliance-audit.yml` workflow now installs dependencies, including
-`tqdm`, using Python 3.11 before invoking this script.
+**Contact & Support**
+^^^^^^^^^^^^^^^^^^^^^
 
-# Generate scored documentation templates
-python docs/quantum_template_generator.py
-
-# Safely commit staged changes with Git LFS auto-tracking
-export GH_COPILOT_BACKUP_ROOT=/path/to/backups
-ALLOW_AUTOLFS=1 tools/git_safe_add_commit.py "<commit message>" [--push]
-# Bash fallback:
-ALLOW_AUTOLFS=1 tools/git_safe_add_commit.sh "<commit message>" [--push]
-
-The audit results are used by the `/dashboard/compliance` endpoint to
-report ongoing placeholder removal progress and overall compliance
-metrics. A machine-readable summary is also written to
-`dashboard/compliance/placeholder_summary.json`. This file tracks total
-findings, resolved counts, and the current compliance score (0–100%). Refer to
-the JSON schema in [dashboard/README.md](dashboard/README.md#placeholder_summaryjson-schema).
-```
-
-### **Contact & Support**
 - **Documentation:** `docs/` directory
 - **Repository Guidelines:** `docs/REPOSITORY_GUIDELINES.md`
 - **Root Maintenance Validator:** `docs/ROOT_MAINTENANCE_VALIDATOR.md`
 - **Enterprise Support:** GitHub Issues with enterprise tag
 - **Learning Pattern Updates:** Automatic integration via autonomous systems
 
-### **WLC Methodology**
+**WLC Methodology**
+^^^^^^^^^^^^^^^^^^^
+
 The **Wrapping, Logging, and Compliance (WLC)** system ensures that long-running
 operations are recorded and validated for enterprise review. The session manager
-in [`scripts/wlc_session_manager.py`](scripts/wlc_session_manager.py) starts a
+in ``scripts/wlc_session_manager.py` <scripts/wlc_session_manager.py>`_ starts a
 session entry in `production.db`, logs progress to an external backup location,
 and finalizes the run with a compliance score. Each run inserts a record into the
 `unified_wrapup_sessions` table with `session_id`, timestamps, status, compliance
 score, and optional error details. Detailed usage instructions are available in
-[docs/WLC_SESSION_MANAGER.md](docs/WLC_SESSION_MANAGER.md).
+`docs/WLC_SESSION_MANAGER.md <docs/WLC_SESSION_MANAGER.md>`_.
 
 ---
 
-## 🔧 Environment Variables
+🔧 Environment Variables
+-----------------------
+
 
 Set these variables in your `.env` file or shell before running scripts:
 
@@ -1326,7 +1565,9 @@ Set these variables in your `.env` file or shell before running scripts:
 - `LOG_WEBSOCKET_ENABLED` – set to `1` to stream logs.
 - `CLW_MAX_LINE_LENGTH` – max line length for the `clw` wrapper (default `1550`).
 
-## 🛠️ Troubleshooting
+🛠️ Troubleshooting
+------------------
+
 
 - **Setup script fails** – ensure network access and rerun `bash setup.sh`.
 - **ImportError in `setup_environment.py`** – the script now adds the repository root to
@@ -1335,9 +1576,11 @@ Set these variables in your `.env` file or shell before running scripts:
 - **`clw` not found** – run `tools/install_clw.sh` to install and then `clw --help`.
 - **Database errors** – verify `GH_COPILOT_WORKSPACE` is configured correctly.
 
-## ✅ Project Status
+✅ Project Status
+----------------
 
-Ruff linting runs and targeted tests pass in simulation, but the full test suite still reports failures. Outstanding tasks—including fixes for failing modules like `documentation_manager` and `cross_database_sync_logger`—are tracked in [docs/STUB_MODULE_STATUS.md](docs/STUB_MODULE_STATUS.md). Dual-copilot validation remains in place and quantum features continue to run in simulation mode.
+
+Ruff linting runs and targeted tests pass in simulation, but the full test suite still reports failures. Outstanding tasks—including fixes for failing modules like `documentation_manager` and `cross_database_sync_logger`—are tracked in `docs/STUB_MODULE_STATUS.md <docs/STUB_MODULE_STATUS.md>`_. Dual-copilot validation remains in place and quantum features continue to run in simulation mode.
 The repository uses GitHub Actions to automate linting, testing, and compliance checks.
 
 - **ci.yml** runs Ruff linting, executes the test suite on multiple Python versions, builds the Docker image, and performs a CodeQL scan.
@@ -1347,17 +1590,20 @@ The repository uses GitHub Actions to automate linting, testing, and compliance 
 
 To mimic CI locally, run:
 
-```bash
-bash setup.sh
-make test
-```
+.. code-block:: bash
+
+   bash setup.sh
+   make test
+
 
 ---
 
 **🏆 gh_COPILOT Toolkit v4.0 Enterprise**
 *GitHub Copilot integration with enterprise-oriented tooling*
 
-## 🔧 Utility Modules
+🔧 Utility Modules
+-----------------
+
 
 Several small modules provide common helpers:
 
@@ -1382,20 +1628,25 @@ Several small modules provide common helpers:
 - `tools.cleanup.cleanup_obsolete_entries` – remove rows from `obsolete_table` in `production.db`.
   - `artifact_manager.py` – package modified files from the temporary directory into the location specified by `session_artifact_dir` (defaults to `codex_sessions`). Run `python artifact_manager.py --package` to create an archive, `--recover` to extract the latest one, use `--tmp-dir` to choose a different temporary directory, and `--sync-gitattributes` to refresh LFS rules.
 
-### Reclone Repository Utility
+Reclone Repository Utility
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 
 The `reclone_repo.py` script downloads a fresh clone of a Git repository. It is
 useful for replacing a corrupted working copy or for disaster recovery
 scenarios.
 
-```bash
-python reclone_repo.py --repo-url <REPO_URL> --dest /path/to/clone --clean
-```
+.. code-block:: bash
+
+   python reclone_repo.py --repo-url <REPO_URL> --dest /path/to/clone --clean
+
 
 Use `--backup-existing` to move any pre-existing destination directory to
 `$GH_COPILOT_BACKUP_ROOT/<name>_TIMESTAMP` before cloning.
 
-## Future Roadmap
+Future Roadmap
+--------------
+
 
 Phase 6 development will introduce additional quantum features, expanded
 machine-learning driven pattern recognition and enhanced compliance checks.
@@ -1414,30 +1665,37 @@ Planned highlights include:
 6. **Cluster-based Template Retrieval** – use `get_cluster_representatives` to group templates for database-first generation.
 7. **Pattern Clustering Sync Utility** – leverage `PatternClusteringSync` and `DBFirstCodeGenerator` to synchronize templates and generate code using the database-first workflow.
 
-### Reconstructing the analytics database
+Reconstructing the analytics database
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 
 To rebuild the `analytics.db` file from its stored Base64 zip, run:
 
-```bash
-base64 -d databases/analytics_db_zip.b64 | tee databases/analytics_db.zip >/dev/null && unzip -o databases/analytics_db.zip -d databases/
-```
+.. code-block:: bash
 
-## Future Work
+   base64 -d databases/analytics_db_zip.b64 | tee databases/analytics_db.zip >/dev/null && unzip -o databases/analytics_db.zip -d databases/
 
-See [Continuous Improvement Roadmap](docs/continuous_improvement_roadmap.md),
-[Stakeholder Roadmap](documentation/continuous_improvement_roadmap.md) and
-[Project Roadmap](documentation/ROADMAP.md) for detailed milestones and
+
+Future Work
+-----------
+
+
+See `Continuous Improvement Roadmap <docs/continuous_improvement_roadmap.md>`_,
+`Stakeholder Roadmap <documentation/continuous_improvement_roadmap.md>`_ and
+`Project Roadmap <documentation/ROADMAP.md>`_ for detailed milestones and
 status tracking.
 
-## gh_copilot skeleton
+gh_copilot skeleton
+-------------------
+
 
 The `src/gh_copilot` package provides a minimal database-first service with a FastAPI app and Typer CLI.
 
-```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -e .
-gh-copilot migrate
-gh-copilot seed-models
-gh-copilot compute-score --lint 0.9 --tests 0.8 --placeholders 0.95 --sessions 1.0
-gh-copilot serve  # http://127.0.0.1:8000/docs
-```
+.. code-block:: bash
+
+   python -m venv .venv && source .venv/bin/activate
+   pip install -e .
+   gh-copilot migrate
+   gh-copilot seed-models
+   gh-copilot compute-score --lint 0.9 --tests 0.8 --placeholders 0.95 --sessions 1.0
+   gh-copilot serve  # http://127.0.0.1:8000/docs


### PR DESCRIPTION
## Summary
- convert Markdown README to reStructuredText
- remove deprecated README.md

## Testing
- `ruff check README.rst` *(fails: SyntaxError: Expected a statement)*
- `pytest` *(fails: pytest: error: unrecognized arguments: --cov=. --cov-report=term)*
- `python secondary_copilot_validator.py --validate` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_689b6de42b5483318cc249e2ee16ee15