### PR TITLE
fix: handle git-lfs install in dry runs

### DIFF
--- a/bootstrap_lfs_precommit.sh
+++ b/bootstrap_lfs_precommit.sh
@@ -26,7 +26,7 @@ if ! has git-lfs; then
     run "apt-get update >/dev/null 2>&1"
     run "apt-get install -y git-lfs >/dev/null 2>&1"
     if [[ "${DRY_RUN:-0}" == "1" ]]; then
-      info "git-lfs installation skipped due to DRY_RUN"
+      info "DRY_RUN: would install git-lfs via apt-get"
     fi
   else
     echo "Warning: unable to install git-lfs automatically." >&2


### PR DESCRIPTION
## Summary
- ensure git-lfs apt install respects DRY_RUN and logs skipped installation

## Testing
- `ruff check .` *(fails: Undefined name `solutions` in existing code)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'session.session_lifecycle_metrics')*

------
https://chatgpt.com/codex/tasks/task_e_689bdc3525ec8331925b64f76c61df29