### PR TITLE
chore: enforce git lfs in workflows

### DIFF
--- a/.github/workflows/artifact_lfs.yml
+++ b/.github/workflows/artifact_lfs.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true # fetch LFS pointers immediately; see ARTIFACT_RECOVERY_WORKFLOW.md
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v3
-      - name: Fetch Git LFS content
-        run: |
-          git lfs fetch --all
-          git lfs checkout
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -150,13 +149,26 @@ jobs:
       - name: Verify template_engine import
         run: python -c "import template_engine"
 
+  lfs-archive-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+      - name: Check LFS tracking for archives
+        run: bash tools/pre-commit-lfs.sh
+
   docs-metrics:
     runs-on: ubuntu-latest
     env:
       GH_COPILOT_WORKSPACE: ${{ github.workspace }}
       GH_COPILOT_BACKUP_ROOT: /tmp/gh_copilot_backup
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
@@ -180,6 +192,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         with:
@@ -224,7 +239,10 @@ jobs:
   optional-deps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -240,7 +258,10 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - uses: github/codeql-action/init@v3
         with:
           languages: python
@@ -257,6 +278,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"

--- a/.github/workflows/compliance-audit.yml
+++ b/.github/workflows/compliance-audit.yml
@@ -10,7 +10,10 @@ jobs:
       GH_COPILOT_WORKSPACE: ${{ github.workspace }}
       FLASK_SECRET_KEY: ${{ secrets.FLASK_SECRET_KEY || 'test_secret' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'

--- a/.github/workflows/daily-whitepaper.yml
+++ b/.github/workflows/daily-whitepaper.yml
@@ -11,13 +11,10 @@ jobs:
   convert:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - name: Fetch LFS objects
-        run: |
-          git lfs fetch --all
-          git lfs checkout
+          fetch-depth: 0
       - name: Verify LFS objects
         run: |
           missing=$(git lfs ls-files -n | while read -r file; do

--- a/.github/workflows/dashboard-compliance.yml
+++ b/.github/workflows/dashboard-compliance.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs-status.yml
+++ b/.github/workflows/docs-status.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -16,7 +16,10 @@ jobs:
       GH_COPILOT_BACKUP_ROOT: /tmp/gh_copilot_backup
       FLASK_SECRET_KEY: ${{ secrets.FLASK_SECRET_KEY || 'test_secret' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
@@ -45,9 +48,10 @@ jobs:
       GH_COPILOT_WORKSPACE: ${{ github.workspace }}
       GH_COPILOT_BACKUP_ROOT: /tmp/gh_copilot_backup
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -8,7 +8,10 @@ jobs:
   policy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -6,7 +6,10 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - name: Validate governance docs
         run: |
           test -f docs/GOVERNANCE_STANDARDS.md

--- a/.github/workflows/lfs-zip-guard.yml
+++ b/.github/workflows/lfs-zip-guard.yml
@@ -12,10 +12,10 @@ jobs:
   verify-lfs-zip:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout (without LFS content)
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          lfs: false
+          lfs: true
           fetch-depth: 0
 
       - name: Ensure Git LFS available

--- a/.github/workflows/status-reconciler.yml
+++ b/.github/workflows/status-reconciler.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/status_drift.yml
+++ b/.github/workflows/status_drift.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- enforce LFS-aware checkouts across workflows
- add CI job to verify archives are LFS-tracked

## Testing
- `ruff check . --statistics` *(fails: F821 undefined-name)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'session.session_lifecycle_metrics')*
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689c0214fd408331b290de57a3560564