### PR TITLE
fix: check ZIP LFS tracking against base branch

### DIFF
--- a/.github/workflows/lfs-zip-guard.yml
+++ b/.github/workflows/lfs-zip-guard.yml
@@ -30,50 +30,51 @@ jobs:
           git lfs install --skip-repo
       - run: git lfs checkout
 
-        - name: Validate that ZIP files are tracked by LFS
-          shell: bash
-          run: |
-            set -euo pipefail
+      - name: Validate that ZIP files are tracked by LFS
+        shell: bash
+        run: |
+          set -euo pipefail
 
-            if [[ -z "${GITHUB_BASE_REF:-}" ]]; then
-              echo "No base ref; skipping ZIP LFS check."
-              exit 0
+          if [[ -z "${GITHUB_BASE_REF:-}" ]]; then
+            echo "No base ref; skipping ZIP LFS check."
+            exit 0
+          fi
+
+          git fetch origin "$GITHUB_BASE_REF"
+          BASE_SHA=$(git merge-base HEAD "origin/$GITHUB_BASE_REF")
+
+          git diff --name-only "$BASE_SHA" HEAD > changed_files.txt
+          grep -E '\.zip$' changed_files.txt > changed_zips.txt || true
+
+          if [[ ! -s changed_zips.txt ]]; then
+            echo "No ZIP files changed."
+            exit 0
+          fi
+
+          bad=0
+          > bad_zips.txt
+          while IFS= read -r file; do
+            attrs=$(git check-attr filter diff merge -- "$file")
+            if ! grep -q 'filter: lfs' <<<"$attrs" || ! grep -q 'diff: lfs' <<<"$attrs" || ! grep -q 'merge: lfs' <<<"$attrs"; then
+              echo "$file" >> bad_zips.txt
+              bad=1
             fi
+          done < changed_zips.txt
 
-            git fetch origin "$GITHUB_BASE_REF"
-            BASE_SHA=$(git merge-base HEAD "origin/$GITHUB_BASE_REF")
-
-            git diff --name-only "$BASE_SHA" HEAD | grep -E '\.zip$' > changed_zips.txt || true
-
-            if [[ ! -s changed_zips.txt ]]; then
-              echo "No ZIP files changed."
-              exit 0
-            fi
-
-            bad=0
-            > bad_zips.txt
-            while IFS= read -r file; do
-              attr=$(git check-attr filter -- "$file" | awk -F': ' '{print $3}')
-              if [[ "$attr" != "lfs" ]]; then
-                echo "$file" >> bad_zips.txt
-                bad=1
-              fi
-            done < changed_zips.txt
-
-            if [[ $bad -eq 1 ]]; then
-              echo "::error title=ZIP files not tracked by LFS::The following ZIP files are not tracked by Git LFS:";
-              sed 's/^/ - /' bad_zips.txt
-              echo ""
-              echo "To fix:"
-              echo "  git lfs track \"*.zip\""
-              echo "  git add .gitattributes $(cat bad_zips.txt)"
-              echo "  git rm --cached $(cat bad_zips.txt)"
-              echo "  git add $(cat bad_zips.txt)"
-              echo "  git commit -m \"Track ZIPs with Git LFS\""
-              exit 1
-            else
-              echo "All changed ZIP files are properly tracked by LFS."
-            fi
+          if [[ $bad -eq 1 ]]; then
+            echo "::error title=ZIP files not tracked by LFS::The following ZIP files are not tracked by Git LFS:";
+            sed 's/^/ - /' bad_zips.txt
+            echo ""
+            echo "To fix:"
+            echo "  git lfs track \"*.zip\""
+            echo "  git add .gitattributes $(cat bad_zips.txt)"
+            echo "  git rm --cached $(cat bad_zips.txt)"
+            echo "  git add $(cat bad_zips.txt)"
+            echo "  git commit -m \"Track ZIPs with Git LFS\""
+            exit 1
+          else
+            echo "All changed ZIP files are properly tracked by LFS."
+          fi
 
       - name: Optional — verify LFS pointers resolvable
         if: ${{ always() }}


### PR DESCRIPTION
## Summary
- compute merge-base with PR base branch in ZIP LFS guard
- inspect only changed files from git diff
- verify LFS tracking via git check-attr

## Testing
- `ruff check --exit-zero .github/workflows/lfs-zip-guard.yml` *(fails: invalid-syntax in YAML file)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `.git/hooks/pre-commit-lfs`
- `python scripts/wlc_session_manager.py` *(fails: sqlite3.DatabaseError: file is not a database)*

------
https://chatgpt.com/codex/tasks/task_e_689da0cacc1c8331a8f27153c130329b