### PR TITLE
fix: handle missing flake8 in secondary validator

### DIFF
--- a/scripts/validation/secondary_copilot_validator.py
+++ b/scripts/validation/secondary_copilot_validator.py
@@ -34,7 +34,14 @@ class SecondaryCopilotValidator:
         cmd = ["flake8", *files]
         self.logger.info("Running secondary flake8 validation", extra=None)
         start = time.perf_counter()
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        except FileNotFoundError:
+            self.metrics["duration"] = time.perf_counter() - start
+            self.metrics["returncode"] = -1
+            self.metrics["stderr"] = "flake8 executable not found"
+            self.logger.error("flake8 executable not found", extra=None)
+            return False
         self.metrics["duration"] = time.perf_counter() - start
         self.metrics["returncode"] = result.returncode
         self.metrics["stdout"] = result.stdout

--- a/tests/test_secondary_validator_errors.py
+++ b/tests/test_secondary_validator_errors.py
@@ -6,3 +6,15 @@ def test_secondary_validator_detects_flake8_error(tmp_path):
     bad_file.write_text("import os\n\n\n")
     validator = SecondaryCopilotValidator()
     assert not validator.validate_corrections([str(bad_file)])
+
+
+def test_secondary_validator_handles_missing_flake8(monkeypatch):
+    import scripts.validation.secondary_copilot_validator as scv
+
+    validator = scv.SecondaryCopilotValidator()
+
+    def fake_run(*_args, **_kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(scv.subprocess, "run", fake_run)
+    assert validator.validate_corrections(["dummy.py"]) is False


### PR DESCRIPTION
## Summary
- handle missing flake8 gracefully in SecondaryCopilotValidator
- test SecondaryCopilotValidator behavior when flake8 is unavailable

## Testing
- `ruff check scripts/validation/secondary_copilot_validator.py tests/test_secondary_validator_errors.py`
- `pytest tests/test_secondary_validator_errors.py`
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689ba6881f78833198288471da29291b