### PR TITLE
ci: add LFS archive guard workflow

### DIFF
--- a/.github/workflows/lfs-guard.yml
+++ b/.github/workflows/lfs-guard.yml
@@ -1,0 +1,37 @@
+name: LFS Archive Guard
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+
+      - name: Verify archive files are tracked by LFS
+        shell: bash
+        run: |
+          set -euo pipefail
+          MERGE_BASE=$(git merge-base "${{ github.event.pull_request.base.sha }}" HEAD)
+          git diff --name-status "$MERGE_BASE" HEAD | while IFS=$'\t' read -r status file; do
+            if [[ "$status" =~ ^[AM]$ ]]; then
+              case "$file" in
+                *.zip|*.jar|*.7z|*.tar|*.tar.gz|*.tgz|*.tar.bz2|*.tbz|*.tar.xz|*.txz|*.rar|*.apk|*.ipa|*.nupkg|*.cab|*.iso)
+                  attr=$(git check-attr filter -- "$file" | awk '{print $3}')
+                  if [[ "$attr" != lfs ]]; then
+                    echo "::error file=$file::Archive file is not tracked by Git LFS"
+                    exit_code=1
+                  fi
+                  ;;
+              esac
+            fi
+          done
+          exit ${exit_code:=0}

--- a/README.rst
+++ b/README.rst
@@ -614,6 +614,13 @@ The shell version `tools/git_safe_add_commit.sh` behaves the same and can push
 when invoked with `--push`. See
 `docs/GIT_LFS_WORKFLOW.md <docs/GIT_LFS_WORKFLOW.md>`_ for details.
 
+LFS archive guard
+^^^^^^^^^^^^^^^^^
+
+Pull requests are checked by the ``lfs-guard`` workflow to ensure any added or
+modified archive files (``zip``, ``jar``, ``7z``, ``tar.*``, ``rar``, ``apk``,
+``ipa``, ``nupkg``, ``cab``, ``iso``) are tracked with Git LFS.
+
 Syncing `.gitattributes`
 ^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary
- check pull requests for archive files missing Git LFS via new workflow
- document LFS archive guard in README

## Testing
- `ruff check .` *(fails: F821 Undefined name)*
- `pytest` *(fails: unrecognized arguments: --cov=. --cov-report=term)*
- `python scripts/wlc_session_manager.py` *(fails: No module named 'tqdm')*


------
https://chatgpt.com/codex/tasks/task_e_689c0cccb54883319913b37b5e5a618f