### PR TITLE
feat: log rollback sessions and generate reports

### DIFF
--- a/scripts/database/documentation_db_analyzer.py
+++ b/scripts/database/documentation_db_analyzer.py
@@ -153,6 +153,8 @@ def rollback_db(db: Path, backup: Path | None = None) -> None:
             table="doc_analysis",
             db_path=ANALYTICS_DB,
         )
+        _record_correction_session("rollback", ANALYTICS_DB)
+        _write_session_reports(ANALYTICS_DB, REPORTS_DIR)
 
 
 CLEANUP_SQL = "DELETE FROM enterprise_documentation WHERE doc_type='BACKUP_LOG' OR source_path LIKE '%backup%'"


### PR DESCRIPTION
## Summary
- track rollback actions in new correction_sessions table and emit CSV/JSON session reports
- ensure rollback_db records sessions and generates summary files
- add tests verifying session logging and report creation

## Testing
- `ruff check scripts/database/documentation_db_analyzer.py tests/test_documentation_db_analyzer.py`
- `pytest tests/test_documentation_db_analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_689b8264071c8331919ebbc6c651f0e2