### PR TITLE
feat: enhance compliance validators

### DIFF
--- a/quantum/quantum_compliance_engine.py
+++ b/quantum/quantum_compliance_engine.py
@@ -120,8 +120,6 @@ class QuantumComplianceEngine:
                 patterns = self._ml_pattern_recognition(target)
             pattern_matches = self._multi_pattern_match(target, patterns)
             pbar.update(30)
-            if not self.validator.validate_corrections(list(pattern_matches.keys())):
-                logger.error("Secondary validation failed for pattern matches.")
 
             pbar.set_description("Applying Modular Weighting")
             weighted_score = self._apply_modular_weighting(pattern_matches, modular_weights)
@@ -149,12 +147,13 @@ class QuantumComplianceEngine:
         suggestions = self._cognitive_learning_fetch(patterns)
         if suggestions:
             logger.info("Comparable scripts: %s", suggestions)
-            if not self.validator.validate_corrections(suggestions):
-                logger.error("Secondary validation failed for cognitive suggestions.")
+        files_to_validate = [str(target)]
+        if suggestions:
+            files_to_validate.extend(suggestions)
+        if not self.validator.validate_corrections(files_to_validate):
+            logger.error("Secondary validation failed for provided files.")
         if score < threshold:
             logger.error("Quantum compliance score below threshold.")
-        if not self.validator.validate_corrections([f"{score:.4f}"]):
-            logger.error("Secondary validation failed for computed score.")
         self.status = "COMPLETED"
         return score
 

--- a/scripts/validation/secondary_copilot_validator.py
+++ b/scripts/validation/secondary_copilot_validator.py
@@ -34,7 +34,14 @@ class SecondaryCopilotValidator:
         cmd = ["flake8", *files]
         self.logger.info("Running secondary flake8 validation", extra=None)
         start = time.perf_counter()
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        except FileNotFoundError:
+            self.metrics["duration"] = time.perf_counter() - start
+            self.metrics["returncode"] = -1
+            self.metrics["stderr"] = "flake8 executable not found"
+            self.logger.error("flake8 executable not found", extra=None)
+            return False
         self.metrics["duration"] = time.perf_counter() - start
         self.metrics["returncode"] = result.returncode
         self.metrics["stdout"] = result.stdout

--- a/tests/test_quantum_compliance_engine.py
+++ b/tests/test_quantum_compliance_engine.py
@@ -73,6 +73,6 @@ def test_secondary_validator_invoked(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(qce, "validate_environment_root", lambda: None)
 
     engine = qce.QuantumComplianceEngine(tmp_path)
-    score = engine.score(target, ["quantum"])
+    engine.score(target, ["quantum"])
 
-    assert called["files"] == [f"{score:.4f}"]
+    assert called["files"] == [str(target)]

--- a/tests/validation/test_secondary_copilot_validator.py
+++ b/tests/validation/test_secondary_copilot_validator.py
@@ -1,0 +1,13 @@
+import subprocess
+
+from secondary_copilot_validator import SecondaryCopilotValidator
+
+
+def test_missing_flake8(monkeypatch):
+    def _missing_flake8(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(subprocess, "run", _missing_flake8)
+    validator = SecondaryCopilotValidator()
+    assert validator.validate_corrections(["dummy.py"]) is False
+    assert validator.metrics["returncode"] == -1

--- a/validation/enterprise_compliance_validator.py
+++ b/validation/enterprise_compliance_validator.py
@@ -31,10 +31,12 @@ class EnterpriseComplianceValidator:
         )
         return cur.fetchone() is not None
 
-    def _fetch_latest(self, cur: sqlite3.Cursor, table: str, columns: str) -> Tuple[int, ...]:
+    def _fetch_latest(
+        self, cur: sqlite3.Cursor, table: str, columns: str, order_by: str = "rowid"
+    ) -> Tuple[int, ...]:
         try:
             cur.execute(
-                f"SELECT {columns} FROM {table} ORDER BY 1 DESC LIMIT 1"
+                f"SELECT {columns} FROM {table} ORDER BY {order_by} DESC LIMIT 1"
             )
             row = cur.fetchone()
             if row:
@@ -77,11 +79,13 @@ class EnterpriseComplianceValidator:
             cur = conn.cursor()
 
             # lint issues from ruff_issue_log
-            lint, = self._fetch_latest(cur, "ruff_issue_log", "issues")
+            lint, = self._fetch_latest(cur, "ruff_issue_log", "issues", order_by="run_timestamp")
             metrics["lint_issues"] = lint
 
             # test results from test_run_stats
-            passed, total = self._fetch_latest(cur, "test_run_stats", "passed,total")
+            passed, total = self._fetch_latest(
+                cur, "test_run_stats", "passed,total", order_by="run_timestamp"
+            )
             metrics["tests_passed"] = passed
             metrics["tests_failed"] = max(0, total - passed)
 


### PR DESCRIPTION
## Summary
- ensure quantum compliance engine validates target and comparable scripts instead of numeric scores
- handle missing flake8 executable in SecondaryCopilotValidator
- allow EnterpriseComplianceValidator to fetch latest rows with configurable ordering

## Testing
- `ruff check quantum/quantum_compliance_engine.py scripts/validation/secondary_copilot_validator.py validation/enterprise_compliance_validator.py tests/test_quantum_compliance_engine.py tests/validation/test_secondary_copilot_validator.py tests/validation/test_enterprise_compliance_validator.py`
- `pytest tests/test_quantum_compliance_engine.py tests/validation/test_secondary_copilot_validator.py tests/validation/test_enterprise_compliance_validator.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba41dea7883318a2a340ed2bb48ba