### PR TITLE
feat: add unified ingest and regenerate commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1727,6 +1727,13 @@ The `src/gh_copilot` package provides a minimal database-first service with a Fa
    gh-copilot seed-models
    gh-copilot compute-score --lint 0.9 --tests 0.8 --placeholders 0.95 --sessions 1.0
    gh-copilot serve  # http://127.0.0.1:8000/docs
-   gh-copilot ingest-docs --workspace . --docs-dir documentation
-   gh-copilot ingest-templates --workspace . --templates-dir prompts
-   gh-copilot generate-docs --db-path databases/production.db
+   gh-copilot ingest docs --workspace . --src-dir documentation
+   gh-copilot ingest templates --workspace . --src-dir prompts
+    gh-copilot ingest har --workspace . --src-dir logs
+    gh-copilot generate docs --source-db documentation.db
+    gh-copilot generate scripts --source-db production.db
+
+API endpoints:
+
+* ``POST /api/v1/ingest?kind=docs|templates|har``
+* ``POST /api/v1/regenerate/{docs|scripts}``

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -53,7 +53,7 @@ def test_ingest_docs_cli(tmp_path, monkeypatch):
 
     result = runner.invoke(
         app,
-        ["ingest-docs", "--workspace", str(tmp_path), "--docs-dir", str(docs_dir)],
+        ["ingest", "docs", "--workspace", str(tmp_path), "--src-dir", str(docs_dir)],
     )
     assert result.exit_code == 0
     assert "\"ingested\": 1" in result.stdout
@@ -78,10 +78,11 @@ def test_ingest_templates_cli(tmp_path, monkeypatch):
     result = runner.invoke(
         app,
         [
-            "ingest-templates",
+            "ingest",
+            "templates",
             "--workspace",
             str(tmp_path),
-            "--templates-dir",
+            "--src-dir",
             str(tmpl_dir),
         ],
     )
@@ -106,7 +107,7 @@ def test_ingest_har_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(hi, "tqdm", _DummyTqdm)
 
     result = runner.invoke(
-        app, ["ingest-har", "--workspace", str(tmp_path), "--har-dir", str(logs_dir)]
+        app, ["ingest", "har", "--workspace", str(tmp_path), "--src-dir", str(logs_dir)]
     )
     assert result.exit_code == 0
     assert "\"ingested\": 1" in result.stdout

--- a/tests/test_api_har_ingestion.py
+++ b/tests/test_api_har_ingestion.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from src.gh_copilot.api import app
 
 
-def test_api_ingest_har(monkeypatch, tmp_path):
+def test_api_ingest(monkeypatch, tmp_path):
     called = {}
 
     def fake_ingest(workspace: Path, har_dir: Path | None = None) -> None:  # pragma: no cover - stub
@@ -14,7 +14,7 @@ def test_api_ingest_har(monkeypatch, tmp_path):
     )
     monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
     client = TestClient(app)
-    resp = client.post("/api/v1/ingest-har")
+    resp = client.post("/api/v1/ingest", params={"kind": "har"})
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
     assert Path(called["workspace"]) == tmp_path

--- a/tests/test_api_regenerate.py
+++ b/tests/test_api_regenerate.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+from pathlib import Path
+from src.gh_copilot.api import app
+
+
+def test_api_regenerate(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_generate(kind: str, source_db: Path, out_dir: Path, analytics_db: Path, params: dict | None = None):
+        out = out_dir / "out.txt"
+        out.write_text("x")
+        called["kind"] = kind
+        return [out]
+
+    monkeypatch.setattr(
+        "gh_copilot.generation.generate_from_templates.generate", fake_generate
+    )
+    monkeypatch.setenv("GH_COPILOT_WORKSPACE", str(tmp_path))
+    client = TestClient(app)
+    resp = client.post("/api/v1/regenerate/docs")
+    assert resp.status_code == 200
+    assert resp.json()["written"]
+    assert called["kind"] == "docs"


### PR DESCRIPTION
## Summary
- add single `ingest` CLI/API routes for docs, templates, and HAR files
- expose `/api/v1/regenerate/{kind}` and unify CLI ingest workflow
- document new commands and endpoints

## Testing
- `ruff check src/gh_copilot/api.py src/gh_copilot/cli.py tests/cli/test_cli.py tests/test_api_har_ingestion.py tests/test_api_regenerate.py`
- `pytest tests/cli/test_cli.py tests/test_api_har_ingestion.py tests/test_api_regenerate.py -c /tmp/pytest.ini` *(fails: No module named 'fastapi')*
- `python scripts/wlc_session_manager.py` *(fails: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_689ceca3129483318bc07b869ce31281