### PR TITLE
feat: enhance validation error handling and scoring

### DIFF
--- a/quantum/quantum_compliance_engine.py
+++ b/quantum/quantum_compliance_engine.py
@@ -120,8 +120,8 @@ class QuantumComplianceEngine:
                 patterns = self._ml_pattern_recognition(target)
             pattern_matches = self._multi_pattern_match(target, patterns)
             pbar.update(30)
-            if not self.validator.validate_corrections(list(pattern_matches.keys())):
-                logger.error("Secondary validation failed for pattern matches.")
+            if not self.validator.validate_corrections([str(target)]):
+                logger.error("Secondary validation failed for target file.")
 
             pbar.set_description("Applying Modular Weighting")
             weighted_score = self._apply_modular_weighting(pattern_matches, modular_weights)
@@ -149,12 +149,11 @@ class QuantumComplianceEngine:
         suggestions = self._cognitive_learning_fetch(patterns)
         if suggestions:
             logger.info("Comparable scripts: %s", suggestions)
-            if not self.validator.validate_corrections(suggestions):
+            paths = [str(target)] + suggestions
+            if not self.validator.validate_corrections(paths):
                 logger.error("Secondary validation failed for cognitive suggestions.")
         if score < threshold:
             logger.error("Quantum compliance score below threshold.")
-        if not self.validator.validate_corrections([f"{score:.4f}"]):
-            logger.error("Secondary validation failed for computed score.")
         self.status = "COMPLETED"
         return score
 

--- a/scripts/validation/secondary_copilot_validator.py
+++ b/scripts/validation/secondary_copilot_validator.py
@@ -34,7 +34,14 @@ class SecondaryCopilotValidator:
         cmd = ["flake8", *files]
         self.logger.info("Running secondary flake8 validation", extra=None)
         start = time.perf_counter()
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        except FileNotFoundError:
+            self.metrics["duration"] = time.perf_counter() - start
+            self.metrics["returncode"] = -1
+            self.metrics["stderr"] = "flake8 executable not found"
+            self.logger.error("flake8 executable not found")
+            return False
         self.metrics["duration"] = time.perf_counter() - start
         self.metrics["returncode"] = result.returncode
         self.metrics["stdout"] = result.stdout

