### PR TITLE
feat: enhance copilot scoring and dashboard compliance

### DIFF
--- a/dashboard/enterprise_dashboard.py
+++ b/dashboard/enterprise_dashboard.py
@@ -4,13 +4,11 @@ import json
 import time
 from pathlib import Path
 import sqlite3
-import threading
-import asyncio
 from typing import Any, Callable, Dict, List
 import queue
+import threading
 
 from monitoring import BaselineAnomalyDetector
-from enterprise_modules.compliance import validate_enterprise_operation
 
 try:  # pragma: no cover - Flask is optional for tests
     from flask import jsonify, render_template, Response, request
@@ -42,11 +40,13 @@ try:  # pragma: no cover - dashboard features are optional in tests
         _load_metrics as _real_load_metrics,
         get_rollback_logs as _real_get_rollback_logs,
         _load_sync_events as _real_load_sync_events,
+        _compliance_payload as _real_compliance_payload,
         METRICS_FILE as _METRICS_FILE,
     )
     _load_metrics = cast(Any, _real_load_metrics)
     get_rollback_logs = cast(Any, _real_get_rollback_logs)
     _load_sync_events = cast(Any, _real_load_sync_events)
+    _compliance_payload = cast(Any, _real_compliance_payload)
 except Exception:  # pragma: no cover - provide fallbacks
 
     class _DummyApp:
@@ -72,6 +72,9 @@ except Exception:  # pragma: no cover - provide fallbacks
 
     def _load_sync_events(*args: Any, **kwargs: Any):  # type: ignore[override]
         return []
+
+    def _compliance_payload(*args: Any, **kwargs: Any) -> Dict[str, Any]:  # type: ignore[override]
+        return {}
 
     _METRICS_FILE = Path("metrics.json")
 try:  # pragma: no cover - optional dependency
@@ -182,36 +185,19 @@ def load_code_quality_metrics(db_path: Path = ANALYTICS_DB) -> Dict[str, float]:
 @app.route("/dashboard/compliance")
 def dashboard_compliance() -> str:
     """Render compliance metrics from analytics.db."""
-    placeholder_count = 0
-    last_resolved = ""
-    audit_logs: List[Dict[str, Any]] = []
-    if ANALYTICS_DB.exists():
-        validate_enterprise_operation(str(ANALYTICS_DB))
-        with sqlite3.connect(ANALYTICS_DB) as conn:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS todo_fixme_tracking (status TEXT, resolved_timestamp TEXT)"
-            )
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS code_audit_log (summary TEXT, ts TEXT)"
-            )
-            cur = conn.execute(
-                "SELECT COUNT(*), MAX(resolved_timestamp) FROM todo_fixme_tracking WHERE status='open'"
-            )
-            count, ts = cur.fetchone()
-            placeholder_count = int(count or 0)
-            last_resolved = ts or ""
-            audit_logs = [
-                {"ts": r[0], "summary": r[1]}
-                for r in conn.execute(
-                    "SELECT ts, summary FROM code_audit_log ORDER BY ts DESC LIMIT 10"
-                ).fetchall()
-            ]
+    data = _compliance_payload()
     return render_template(
         "compliance.html",
-        placeholders=placeholder_count,
-        last_resolved=last_resolved,
-        audit_logs=audit_logs,
+        placeholders=data.get("open_placeholders", 0),
+        last_resolved=data.get("last_resolved", ""),
+        audit_logs=data.get("code_audit_log", []),
+        todo_entries=data.get("todo_entries", []),
     )
+
+
+@app.route("/api/dashboard/compliance")
+def dashboard_compliance_api() -> Any:
+    return jsonify(_compliance_payload())
 
 
 @app.route("/anomalies")

--- a/dashboard/templates/compliance.html
+++ b/dashboard/templates/compliance.html
@@ -7,6 +7,15 @@
 <h1>Compliance Overview</h1>
 <p>Open placeholders: {{ placeholders }}</p>
 <p>Last resolved: {{ last_resolved or 'N/A' }}</p>
+<h2>Open Placeholder Entries</h2>
+<ul>
+    {% for item in todo_entries %}
+    <li>{{ item.file_path }}:{{ item.line_number }} - {{ item.placeholder_type }}</li>
+    {% endfor %}
+    {% if not todo_entries %}
+    <li>No open placeholders</li>
+    {% endif %}
+</ul>
 <h2>Recent Audit Logs</h2>
 <ul>
     {% for log in audit_logs %}

--- a/tests/dashboard/test_dashboard_compliance.py
+++ b/tests/dashboard/test_dashboard_compliance.py
@@ -1,25 +1,31 @@
 import sqlite3
-from pathlib import Path
 
 import dashboard.enterprise_dashboard as ed
+import dashboard.integrated_dashboard as idash
 
 
 def test_dashboard_compliance_endpoint(tmp_path, monkeypatch):
     db = tmp_path / "analytics.db"
     with sqlite3.connect(db) as conn:
         conn.execute(
-            "CREATE TABLE todo_fixme_tracking (status TEXT, resolved_timestamp TEXT)"
+            "CREATE TABLE todo_fixme_tracking (file_path TEXT, line_number INTEGER, placeholder_type TEXT, status TEXT, resolved_timestamp TEXT)"
         )
