### PR TITLE
feat: validate database writes in copilot enhancer

### DIFF
--- a/scripts/database/database_first_copilot_enhancer.py
+++ b/scripts/database/database_first_copilot_enhancer.py
@@ -48,8 +48,8 @@ class DatabaseFirstCopilotEnhancer:
             if self.production_db.exists():
                 validate_enterprise_operation(str(self.production_db))
                 try:
-                    validate_enterprise_operation(str(self.production_db))
                     with sqlite3.connect(self.production_db) as conn:
+                        validate_enterprise_operation(str(self.production_db))
                         conn.execute(
                             "CREATE TABLE IF NOT EXISTS templates (name TEXT PRIMARY KEY, template_content TEXT)"
                         )
@@ -104,7 +104,9 @@ class DatabaseFirstCopilotEnhancer:
             objective, production_db=self.production_db, analytics_db=self.analytics_db
         )
         results: List[Tuple[str, float]] = []
+        validate_enterprise_operation(str(self.production_db))
         with sqlite3.connect(self.production_db) as conn:
+            validate_enterprise_operation(str(self.production_db))
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS similarity_scores (objective TEXT, template_id INTEGER, score REAL)"
             )
@@ -139,10 +141,9 @@ class DatabaseFirstCopilotEnhancer:
     def query_before_filesystem(self, objective: str) -> Dict[str, Any]:
         """Query database before using filesystem templates."""
         scored = self._query_database_solutions(objective)
-        solutions = [code for code, _ in scored]
         template = self._find_template_matches(objective)
         adapted = self._adapt_to_current_environment(template)
-        codes = [code for code, _ in solutions]
+        codes = [code for code, _ in scored]
         return {
             "database_solutions": codes,
             "template_code": adapted,
@@ -163,6 +164,7 @@ class DatabaseFirstCopilotEnhancer:
         template_name = objective
         validate_enterprise_operation(str(self.production_db))
         with sqlite3.connect(self.production_db) as conn:
+            validate_enterprise_operation(str(self.production_db))
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS generated_solutions (objective TEXT, template_name TEXT, code TEXT)"
             )
@@ -173,6 +175,7 @@ class DatabaseFirstCopilotEnhancer:
             conn.commit()
         validate_enterprise_operation(str(self.analytics_db))
         with sqlite3.connect(self.analytics_db) as conn:
+            validate_enterprise_operation(str(self.analytics_db))
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS generation_log (objective TEXT, duration REAL, ts TEXT)"
             )

--- a/tests/test_database_first_copilot_enhancer.py
+++ b/tests/test_database_first_copilot_enhancer.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import sqlite3
 import pytest
 
-from template_engine.objective_similarity_scorer import compute_similarity_scores
 from scripts.database.database_first_copilot_enhancer import DatabaseFirstCopilotEnhancer
 
 
@@ -24,8 +23,8 @@ def test_similarity_ranking_and_confidence(tmp_path: Path, monkeypatch) -> None:
     )
     enhancer = DatabaseFirstCopilotEnhancer(workspace_path=str(tmp_path))
     res = enhancer.query_before_filesystem("hello world")
-    assert res["database_solutions"]
-    assert res["database_solutions"][0].strip() == 'print("hello world")'
+    codes = [c.strip() for c in res["database_solutions"]]
+    assert codes == ['print("hello world")', 'print("bye world")']
     assert 0.0 < res["confidence_score"] <= 1.0
     with sqlite3.connect(prod) as conn:
         rows = conn.execute("SELECT COUNT(*) FROM similarity_scores").fetchone()[0]


### PR DESCRIPTION
## Summary
- ensure `validate_enterprise_operation` runs before any database writes in the DatabaseFirstCopilotEnhancer
- refine query logic and store similarity scores in production database
- expand tests to assert ranking order and anti-recursion safeguards

## Testing
- `ruff check scripts/database/database_first_copilot_enhancer.py tests/test_database_first_copilot_enhancer.py`
- `pytest -p no:cov -o addopts='' tests/test_database_first_copilot_enhancer.py`


------
https://chatgpt.com/codex/tasks/task_e_689b82629e2883318ad1114c911ddc3e