### PR TITLE
chore(lfs): clean up archive rules

### DIFF
--- a/.codex_lfs_policy.yaml
+++ b/.codex_lfs_policy.yaml
@@ -7,7 +7,6 @@ size_threshold_mb: 50
 # File extensions that should always be committed via Git LFS
 binary_extensions:
   - .db
-  - .zip
   - .7z
   - .bak
   - .dot
@@ -78,3 +77,7 @@ gitattributes_template: |
   *.cab filter=lfs diff=lfs merge=lfs -text
   *.iso filter=lfs diff=lfs merge=lfs -text
   # END LFS ARCHIVES (autogen)
+  # Explicit text placeholders (never LFS)
+  **/.gitkeep      -filter -diff -merge text
+  **/.keep         -filter -diff -merge text
+  **/.placeholder  -filter -diff -merge text

--- a/.gitattributes
+++ b/.gitattributes
@@ -38,9 +38,8 @@ web_gui/assets/fonts/** filter=lfs diff=lfs merge=lfs -text
 *.cab filter=lfs diff=lfs merge=lfs -text
 *.iso filter=lfs diff=lfs merge=lfs -text
 # END LFS ARCHIVES (autogen)
-*.zip filter=lfs diff=lfs merge=lfs -text
-# End of LFS patterns
 # Explicit text placeholders (never LFS)
 **/.gitkeep      -filter -diff -merge text
 **/.keep         -filter -diff -merge text
 **/.placeholder  -filter -diff -merge text
+# End of LFS patterns


### PR DESCRIPTION
## Summary
- remove redundant `*.zip` rule from `.gitattributes`
- keep placeholder files tracked as text

## Testing
- `ruff check .` *(fails: invalid syntax in existing files)*
- `pytest` *(fails: No module named 'typer')*
- `git lfs fetch --all && git lfs checkout || true && git lfs fsck`


------
https://chatgpt.com/codex/tasks/task_e_689d175ee2988331bb05156804666bb2