### PR TITLE
feat: add HAR asset ingestor

### DIFF
--- a/scripts/database/asset_ingestion_schema.sql
+++ b/scripts/database/asset_ingestion_schema.sql
@@ -29,6 +29,9 @@ CREATE TABLE IF NOT EXISTS har_entries (
     id INTEGER PRIMARY KEY,
     har_path TEXT NOT NULL,
     content_hash TEXT NOT NULL UNIQUE,
+    md5 TEXT NOT NULL,
+    raw_content TEXT NOT NULL,
+    content_size INTEGER NOT NULL,
     created_at TEXT NOT NULL
 );
 

--- a/scripts/database/har_asset_ingestor.py
+++ b/scripts/database/har_asset_ingestor.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Ingest HAR files into enterprise_assets.db."""
+"""Ingest HAR files into ``enterprise_assets.db``.
+
+The ingestor stores the raw HAR content along with basic metadata. Duplicate
+files are skipped based on SHA256 hash comparisons.
+"""
 
 from __future__ import annotations
 
@@ -9,23 +13,41 @@ import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 from tqdm import tqdm
 
-from enterprise_modules.compliance import pid_recursion_guard, validate_enterprise_operation
+from enterprise_modules.compliance import (
+    enforce_anti_recursion,
+    validate_enterprise_operation,
+)
+
+# Optional guard for recursion detection
+try:  # pragma: no cover - optional import
+    from enterprise_modules.compliance import pid_recursion_guard  # type: ignore
+    _PID_GUARD_AVAILABLE = True
+except Exception:  # pragma: no cover - fallback to no-op
+    _PID_GUARD_AVAILABLE = False
+
+    def pid_recursion_guard(func):  # type: ignore
+        return func
+
+from secondary_copilot_validator import SecondaryCopilotValidator
 
 from .cross_database_sync_logger import _table_exists, log_sync_operation
 from .size_compliance_checker import check_database_sizes
 from .unified_database_initializer import initialize_database
-from scripts.validation.dual_copilot_orchestrator import DualCopilotOrchestrator
 from utils.log_utils import log_event
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
+_RECURSION_CTX = SimpleNamespace(recursion_depth=0, ancestors=[])
+
 
 def _gather_har_files(directory: Path) -> list[Path]:
     """Return a sorted list of HAR files under ``directory``."""
+
     return sorted(p for p in directory.rglob("*.har") if p.is_file())
 
 
@@ -41,7 +63,11 @@ def ingest_har_entries(workspace: Path, har_dir: Path | None = None) -> None:
         Optional path to the directory containing HAR files. Defaults to
         ``workspace / 'logs'``.
     """
+
     validate_enterprise_operation()
+    enforce_anti_recursion(_RECURSION_CTX)
+    _RECURSION_CTX.recursion_depth += 1
+
     db_dir = workspace / "databases"
     db_path = db_dir / "enterprise_assets.db"
     if not db_path.exists():
@@ -50,10 +76,11 @@ def ingest_har_entries(workspace: Path, har_dir: Path | None = None) -> None:
     har_dir = har_dir or (workspace / "logs")
     files = _gather_har_files(har_dir)
 
-    start_time = datetime.now(timezone.utc)
     analytics_db = db_dir / "analytics.db"
+    start_time = datetime.now(timezone.utc)
     new_count = 0
     dup_count = 0
+    validator = SecondaryCopilotValidator()
 
     conn = sqlite3.connect(db_path)
     try:
@@ -61,6 +88,7 @@ def ingest_har_entries(workspace: Path, har_dir: Path | None = None) -> None:
             conn.close()
             initialize_database(db_path)
             conn = sqlite3.connect(db_path)
+
         existing_hashes = {
             row[0] for row in conn.execute("SELECT content_hash FROM har_entries")
         }
@@ -69,18 +97,25 @@ def ingest_har_entries(workspace: Path, har_dir: Path | None = None) -> None:
             for path in files:
                 file_start = datetime.now(timezone.utc)
                 rel_path = str(path.relative_to(workspace))
-                content = path.read_text(encoding="utf-8")
-                digest = hashlib.sha256(content.encode()).hexdigest()
-                status = "DUPLICATE" if digest in existing_hashes else "SUCCESS"
-                logger.info(
-                    json.dumps(
-                        {
-                            "har_hash": digest,
-                            "status": status,
-                            "db_path": str(db_path),
-                        }
-                    )
+                raw = path.read_bytes()
+                sha256 = hashlib.sha256(raw).hexdigest()
+                md5 = hashlib.md5(raw).hexdigest()
+                size = len(raw)
+
+                status = "DUPLICATE" if sha256 in existing_hashes else "SUCCESS"
+
+                log_event(
+                    {
+                        "module": "har_asset_ingestor",
+                        "level": "INFO",
+                        "har_path": rel_path,
+                        "status": status,
+                        "sha256": sha256,
+                        "md5": md5,
+                    },
+                    db_path=analytics_db,
                 )
+
                 if status == "DUPLICATE":
                     dup_count += 1
                     conn.commit()
@@ -92,15 +127,20 @@ def ingest_har_entries(workspace: Path, har_dir: Path | None = None) -> None:
                     )
                     bar.update(1)
                     continue
