### PR TITLE
feat: add schema validation before asset ingestion

### DIFF
--- a/scripts/database/documentation_ingestor.py
+++ b/scripts/database/documentation_ingestor.py
@@ -32,6 +32,8 @@ from tqdm import tqdm
 from .cross_database_sync_logger import log_sync_operation
 from .ingestion_utils import AssetIngestor, IngestorConfig
 from .size_compliance_checker import check_database_sizes
+from .schema_validators import ensure_documentation_schema
+from .unified_database_initializer import initialize_database
 
 __all__ = ["ingest_documentation", "pid_recursion_guard", "_PID_GUARD_AVAILABLE"]
 
@@ -59,6 +61,11 @@ def ingest_documentation(
     db_dir = workspace / "databases"
     analytics_db = Path(os.getenv("ANALYTICS_DB", str(db_dir / "analytics.db")))
     analytics_db.parent.mkdir(parents=True, exist_ok=True)
+
+    db_path = db_dir / "enterprise_assets.db"
+    if not db_path.exists():
+        initialize_database(db_path)
+    ensure_documentation_schema(db_path)
 
     docs_dir = docs_dir or (workspace / "documentation")
     dataset_dbs = get_dataset_sources(str(workspace))

--- a/scripts/database/har_ingestor.py
+++ b/scripts/database/har_ingestor.py
@@ -39,6 +39,7 @@ from utils.log_utils import log_event
 from .cross_database_sync_logger import _table_exists, log_sync_operation
 from .size_compliance_checker import check_database_sizes
 from .unified_database_initializer import initialize_database
+from .schema_validators import ensure_har_schema
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -74,6 +75,7 @@ def ingest_har_entries(workspace: Path, har_dir: Path | None = None) -> None:
 
     if not db_path.exists():
         initialize_database(db_path)
+    ensure_har_schema(db_path)
 
     har_dir = har_dir or (workspace / "logs")
     files = _gather_har_files(har_dir)

--- a/scripts/database/schema_validators.py
+++ b/scripts/database/schema_validators.py
@@ -1,0 +1,68 @@
+"""Schema validation helpers for asset ingestion.
+
+These helpers ensure that the target database has the expected tables and
+columns before any ingestion takes place. They also perform a quick integrity
+check using ``PRAGMA quick_check``. The table definitions are sourced from
+``unified_database_initializer.TABLES`` to avoid duplication.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+
+from .unified_database_initializer import TABLES
+
+
+def _expected_columns(table: str) -> list[str]:
+    """Return the column names defined for ``table``."""
+
+    create_stmt = TABLES[table]
+    cols_section = re.search(r"\((.*)\)", create_stmt, re.DOTALL)
+    if not cols_section:
+        return []
+    raw_cols = cols_section.group(1).split(",")
+    return [c.strip().split()[0].strip('"') for c in raw_cols if c.strip()]
+
+
+def _ensure_schema(db_path: Path, table: str) -> None:
+    """Ensure ``table`` exists in ``db_path`` with all expected columns."""
+
+    with sqlite3.connect(db_path, isolation_level=None) as conn:
+        res = conn.execute("PRAGMA quick_check").fetchone()
+        if not res or res[0] != "ok":
+            raise RuntimeError(f"integrity check failed for {db_path}")
+
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+        if not row:
+            raise RuntimeError(f"missing table: {table}")
+
+        existing = {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+        expected = set(_expected_columns(table))
+        missing = expected - existing
+        if missing:
+            raise RuntimeError(f"table {table} missing columns: {', '.join(sorted(missing))}")
+
+
+def ensure_documentation_schema(db_path: Path) -> None:
+    _ensure_schema(db_path, "documentation_assets")
+
+
+def ensure_template_schema(db_path: Path) -> None:
+    _ensure_schema(db_path, "template_assets")
+
+
+def ensure_har_schema(db_path: Path) -> None:
+    _ensure_schema(db_path, "har_entries")
+
+
+__all__ = [
+    "ensure_documentation_schema",
+    "ensure_template_schema",
+    "ensure_har_schema",
+]
+

--- a/scripts/database/template_asset_ingestor.py
+++ b/scripts/database/template_asset_ingestor.py
@@ -23,6 +23,8 @@ from tqdm import tqdm
 from .cross_database_sync_logger import log_sync_operation
 from .ingestion_utils import AssetIngestor, IngestorConfig
 from .size_compliance_checker import check_database_sizes
+from .schema_validators import ensure_template_schema
+from .unified_database_initializer import initialize_database
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -39,6 +41,11 @@ def ingest_templates(workspace: Path, template_dir: Path | None = None) -> None:
     db_dir = workspace / "databases"
     analytics_db = db_dir / "analytics.db"
     analytics_db.parent.mkdir(parents=True, exist_ok=True)
+
+    db_path = db_dir / "enterprise_assets.db"
+    if not db_path.exists():
+        initialize_database(db_path)
+    ensure_template_schema(db_path)
 
     template_dir = template_dir or (workspace / "prompts")
     dataset_dbs = get_dataset_sources(str(workspace))

--- a/tests/database/test_schema_validators.py
+++ b/tests/database/test_schema_validators.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import re
+import sqlite3
+
+import pytest
+
+from scripts.database.schema_validators import (
+    ensure_documentation_schema,
+    ensure_har_schema,
+    ensure_template_schema,
+)
+from scripts.database.unified_database_initializer import TABLES
+
+
+def _create_db(tmp_path: Path, table: str, omit: str | None = None) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    db = tmp_path / "db.sqlite"
+    stmt = TABLES[table]
+    if omit:
+        stmt = re.sub(rf"{omit}[^,]*,?", "", stmt)
+    with sqlite3.connect(db) as conn:
+        conn.execute(stmt)
+        conn.commit()
+    return db
+
+
+def test_ensure_documentation_schema_pass(tmp_path: Path) -> None:
+    db = _create_db(tmp_path, "documentation_assets")
+    ensure_documentation_schema(db)
+
+
+def test_ensure_documentation_schema_missing(tmp_path: Path) -> None:
+    db = _create_db(tmp_path, "documentation_assets", omit="version")
+    with pytest.raises(RuntimeError):
+        ensure_documentation_schema(db)
+
+
+def test_template_and_har_validators(tmp_path: Path) -> None:
+    tdb = _create_db(tmp_path / "t", "template_assets")
+    hdb = _create_db(tmp_path / "h", "har_entries")
+    ensure_template_schema(tdb)
+    ensure_har_schema(hdb)
+


### PR DESCRIPTION

This pull request introduces schema validation checks for asset ingestion scripts to ensure that the target databases have the correct tables and columns before any data is ingested. It adds a new module, `schema_validators.py`, which provides schema validation helpers, and integrates these checks into the documentation, template, and HAR ingestion scripts. Comprehensive tests have also been added to verify the correctness of the schema validation logic.

**Schema validation and initialization:**

* Added a new module `schema_validators.py` that defines helpers (`ensure_documentation_schema`, `ensure_template_schema`, `ensure_har_schema`) to verify that required tables and columns exist in the database, and to perform integrity checks before ingestion. These helpers use the canonical table definitions from `unified_database_initializer.TABLES`.
* Updated `documentation_ingestor.py`, `template_asset_ingestor.py`, and `har_ingestor.py` to call the appropriate schema validation helper after database initialization and before data ingestion. This ensures ingestion only proceeds on a valid schema. [[1]](diffhunk://#diff-b96a7c9427a2921192ee59060eb0fe6e3e826e5a88b3e2d6a16f256aea6ac219R35-R36) [[2]](diffhunk://#diff-b96a7c9427a2921192ee59060eb0fe6e3e826e5a88b3e2d6a16f256aea6ac219R65-R69) [[3]](diffhunk://#diff-4b966c50ae107409de63fb438c9d26d105eb3122aa48d2842730c315fa17e0d0R26-R27) [[4]](diffhunk://#diff-4b966c50ae107409de63fb438c9d26d105eb3122aa48d2842730c315fa17e0d0R45-R49) [[5]](diffhunk://#diff-279453a306f3a3700b286a45b01982f440a97b9e90c601d454af7e933f1d16feR42) [[6]](diffhunk://#diff-279453a306f3a3700b286a45b01982f440a97b9e90c601d454af7e933f1d16feR78)

**Testing:**

* Added `test_schema_validators.py` with tests that verify schema validation passes on correct schemas and raises errors when required columns are missing. This covers all three types of assets (documentation, template, HAR).