### PR TITLE
ci: ensure docs metrics checkout hydrates LFS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,20 +156,20 @@ jobs:
         GH_COPILOT_BACKUP_ROOT: /tmp/gh_copilot_backup
       steps:
         - uses: actions/checkout@v4
-        with:
-          lfs: true
-          fetch-depth: 0
+          with:
+            lfs: true
+            fetch-depth: 0
         - uses: actions/setup-python@v4
           with:
             python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Generate docs metrics
-        run: python scripts/generate_docs_metrics.py
-      - name: Validate docs metrics
-        run: python scripts/validate_docs_metrics.py
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+        - name: Generate docs metrics
+          run: python scripts/generate_docs_metrics.py
+        - name: Validate docs metrics
+          run: python scripts/validate_docs_metrics.py
 
   docker-build:
     needs: lint-test


### PR DESCRIPTION
## Summary
- ensure docs-metrics job in CI uses actions/checkout@v4 with lfs and full history

## Testing
- `ruff check .`
- `pytest -o addopts="" -q` *(fails: TypeError, unsupported operand types)*
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689d5fa31ae0833193beb15ca223d6e4