### PR TITLE
feat: streamline quantum backend selection

### DIFF
--- a/docs/quantum_integration_plan.md
+++ b/docs/quantum_integration_plan.md
@@ -7,6 +7,12 @@ line entry point.  Usage:
 python quantum_integration_orchestrator.py --provider <simulator|ibm|ionq|dwave>
 ```
 
+The entry point delegates backend construction to
+`quantum.providers.get_provider`.  Lightweight stubs in
+`quantum.providers.backends` (`IBMBackend`, `IonQBackend`, `DWaveBackend`)
+mirror vendor behaviour so the orchestration flow can be tested without
+installing hardware SDKs.
+
 ## Configuration
 
 Each provider relies on an environment token.  When the token is missing the

--- a/quantum/providers/__init__.py
+++ b/quantum/providers/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Dict, Type
 
+from .backends import DWaveBackend, IBMBackend, IonQBackend, ProviderBackend
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .base import BackendProvider
 
@@ -34,4 +36,10 @@ def get_provider(name: str) -> "BackendProvider":
     return _load_provider(path)
 
 
-__all__ = ["get_provider"]
+__all__ = [
+    "get_provider",
+    "ProviderBackend",
+    "IBMBackend",
+    "IonQBackend",
+    "DWaveBackend",
+]

--- a/quantum_integration_orchestrator.py
+++ b/quantum_integration_orchestrator.py
@@ -22,17 +22,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    from quantum.providers.dwave_provider import DWaveProvider
-    from quantum.providers.ibm_provider import IBMBackendProvider
-    from quantum.providers.ionq_provider import IonQProvider
-    from quantum.providers.simulator import SimulatorProvider
+    from quantum.providers import get_provider
 
-    provider_map = {
-        "simulator": SimulatorProvider(),
-        "ibm": IBMBackendProvider(),
-        "ionq": IonQProvider(),
-        "dwave": DWaveProvider(),
-    }
+    provider = get_provider(args.provider)
     token_env = {
         "ibm": "QISKIT_IBM_TOKEN",
         "ionq": "IONQ_API_KEY",
@@ -43,7 +35,7 @@ def main(argv: list[str] | None = None) -> int:
         if not os.getenv(env):
             parser.error(f"--provider {args.provider} requires {env} to be set")
 
-    backend = provider_map[args.provider].get_backend()
+    backend = provider.get_backend()
     util = EnterpriseUtility(backend=backend)
     success = util.execute_utility()
     return 0 if success else 1


### PR DESCRIPTION
## Summary
- export provider stub classes for IBM, IonQ and D-Wave
- streamline orchestrator to resolve providers via registry helper
- document provider tokens and stub backend usage

## Testing
- `ruff check quantum/providers/__init__.py quantum_integration_orchestrator.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'session.session_lifecycle_metrics')*

------
https://chatgpt.com/codex/tasks/task_e_689bc8e635d483318f2b512be0f52348