### PR TITLE
feat: add consistency auditor to maintenance cycle

### DIFF
--- a/scripts/database/consistency_auditor.py
+++ b/scripts/database/consistency_auditor.py
@@ -1,7 +1,10 @@
+"""CLI entrypoint for filesystem/database consistency auditing."""
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
+
 import typer
 
 from gh_copilot.auditor.consistency import run_audit

--- a/src/gh_copilot/auditor/consistency.py
+++ b/src/gh_copilot/auditor/consistency.py
@@ -7,7 +7,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
+from typing import Iterator, List, Optional, Sequence, Tuple
 
 # SQLite pragmas: WAL improves concurrent readers; busy_timeout reduces SQLITE_BUSY.
 # See: https://sqlite.org/wal.html ; https://highperformancesqlite.com/articles/sqlite-recommended-pragmas

--- a/tests/auditor/test_consistency_auditor.py
+++ b/tests/auditor/test_consistency_auditor.py
@@ -19,22 +19,28 @@ def test_audit_minimal(tmp_path: Path) -> None:
     ana = tmp_path / "analytics.db"
 
     with _mk_db(ent) as c:
-        c.executescript(
+        c.execute(
             """
             CREATE TABLE IF NOT EXISTS documentation_assets(
               id INTEGER PRIMARY KEY, path TEXT NOT NULL, content_hash TEXT
-            );
-            INSERT INTO documentation_assets(path, content_hash) VALUES('README.md','abc');
+            )
             """
         )
+        c.execute(
+            "INSERT INTO documentation_assets(path, content_hash) VALUES(?, 'abc')",
+            (str(tmp_path / "README.md"),),
+        )
     with _mk_db(prod) as c:
-        c.executescript(
+        c.execute(
             """
             CREATE TABLE IF NOT EXISTS har_entries(
               id INTEGER PRIMARY KEY, path TEXT NOT NULL, sha256 TEXT
-            );
-            INSERT INTO har_entries(path, sha256) VALUES('missing.har','def');
+            )
             """
+        )
+        c.execute(
+            "INSERT INTO har_entries(path, sha256) VALUES(?, 'def')",
+            (str(tmp_path / "missing.har"),),
         )
     with _mk_db(ana) as c:
         c.executescript(

--- a/tests/test_maintenance_scheduler.py
+++ b/tests/test_maintenance_scheduler.py
@@ -87,7 +87,25 @@ def test_run_cycle_logging_and_progress(tmp_path: Path, monkeypatch) -> None:
 
     run_cycle(tmp_path)
 
-    assert bars and bars[0].updates == 2
+    assert bars and bars[0].updates == 3
     with sqlite3.connect(log_db) as conn:
         count = conn.execute("SELECT COUNT(*) FROM cross_database_sync_operations").fetchone()[0]
     assert count >= 3
+    analytics_db = db_dir / "analytics.db"
+    with sqlite3.connect(analytics_db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS consistency_audit_events(
+              id INTEGER PRIMARY KEY, started_at TEXT, finished_at TEXT,
+              scanned_paths TEXT, missing_count INTEGER, stale_count INTEGER,
+              regenerated_count INTEGER, reingested_count INTEGER,
+              details_json TEXT, status TEXT
+            )
+            """
+        )
+    run_cycle(tmp_path)
+    with sqlite3.connect(analytics_db) as conn:
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM consistency_audit_events"
+        ).fetchone()[0]
+    assert rows >= 1


### PR DESCRIPTION
## Summary
- add CLI for database/file consistency auditing
- integrate auditor into maintenance scheduler and log to analytics
- test asset audit and maintenance scheduling

## Testing
- `ruff check scripts/database/consistency_auditor.py scripts/database/maintenance_scheduler.py src/gh_copilot/auditor/consistency.py tests/auditor/test_consistency_auditor.py tests/test_maintenance_scheduler.py`
- `pytest tests/auditor/test_consistency_auditor.py tests/test_maintenance_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_689d998163b88331a957131bcd398a5b