### PR TITLE
fix: remove code_audit_log duplication

### DIFF
--- a/databases/migrations/README.md
+++ b/databases/migrations/README.md
@@ -132,6 +132,7 @@ automatically when called by recovery scripts.
 
 ## Notes
 - All migrations are idempotent and safe to re-run.
+- `code_audit_log` is created exclusively by `add_code_audit_log.sql`; the unified database initializer no longer defines this table.
 - For compliance details see `scripts/database/add_code_audit_log.py`.
 - Audit logging is integrated via `scripts/code_placeholder_audit.py`.
 - You can apply all migrations at once by running `python scripts/run_migrations.py`.

--- a/scripts/database/unified_database_initializer.py
+++ b/scripts/database/unified_database_initializer.py
@@ -24,12 +24,10 @@ from utils.cross_platform_paths import CrossPlatformPathManager
 from utils.logging_utils import setup_enterprise_logging
 from utils.validation_utils import anti_recursion_guard, detect_zero_byte_files, validate_path
 
-from .add_code_audit_log import ensure_code_audit_log
 from .cross_database_sync_logger import log_sync_operation
 
 # Database paths
 PRODUCTION_DB = CrossPlatformPathManager.get_workspace_path() / "databases" / "production.db"
-ANALYTICS_DB = CrossPlatformPathManager.get_workspace_path() / "databases" / "analytics.db"
 
 logger = logging.getLogger(__name__)
 
@@ -109,16 +107,6 @@ TABLES: dict[str, str] = {
         "status TEXT NOT NULL,"
         "start_time TEXT NOT NULL,"
         "duration REAL NOT NULL,"
-        "timestamp TEXT NOT NULL"
-        ")"
-    ),
-    "code_audit_log": (
-        "CREATE TABLE IF NOT EXISTS code_audit_log ("
-        "id INTEGER PRIMARY KEY,"
-        "file_path TEXT NOT NULL,"
-        "line_number INTEGER NOT NULL,"
-        "placeholder_type TEXT NOT NULL,"
-        "context TEXT,"
         "timestamp TEXT NOT NULL"
         ")"
     ),
@@ -250,10 +238,8 @@ def main() -> None:
     db_path = root / "databases" / "enterprise_assets.db"
     if db_path.exists():
         logger.info("%s already exists", db_path)
-        ensure_code_audit_log(ANALYTICS_DB)
         return
     initialize_database(db_path)
-    ensure_code_audit_log(ANALYTICS_DB)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rely on migration to create `code_audit_log` table and drop duplicate initializer definition
- clarify migration docs about `code_audit_log`

## Testing
- `ruff check scripts/database/unified_database_initializer.py`
- `pytest -q tests/test_unified_database_initializer.py tests/test_add_code_audit_log.py`


------
https://chatgpt.com/codex/tasks/task_e_689cbf72e94083318fc0c087091bb55e