### PR TITLE
ci: ensure LFS checkout in workflows

### DIFF
--- a/.github/workflows/artifact_lfs.yml
+++ b/.github/workflows/artifact_lfs.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           lfs: true # fetch LFS pointers immediately; see ARTIFACT_RECOVERY_WORKFLOW.md
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -163,6 +164,7 @@ jobs:
           with:
             lfs: true
             fetch-depth: 0
+        - run: git lfs checkout
         - uses: actions/setup-python@v4
           with:
             python-version: '3.11'
@@ -189,6 +191,7 @@ jobs:
           with:
             lfs: true
             fetch-depth: 0
+        - run: git lfs checkout
         - uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python-version }}
@@ -236,6 +239,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -255,6 +259,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: github/codeql-action/init@v3
         with:
           languages: python
@@ -274,6 +279,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"

--- a/.github/workflows/compliance-audit.yml
+++ b/.github/workflows/compliance-audit.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'

--- a/.github/workflows/daily-whitepaper.yml
+++ b/.github/workflows/daily-whitepaper.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - name: Verify LFS objects
         run: |
           missing=$(git lfs ls-files -n | while read -r file; do

--- a/.github/workflows/dashboard-compliance.yml
+++ b/.github/workflows/dashboard-compliance.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs-status.yml
+++ b/.github/workflows/docs-status.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
@@ -52,6 +53,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -10,6 +10,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - name: Validate governance docs
         run: |
           test -f docs/GOVERNANCE_STANDARDS.md

--- a/.github/workflows/lfs-zip-guard.yml
+++ b/.github/workflows/lfs-zip-guard.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
 
       - name: Enforce LFS for archive files
         shell: bash

--- a/.github/workflows/status-reconciler.yml
+++ b/.github/workflows/status-reconciler.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/status_drift.yml
+++ b/.github/workflows/status_drift.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - run: git lfs checkout
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- hydrate Git LFS files after checkout across workflows

## Testing
- `ruff check .github/workflows`
- `pytest -q` *(fails: No module named 'typer')*
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689d8833b4608331bfc965b4a5576507