### PR TITLE
fix: respect DRY_RUN for apt-get install

### DIFF
--- a/bootstrap_lfs_precommit.sh
+++ b/bootstrap_lfs_precommit.sh
@@ -17,16 +17,20 @@ fi
 
 has() { command -v "$1" >/dev/null 2>&1; }
 
+info() { echo "[info] $*"; }
+run()  { if [[ "${DRY_RUN:-0}" == "1" ]]; then echo "DRY: $*"; else eval "$*"; fi }
+
 if ! has git; then echo "❌ git not found on PATH" >&2; exit 1; fi
 
 # Ensure Git LFS is installed
 if ! has git-lfs; then
   echo "Installing git-lfs..."
   if has apt-get; then
-    run "apt-get update >/dev/null 2>&1"
-    run "apt-get install -y git-lfs >/dev/null 2>&1"
     if [[ "${DRY_RUN:-0}" == "1" ]]; then
       info "DRY_RUN: would install git-lfs via apt-get"
+    else
+      run "apt-get update >/dev/null 2>&1"
+      run "apt-get install -y git-lfs >/dev/null 2>&1"
     fi
   else
     echo "Warning: unable to install git-lfs automatically." >&2
@@ -66,8 +70,7 @@ PAT
 )
 
 # -------------- helper fns --------------
-info() { echo "[info] $*"; }
-run()  { if [[ "${DRY_RUN:-0}" == "1" ]]; then echo "DRY: $*"; else eval "$*"; fi }
+# (info and run defined near top)
 
 ensure_trailing_newline() {
   local file="$1"


### PR DESCRIPTION
## Summary
- guard bootstrap git-lfs installation with DRY_RUN check
- define helper functions earlier for consistent usage

## Testing
- `ruff check bootstrap_lfs_precommit.sh`
- `pytest` *(fails: No module named 'session.session_lifecycle_metrics')*
- `.git/hooks/pre-commit-lfs`
- `python secondary_copilot_validator.py`
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689bfc32739c8331885b8af325294344