### PR TITLE
ci: enforce LFS tracking for archives

### DIFF
--- a/.github/workflows/lfs-guard.yml
+++ b/.github/workflows/lfs-guard.yml
@@ -20,7 +20,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          MERGE_BASE=$(git merge-base "${{ github.event.pull_request.base.sha }}" HEAD)
+          MERGE_BASE=$(git merge-base "origin/${GITHUB_BASE_REF}" HEAD)
+          exit_code=0
           git diff --name-status "$MERGE_BASE" HEAD | while IFS=$'\t' read -r status file; do
             if [[ "$status" =~ ^[AM]$ ]]; then
               case "$file" in
@@ -34,4 +35,4 @@ jobs:
               esac
             fi
           done
-          exit ${exit_code:=0}
+          exit $exit_code


### PR DESCRIPTION
## Summary
- enforce LFS archive validation workflow using actions/checkout@v4

## Testing
- `ruff check .` (fails: F821 undefined name and others)
- `pytest` (fails: ModuleNotFoundError: No module named 'typer')


------
https://chatgpt.com/codex/tasks/task_e_689d38085b008331bbe0377f3c2385ab