### PR TITLE
feat: add correction summary reporting

### DIFF
--- a/monitoring/health_monitor.py
+++ b/monitoring/health_monitor.py
@@ -8,7 +8,18 @@ import sqlite3
 from pathlib import Path
 from typing import Dict, Optional
 
-import psutil
+from types import SimpleNamespace
+
+try:  # pragma: no cover - psutil optional in some environments
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - fallback stub
+    psutil = SimpleNamespace(
+        cpu_percent=lambda interval=0: 0.0,
+        virtual_memory=lambda: SimpleNamespace(percent=0.0),
+        disk_usage=lambda _p: SimpleNamespace(percent=0.0),
+        net_io_counters=lambda: SimpleNamespace(bytes_sent=0, bytes_recv=0),
+    )
+
 from quantum_algorithm_library_expansion import quantum_score_stub
 
 WORKSPACE_ROOT = Path(os.getenv("GH_COPILOT_WORKSPACE", Path.cwd()))

--- a/tests/test_compliance_metrics_updater.py
+++ b/tests/test_compliance_metrics_updater.py
@@ -43,8 +43,10 @@ def test_compliance_metrics_updater(tmp_path, monkeypatch, simulate, test_mode):
         push_metrics=dummy_push,
         EnterpriseUtility=DummyEnterpriseUtility,
     )
+    stub_quantum = types.SimpleNamespace(quantum_score_stub=lambda x: 0.0)
     monkeypatch.setitem(sys.modules, "scripts.correction_logger_and_rollback", stub_corr)
     monkeypatch.setitem(sys.modules, "unified_monitoring_optimization_system", stub_monitor)
+    monkeypatch.setitem(sys.modules, "quantum_algorithm_library_expansion", stub_quantum)
     logging.getLogger().handlers.clear()
     module = importlib.import_module("dashboard.compliance_metrics_updater")
     importlib.reload(module)


### PR DESCRIPTION
## Summary
- aggregate correction history metrics and expose via CLI
- add monitoring fallbacks for missing psutil and sklearn
- improve tests for correction history and compliance metrics

## Testing
- `ruff check tests/test_documentation_db_analyzer.py tests/test_correction_history.py tests/test_compliance_metrics_updater.py scripts/database/documentation_db_analyzer.py unified_monitoring_optimization_system.py monitoring/health_monitor.py`
- `pyright tests/test_documentation_db_analyzer.py tests/test_correction_history.py tests/test_compliance_metrics_updater.py scripts/database/documentation_db_analyzer.py unified_monitoring_optimization_system.py monitoring/health_monitor.py`
- `pytest --override-ini=addopts="" tests/test_compliance_metrics_updater.py tests/test_correction_history.py tests/test_documentation_db_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_e_689b6ee07d2483318807879a4c10ed7e