### PR TITLE
fix: streamline pre-commit installation in LFS bootstrap

### DIFF
--- a/bootstrap_lfs_precommit.sh
+++ b/bootstrap_lfs_precommit.sh
@@ -234,12 +234,9 @@ if ! has pre-commit; then
   exit 1
 fi
 
-# Initialize Git LFS and pre-commit hooks if available
+# Initialize Git LFS hooks if available
 if has git-lfs; then
   git lfs install --local >/dev/null 2>&1 || true
-fi
-if has pre-commit; then
-  pre-commit install --install-hooks >/dev/null 2>&1 || true
 fi
 
 # Ensure a config exists, then install hooks


### PR DESCRIPTION
## Summary
- remove early `pre-commit install --install-hooks` call in `bootstrap_lfs_precommit.sh`
- rely on later hook installation after `ensure_precommit_config`

## Testing
- `ruff check bootstrap_lfs_precommit.sh`
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `python secondary_copilot_validator.py`
- `./.git/hooks/pre-commit-lfs`


------
https://chatgpt.com/codex/tasks/task_e_689cc83e05e88331898cc955cd59aae7