### PR TITLE
ci: remove redundant LFS checkout steps

### DIFF
--- a/.github/workflows/artifact_lfs.yml
+++ b/.github/workflows/artifact_lfs.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           lfs: true # fetch LFS pointers immediately; see ARTIFACT_RECOVERY_WORKFLOW.md
           fetch-depth: 0
-      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -157,10 +156,9 @@ jobs:
         GH_COPILOT_BACKUP_ROOT: /tmp/gh_copilot_backup
       steps:
         - uses: actions/checkout@v4
-          with:
-            lfs: true
-            fetch-depth: 0
-        - run: git lfs checkout
+        with:
+          lfs: true
+          fetch-depth: 0
         - uses: actions/setup-python@v4
           with:
             python-version: '3.11'
@@ -187,7 +185,6 @@ jobs:
           with:
             lfs: true
             fetch-depth: 0
-        - run: git lfs checkout
         - uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python-version }}
@@ -235,7 +232,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -255,7 +251,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - run: git lfs checkout
       - uses: github/codeql-action/init@v3
         with:
           languages: python
@@ -275,7 +270,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"

--- a/.github/workflows/compliance-audit.yml
+++ b/.github/workflows/compliance-audit.yml
@@ -14,7 +14,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'

--- a/.github/workflows/daily-whitepaper.yml
+++ b/.github/workflows/daily-whitepaper.yml
@@ -15,7 +15,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - run: git lfs checkout
       - name: Verify LFS objects
         run: |
           missing=$(git lfs ls-files -n | while read -r file; do

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
@@ -53,7 +52,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -12,7 +12,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- ensure checkout in CI workflows hydrates Git LFS via actions/checkout@v4 with lfs and full history
- drop manual `git lfs checkout` steps now handled by checkout

## Testing
- `ruff check .` *(fails: Undefined name `compute_similarity_scores`)*
- `pytest` *(fails: tests/cli/test_cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_689d4a7f55788331a04b37398e7e4392