### PR TITLE
fix: remove duplicate zip LFS rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,5 +41,4 @@ web_gui/assets/fonts/** filter=lfs diff=lfs merge=lfs -text
 **/.gitkeep      -filter -diff -merge text
 **/.keep         -filter -diff -merge text
 **/.placeholder  -filter -diff -merge text
-codex_sessions/*.zip filter=lfs diff=lfs merge=lfs -text
 # End of LFS patterns


### PR DESCRIPTION
## Summary
- remove redundant `codex_sessions/*.zip` entry from `.gitattributes`

## Testing
- `ruff check .` *(fails: Found 11 errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689d5159b58483318c473f3685e50bf5