### PR TITLE
chore: validate zip lfs tracking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -629,6 +629,27 @@ The script rebuilds `.gitattributes` from `gitattributes_template`, adds any
 missing patterns for session archives and `binary_extensions`, and should be run
 before committing policy changes.
 
+Troubleshooting Git LFS pointer errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If `git` reports::
+
+   Encountered N files that should have been pointers, but weren't
+
+some binaries were committed without Git LFS. Recover by migrating the files and
+retrofitting LFS tracking:
+
+1. ``git lfs migrate import --yes --no-rewrite <path-to-zip>``
+2. ``git push``
+3. ``git gc --prune=now``
+4. ``git lfs track "*.zip"`` and ``git add .gitattributes``
+5. ``git rm --cached <file>.zip && git add <file>.zip``
+6. ``git commit -m "fix: track zip via Git LFS"``
+
+Verify with ``git lfs ls-files`` or ``git lfs status``. See GitHub's
+`LFS configuration guide <https://docs.github.com/en/github/managing-large-files/configuring-git-large-file-storage>`_
+for additional details.
+
 Docker Usage
 ^^^^^^^^^^^^
 

--- a/tools/pre-commit-lfs.sh
+++ b/tools/pre-commit-lfs.sh
@@ -36,4 +36,25 @@ if [ -n "$untracked_db_files" ]; then
   exit 1
 fi
 
+# Collect staged .zip files
+staged_zip_files=$(git diff --cached --name-only -- '*.zip')
+
+# Verify each staged .zip file is managed by Git LFS
+for f in $staged_zip_files; do
+  if ! git lfs ls-files | grep -Fq " $f"; then
+    echo "Error: $f is a .zip file not tracked by Git LFS" >&2
+    echo "Run 'git lfs track \"*.zip\"' and re-add the file." >&2
+    exit 1
+  fi
+done
+
+# Check for untracked .zip files in working tree
+untracked_zip_files=$(git ls-files --others --exclude-standard '*.zip')
+if [ -n "$untracked_zip_files" ]; then
+  echo "Error: Untracked .zip file(s) found:" >&2
+  echo "$untracked_zip_files" >&2
+  echo "Ensure they are added and tracked by Git LFS." >&2
+  exit 1
+fi
+
 exit 0


### PR DESCRIPTION
## Summary
- document resolution for "should have been pointers" errors in Git LFS
- extend pre-commit hook to ensure zipped archives are tracked by Git LFS

## Testing
- `ruff check tools/pre-commit-lfs.sh` *(fails: invalid-syntax, ruff doesn't parse shell scripts)*
- `pytest tests/placeholder_audit/test_placeholder_density.py`


------
https://chatgpt.com/codex/tasks/task_e_689b9e1ec61c8331b62adf8b52907cb2