### PR TITLE
chore(lfs): normalize archive pointers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,4 +41,5 @@ web_gui/assets/fonts/** filter=lfs diff=lfs merge=lfs -text
 **/.gitkeep      -filter -diff -merge text
 **/.keep         -filter -diff -merge text
 **/.placeholder  -filter -diff -merge text
+codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text
 # End of LFS patterns


### PR DESCRIPTION
## Summary
- sync `.gitattributes` to track codex session archives via Git LFS

## Testing
- `ruff check .` *(fails: invalid syntax in assemble_db_first_bundle.py)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_689d3650d97c8331a693db27fb15b2b2