### PR TITLE
chore(lfs): clean up archive rules

### DIFF
--- a/.codex_lfs_policy.yaml
+++ b/.codex_lfs_policy.yaml
@@ -36,7 +36,6 @@ binary_extensions:
   - .iso
 # Template used when generating .gitattributes automatically
 gitattributes_template: |
-  codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text
   *.db filter=lfs diff=lfs merge=lfs -text
   *.bak filter=lfs diff=lfs merge=lfs -text
   *.sqlite filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 # Git LFS rules for binary artifacts
-codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text
 *.db filter=lfs diff=lfs merge=lfs -text
 *.bak filter=lfs diff=lfs merge=lfs -text
 *.sqlite filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- drop redundant codex_sessions zip rule from LFS config
- keep placeholder files explicitly marked as text

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_689d2c464da483319c87b472b66ab7ab