### PR TITLE
ci: centralize archive LFS guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,11 @@ on:
   pull_request:
     branches: [main]
 jobs:
+  lfs-archive-guard:
+    uses: ./.github/workflows/lfs-zip-guard.yml
+
   lint-test:
+    needs: lfs-archive-guard
     runs-on: ubuntu-latest
     env:
       FLASK_SECRET_KEY: ${{ secrets.FLASK_SECRET_KEY || 'test_secret' }}

--- a/.github/workflows/dashboard-compliance.yml
+++ b/.github/workflows/dashboard-compliance.yml
@@ -18,7 +18,11 @@ permissions:
   contents: read
 
 jobs:
+  lfs-archive-guard:
+    uses: ./.github/workflows/lfs-zip-guard.yml
+
   build-and-smoke:
+    needs: lfs-archive-guard
     name: Build & UI Smoke
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lfs-zip-guard.yml
+++ b/.github/workflows/lfs-zip-guard.yml
@@ -1,10 +1,7 @@
-name: LFS Guard
+name: LFS Archive Guard
 
 on:
-  pull_request:
-
-permissions:
-  contents: read
+  workflow_call:
 
 jobs:
   verify-lfs:
@@ -20,7 +17,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch origin ${{ github.base_ref }} --depth=1
+          git fetch origin "$GITHUB_BASE_REF" --depth=1
           git diff --name-only --diff-filter=AM FETCH_HEAD...HEAD > changed_files.txt
           archives=$(grep -E '\\.(zip|jar|tar.*|7z|rar|apk|ipa|nupkg|cab|iso)$' changed_files.txt || true)
           if [[ -z "$archives" ]]; then

--- a/README.rst
+++ b/README.rst
@@ -617,8 +617,8 @@ when invoked with `--push`. See
 LFS archive guard
 ^^^^^^^^^^^^^^^^^
 
-Pull requests are checked by the ``lfs-guard`` workflow to ensure any added or
-modified archive files (``zip``, ``jar``, ``7z``, ``tar.*``, ``rar``, ``apk``,
+Pull requests run a reusable ``lfs-zip-guard`` job that ensures any added or
+modified archive files (``zip``, ``jar``, ``tar.*``, ``7z``, ``rar``, ``apk``,
 ``ipa``, ``nupkg``, ``cab``, ``iso``) are tracked with Git LFS.
 
 Syncing `.gitattributes`


### PR DESCRIPTION
## Summary
- add reusable LFS archive guard workflow
- reuse archive guard in CI and dashboard compliance workflows
- document archive guard job in README

## Testing
- `ruff check .github/workflows`
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689d5fa257648331ba7352f088071124