### PR TITLE
feat: add template asset versioning

### DIFF
--- a/scripts/database/add_version_to_template_assets.py
+++ b/scripts/database/add_version_to_template_assets.py
@@ -1,0 +1,48 @@
+"""Add a version column to the ``template_assets`` table."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from tqdm import tqdm
+
+from .size_compliance_checker import check_database_sizes
+from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
+from utils.log_utils import _log_event
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_SQL = "ALTER TABLE template_assets ADD COLUMN version INTEGER NOT NULL DEFAULT 1"
+
+
+def add_column(db_path: Path) -> None:
+    """Ensure ``template_assets`` has a ``version`` column."""
+    start_time = datetime.now()
+    logger.info("[START] add_column for %s", db_path)
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn, tqdm(total=1, desc="add-column", unit="step") as bar:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(template_assets)")}
+        if "version" not in columns:
+            conn.execute(SCHEMA_SQL)
+            conn.commit()
+        bar.update(1)
+
+    check_database_sizes(db_path.parent)
+    _log_event({"event": "template_assets_version_ready", "db": str(db_path)})
+    DualCopilotOrchestrator().validator.validate_corrections([str(db_path)])
+    elapsed = datetime.now() - start_time
+    etc = start_time + timedelta(seconds=1)
+    logger.info("[SUCCESS] Completed in %s | ETC was %s", str(elapsed), etc.strftime("%Y-%m-%d %H:%M:%S"))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    root = Path(__file__).resolve().parents[1]
+    db = root / "databases" / "enterprise_assets.db"
+    add_column(db)
+
+__all__ = ["add_column"]

--- a/scripts/database/asset_ingestion_schema.sql
+++ b/scripts/database/asset_ingestion_schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS template_assets (
     id INTEGER PRIMARY KEY,
     template_path TEXT NOT NULL,
     content_hash TEXT NOT NULL UNIQUE,
+    version INTEGER NOT NULL DEFAULT 1,
     created_at TEXT NOT NULL
 );
 

--- a/scripts/database/template_asset_ingestor.py
+++ b/scripts/database/template_asset_ingestor.py
@@ -64,8 +64,25 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
         try:
             with sqlite3.connect(db_path) as conn:
                 if _table_exists(conn, "template_assets"):
-                    existing_paths.update(row[0] for row in conn.execute("SELECT template_path FROM template_assets"))
-                    existing_hashes.update(row[0] for row in conn.execute("SELECT content_hash FROM template_assets"))
+                    columns = {
+                        row[1] for row in conn.execute("PRAGMA table_info(template_assets)")
+                    }
+                    if "version" not in columns:
+                        conn.execute(
+                            "ALTER TABLE template_assets ADD COLUMN version INTEGER NOT NULL DEFAULT 1"
+                        )
+                    existing_paths.update(
+                        row[0]
+                        for row in conn.execute(
+                            "SELECT template_path FROM template_assets"
+                        )
+                    )
+                    existing_hashes.update(
+                        row[0]
+                        for row in conn.execute(
+                            "SELECT content_hash FROM template_assets"
+                        )
+                    )
         except sqlite3.Error:
             existing_paths = set()
             existing_hashes = set()
@@ -75,11 +92,25 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
         try:
             with sqlite3.connect(primary_db) as prod_conn:
                 if _table_exists(prod_conn, "template_assets"):
+                    columns = {
+                        row[1]
+                        for row in prod_conn.execute("PRAGMA table_info(template_assets)")
+                    }
+                    if "version" not in columns:
+                        prod_conn.execute(
+                            "ALTER TABLE template_assets ADD COLUMN version INTEGER NOT NULL DEFAULT 1"
+                        )
                     existing_paths.update(
-                        row[0] for row in prod_conn.execute("SELECT template_path FROM template_assets")
+                        row[0]
+                        for row in prod_conn.execute(
+                            "SELECT template_path FROM template_assets"
+                        )
                     )
                     existing_hashes.update(
-                        row[0] for row in prod_conn.execute("SELECT content_hash FROM template_assets")
+                        row[0]
+                        for row in prod_conn.execute(
+                            "SELECT content_hash FROM template_assets"
+                        )
                     )
         except sqlite3.Error:
             pass
@@ -95,7 +126,9 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
             conn.close()
             initialize_database(db_path)
             conn = sqlite3.connect(db_path)
-        existing_hashes = {row[0] for row in conn.execute("SELECT content_hash FROM template_assets")}
+        existing_hashes = {
+            row[0] for row in conn.execute("SELECT content_hash FROM template_assets")
+        }
 
         with conn, tqdm(total=len(files), desc="Templates", unit="file") as bar:
             for path in files:
@@ -103,31 +136,66 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
                 rel_path = str(path.relative_to(workspace))
                 content = path.read_text(encoding="utf-8")
                 digest = hashlib.sha256(content.encode()).hexdigest()
-                status = "DUPLICATE" if digest in existing_hashes else "NEW"
-                logger.info(
-                    json.dumps(
-                        {
-                            "template_hash": digest,
-                            "status": status,
-                            "db_path": str(db_path),
-                        }
+
+                existing = conn.execute(
+                    (
+                        "SELECT content_hash, version FROM template_assets "
+                        "WHERE template_path=? ORDER BY version DESC LIMIT 1"
+                    ),
+                    (rel_path,),
+                ).fetchone()
+
+                if existing:
+                    if existing[0] == digest:
+                        status = "UNCHANGED"
+                    else:
+                        status = "UPDATED"
+                        new_version = existing[1] + 1
+                        conn.execute(
+                            (
+                                "INSERT INTO template_assets "
+                                "(template_path, content_hash, version, created_at) "
+                                "VALUES (?, ?, ?, ?)"
+                            ),
+                            (
+                                rel_path,
+                                digest,
+                                new_version,
+                                datetime.now(timezone.utc).isoformat(),
+                            ),
+                        )
+                        existing_hashes.discard(existing[0])
+                        existing_hashes.add(digest)
+                    conn.commit()
+                    log_sync_operation(
+                        db_path,
+                        "template_ingestion",
+                        status=status,
+                        start_time=file_start,
                     )
-                )
+                    bar.update(1)
+                    continue
+
+                status = "DUPLICATE" if digest in existing_hashes else "SUCCESS"
                 if status == "DUPLICATE":
                     dup_count += 1
                     conn.commit()
                     log_sync_operation(
                         db_path,
                         "template_ingestion",
-                        status="DUPLICATE",
+                        status=status,
                         start_time=file_start,
                     )
                     bar.update(1)
                     continue
+
                 new_count += 1
-                existing_hashes.add(digest)
                 conn.execute(
-                    ("INSERT INTO template_assets (template_path, content_hash, created_at) VALUES (?, ?, ?)"),
+                    (
+                        "INSERT INTO template_assets "
+                        "(template_path, content_hash, version, created_at) "
+                        "VALUES (?, ?, 1, ?)"
+                    ),
                     (
                         rel_path,
                         digest,
@@ -135,7 +203,9 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
                     ),
                 )
                 conn.execute(
-                    ("INSERT INTO pattern_assets (pattern, usage_count, created_at) VALUES (?, 0, ?)"),
+                    (
+                        "INSERT INTO pattern_assets (pattern, usage_count, created_at) VALUES (?, 0, ?)"
+                    ),
                     (content[:1000], datetime.now(timezone.utc).isoformat()),
                 )
                 conn.commit()

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -59,6 +59,7 @@ TABLES: dict[str, str] = {
         "id INTEGER PRIMARY KEY,"
         "template_path TEXT NOT NULL,"
         "content_hash TEXT NOT NULL UNIQUE,"
+        "version INTEGER NOT NULL DEFAULT 1,"
         "created_at TEXT NOT NULL"
         ")"
     ),

--- a/tests/template_engine/test_template_asset_versioning.py
+++ b/tests/template_engine/test_template_asset_versioning.py
@@ -1,0 +1,32 @@
+import sqlite3
+
+from scripts.database.template_asset_ingestor import ingest_templates
+
+
+def test_template_version_increment(tmp_path, monkeypatch):
+    workspace = tmp_path
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(workspace))
+    prompts = workspace / "prompts"
+    prompts.mkdir()
+    template = prompts / "sample.md"
+    template.write_text("v1")
+
+    ingest_templates(workspace)
+
+    db_path = workspace / "databases" / "enterprise_assets.db"
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT version FROM template_assets WHERE template_path=?",
+            ("prompts/sample.md",),
+        ).fetchall()
+        assert rows == [(1,)]
+
+    template.write_text("v2")
+    ingest_templates(workspace)
+
+    with sqlite3.connect(db_path) as conn:
+        versions = [row[0] for row in conn.execute(
+            "SELECT version FROM template_assets WHERE template_path=? ORDER BY version",
+            ("prompts/sample.md",),
+        ).fetchall()]
+        assert versions == [1, 2]


### PR DESCRIPTION
## Summary
- add `version` column to `template_assets` schema and initializer
- track template updates with version increments
- ensure migration and tests for template asset versioning

## Testing
- `ruff check scripts/database/template_asset_ingestor.py scripts/database/unified_database_initializer.py scripts/database/add_version_to_template_assets.py tests/template_engine/test_template_asset_versioning.py`
- `pytest tests/template_engine/test_template_asset_versioning.py`
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689ca9b3e8ec8331a7782625f510251e