### PR TITLE
feat: add disaster recovery CI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,3 +252,36 @@ jobs:
         with:
           name: codeql-results
           path: codeql-results
+
+  backup-restore:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run backup and restore drill
+        env:
+          GH_COPILOT_WORKSPACE: ${{ github.workspace }}
+          GH_COPILOT_BACKUP_ROOT: /tmp/gh_copilot_backup
+          ANALYTICS_DB: /tmp/analytics.db
+        run: |
+          python - <<'PY'
+          from unified_disaster_recovery_system import schedule_backups, restore_backup
+          import sqlite3, os
+          backup = schedule_backups()
+          assert restore_backup(backup)
+          conn = sqlite3.connect(os.environ["ANALYTICS_DB"])
+          cur = conn.cursor()
+          cur.execute(
+              "SELECT description FROM event_log WHERE description IN (?, ?)",
+              ("backup_scheduled", "restore_success"),
+          )
+          rows = {r[0] for r in cur.fetchall()}
+          assert "backup_scheduled" in rows
+          assert "restore_success" in rows
+          PY

--- a/docs/enterprise_backup_guide.md
+++ b/docs/enterprise_backup_guide.md
@@ -30,6 +30,13 @@ verifies restore operations; misconfigured paths abort with an error.
    placed in `archive/` at the repository root.
 4. Backups remain stored within `$GH_COPILOT_BACKUP_ROOT` by default.
 
+### Recommended Frequency
+
+Run automated backups at least once per day and retain the most recent
+five archives. The `schedule_backups()` helper respects the
+`GH_COPILOT_MAX_BACKUPS` environment variable so older archives are
+pruned automatically.
+
 ## Programmatic Backups
 
 The `create_external_backup()` helper ensures backups are written outside
@@ -52,3 +59,15 @@ create_external_backup(source, "invalid", backup_dir=Path("disaster_recovery"))
 ```
 
 For more details on advanced options and restoration procedures, see the documentation in `disaster_recovery/`.
+
+## Restore Drills
+
+Regular restore drills validate that backups are usable. To perform a
+drill:
+
+1. Create a backup using `schedule_backups()`.
+2. Run `restore_backup()` on the generated file.
+3. Confirm a `restore_success` event is logged in `analytics.db` and the
+   file is copied to the workspace.
+
+Conduct these drills quarterly to ensure operational readiness.


### PR DESCRIPTION
## Summary
- run scheduled backup and restore in CI with log assertions
- validate restore paths in disaster recovery tests
- document backup cadence and restore drill process

## Testing
- `ruff check tests/test_disaster_recovery_backup_validation.py`
- `pytest tests/test_disaster_recovery_backup_validation.py::test_restore_rejects_untrusted_path -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc4585bd48331b15095f40ebde978