### PR TITLE
chore: ensure placeholders are treated as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -40,3 +40,7 @@ web_gui/assets/fonts/** filter=lfs diff=lfs merge=lfs -text
 # END LFS ARCHIVES (autogen)
 *.zip filter=lfs diff=lfs merge=lfs -text
 # End of LFS patterns
+# Explicit text placeholders (never LFS)
+**/.gitkeep      -filter -diff -merge text
+**/.keep         -filter -diff -merge text
+**/.placeholder  -filter -diff -merge text


### PR DESCRIPTION
## Summary
- add `.gitattributes` rules to treat placeholder files as regular text

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'session.session_lifecycle_metrics')*
- `git lfs fetch --all` *(fails: Authorization error: https://github.com/Aries-Serpent/gh_COPILOT/info/lfs/objects/batch)*
- `git lfs checkout || true`
- `git lfs fsck` *(fails: multiple missing objects and unexpected Git objects)*
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689cce7cd4e48331a9a0c2e0c1d4b9c6