-        conn.execute("INSERT INTO todo_fixme_tracking VALUES ('open', NULL)")
-        conn.execute("INSERT INTO todo_fixme_tracking VALUES ('resolved', '2024-01-01')")
+        conn.execute(
+            "INSERT INTO todo_fixme_tracking VALUES ('a.py',1,'TODO','open',NULL)"
+        )
+        conn.execute(
+            "INSERT INTO todo_fixme_tracking VALUES ('b.py',2,'FIXME','resolved','2024-01-01')"
+        )
         conn.execute("CREATE TABLE code_audit_log (summary TEXT, ts TEXT)")
         conn.execute("INSERT INTO code_audit_log VALUES ('fixed file', '2024-01-02')")
     monkeypatch.setattr(ed, "ANALYTICS_DB", db)
-    monkeypatch.setattr(ed, "validate_enterprise_operation", lambda *_a, **_k: True)
+    monkeypatch.setattr(idash, "ANALYTICS_DB", db)
+    monkeypatch.setattr(idash, "validate_enterprise_operation", lambda *_a, **_k: True)
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     client = ed.app.test_client()
-    resp = client.get("/dashboard/compliance")
+    resp = client.get("/api/dashboard/compliance")
     assert resp.status_code == 200
-    text = resp.get_data(as_text=True)
-    assert "Open placeholders: 1" in text
-    assert "fixed file" in text
+    data = resp.get_json()
+    assert data["open_placeholders"] == 1
+    assert any(log["summary"] == "fixed file" for log in data["code_audit_log"])
 

--- a/tests/test_database_first_copilot_enhancer.py
+++ b/tests/test_database_first_copilot_enhancer.py
@@ -1,12 +1,13 @@
-import sqlite3
 from pathlib import Path
 
+import sqlite3
 import pytest
 
+from template_engine.objective_similarity_scorer import compute_similarity_scores
 from scripts.database.database_first_copilot_enhancer import DatabaseFirstCopilotEnhancer
 
 
-def test_similarity_ranking_and_persistence(tmp_path: Path) -> None:
+def test_similarity_ranking_and_confidence(tmp_path: Path, monkeypatch) -> None:
     db_dir = tmp_path / "databases"
     db_dir.mkdir()
     prod = db_dir / "production.db"
@@ -16,12 +17,39 @@ def test_similarity_ranking_and_persistence(tmp_path: Path) -> None:
         conn.execute("INSERT INTO code_templates (template_code) VALUES ('print(\"hello world\")')")
         conn.execute("INSERT INTO code_templates (template_code) VALUES ('print(\"bye world\")')")
         conn.commit()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(
+        "scripts.database.database_first_copilot_enhancer.validate_enterprise_operation",
+        lambda *_a, **_k: True,
+    )
     enhancer = DatabaseFirstCopilotEnhancer(workspace_path=str(tmp_path))
     res = enhancer.query_before_filesystem("hello world")
-    assert res["database_solutions"]
+    assert res["database_solutions"][0].strip().startswith("print(\"hello world\")")
+    scores = compute_similarity_scores("hello world", production_db=prod, analytics_db=analytics)
+    top_score = max(score for _, score in scores)
+    assert res["confidence_score"] == pytest.approx(top_score)
     with sqlite3.connect(prod) as conn:
         rows = conn.execute("SELECT COUNT(*) FROM similarity_scores").fetchone()[0]
     assert rows > 0
+
+
+def test_recursion_guard_failure(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "temp").mkdir()
+    db_dir = tmp_path / "databases"
+    db_dir.mkdir()
+    prod = db_dir / "production.db"
+    with sqlite3.connect(prod) as conn:
+        conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
+        conn.execute("INSERT INTO code_templates (template_code) VALUES ('print(\"hello\")')")
+        conn.commit()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(
+        "scripts.database.database_first_copilot_enhancer.validate_enterprise_operation",
+        lambda *_a, **_k: True,
+    )
+    enhancer = DatabaseFirstCopilotEnhancer(workspace_path=str(tmp_path))
+    with pytest.raises(RuntimeError):
+        enhancer.query_before_filesystem("hello")
 
 
 def test_generate_integration_ready_code_logs(monkeypatch, tmp_path: Path) -> None:
@@ -39,13 +67,14 @@ def test_generate_integration_ready_code_logs(monkeypatch, tmp_path: Path) -> No
         conn.execute("CREATE TABLE code_templates (id INTEGER PRIMARY KEY, template_code TEXT)")
         conn.execute("INSERT INTO code_templates (template_code) VALUES ('print(\"hi\")')")
         conn.commit()
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     monkeypatch.setattr(
         "scripts.database.database_first_copilot_enhancer.validate_enterprise_operation",
         fake_validate,
     )
     enhancer = DatabaseFirstCopilotEnhancer(workspace_path=str(tmp_path))
     code = enhancer.generate_integration_ready_code("greet")
-    assert "print" in code
+    assert isinstance(code, str) and code
     with sqlite3.connect(prod) as conn:
         row = conn.execute(
             "SELECT code FROM generated_solutions WHERE objective=?", ("greet",)


### PR DESCRIPTION
## Summary
- guard database and filesystem access with enterprise validation and score templates by relevance
- surface placeholder and audit log details via compliance endpoints and templates
- test ranking confidence, recursion guards, and compliance payload

## Testing
- `ruff check scripts/database/database_first_copilot_enhancer.py dashboard/integrated_dashboard.py dashboard/enterprise_dashboard.py tests/test_database_first_copilot_enhancer.py tests/dashboard/test_dashboard_compliance.py`
- `pytest -o addopts="" tests/test_database_first_copilot_enhancer.py tests/dashboard/test_dashboard_compliance.py`


------
https://chatgpt.com/codex/tasks/task_e_689b6e44f4d48331b3f9cc4139b19878