### PR TITLE
feat: add order column support tests for compliance validator

### DIFF
--- a/validation/enterprise_compliance_validator.py
+++ b/validation/enterprise_compliance_validator.py
@@ -38,6 +38,20 @@ class EnterpriseComplianceValidator:
         columns: str,
         order_by: str = "rowid",
     ) -> Tuple[int, ...]:
+        """Return the latest row from ``table`` ordered by ``order_by``.
+
+        Parameters
+        ----------
+        cur:
+            Active database cursor.
+        table:
+            Name of the table to query.
+        columns:
+            Comma-separated list of columns to select.
+        order_by:
+            Column used to determine recency. Defaults to ``rowid`` so that
+            tables without an explicit timestamp can still be queried safely.
+        """
         try:
             cur.execute(
                 f"SELECT {columns} FROM {table} ORDER BY {order_by} DESC LIMIT 1"


### PR DESCRIPTION
## Summary
- document order-based queries in `EnterpriseComplianceValidator._fetch_latest`
- add dynamic import in tests to avoid heavy validation package dependencies
- cover differing primary key and timestamp orders to ensure correct ordering

## Testing
- `ruff check validation/enterprise_compliance_validator.py tests/validation/test_enterprise_compliance_validator.py`
- `pytest -c /dev/null tests/validation/test_enterprise_compliance_validator.py`


------
https://chatgpt.com/codex/tasks/task_e_689bb0f92c2c8331859ce326bd2e43d2