### PR TITLE
feat: improve sqlite concurrency handling

### DIFF
--- a/src/gh_copilot/compliance/dao.py
+++ b/src/gh_copilot/compliance/dao.py
@@ -15,11 +15,12 @@ PRAGMAS: tuple[str, ...] = (
 )
 
 
-def get_conn(db_path: Path) -> sqlite3.Connection:
-    conn = sqlite3.connect(db_path)
+def get_conn(db_path: Path, timeout: float = 30.0) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path, timeout=timeout)
     conn.row_factory = sqlite3.Row
     for p in PRAGMAS:
         conn.execute(p)
+    conn.execute(f"PRAGMA busy_timeout = {int(timeout * 1000)}")
     return conn
 
 

--- a/src/gh_copilot/dao.py
+++ b/src/gh_copilot/dao.py
@@ -25,11 +25,12 @@ PRAGMAS = (
 )
 
 
-def get_conn(db_path: Path) -> sqlite3.Connection:
-    conn = sqlite3.connect(db_path)
+def get_conn(db_path: Path, timeout: float = 30.0) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path, timeout=timeout)
     conn.row_factory = sqlite3.Row
     for p in PRAGMAS:
         conn.execute(p)
+    conn.execute(f"PRAGMA busy_timeout = {int(timeout * 1000)}")
     return conn
 
 

--- a/tests/database/test_wal_concurrency.py
+++ b/tests/database/test_wal_concurrency.py
@@ -1,0 +1,68 @@
+import os
+import threading
+import time
+from pathlib import Path
+
+from enterprise_modules.database_utils import (
+    execute_safe_batch_insert,
+    get_enterprise_database_connection,
+)
+
+
+def test_wal_mode_and_busy_timeout(tmp_path):
+    db = tmp_path / "t.db"
+    with get_enterprise_database_connection(db) as conn:
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+    assert mode.lower() == "wal"
+    assert timeout == 30000
+
+
+def test_concurrent_reads_and_writes():
+    workspace = Path(os.getenv("GH_COPILOT_WORKSPACE"))
+    db = workspace / "tmp" / "wal_concurrency.db"
+    db.parent.mkdir(exist_ok=True)
+    db.unlink(missing_ok=True)
+    with get_enterprise_database_connection(db) as conn:
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        conn.commit()
+
+    errors: list[Exception] = []
+
+    def writer() -> None:
+        try:
+            conn = get_enterprise_database_connection(db)
+            execute_safe_batch_insert(
+                conn,
+                "t",
+                [{"id": i} for i in range(100)],
+                chunk_size=10,
+                checkpoint_interval=50,
+            )
+            conn.close()
+        except Exception as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    def reader() -> None:
+        try:
+            conn = get_enterprise_database_connection(db)
+            for _ in range(20):
+                conn.execute("SELECT COUNT(*) FROM t").fetchone()
+                time.sleep(0.01)
+            conn.close()
+        except Exception as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    t_w = threading.Thread(target=writer)
+    t_r = threading.Thread(target=reader)
+    t_w.start()
+    t_r.start()
+    t_w.join()
+    t_r.join()
+
+    assert not errors
+    with get_enterprise_database_connection(db) as conn:
+        total = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+    assert total == 100
+    db.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- enable WAL mode and busy timeouts on SQLite connections
- add batch insert helper with optional WAL checkpointing
- test concurrent read/write access under WAL mode

## Testing
- `ruff check enterprise_modules/database_utils.py src/gh_copilot/dao.py src/gh_copilot/compliance/dao.py tests/database/test_wal_concurrency.py`
- `pytest tests/database/test_wal_concurrency.py`
- `python scripts/wlc_session_manager.py --db-path databases/production.db` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689c011c7a68833194e9251043a4b144