--- a/tests/test_quantum_compliance_engine.py
+++ b/tests/test_quantum_compliance_engine.py
@@ -73,6 +73,6 @@ def test_secondary_validator_invoked(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(qce, "validate_environment_root", lambda: None)
 
     engine = qce.QuantumComplianceEngine(tmp_path)
-    score = engine.score(target, ["quantum"])
+    engine.score(target, ["quantum"])
 
-    assert called["files"] == [f"{score:.4f}"]
+    assert called["files"] == [str(target)]

--- a/tests/validation/test_enterprise_compliance_validator.py
+++ b/tests/validation/test_enterprise_compliance_validator.py
@@ -16,14 +16,16 @@ def _setup_db(path: Path) -> None:
         conn.execute(
             "CREATE TABLE ruff_issue_log(run_timestamp INTEGER, issues INTEGER)"
         )
-        conn.execute(
-            "INSERT INTO ruff_issue_log(run_timestamp, issues) VALUES(1, 5)"
+        conn.executemany(
+            "INSERT INTO ruff_issue_log(run_timestamp, issues) VALUES(?, ?)",
+            [(1, 5), (2, 4)],
         )
         conn.execute(
             "CREATE TABLE test_run_stats(run_timestamp INTEGER, passed INTEGER, total INTEGER)"
         )
-        conn.execute(
-            "INSERT INTO test_run_stats(run_timestamp, passed, total) VALUES(1, 8, 10)"
+        conn.executemany(
+            "INSERT INTO test_run_stats(run_timestamp, passed, total) VALUES(?, ?, ?)",
+            [(1, 8, 10), (2, 9, 12)],
         )
         conn.execute(
             "CREATE TABLE todo_fixme_tracking(id INTEGER PRIMARY KEY, status TEXT)"
@@ -46,9 +48,9 @@ def test_evaluate_success(tmp_path: Path) -> None:
     _setup_db(db)
     validator = EnterpriseComplianceValidator(db)
     metrics = validator.evaluate()
-    assert metrics["lint_issues"] == 5
-    assert metrics["tests_passed"] == 8
-    assert metrics["tests_failed"] == 2
+    assert metrics["lint_issues"] == 4
+    assert metrics["tests_passed"] == 9
+    assert metrics["tests_failed"] == 3
     assert metrics["placeholders_open"] == 1
     assert metrics["placeholders_resolved"] == 1
     assert metrics["composite_score"] > 0
@@ -76,4 +78,19 @@ def test_wrapper_function(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(wrapper, "EnterpriseComplianceValidator", _factory)
     score = wrapper.record_compliance_metrics()
     assert score > 0
+
+
+def test_fetch_latest_order_by(tmp_path: Path) -> None:
+    db = tmp_path / "analytics.db"
+    with sqlite3.connect(db) as conn:
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE sample(id INTEGER PRIMARY KEY, value INTEGER)")
+        cur.executemany("INSERT INTO sample(value) VALUES (?)", [(1,), (2,)])
+        cur.execute("CREATE TABLE sample_ts(ts INTEGER, value INTEGER)")
+        cur.executemany(
+            "INSERT INTO sample_ts(ts, value) VALUES (?, ?)", [(1, 1), (2, 2)]
+        )
+        validator = EnterpriseComplianceValidator(db)
+        assert validator._fetch_latest(cur, "sample", "value") == (2,)
+        assert validator._fetch_latest(cur, "sample_ts", "value", order_by="ts") == (2,)
 

--- a/tests/validation/test_secondary_copilot_validator.py
+++ b/tests/validation/test_secondary_copilot_validator.py
@@ -1,0 +1,16 @@
+import subprocess
+
+import pytest
+
+from scripts.validation.secondary_copilot_validator import SecondaryCopilotValidator
+
+
+def test_missing_flake8(monkeypatch: pytest.MonkeyPatch) -> None:
+    validator = SecondaryCopilotValidator()
+
+    def _missing_flake8(*args, **kwargs):
+        raise FileNotFoundError("flake8 not found")
+
+    monkeypatch.setattr(subprocess, "run", _missing_flake8)
+    assert validator.validate_corrections(["dummy.py"]) is False
+

--- a/validation/enterprise_compliance_validator.py
+++ b/validation/enterprise_compliance_validator.py
@@ -31,10 +31,16 @@ class EnterpriseComplianceValidator:
         )
         return cur.fetchone() is not None
 
-    def _fetch_latest(self, cur: sqlite3.Cursor, table: str, columns: str) -> Tuple[int, ...]:
+    def _fetch_latest(
+        self,
+        cur: sqlite3.Cursor,
+        table: str,
+        columns: str,
+        order_by: str = "rowid",
+    ) -> Tuple[int, ...]:
         try:
             cur.execute(
-                f"SELECT {columns} FROM {table} ORDER BY 1 DESC LIMIT 1"
+                f"SELECT {columns} FROM {table} ORDER BY {order_by} DESC LIMIT 1"
             )
             row = cur.fetchone()
             if row:
@@ -77,11 +83,15 @@ class EnterpriseComplianceValidator:
             cur = conn.cursor()
 
             # lint issues from ruff_issue_log
-            lint, = self._fetch_latest(cur, "ruff_issue_log", "issues")
+            lint, = self._fetch_latest(
+                cur, "ruff_issue_log", "issues", order_by="run_timestamp"
+            )
             metrics["lint_issues"] = lint
 
             # test results from test_run_stats
-            passed, total = self._fetch_latest(cur, "test_run_stats", "passed,total")
+            passed, total = self._fetch_latest(
+                cur, "test_run_stats", "passed,total", order_by="run_timestamp"
+            )
             metrics["tests_passed"] = passed
             metrics["tests_failed"] = max(0, total - passed)
 


### PR DESCRIPTION
## Summary
- ensure quantum compliance scoring validates target and suggestion paths directly
- gracefully handle missing flake8 in SecondaryCopilotValidator
- allow EnterpriseComplianceValidator to order metrics retrieval by column

## Testing
- `ruff check quantum/quantum_compliance_engine.py scripts/validation/secondary_copilot_validator.py validation/enterprise_compliance_validator.py tests/test_quantum_compliance_engine.py tests/validation/test_secondary_copilot_validator.py tests/validation/test_enterprise_compliance_validator.py`
- `pytest -o addopts='' tests/test_quantum_compliance_engine.py tests/validation/test_secondary_copilot_validator.py tests/validation/test_enterprise_compliance_validator.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba41dea7883318a2a340ed2bb48ba