+
                 new_count += 1
-                existing_hashes.add(digest)
+                existing_hashes.add(sha256)
                 conn.execute(
                     (
-                        "INSERT INTO har_entries (har_path, content_hash, created_at) VALUES (?, ?, ?)"
+                        "INSERT INTO har_entries (har_path, content_hash, md5, raw_content, content_size, created_at) "
+                        "VALUES (?, ?, ?, ?, ?, ?)"
                     ),
                     (
                         rel_path,
-                        digest,
+                        sha256,
+                        md5,
+                        raw.decode("utf-8"),
+                        size,
                         datetime.now(timezone.utc).isoformat(),
                     ),
                 )
@@ -111,33 +151,34 @@ def ingest_har_entries(workspace: Path, har_dir: Path | None = None) -> None:
                     status="SUCCESS",
                     start_time=file_start,
                 )
+                validator.validate_corrections([str(path)])
                 bar.update(1)
     finally:
         conn.commit()
         conn.close()
 
     log_sync_operation(db_path, "har_ingestion", start_time=start_time)
-    summary = {
-        "description": "har_ingestion_summary",
-        "details": json.dumps(
-            {
-                "db_path": str(db_path),
-                "new": new_count,
-                "duplicates": dup_count,
-            }
-        ),
-    }
-    log_event(summary, db_path=analytics_db)
-    logger.info(
-        json.dumps(
-            {"event": "har_ingestion_summary", **json.loads(summary["details"])}
-        )
+
+    log_event(
+        {
+            "module": "har_asset_ingestor",
+            "level": "INFO",
+            "description": "har_ingestion_summary",
+            "details": json.dumps(
+                {"db_path": str(db_path), "new": new_count, "duplicates": dup_count}
+            ),
+        },
+        db_path=analytics_db,
     )
 
     if not check_database_sizes(db_dir):
         raise RuntimeError("Database size limit exceeded")
 
-    DualCopilotOrchestrator().validator.validate_corrections([str(db_path)])
+    if getattr(_RECURSION_CTX, "recursion_depth", 0) > 0:
+        _RECURSION_CTX.recursion_depth -= 1
+        ancestors = getattr(_RECURSION_CTX, "ancestors", [])
+        if ancestors:
+            ancestors.pop()
 
 
 if __name__ == "__main__":
@@ -157,3 +198,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     ingest_har_entries(args.workspace, args.har_dir)
+

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -77,6 +77,9 @@ TABLES: dict[str, str] = {
         "id INTEGER PRIMARY KEY,"
         "har_path TEXT NOT NULL,"
         "content_hash TEXT NOT NULL UNIQUE,"
+        "md5 TEXT NOT NULL,"
+        "raw_content TEXT NOT NULL,"
+        "content_size INTEGER NOT NULL,"
         "created_at TEXT NOT NULL"
         ")"
     ),

--- a/tests/ingestion/test_har_asset_ingestor.py
+++ b/tests/ingestion/test_har_asset_ingestor.py
@@ -1,0 +1,47 @@
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+from scripts.database.har_asset_ingestor import ingest_har_entries
+from scripts.database.unified_database_initializer import initialize_database
+
+
+def _write_har(path: Path, comment: str) -> None:
+    data = {"log": {"comment": comment, "entries": []}}
+    path.write_text(json.dumps(data))
+
+
+def test_har_ingestor_stores_content_and_skips_duplicates(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GH_COPILOT_DISABLE_VALIDATION", "1")
+    workspace = tmp_path
+    os.environ["GH_COPILOT_WORKSPACE"] = str(workspace)
+    db_dir = workspace / "databases"
+    db_dir.mkdir()
+    db_path = db_dir / "enterprise_assets.db"
+    initialize_database(db_path)
+
+    logs_dir = workspace / "logs"
+    logs_dir.mkdir()
+    file1 = logs_dir / "a.har"
+    file2 = logs_dir / "b.har"
+    _write_har(file1, "first")
+    _write_har(file2, "first")  # duplicate content
+
+    ingest_har_entries(workspace, logs_dir)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT har_path, content_hash, md5, raw_content, content_size FROM har_entries"
+        ).fetchall()
+
+    assert len(rows) == 1
+    path, sha256, md5, raw, size = rows[0]
+    assert path.endswith("a.har") or path.endswith("b.har")
+    assert json.loads(raw)["log"]["comment"] == "first"
+    assert size == len(raw.encode())
+    # simple duplicate check: hash of file1 equals stored hash
+    content = file1.read_bytes()
+    assert sha256 == __import__("hashlib").sha256(content).hexdigest()
+    assert md5 == __import__("hashlib").md5(content).hexdigest()
+


### PR DESCRIPTION
## Summary
- ingest HAR files into enterprise_assets.db with SHA256/MD5 hashing and raw content storage
- log HAR ingestion events and enforce database size checks
- test HAR ingestion to ensure duplicates are skipped and content saved

## Testing
- `ruff check scripts/database/har_asset_ingestor.py scripts/database/unified_database_initializer.py tests/ingestion/test_har_asset_ingestor.py`
- `pytest tests/ingestion/test_har_asset_ingestor.py -q`
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689cad9b2630833181f3460052e70e5e